### PR TITLE
chore: sha-pin third-party github actions + fix dependabot npm path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,28 @@
 
 version: 2
 updates:
-  # Keep GitHub Actions up to date
+  # Keep GitHub Actions up to date. Workflows are SHA-pinned (#955);
+  # Dependabot detects the SHA+tag-comment format and updates both.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "github-actions"
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    # Group minor/patch updates so we don't get 17 PRs every week.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Keep Go dependencies up to date
   - package-ecosystem: "gomod"
@@ -39,9 +48,11 @@ updates:
           - "minor"
           - "patch"
 
-  # Keep npm dependencies up to date
+  # Keep npm dependencies up to date.
+  # Directory was /web before the web → ui rename; corrected to /ui so
+  # this ecosystem actually runs.
   - package-ecosystem: "npm"
-    directory: "/web"
+    directory: "/ui"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           echo "✅ Coverage check passed (${COVERAGE}% >= ${MIN_COVERAGE}%)"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: coverage.out
           flags: backend
@@ -231,7 +231,7 @@ jobs:
           govulncheck ./...
 
       - name: Run gosec
-        uses: securego/gosec@v2.22.11
+        uses: securego/gosec@424fc4cd9c82ea0fd6bee9cd49c2db2c3cc0c93f # v2.22.11
         continue-on-error: true
         with:
           args: "-fmt sarif -out gosec-results.sarif ./..."
@@ -253,12 +253,12 @@ jobs:
           npm audit --audit-level=high
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: "fs"
           scan-ref: "."
@@ -518,14 +518,14 @@ jobs:
         run: npm ci
 
       - name: Check markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
         continue-on-error: true
         with:
           use-quiet-mode: "yes"
           config-file: ".github/markdown-link-check.json"
 
       - name: Lint markdown files
-        uses: DavidAnson/markdownlint-cli2-action@v19
+        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19
         continue-on-error: true
         with:
           globs: |
@@ -794,7 +794,7 @@ jobs:
           exit 1
 
       - name: Run Lighthouse CI
-        uses: treosh/lighthouse-ci-action@v12
+        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
         with:
           urls: |
             https://localhost:8443

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,15 +42,15 @@ jobs:
 
       - name: Set up QEMU
         if: steps.dockerfile.outputs.exists == 'true'
-        uses: docker/setup-qemu-action@v4.0.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         if: steps.dockerfile.outputs.exists == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Container Registry
         if: steps.dockerfile.outputs.exists == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build and push Docker image (multi-arch)
         if: steps.dockerfile.outputs.exists == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Sync labels
-        uses: crazy-max/ghaction-github-labeler@v5.3.0
+        uses: crazy-max/ghaction-github-labeler@24d110aa46a59976b8a7f35518cb7f14f434c916 # v5.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml

--- a/.github/workflows/release-goreleaser.yml
+++ b/.github/workflows/release-goreleaser.yml
@@ -131,14 +131,14 @@ jobs:
           echo "hash=$UI_BUILD_HASH" >> "$GITHUB_OUTPUT"
 
       - name: Install Syft (SBOM)
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Run goreleaser (snapshot/dry-run)
         if: inputs.dry_run
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -149,7 +149,7 @@ jobs:
 
       - name: Run goreleaser (publish)
         if: ${{ !inputs.dry_run }}
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -548,7 +548,7 @@ jobs:
           cat checksums.txt
 
       - name: Install Syft for SBOM generation
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
       - name: Generate SBOMs for packages
         run: |
@@ -559,7 +559,7 @@ jobs:
           done
 
       - name: Install Cosign for signing
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign release artifacts with cosign (keyless OIDC)
         run: |
@@ -623,7 +623,7 @@ jobs:
 
       - name: Create Release
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
-        uses: softprops/action-gh-release@v3.0.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           body: |
             ## Changes

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Closes #955. Supply-chain hardening per OpenSSF Scorecard's Pinned-Dependencies check.

## What changed

Every third-party action reference now uses a full 40-char commit SHA with a comment showing the human-readable tag:

\`\`\`yaml
# Before
uses: aquasecurity/trivy-action@v0.36.0
# After
uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
\`\`\`

Dependabot detects the SHA+tag-comment format and auto-updates both fields, so this isn't manual maintenance going forward.

## 18 actions SHA-pinned

anchore/sbom-action, aquasecurity/trivy-action, codecov/codecov-action, crazy-max/ghaction-github-labeler, DavidAnson/markdownlint-cli2-action, docker/build-push-action, docker/login-action, docker/setup-buildx-action, docker/setup-qemu-action, gaurav-nelson/github-action-markdown-link-check, gitleaks/gitleaks-action, googleapis/release-please-action, goreleaser/goreleaser-action, ossf/scorecard-action, securego/gosec, sigstore/cosign-installer, softprops/action-gh-release, treosh/lighthouse-ci-action.

## Left at major-version (GitHub-owned, lower supply-chain risk)

\`actions/*\` and \`github/codeql-action/*\` — first-party. OpenSSF Scorecard doesn't flag these.

## Dependabot fixes

- **Grouped github-actions updates** so we get 1 PR/week instead of 18 separate PRs every Monday
- **Fixed `web/` → `ui/` rename remnant** in the npm ecosystem path. Was scoped to `/web` (doesn't exist), so npm dependency updates haven't actually been running. Now scoped to `/ui`. ❗ Side effect: this PR may shake loose npm updates that have been silently queued for months.

## Risk

Low. SHA pins are content-addressed; behaviour is identical to the previous tag references. CI will validate.