### PR TITLE
refactor(ci): native ubuntu-24.04-arm runner for arm64 release leg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,43 +36,36 @@ jobs:
   # ===========================================================================
   build-iperf3:
     name: Build iperf3
-    runs-on: ubuntu-latest
+    # Native runner per arch — amd64 stays on ubuntu-latest, arm64 uses the
+    # GitHub-hosted ubuntu-24.04-arm runner. Removes the QEMU / cross-toolchain
+    # / qemu-aarch64-static-smoke-test plumbing entirely.
+    runs-on: ${{ matrix.runner }}
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: amd64
-            cc: gcc
+            runner: ubuntu-latest
           - arch: arm64
-            cc: aarch64-linux-gnu-gcc
+            runner: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v6.0.2
-
-      - name: Set up QEMU for cross-arch testing
-        if: matrix.arch == 'arm64'
-        uses: docker/setup-qemu-action@v4.0.0
-        with:
-          platforms: arm64
 
       - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential autoconf automake libtool
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            sudo apt-get install -y gcc-aarch64-linux-gnu qemu-user-static
-          fi
 
       - name: Get latest iperf3 version
         id: iperf3_version
         run: |
           LATEST=$(curl -s https://api.github.com/repos/esnet/iperf/releases/latest | jq -r '.tag_name')
-          echo "version=$LATEST" >> $GITHUB_OUTPUT
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
           echo "Latest iperf3 version: $LATEST"
 
       - name: Download and build iperf3
-        env:
-          CC: ${{ matrix.cc }}
         run: |
           VERSION="${{ steps.iperf3_version.outputs.version }}"
           curl -L -o iperf3.tar.gz "https://github.com/esnet/iperf/archive/refs/tags/${VERSION}.tar.gz"
@@ -83,12 +76,7 @@ jobs:
             ./bootstrap.sh || autoreconf -i
           fi
 
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            ./configure --host=aarch64-linux-gnu --prefix=/tmp/iperf3-install --disable-shared --enable-static-bin
-          else
-            ./configure --prefix=/tmp/iperf3-install --disable-shared --enable-static-bin
-          fi
-
+          ./configure --prefix=/tmp/iperf3-install --disable-shared --enable-static-bin
           make -j$(nproc)
           make install
 
@@ -103,11 +91,7 @@ jobs:
 
           echo ""
           echo "=== Version smoke test ==="
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            qemu-aarch64-static dist/iperf3-linux-${{ matrix.arch }} --version
-          else
-            ./dist/iperf3-linux-${{ matrix.arch }} --version
-          fi
+          ./dist/iperf3-linux-${{ matrix.arch }} --version
           echo "✅ iperf3 smoke test passed"
 
       - name: Upload iperf3 artifact
@@ -121,7 +105,11 @@ jobs:
   # ===========================================================================
   release:
     name: Create Release
-    runs-on: ubuntu-latest
+    # Native runner per arch — drops the entire deb822 source-list rewriting
+    # dance, the cross-toolchain install, the QEMU smoke-test plumbing, and
+    # the PKG_CONFIG_PATH branch. cgo just compiles against the runner's own
+    # libpcap-dev.
+    runs-on: ${{ matrix.runner }}
     needs: build-iperf3
     permissions:
       contents: write
@@ -132,11 +120,9 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            cc: gcc
-            pkg_config_path: /usr/lib/x86_64-linux-gnu/pkgconfig
+            runner: ubuntu-latest
           - arch: arm64
-            cc: aarch64-linux-gnu-gcc
-            pkg_config_path: /usr/lib/aarch64-linux-gnu/pkgconfig
+            runner: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v6.0.2
@@ -156,63 +142,10 @@ jobs:
           cache: npm
           cache-dependency-path: ui/package-lock.json
 
-      - name: Set up QEMU for cross-arch testing
-        if: matrix.arch == 'arm64'
-        uses: docker/setup-qemu-action@v4.0.0
-        with:
-          platforms: arm64
-
       - name: Install build dependencies
         run: |
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            sudo dpkg --add-architecture arm64
-            # Replace Ubuntu's default deb822 sources with explicit amd64
-            # .list entries. The deb822 format groups each repo into a
-            # multi-line stanza, and appending `Architectures: amd64` at
-            # end-of-file only attaches to the last stanza — which leaves
-            # apt fetching arm64 indexes from azure/security.ubuntu.com
-            # (404, since arm64 packages are at ports.ubuntu.com).
-            sudo rm -f /etc/apt/sources.list.d/ubuntu.sources
-            sudo tee /etc/apt/sources.list.d/ubuntu-amd64.list >/dev/null <<'EOF'
-          deb [arch=amd64] http://azure.archive.ubuntu.com/ubuntu noble main universe multiverse restricted
-          deb [arch=amd64] http://azure.archive.ubuntu.com/ubuntu noble-updates main universe multiverse restricted
-          deb [arch=amd64] http://azure.archive.ubuntu.com/ubuntu noble-backports main universe multiverse restricted
-          deb [arch=amd64] http://security.ubuntu.com/ubuntu noble-security main universe multiverse restricted
-          EOF
-            # Restrict third-party .list sources to amd64 too, but skip
-            # entries that already have [arch=...] (e.g. microsoft-prod.list
-            # would otherwise become malformed) and skip our own files.
-            for f in /etc/apt/sources.list.d/*.list /etc/apt/sources.list; do
-              [ -f "$f" ] || continue
-              case "$f" in
-                */ubuntu-amd64.list|*/ports-arm64.list) continue ;;
-              esac
-              sudo sed -i '/^deb \[/!s|^deb |deb [arch=amd64] |' "$f"
-            done
-            # Add arm64 sources from ports.ubuntu.com (the canonical home
-            # for non-amd64 Ubuntu architectures).
-            sudo tee /etc/apt/sources.list.d/ports-arm64.list >/dev/null <<'EOF'
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main universe multiverse restricted
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main universe multiverse restricted
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-security main universe multiverse restricted
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-backports main universe multiverse restricted
-          EOF
-          fi
-
-          # apt-get update can return 100 on partial source failures (e.g.
-          # third-party repos that don't publish arm64 indexes). Tolerate it
-          # here — the install step below is the actual gate: if the arm64
-          # libpcap headers don't land we'll still fail loudly.
-          sudo apt-get update || true
-          sudo apt-get install -y rpm
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            # linux-libc-dev:arm64 brings kernel headers needed by libpcap's
-            # netlink probes during cgo link. libpcap0.8-dev was redundant —
-            # libpcap-dev already pulls the right SO links.
-            sudo apt-get install -y gcc-aarch64-linux-gnu linux-libc-dev:arm64 libpcap-dev:arm64 pkg-config qemu-user-static
-          else
-            sudo apt-get install -y libpcap-dev pkg-config
-          fi
+          sudo apt-get update
+          sudo apt-get install -y rpm libpcap-dev pkg-config
 
       - name: Download iperf3 binary
         uses: actions/download-artifact@v8.0.1
@@ -252,8 +185,6 @@ jobs:
           GOOS: linux
           GOARCH: ${{ matrix.arch }}
           CGO_ENABLED: 1
-          CC: ${{ matrix.cc }}
-          PKG_CONFIG_PATH: ${{ matrix.pkg_config_path }}
           VERSION: ${{ github.ref_name }}
           COMMIT: ${{ github.sha }}
           UI_HASH: ${{ steps.ui-hash.outputs.hash }}
@@ -274,11 +205,7 @@ jobs:
 
           echo ""
           echo "=== Seed version smoke test ==="
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            qemu-aarch64-static dist/seed-linux-${{ matrix.arch }} --version || qemu-aarch64-static dist/seed-linux-${{ matrix.arch }} version || echo "Version flag not supported, checking binary runs..."
-          else
-            ./dist/seed-linux-${{ matrix.arch }} --version || ./dist/seed-linux-${{ matrix.arch }} version || echo "Version flag not supported, checking binary runs..."
-          fi
+          ./dist/seed-linux-${{ matrix.arch }} --version || ./dist/seed-linux-${{ matrix.arch }} version || echo "Version flag not supported, checking binary runs..."
           echo "✅ Seed binary smoke test passed"
 
           echo ""
@@ -287,11 +214,7 @@ jobs:
 
           echo ""
           echo "=== iperf3 version smoke test ==="
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            qemu-aarch64-static bin/iperf3-linux-${{ matrix.arch }} --version
-          else
-            ./bin/iperf3-linux-${{ matrix.arch }} --version
-          fi
+          ./bin/iperf3-linux-${{ matrix.arch }} --version
           echo "✅ iperf3 binary smoke test passed"
 
       - name: Install nfpm


### PR DESCRIPTION
## Summary

Phase 2 of #920. Switches the Linux arm64 build off cross-compile and onto the GitHub-hosted `ubuntu-24.04-arm` runner. Closes #920.

**release.yml: -60 net lines, every brittle piece of the cross-compile path eliminated.**

## What goes away

- The deb822 source-list rewriting (~30 lines): existed only because apt was being asked to fetch arm64 packages on an amd64 runner
- `linux-libc-dev:arm64`, `libpcap-dev:arm64`, `libpcap0.8-dev:arm64`, `qemu-user-static`
- The `gcc-aarch64-linux-gnu` cross-toolchain
- The `PKG_CONFIG_PATH` if/else branch (default location works on native)
- QEMU setup in both `build-iperf3` and `release` jobs
- `qemu-aarch64-static` smoke-test invocations
- `cc` matrix entry (`aarch64-linux-gnu-gcc` not needed)
- `--host=aarch64-linux-gnu` configure flag for iperf3

## What stays

- `release-macos` already used native runners (`macos-14` for arm64, `macos-15-intel` for amd64) — unchanged
- `release-windows` cross-compiles from `ubuntu-latest` with `CGO_ENABLED=0` (no libpcap on Windows) — unchanged
- All artifacts produced are identical: `.tar.gz`, `.deb`, `.rpm` for both arches

## How the new matrix works

\`\`\`yaml
strategy:
  fail-fast: false
  matrix:
    include:
      - arch: amd64
        runner: ubuntu-latest
      - arch: arm64
        runner: ubuntu-24.04-arm
runs-on: \${{ matrix.runner }}
\`\`\`

## Validation

**Cannot be confirmed locally** — needs a workflow_dispatch dry-run on GitHub to verify:

- [ ] `ubuntu-24.04-arm` is available to this repo (GitHub-hosted, GA, public-repo-free)
- [ ] `apt install libpcap-dev` succeeds on the native arm64 runner
- [ ] cgo link succeeds for arm64 build (libpcap.so picked up at default path)
- [ ] `seed-<ver>-linux-arm64.tar.gz` + `.deb` + `.rpm` appear in the artifact bundle
- [ ] iperf3 builds and the bundled binary runs natively on the arm64 runner

After merge: trigger `workflow_dispatch` with `dry_run=true` and verify the artifact bundle.

## What this PR does NOT do

- Does not change macOS or Windows release paths
- Does not change `release-please.yml` or any other workflow
- Does not touch product Go code

Closes #920