### PR TITLE
chore: oss hygiene — code of conduct, scorecard, artifact retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -735,6 +735,7 @@ jobs:
         with:
           name: server-logs
           path: server.log
+          retention-days: 7
 
   # ===========================================================================
   # Lighthouse CI - Performance & Accessibility Audits
@@ -801,3 +802,4 @@ jobs:
         with:
           name: lighthouse-server-logs
           path: server.log
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
         with:
           name: iperf3-linux-${{ matrix.arch }}
           path: dist/iperf3-linux-${{ matrix.arch }}
+          retention-days: 1
 
   # ===========================================================================
   # Build Release Packages
@@ -269,6 +270,7 @@ jobs:
             release/*.tar.gz
             release/*.deb
             release/*.rpm
+          retention-days: 7
 
   # ===========================================================================
   # Build macOS Release (closes #474)
@@ -402,6 +404,7 @@ jobs:
           path: |
             release/*.tar.gz
             dist/*.pkg
+          retention-days: 7
 
   # ===========================================================================
   # Build Windows Release
@@ -509,6 +512,7 @@ jobs:
         with:
           name: release-windows-${{ matrix.arch }}
           path: release/*.zip
+          retention-days: 7
 
   # ===========================================================================
   # Publish Release

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,54 @@
+# =============================================================================
+# OpenSSF Scorecard
+# =============================================================================
+# Measures supply-chain security posture against the OpenSSF Scorecard checks:
+# branch protection, code review, dependency update tools, signed releases,
+# pinned dependencies, SAST, vulnerabilities, etc.
+#
+# Runs weekly + on push to main. Results upload to GitHub's code-scanning
+# Security tab and (when publish_results=true) to the public OpenSSF
+# Scorecard API so projects can be compared.
+# =============================================================================
+
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "37 9 * * 1"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # publish_results: lets the OpenSSF Scorecard project ingest results
+          # so the public scorecard badge stays up to date. Safe for public
+          # repos; only metadata about checks is published, no source.
+          publish_results: true
+
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at kris.armstrong@icloud.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
Three small public-repo improvements bundled together.

### 1. CODE_OF_CONDUCT.md
Contributor Covenant 2.1, sourced from upstream EthicalSource/contributor_covenant. Contact email points at the existing git committer address.

### 2. OpenSSF Scorecard workflow
`.github/workflows/scorecard.yml` — runs weekly + on push to main. SARIF uploads to GitHub Security tab; \`publish_results: true\` makes results visible on the public Scorecard API. Catches supply-chain regressions early (branch protection slipping, unpinned deps, missing signing, etc.).

### 3. Artifact retention windows
GitHub default is 90 days. Tightened:

| Artifact | Was | Now |
|---|---|---|
| frontend-dist | 1 day | unchanged |
| server-logs | 90 (default) | 7 |
| lighthouse-server-logs | 90 (default) | 7 |
| iperf3-linux-* | 90 (default) | 1 (intermediate) |
| release-linux/darwin/windows-* | 90 (default) | 7 |
| release-bundle (publish job) | 14 | unchanged |

Public-repo storage is free; this is just tidiness so the artifact lists during debugging stay readable.

### Out of scope (filed as follow-ups)
- Migrate to goreleaser (#19, on roadmap)
- Pin third-party actions to commit SHAs
- Trim pre-commit hook duplication
- Enable Secret scanning + push protection in repo settings