### PR TITLE
ci: goreleaser config + parallel-rollout workflow (#956 part 1)

### DIFF
--- a/.github/workflows/release-goreleaser.yml
+++ b/.github/workflows/release-goreleaser.yml
@@ -1,0 +1,167 @@
+# =============================================================================
+# Release via goreleaser (parallel-rollout candidate)
+# =============================================================================
+# Side-by-side with the existing release.yml. workflow_dispatch only — never
+# auto-triggers on tag push. Used to validate that .goreleaser.yml produces
+# artifacts equivalent to release.yml's output before we swap the cutover.
+#
+# Once a dry-run here produces the same artifact names, signatures, and
+# SBOMs as a recent release.yml run, follow-up PR will:
+#   1. Move the `on: push: tags` trigger from release.yml to this file
+#   2. Delete release.yml and its build-iperf3 job dependency
+#   3. Rename this file to release.yml
+# =============================================================================
+
+name: Release (goreleaser, parallel rollout)
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Snapshot build only — do not publish or sign"
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write # cosign keyless OIDC
+  packages: write
+
+jobs:
+  # =========================================================================
+  # iperf3 binaries — same matrix as release.yml's build-iperf3 job.
+  # goreleaser picks these up from bin/ in the next job.
+  # =========================================================================
+  build-iperf3:
+    name: Build iperf3 (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf automake libtool
+
+      - name: Get latest iperf3 version
+        id: iperf3_version
+        run: |
+          LATEST=$(curl -s https://api.github.com/repos/esnet/iperf/releases/latest | jq -r '.tag_name')
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+
+      - name: Download and build iperf3
+        run: |
+          VERSION="${{ steps.iperf3_version.outputs.version }}"
+          curl -L -o iperf3.tar.gz "https://github.com/esnet/iperf/archive/refs/tags/${VERSION}.tar.gz"
+          tar -xzf iperf3.tar.gz
+          cd iperf-*
+          if [ ! -f configure ]; then ./bootstrap.sh || autoreconf -i; fi
+          ./configure --prefix=/tmp/iperf3-install --disable-shared --enable-static-bin
+          make -j$(nproc)
+          make install
+          mkdir -p ../dist
+          cp /tmp/iperf3-install/bin/iperf3 ../dist/iperf3-linux-${{ matrix.arch }}
+          chmod +x ../dist/iperf3-linux-${{ matrix.arch }}
+
+      - name: Upload iperf3 artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: iperf3-linux-${{ matrix.arch }}
+          path: dist/iperf3-linux-${{ matrix.arch }}
+          retention-days: 1
+
+  # =========================================================================
+  # goreleaser build + publish (or snapshot)
+  # =========================================================================
+  goreleaser:
+    name: goreleaser ${{ inputs.dry_run && '(snapshot)' || '(release)' }}
+    runs-on: ubuntu-latest
+    needs: build-iperf3
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "25.2.1"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install libpcap-dev (host CGO link target)
+        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
+
+      - name: Download iperf3 artifacts (amd64 + arm64)
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: iperf3-linux-*
+          path: bin/
+          merge-multiple: true
+
+      - name: Restore iperf3 executable bits
+        run: chmod +x bin/iperf3-linux-*
+
+      - name: Compute UI build hash
+        id: ui-hash
+        run: |
+          # The before-hook in .goreleaser.yml builds ui/dist; compute the
+          # hash now and pass via env so the ldflag substitution sees it.
+          cd ui && npm ci && npm run build
+          cd ..
+          UI_BUILD_HASH=$(find ui/dist -type f -exec md5sum {} \; | sort | md5sum | cut -d' ' -f1)
+          echo "hash=$UI_BUILD_HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Install Syft (SBOM)
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Run goreleaser (snapshot/dry-run)
+        if: inputs.dry_run
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean --skip=publish,announce
+        env:
+          UI_BUILD_HASH: ${{ steps.ui-hash.outputs.hash }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run goreleaser (publish)
+        if: ${{ !inputs.dry_run }}
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          UI_BUILD_HASH: ${{ steps.ui-hash.outputs.hash }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload dry-run artifact bundle for inspection
+        if: inputs.dry_run
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: goreleaser-dryrun-${{ github.run_id }}
+          path: dist/
+          retention-days: 14

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,253 @@
+# =============================================================================
+# goreleaser config for The Seed
+# =============================================================================
+# First-pass migration of release.yml's hand-coded pipeline (#956).
+#
+# Status: PARALLEL ROLLOUT. The canonical release pipeline is still
+# .github/workflows/release.yml. This config is exercised only by
+# .github/workflows/release-goreleaser.yml (workflow_dispatch). Once a
+# dry-run produces artifacts equivalent to release.yml's output, a
+# follow-up PR will swap the trigger over and delete the old workflow.
+#
+# Things this config covers natively:
+#   - Multi-arch builds (linux amd64/arm64, darwin amd64/arm64, windows
+#     amd64/arm64)
+#   - .tar.gz, .zip, .deb, .rpm
+#   - ldflags injection (Version, Commit, BuildTime, UIBuildHash)
+#   - cosign keyless signing of every artifact
+#   - syft SBOM per archive
+#   - SHA-256 checksums
+#   - release-please CHANGELOG.md as release body
+#
+# Things still handled outside goreleaser (custom hooks / sidecar jobs):
+#   - iperf3 binary bundled into Linux archives — pre-built by the existing
+#     build-iperf3 matrix job; goreleaser picks it up via extra_files
+#   - macOS .pkg installer via deploy/macos/build-pkg.sh — see "after" hook
+#   - UI frontend build (npm run build) — runs in the "before" hook so
+#     ui/embed.go picks up the dist before the Go build starts
+#
+# Tested against goreleaser v2.x.
+# =============================================================================
+
+version: 2
+
+project_name: seed
+
+before:
+  hooks:
+    - go mod download
+    # Build the embedded frontend. ui/embed.go relies on ui/dist existing
+    # before Go compiles. Mirrors the "verify embedded frontend" step in
+    # release.yml.
+    - bash -c "cd ui && npm ci && npm run build"
+    - bash -c 'test -d ui/dist && test -n "$(ls -A ui/dist)" || (echo "ui/dist empty — npm run build failed silently"; exit 1)'
+
+builds:
+  - id: seed-linux
+    main: ./cmd/seed
+    binary: seed
+    env:
+      - CGO_ENABLED=1
+    goos: [linux]
+    goarch: [amd64, arm64]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags: &ldflags
+      - -s -w
+      - -X github.com/krisarmstrong/seed/internal/version.Version={{.Version}}
+      - -X github.com/krisarmstrong/seed/internal/version.Commit={{.Commit}}
+      - -X github.com/krisarmstrong/seed/internal/version.BuildTime={{.Date}}
+      - -X github.com/krisarmstrong/seed/internal/version.UIBuildHash={{.Env.UI_BUILD_HASH}}
+
+  - id: seed-darwin
+    main: ./cmd/seed
+    binary: seed
+    env:
+      - CGO_ENABLED=1
+    goos: [darwin]
+    goarch: [amd64, arm64]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags: *ldflags
+
+  - id: seed-windows
+    main: ./cmd/seed
+    binary: seed
+    # Windows: CGO disabled (gopacket/pcap fork handles arm64 build without
+    # native libpcap-windows toolchain). Matches release.yml.
+    env:
+      - CGO_ENABLED=0
+    goos: [windows]
+    goarch: [amd64, arm64]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags: *ldflags
+
+archives:
+  - id: linux-archive
+    ids: [seed-linux]
+    name_template: "seed-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    formats: [tar.gz]
+    files:
+      - src: configs
+        dst: configs
+      - src: ui/dist
+        dst: ui
+      # iperf3 binary, pre-built by the build-iperf3 job and downloaded into
+      # bin/ before goreleaser runs. One per arch.
+      - src: "bin/iperf3-linux-{{ .Arch }}"
+        dst: iperf3
+        info:
+          mode: 0o755
+
+  - id: darwin-archive
+    ids: [seed-darwin]
+    name_template: "seed-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    formats: [tar.gz]
+    files:
+      - src: configs
+        dst: configs
+      - src: ui/dist
+        dst: ui
+
+  - id: windows-archive
+    ids: [seed-windows]
+    name_template: "seed-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    formats: [zip]
+    files:
+      - src: configs
+        dst: configs
+      - src: ui/dist
+        dst: ui
+      - src: deploy/windows/build.ps1
+        dst: install.ps1
+
+# Linux .deb + .rpm via nfpm (built into goreleaser). Port of .nfpm.yaml.
+nfpms:
+  - id: linux-packages
+    ids: [seed-linux]
+    package_name: seed
+    vendor: Mustard Seed Networks
+    homepage: https://github.com/krisarmstrong/seed
+    maintainer: Kris Armstrong <kris@mustardseednetworks.com>
+    description: |
+      The Seed - Network Diagnostic Tool by Mustard Seed Networks
+      .
+      The Seed is a professional-grade network diagnostic appliance designed
+      for network technicians and engineers. Plug it into any network jack
+      and instantly see link status, switch information, DHCP details, DNS
+      health, gateway connectivity, Wi-Fi survey data, and vulnerability
+      findings.
+    license: BSL-1.1
+    section: net
+    priority: optional
+    formats:
+      - deb
+      - rpm
+    file_name_template: >-
+      {{- if eq .ConventionalExtension ".deb" -}}
+        seed_{{ .Version }}_{{ .Arch }}
+      {{- else if eq .ConventionalExtension ".rpm" -}}
+        {{- $rpmarch := .Arch -}}
+        {{- if eq .Arch "amd64" }}{{ $rpmarch = "x86_64" }}{{ end -}}
+        {{- if eq .Arch "arm64" }}{{ $rpmarch = "aarch64" }}{{ end -}}
+        seed-{{ .Version }}-1.{{ $rpmarch }}
+      {{- end -}}
+    dependencies:
+      - systemd
+    overrides:
+      deb:
+        dependencies:
+          - libpcap0.8 | libpcap0.8t64
+          - systemd
+          - libcap2-bin
+      rpm:
+        dependencies:
+          - libpcap
+          - systemd
+          - libcap
+    contents:
+      - src: ./deploy/deb/seed.service
+        dst: /usr/lib/systemd/system/seed.service
+        file_info:
+          mode: 0o644
+      - dst: /etc/seed
+        type: dir
+        file_info:
+          mode: 0o750
+          owner: seed
+          group: seed
+      - dst: /var/lib/seed
+        type: dir
+        file_info:
+          mode: 0o750
+          owner: seed
+          group: seed
+      - dst: /var/lib/seed/logs
+        type: dir
+        file_info:
+          mode: 0o750
+          owner: seed
+          group: seed
+      - dst: /var/log/seed
+        type: dir
+        file_info:
+          mode: 0o750
+          owner: seed
+          group: seed
+    scripts:
+      preinstall: ./deploy/nfpm/preinstall.sh
+      postinstall: ./deploy/nfpm/postinstall.sh
+      preremove: ./deploy/nfpm/preremove.sh
+      postremove: ./deploy/nfpm/postremove.sh
+    # Default install location for the binary (overrides nfpm default of
+    # /usr/local/bin). Matches existing .deb/.rpm contract.
+    bindir: /usr/bin
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+sboms:
+  - id: archives-sbom
+    artifacts: archive
+    documents:
+      - "{{ .ArtifactName }}.sbom.json"
+
+signs:
+  # Sign all release artifacts via cosign keyless OIDC. Mirrors release.yml's
+  # cosign sign-blob loop. Bundle format preserves Sigstore transparency log
+  # entry.
+  - cmd: cosign
+    signature: "${artifact}.cosign.bundle"
+    args:
+      - sign-blob
+      - "--yes"
+      - "--bundle"
+      - "${artifact}.cosign.bundle"
+      - "${artifact}"
+    artifacts: all
+    output: true
+
+release:
+  github:
+    owner: krisarmstrong
+    name: seed
+  # Use release-please's CHANGELOG.md section as the release body. The
+  # `replace_existing_artifacts: true` lets a re-run overwrite a partial
+  # earlier failure cleanly.
+  replace_existing_artifacts: true
+  draft: false
+  prerelease: auto
+  mode: replace
+  header: |
+    The Seed {{ .Tag }} — Network Diagnostic Tool by Mustard Seed Networks.
+
+    See [CHANGELOG.md](https://github.com/krisarmstrong/seed/blob/main/CHANGELOG.md)
+    for the full release notes.
+
+snapshot:
+  version_template: "0.0.0-dryrun-{{ .ShortCommit }}"


### PR DESCRIPTION
First pass at the goreleaser migration. Lands the config and a side-by-side workflow_dispatch-only workflow so we can validate artifacts before swapping the cutover. The existing `release.yml` stays canonical until a dry-run proves parity.

## What's in this PR

**`.goreleaser.yml`** covers:
- Multi-arch builds (linux amd64+arm64, darwin amd64+arm64, windows amd64+arm64) with CGO settings per platform
- `.tar.gz` / `.zip` archives with configs/, ui/dist/, install.ps1
- iperf3 binary bundled into Linux archives via `extra_files`
- `.deb` + `.rpm` via built-in nfpm — full port of `.nfpm.yaml` including overrides, systemd contents, pre/post install scripts
- ldflags injection: Version / Commit / BuildTime / UIBuildHash
- Frontend build in `before` hook so `ui/embed.go` picks up `ui/dist`
- syft SBOM per archive
- cosign keyless OIDC signing of every artifact
- SHA-256 checksums

**`.github/workflows/release-goreleaser.yml`**:
- `workflow_dispatch` only, never auto-fires on tags
- `dry_run` input (default `true`) → snapshot mode + artifact upload
- `dry_run=false` → real publish (only run after dry-run validates)
- Existing build-iperf3 matrix unchanged
- goreleaser job downloads iperf3 artifacts, computes UI build hash, runs goreleaser-action v6

## How to validate

1. From the repo: **Actions tab → "Release (goreleaser, parallel rollout)" → Run workflow → dry_run: true**
2. Download the `goreleaser-dryrun-<run_id>` artifact bundle
3. Compare names + sizes against v0.186.0's published release assets
4. Once equivalent, follow-up PR swaps trigger to push-tags and deletes release.yml

## Known gaps to address before cutover

- [ ] macOS `.pkg` installer (`deploy/macos/build-pkg.sh`) not yet hooked in. Either as a goreleaser post-hook or kept in release.yml.
- [ ] SLSA provenance — goreleaser-action v6 supports it natively; enable once the dry-run is otherwise green
- [ ] Validate `.deb`/`.rpm` filenames match the existing convention (template uses `.ConventionalExtension`)

## Won't fail anything on this PR

This PR only adds files. release.yml is untouched. Tag pushes still trigger the old (working) pipeline.

Refs #956