### PR TITLE
refactor(ci): use release-please CHANGELOG.md in release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -576,16 +576,36 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          if [ -n "$PREV_TAG" ]; then
-            CHANGELOG=$(git log --pretty=format:"- %s (%h)" $PREV_TAG..HEAD)
-          else
-            CHANGELOG=$(git log --pretty=format:"- %s (%h)" -20)
+          # Prefer the section release-please emits in CHANGELOG.md — it's
+          # grouped by conventional-commit type and includes commit links.
+          # The git-log fallback is for dry-runs and any manually pushed tag
+          # that release-please didn't produce. (#921)
+          CHANGELOG=""
+          if [ "${REF_TYPE}" = "tag" ] && [ -f CHANGELOG.md ]; then
+            VER="${REF_NAME#v}"
+            CHANGELOG=$(awk -v v="$VER" '
+              $0 ~ "^## \\[" v "\\]" {found=1; print; next}
+              found && /^## \[/ {exit}
+              found {print}
+            ' CHANGELOG.md)
           fi
-          echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          if [ -z "$CHANGELOG" ]; then
+            PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+            if [ -n "$PREV_TAG" ]; then
+              CHANGELOG=$(git log --pretty=format:"- %s (%h)" "$PREV_TAG"..HEAD)
+            else
+              CHANGELOG=$(git log --pretty=format:"- %s (%h)" -20)
+            fi
+          fi
+          {
+            echo "changelog<<EOF"
+            echo "$CHANGELOG"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Get versions
         id: versions


### PR DESCRIPTION
## Summary

Closes #921. The actual duplication between `release.yml` and `release-please.yml` was a single step: the publish job's `Generate changelog` ran `git log` to assemble a release body even though release-please already produces a grouped, linked `CHANGELOG.md` section for the same tag.

This PR makes release.yml prefer the release-please-emitted section when available, with the existing `git log` summary as fallback.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| release-please tag (e.g. `v0.185.13`) with matching CHANGELOG.md section | git log dump | release-please section (grouped + linked) |
| Manually pushed tag with no CHANGELOG.md entry | git log dump | git log dump (unchanged) |
| `workflow_dispatch` dry-run (no tag) | git log dump | git log dump (unchanged) |

Strictly additive — no path gets worse.

## Implementation notes

- Extracts the CHANGELOG.md section via `awk`: matches `## [VER]`, prints until the next `## [` line. Verified against the current `CHANGELOG.md` for `v0.185.13`.
- Moves `github.ref_name` / `github.ref_type` into `env:` instead of inlining `${{ }}` in the shell body — keeps shellcheck quiet and tightens against the injection patterns flagged by the workflow security hook.
- Quotes `$PREV_TAG` and `$GITHUB_OUTPUT`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` parses
- [x] Local awk against actual `CHANGELOG.md` for `v0.185.13` returns the expected section (header + Bug Fixes block)
- [ ] Manually verify the next release PR shows the grouped changelog in the GitHub release body (post-merge)

## What this PR does NOT do

- Does not adopt option B (`workflow_call` from release-please.yml) or option C (drop release-please.yml entirely). Both are bigger restructures with real trade-offs and worth their own discussion. The minimal trim closes the visible duplication without committing to a larger direction.

Closes #921