### PR TITLE
feat: implement Universal Build Contract for seed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,20 +208,46 @@ jobs:
           npm ci
           npm run build
 
+      - name: Verify embedded frontend
+        run: |
+          # ui/dist is consumed by ui/embed.go via //go:embed all:dist before
+          # the Go build runs. If npm run build silently produced nothing,
+          # the binary would ship without a UI — fail loudly here.
+          if [ ! -d ui/dist ] || [ -z "$(ls -A ui/dist)" ]; then
+            echo "ui/dist is missing or empty after npm run build"
+            exit 1
+          fi
+          ls -la ui/dist/
+
+      - name: Generate UI build hash
+        id: ui-hash
+        run: |
+          UI_HASH=$(find ui/dist -type f -exec md5sum {} \; | sort | md5sum | cut -d' ' -f1)
+          echo "hash=$UI_HASH" >> "$GITHUB_OUTPUT"
+          echo "UI Build Hash: $UI_HASH"
+
       - name: Build The Seed
         env:
           GOOS: linux
           GOARCH: ${{ matrix.arch }}
           CGO_ENABLED: 1
           CC: ${{ matrix.cc }}
+          VERSION: ${{ github.ref_name }}
+          COMMIT: ${{ github.sha }}
+          UI_HASH: ${{ steps.ui-hash.outputs.hash }}
         run: |
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
           else
             export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig
           fi
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           go build -trimpath -buildvcs=false \
-            -ldflags="-s -w -X github.com/krisarmstrong/seed/internal/version.Version=${{ github.ref_name }}" \
+            -ldflags="-s -w \
+              -X github.com/krisarmstrong/seed/internal/version.Version=${VERSION} \
+              -X github.com/krisarmstrong/seed/internal/version.Commit=${COMMIT} \
+              -X github.com/krisarmstrong/seed/internal/version.BuildTime=${BUILD_TIME} \
+              -X github.com/krisarmstrong/seed/internal/version.UIBuildHash=${UI_HASH}" \
             -o dist/seed-linux-${{ matrix.arch }} ./cmd/seed
 
       - name: Verify binaries (smoke test)
@@ -353,14 +379,42 @@ jobs:
           npm ci
           npm run build
 
+      - name: Verify embedded frontend
+        run: |
+          if [ ! -d ui/dist ] || [ -z "$(ls -A ui/dist)" ]; then
+            echo "ui/dist is missing or empty after npm run build"
+            exit 1
+          fi
+          ls -la ui/dist/
+
+      - name: Generate UI build hash
+        id: ui-hash
+        run: |
+          # macOS md5 has a -q quiet flag; fall back to md5sum for portability.
+          if command -v md5sum >/dev/null 2>&1; then
+            UI_HASH=$(find ui/dist -type f -exec md5sum {} \; | sort | md5sum | cut -d' ' -f1)
+          else
+            UI_HASH=$(find ui/dist -type f -exec md5 -q {} \; | sort | md5 -q | tr -d '[:space:]')
+          fi
+          echo "hash=$UI_HASH" >> "$GITHUB_OUTPUT"
+          echo "UI Build Hash: $UI_HASH"
+
       - name: Build The Seed for macOS
         env:
           GOOS: darwin
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 1
+          VERSION: ${{ github.ref_name }}
+          COMMIT: ${{ github.sha }}
+          UI_HASH: ${{ steps.ui-hash.outputs.hash }}
         run: |
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           go build -trimpath -buildvcs=false \
-            -ldflags="-s -w -X github.com/krisarmstrong/seed/internal/version.Version=${{ github.ref_name }}" \
+            -ldflags="-s -w \
+              -X github.com/krisarmstrong/seed/internal/version.Version=${VERSION} \
+              -X github.com/krisarmstrong/seed/internal/version.Commit=${COMMIT} \
+              -X github.com/krisarmstrong/seed/internal/version.BuildTime=${BUILD_TIME} \
+              -X github.com/krisarmstrong/seed/internal/version.UIBuildHash=${UI_HASH}" \
             -o dist/seed-darwin-${{ matrix.arch }} ./cmd/seed
 
       - name: Verify binary (smoke test)
@@ -451,15 +505,37 @@ jobs:
           npm ci
           npm run build
 
+      - name: Verify embedded frontend
+        run: |
+          if [ ! -d ui/dist ] || [ -z "$(ls -A ui/dist)" ]; then
+            echo "ui/dist is missing or empty after npm run build"
+            exit 1
+          fi
+          ls -la ui/dist/
+
+      - name: Generate UI build hash
+        id: ui-hash
+        run: |
+          UI_HASH=$(find ui/dist -type f -exec md5sum {} \; | sort | md5sum | cut -d' ' -f1)
+          echo "hash=$UI_HASH" >> "$GITHUB_OUTPUT"
+          echo "UI Build Hash: $UI_HASH"
+
       - name: Build The Seed for Windows
         env:
           GOOS: windows
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
           VERSION: ${{ github.ref_name }}
+          COMMIT: ${{ github.sha }}
+          UI_HASH: ${{ steps.ui-hash.outputs.hash }}
         run: |
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           go build -trimpath -buildvcs=false \
-            -ldflags="-s -w -X github.com/krisarmstrong/seed/internal/version.Version=${VERSION}" \
+            -ldflags="-s -w \
+              -X github.com/krisarmstrong/seed/internal/version.Version=${VERSION} \
+              -X github.com/krisarmstrong/seed/internal/version.Commit=${COMMIT} \
+              -X github.com/krisarmstrong/seed/internal/version.BuildTime=${BUILD_TIME} \
+              -X github.com/krisarmstrong/seed/internal/version.UIBuildHash=${UI_HASH}" \
             -o dist/seed-windows-${{ matrix.arch }}.exe ./cmd/seed
 
       - name: Verify binary

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -136,6 +136,11 @@ func (s *Server) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	s.handleStatus(w, r)
 }
 
+// HandleBuildVersion exports handleBuildVersion for testing.
+func (s *Server) HandleBuildVersion(w http.ResponseWriter, r *http.Request) {
+	s.handleBuildVersion(w, r)
+}
+
 // HandleExport exports handleExport for testing.
 func (s *Server) HandleExport(w http.ResponseWriter, r *http.Request) {
 	s.handleExport(w, r)

--- a/internal/api/handlers_buildversion.go
+++ b/internal/api/handlers_buildversion.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/krisarmstrong/seed/internal/logging"
+	"github.com/krisarmstrong/seed/internal/version"
+)
+
+// handleBuildVersion serves GET /__version with build metadata for deployment
+// validation. Unauthenticated by design — operators need to verify which
+// binary is running without holding a session. Required by the Universal
+// Build Contract; see CLAUDE.md.
+func (s *Server) handleBuildVersion(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+	if r.Method != http.MethodGet {
+		sendErrorResponseWithDetails(
+			w,
+			logger,
+			http.StatusMethodNotAllowed,
+			ErrCodeMethodNotAllowed,
+			"Method not allowed",
+			"",
+		)
+		return
+	}
+	sendJSONResponse(w, logger, http.StatusOK, version.Info())
+}

--- a/internal/api/handlers_buildversion_test.go
+++ b/internal/api/handlers_buildversion_test.go
@@ -1,0 +1,51 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/api"
+)
+
+func TestHandleBuildVersionGET(t *testing.T) {
+	server := api.NewTestServer()
+	defer server.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/__version", http.NoBody)
+	w := httptest.NewRecorder()
+	server.HandleBuildVersion(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	for _, key := range []string{"version", "commit", "buildTime", "uiBuildHash"} {
+		if body[key] == "" {
+			t.Errorf("response missing or empty field %q (got %#v)", key, body)
+		}
+	}
+}
+
+func TestHandleBuildVersionMethodNotAllowed(t *testing.T) {
+	server := api.NewTestServer()
+	defer server.Close()
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/__version", http.NoBody)
+			w := httptest.NewRecorder()
+			server.HandleBuildVersion(w, req)
+
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -760,6 +760,7 @@ func (s *Server) onLinkStateChange(event netif.LinkEvent) {
 
 // setupRoutes configures all HTTP routes.
 func (s *Server) setupRoutes() {
+	s.mux.HandleFunc("/__version", s.handleBuildVersion)
 	s.setupCoreRoutes()
 	s.registerUpdateRoutes()
 	s.setupSAPRoutes()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -12,9 +12,10 @@ import (
 //
 //nolint:gochecknoglobals // Build metadata injected via ldflags.
 var (
-	Version   string // Set via -ldflags
-	Commit    string // Set via -ldflags
-	BuildTime string // Set via -ldflags
+	Version     string // Set via -ldflags
+	Commit      string // Set via -ldflags
+	BuildTime   string // Set via -ldflags
+	UIBuildHash string // Set via -ldflags; md5 of all files under ui/dist
 )
 
 const (
@@ -109,12 +110,22 @@ func GetBuildTime() string {
 	return buildTime
 }
 
+// GetUIBuildHash returns the md5 hash of the embedded UI assets.
+// Returns unknownValue when not injected via -ldflags at build time.
+func GetUIBuildHash() string {
+	if UIBuildHash == "" {
+		return unknownValue
+	}
+	return UIBuildHash
+}
+
 // Info returns all version information.
 func Info() map[string]string {
 	ver, commit, buildTime := getVersionInfo()
 	return map[string]string{
-		"version":   ver,
-		"commit":    commit,
-		"buildTime": buildTime,
+		"version":     ver,
+		"commit":      commit,
+		"buildTime":   buildTime,
+		"uiBuildHash": GetUIBuildHash(),
 	}
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -13,7 +13,7 @@ func TestInfo(t *testing.T) {
 	}{
 		{
 			name:     "returns all version fields",
-			wantKeys: []string{"version", "commit", "buildTime"},
+			wantKeys: []string{"version", "commit", "buildTime", "uiBuildHash"},
 		},
 	}
 
@@ -50,6 +50,10 @@ func TestInfoDefaultValues(t *testing.T) {
 
 	if info["buildTime"] == "" {
 		t.Error("Info() buildTime should not be empty")
+	}
+
+	if info["uiBuildHash"] == "" {
+		t.Error("Info() uiBuildHash should not be empty")
 	}
 }
 
@@ -88,6 +92,11 @@ func TestGetterFunctions(t *testing.T) {
 		{
 			name:     "GetBuildTime returns value",
 			getter:   version.GetBuildTime,
+			notEmpty: true,
+		},
+		{
+			name:     "GetUIBuildHash returns value",
+			getter:   version.GetUIBuildHash,
 			notEmpty: true,
 		},
 	}


### PR DESCRIPTION
## Summary

Brings seed in line with the **Universal Build Contract** requirements in `CLAUDE.md` (version + commit + buildTime + uiBuildHash + `/__version` endpoint), mirroring the pattern niac already follows. Required for `make deploy-validate HOST=server` to work.

## Why this matters

CLAUDE.md says every build must embed version/commit/buildTime/uiBuildHash and expose a no-auth `/__version` endpoint so post-deploy validation can confirm the running binary matches the published one. seed had the version package infrastructure already, but the release workflow only set `Version` via ldflags — `Commit` and `BuildTime` defaulted to "unknown" and `UIBuildHash` didn't exist at all.

## Changes

**`internal/version`**
- Add `UIBuildHash` global, set via `-ldflags` at build time
- `GetUIBuildHash()` returns `"unknown"` when not injected (parity with commit/buildTime fallbacks)
- `Info()` now returns four keys: `version`, `commit`, `buildTime`, `uiBuildHash`

**`internal/api`**
- New unauthenticated `GET /__version` handler returning `version.Info()` as JSON
- Path is non-`/api/`, non-`/ws`, so it auto-bypasses the JWT + CSRF middleware via the existing `shouldBypassAuth` non-API rule
- Test coverage: GET returns 200 with all four fields; POST/PUT/DELETE return 405

**`.github/workflows/release.yml`**
- All three legs (linux release, release-macos, release-windows) now:
  - **Verify embedded frontend** — fail loudly if `ui/dist` is missing or empty after `npm run build` (was a silent failure mode)
  - **Generate UI build hash** — md5 of every file under `ui/dist`, exposed as a step output
  - **Extended ldflags** — set `Version`, `Commit` (`github.sha`), `BuildTime` (UTC ISO-8601), `UIBuildHash` together

## Verification

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` passes — 47 packages, zero failures
- [x] Targeted tests pass: `TestInfo`, `TestInfoDefaultValues`, `TestInfoMapStructure`, `TestGetterFunctions`, `TestHandleBuildVersionGET`, `TestHandleBuildVersionMethodNotAllowed`
- [ ] Release dry-run produces a binary whose `/__version` shows the four populated fields (validate post-merge)

## Test plan

After merge:

```bash
# Trigger release dry-run, download bundle, install, then:
curl -s http://server:8080/__version | jq
# Expect: { "version": "...", "commit": "...", "buildTime": "...", "uiBuildHash": "..." }
```

## Notes

- This PR keeps `ui/dist` as the embed path (rather than the `internal/api/ui` path niac uses). Both are functionally equivalent — picked minimal change. CLAUDE.md may want a small tweak to its "internal/api/ui must contain built assets" line to reflect either-or; deferred to a docs PR.
- Branched off `main` after #944 (gopacket / Windows arm64). Minor conflict possible on `release.yml` if PRs merge out of order — trivial to resolve.