### PR TITLE
chore: post-cutover polish — badges, SLSA L3, brew tap, OUI test guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Run tests
         env:
           SKIP_IPERF_TEST: "1"
+          SKIP_NETWORK_TESTS: "1"
         run: go test -v -coverprofile=coverage.out ./...
 
       - name: Check coverage threshold
@@ -163,6 +164,7 @@ jobs:
       - name: Run tests with race detector
         env:
           SKIP_IPERF_TEST: "1"
+          SKIP_NETWORK_TESTS: "1"
         run: go test -short -race ./...
 
   # ===========================================================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,11 @@ jobs:
         env:
           UI_BUILD_HASH: ${{ needs.build-ui.outputs.ui_hash }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional. When present, goreleaser publishes the Homebrew
+          # formula to krisarmstrong/homebrew-tap. When absent, the brew
+          # step is skipped (config sets skip_upload: auto). PAT scope:
+          # fine-grained with contents:write on this repo and the tap.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
         run: goreleaser release --clean
 
       - name: Capture artifact hashes for SLSA provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,11 @@ jobs:
       # tracks Go 1.26.2 + goreleaser v2.15.4. Pin so behaviour stays
       # reproducible; bump via dependabot when newer revs land.
       image: goreleaser/goreleaser-cross:v1.26.2-3
+    outputs:
+      # base64-encoded SHA-256 hashes of all release artifacts, formatted
+      # for slsa-github-generator's base64-subjects input. Set only on a
+      # real (non-snapshot) release.
+      hashes: ${{ steps.hashes.outputs.hashes }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -220,6 +225,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goreleaser release --clean
 
+      - name: Capture artifact hashes for SLSA provenance
+        if: ${{ !inputs.dry_run }}
+        id: hashes
+        shell: bash
+        run: |
+          # goreleaser drops artifacts.json describing every produced
+          # artifact. Filter to the user-facing ones (archive/package
+          # types) and base64-encode their SHA-256 list for the
+          # slsa-github-generator reusable workflow.
+          set -euo pipefail
+          hashes=$(jq -r '
+            map(select(.type == "Archive" or .type == "Linux Package")) |
+            map("\(.extra.Checksum | sub("^sha256:"; ""))  \(.name)") |
+            join("\n")
+          ' dist/artifacts.json | base64 -w0)
+          echo "hashes=${hashes}" >> "$GITHUB_OUTPUT"
+
       - name: Upload dry-run artifact bundle for inspection
         if: inputs.dry_run
         uses: actions/upload-artifact@v7.0.1
@@ -227,3 +249,23 @@ jobs:
           name: goreleaser-dryrun-${{ github.run_id }}
           path: dist/
           retention-days: 14
+
+  # =========================================================================
+  # SLSA Level 3 provenance — runs only on real releases (not dry-run).
+  # The slsa-github-generator reusable workflow builds an in-toto
+  # attestation signed via Sigstore keyless OIDC and uploads it alongside
+  # the release artifacts.
+  # =========================================================================
+  provenance:
+    name: SLSA provenance
+    if: ${{ !inputs.dry_run }}
+    needs: [goreleaser]
+    permissions:
+      id-token: write   # for Sigstore OIDC
+      contents: write   # for uploading attestation to the release
+      actions: read
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: ${{ needs.goreleaser.outputs.hashes }}
+      upload-assets: true
+      provenance-name: seed-slsa-provenance.intoto.jsonl

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -253,6 +253,35 @@ signs:
     artifacts: all
     output: true
 
+# Homebrew formula published to krisarmstrong/homebrew-tap on every
+# release. Requires a HOMEBREW_TAP_TOKEN repository secret (fine-grained
+# PAT with contents:write on both krisarmstrong/seed and
+# krisarmstrong/homebrew-tap). When the secret is absent, goreleaser
+# skips this step gracefully.
+brews:
+  - name: seed
+    repository:
+      owner: krisarmstrong
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/krisarmstrong/seed
+    description: |
+      The Seed — Network Diagnostic Tool by Mustard Seed Networks.
+      Plug into any network jack for real-time link, switch, DHCP, DNS,
+      gateway, Wi-Fi, and vulnerability diagnostics via a web UI.
+    license: BSL-1.1
+    # macOS only; Linux users have first-class .deb/.rpm/.tar.gz.
+    skip_upload: auto
+    test: |
+      system "#{bin}/seed --version"
+    install: |
+      bin.install "seed"
+    commit_author:
+      name: goreleaser-bot
+      email: bot@krisarmstrong.dev
+    commit_msg_template: "chore(brew): seed {{ .Tag }}"
+
 release:
   github:
     owner: krisarmstrong

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 > Portable Network Diagnostic Tool with Real-Time Web UI
 
 [![CI](https://github.com/krisarmstrong/seed/actions/workflows/ci.yml/badge.svg)](https://github.com/krisarmstrong/seed/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/krisarmstrong/seed?logo=github)](https://github.com/krisarmstrong/seed/releases/latest)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/krisarmstrong/seed/badge)](https://scorecard.dev/viewer/?uri=github.com/krisarmstrong/seed)
+[![Go Reference](https://pkg.go.dev/badge/github.com/krisarmstrong/seed.svg)](https://pkg.go.dev/github.com/krisarmstrong/seed)
+[![Go Report Card](https://goreportcard.com/badge/github.com/krisarmstrong/seed)](https://goreportcard.com/report/github.com/krisarmstrong/seed)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL%201.1-blue.svg)](LICENSE)
 
 The Seed is a professional-grade network diagnostic appliance designed for network technicians and engineers. Plug it

--- a/internal/services/discovery/oui_test.go
+++ b/internal/services/discovery/oui_test.go
@@ -183,6 +183,9 @@ func TestOUIDownloadDatabase(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping network test in short mode")
 	}
+	if os.Getenv("SKIP_NETWORK_TESTS") != "" {
+		t.Skip("SKIP_NETWORK_TESTS set — skipping network-dependent test")
+	}
 
 	tmpDir := t.TempDir()
 	ouiFile := filepath.Join(tmpDir, "oui.txt")
@@ -221,6 +224,9 @@ func TestOUIDownloadDatabase(t *testing.T) {
 func TestOUIUpdateIfNeeded(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping network test in short mode")
+	}
+	if os.Getenv("SKIP_NETWORK_TESTS") != "" {
+		t.Skip("SKIP_NETWORK_TESTS set — skipping network-dependent test")
 	}
 
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Four follow-ups from the post-goreleaser cutover. Independent commits — review them individually:

1. **`docs: add badges for release, scorecard, godoc, go report card`** — README header gains Release / OpenSSF Scorecard / pkg.go.dev / Go Report Card badges alongside the existing CI + License badges.

2. **`test(discovery): guard OUI download tests behind SKIP_NETWORK_TESTS`** — `TestOUIDownloadDatabase` and `TestOUIUpdateIfNeeded` fetch the IEEE OUI file from `standards-oui.ieee.org`. They caused one CI retry today. Added a `SKIP_NETWORK_TESTS=1` env-var skip alongside the existing `testing.Short()` guard; set it in CI for both the backend and race jobs. Local `go test ./...` still runs them.

3. **`ci(release): add SLSA Level 3 provenance via slsa-github-generator`** — After goreleaser publishes, captures SHA-256 hashes of every user-facing artifact and feeds them to `slsa-framework/slsa-github-generator`. Generator runs in an isolated reusable workflow (the SLSA trusted builder), produces an in-toto attestation signed via Sigstore keyless OIDC, and uploads `seed-slsa-provenance.intoto.jsonl` to the release. Verifiable client-side via `slsa-verifier`.

4. **`ci(release): publish homebrew formula to krisarmstrong/homebrew-tap`** — Added `brews:` block to `.goreleaser.yml`. Goreleaser pushes a formula update to `krisarmstrong/homebrew-tap` (created alongside this PR) so macOS users can `brew install krisarmstrong/tap/seed` instead of unpacking a tarball. **Requires a one-time setup**: create a `HOMEBREW_TAP_TOKEN` repository secret (fine-grained PAT with `contents:write` on both repos). Without it, the brew step skips silently — release artifacts still publish fine.

## Verification

- [x] `.goreleaser.yml` + `release.yml` YAML valid
- [x] OUI tests skip locally with `SKIP_NETWORK_TESTS=1` set, run without
- [ ] First post-merge release will validate SLSA provenance generation
- [ ] First post-merge release (after PAT added) will validate brew tap push

Closes none — these were the 4 "noticed but didn't file" follow-ups from earlier.