### PR TITLE
refactor(ui): extract SettingsDrawer normalizer + defaults (partial)

### DIFF
--- a/ui/src/components/settings/SettingsDrawer.tsx
+++ b/ui/src/components/settings/SettingsDrawer.tsx
@@ -31,17 +31,17 @@ import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSettings } from '../../contexts/useSettings';
 import { useDebouncedAutoSave } from '../../hooks/useDebouncedAutoSave';
+import { useSettingsDrawerLoaders } from '../../hooks/useSettingsDrawerLoaders';
+import { useSettingsDrawerSavers } from '../../hooks/useSettingsDrawerSavers';
 import { useSubnetSettings } from '../../hooks/useSubnetSettings';
 import { useTheme } from '../../hooks/useTheme';
 import { useVulnerabilitySettings } from '../../hooks/useVulnerabilitySettings';
-import { LogComponents, logger } from '../../lib/logger';
 import { button, cn, icon as iconTokens, layout, radius, spacing } from '../../styles/theme';
 import type {
   CableTestSettings as CableTestSettingsType,
   IperfSuggestion,
   IpSettings,
   LinkSettings as LinkSettingsType,
-  LogsResponse,
   NetworkDiscoverySettings,
   SettingsThresholds,
   SnmpSettings as SnmpSettingsType,
@@ -65,8 +65,6 @@ import { WiFiSettings } from './sections/WiFiSettings';
 import {
   INLINE_DEFAULT_CABLE_TEST_SETTINGS,
   INLINE_DEFAULT_LINK_SETTINGS,
-  normalizeTestsSettingsForSave,
-  withIds,
 } from './settingsDrawerNormalizer';
 
 const API_BASE: string = import.meta.env.VITE_API_BASE || '';
@@ -322,401 +320,65 @@ export const SettingsDrawer: React.MemoExoticComponent<
   const [savingIp, setSavingIp] = useState(false);
   const [ipMessage, setIpMessage] = useState<string | null>(null);
 
-  // Fetch current thresholds
-  const fetchThresholds = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_BASE}/api/settings`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await (response.json() as Promise<Record<string, unknown>>);
-        if (data.thresholds) {
-          setThresholds((prev) => ({
-            ...prev,
-            ...data.thresholds,
-          }));
-        }
-      }
-    } catch (err) {
-      logger.error(LogComponents.CONFIG, 'Failed to fetch thresholds', err);
-    }
-  }, []);
-
-  // Fetch current IP settings
-  const fetchIpSettings = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_BASE}/api/ipconfig/settings`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await (response.json() as Promise<Record<string, unknown>>);
-        setIpSettings({
-          mode: data.mode || 'dhcp',
-          address: data.address || '',
-          netmask: data.netmask || '24',
-          gateway: data.gateway || '',
-          dns: data.dns || [],
-        });
-        setDnsInput((data.dns || []).join(', '));
-      }
-    } catch (err) {
-      logger.error(LogComponents.CONFIG, 'Failed to fetch IP settings', err);
-    }
-  }, []);
-
-  // Fetch current tests settings
-  const fetchTestsSettings = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_BASE}/api/health-checks/settings`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await (response.json() as Promise<Record<string, unknown>>);
-        setTestsSettings({
-          dnsHostname: data.dnsHostname || 'google.com',
-          dnsServers: withIds(data.dnsServers || []).map((server) => ({
-            ...server,
-            enabled: server.enabled !== false,
-          })),
-          pingTargets: withIds(data.pingTargets || []).map((target) => ({
-            ...target,
-            enabled: target.enabled !== false,
-          })),
-          tcpPorts: withIds(data.tcpPorts || []).map((port) => ({
-            ...port,
-            port: port.port || 80,
-            enabled: port.enabled !== false,
-          })),
-          udpPorts: withIds(data.udpPorts || []).map((port) => ({
-            ...port,
-            port: port.port || 53,
-            enabled: port.enabled !== false,
-          })),
-          httpEndpoints: withIds(data.httpEndpoints || []).map((endpoint) => ({
-            ...endpoint,
-            expectedStatus: endpoint.expectedStatus || 200,
-            enabled: endpoint.enabled !== false,
-          })),
-          runPerformance: data.runPerformance ?? true,
-          runSpeedtest: data.runSpeedtest ?? true,
-          runIperf: data.runIperf ?? true,
-          runDiscovery: data.runDiscovery ?? true,
-          speedtest: {
-            serverId: data.speedtest?.serverId || '',
-            autoRunOnLink: data.speedtest?.autoRunOnLink ?? true, // Default to true
-          },
-          iperf: {
-            autoRunOnLink: data.iperf?.autoRunOnLink,
-          },
-        });
-      }
-    } catch (err) {
-      logger.error(LogComponents.CONFIG, 'Failed to fetch tests settings', err);
-    }
-  }, []);
-
-  const fetchIperfSuggestions = useCallback(async () => {
-    setIperfSuggestionsStatus('loading');
-    setIperfSuggestionsError(null);
-    try {
-      const response = await fetch(`${API_BASE}/api/sap/iperf/suggestions`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await (response.json() as Promise<Record<string, unknown>>);
-        setIperfSuggestions(Array.isArray(data) ? data : []);
-        setIperfSuggestionsStatus('idle');
-      } else {
-        setIperfSuggestionsStatus('error');
-        setIperfSuggestionsError('No iperf hosts found');
-      }
-    } catch (err) {
-      setIperfSuggestionsStatus('error');
-      setIperfSuggestionsError(err instanceof Error ? err.message : 'Failed to find iperf hosts');
-    }
-  }, []);
-
-  // Fetch WiFi settings
-  const fetchWifiSettings = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_BASE}/api/canopy/wifi/settings`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await (response.json() as Promise<Record<string, unknown>>);
-        setWifiSettings({
-          interface: data.interface || '',
-          availableWifi: data.availableWifi || [],
-          isWireless: data.isWireless,
-        });
-      }
-    } catch (err) {
-      logger.error(LogComponents.Wifi, 'Failed to fetch WiFi settings', err);
-    }
-  }, []);
-
-  // FAB options, display options, and iperf settings now come from SettingsContext
-  // (loaded automatically by the context provider)
-
-  // Fetch Network Discovery settings from API
-  const fetchNetworkDiscoverySettings = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_BASE}/api/v1/shell/devices/settings`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await (response.json() as Promise<Record<string, unknown>>);
-        setNetworkDiscoverySettings({
-          enabled: data.enabled ?? true,
-          arpScanWorkers: data.arpScanWorkers ?? 50,
-          pingTimeoutMs: data.pingTimeoutMs ?? 500,
-          scanTimeoutMs: data.scanTimeoutMs ?? 30000,
-          autoScan: data.autoScan ?? false,
-          scanIntervalMs: data.scanIntervalMs ?? 0,
-          ipv6Enabled: data.ipv6Enabled ?? true,
-          options: data.options ?? {
-            passiveProtocols: {
-              lldp: true,
-              cdp: true,
-              edp: true,
-              ndp: true,
-            },
-            arpScan: true,
-            icmpScan: true,
-            portScan: {
-              enabled: false,
-              preset: 'common',
-              tcpPorts: '22,80,443,8080-8100',
-              udpPorts: '53,123,161',
-              bannerTimeoutMs: 2000,
-            },
-            tcpProbe: {
-              timeoutMs: 2000,
-              workers: 20,
-            },
-            traceroute: false,
-            snmpQuery: false,
-          },
-          timing: data.timing ?? {
-            probeIntervalMs: 75,
-            rescanIntervalMs: 600000,
-            workers: 50,
-          },
-          profiler: data.profiler ?? {
-            enabled: true,
-            timeoutMs: 2000,
-            maxConcurrent: 5,
-            quickPorts: [22, 80, 443, 8080],
-          },
-          fingerprinting: data.fingerprinting ?? {
-            enabled: false,
-            osDetection: false,
-            serviceProbes: false,
-          },
-        });
-      }
-    } catch (err) {
-      logger.error(LogComponents.Discovery, 'Failed to fetch network discovery settings', err);
-    }
-  }, []);
-
-  // Fetch SNMP settings from API
-  const fetchSnmpSettings = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_BASE}/api/sap/snmp/settings`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await (response.json() as Promise<Record<string, unknown>>);
-        setSnmpSettings({
-          communities: data.communities ?? ['public'],
-          v3Credentials: data.v3Credentials ?? [],
-          timeout: data.timeout ?? 5000,
-          retries: data.retries ?? 2,
-          port: data.port ?? 161,
-        });
-      }
-    } catch (err) {
-      logger.error(LogComponents.CONFIG, 'Failed to fetch SNMP settings', err);
-    }
-  }, []);
-
-  // Fetch link settings from API (fixes #734)
-  const fetchLinkSettings = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_BASE}/api/settings/link`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await (response.json() as Promise<Record<string, unknown>>);
-        // Backend may send separate speed/duplex or combined mode
-        const mode = data.mode ?? (data.auto_negotiation ? 'auto' : `${data.speed}/${data.duplex}`);
-        setLinkSettings({
-          mode: mode,
-          availableModes: data.available_modes ?? [],
-        });
-      }
-    } catch (err) {
-      logger.error(LogComponents.CONFIG, 'Failed to fetch link settings', err);
-    }
-  }, []);
-
-  // Fetch cable test settings from API (fixes #740)
-  const fetchCableTestSettings = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_BASE}/api/settings/cable`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await (response.json() as Promise<Record<string, unknown>>);
-        setCableTestSettings({
-          enabled: data.enabled ?? true,
-        });
-      }
-    } catch (err) {
-      logger.error(LogComponents.CONFIG, 'Failed to fetch cable test settings', err);
-    }
-  }, []);
-
-  // Fetch a small tail of the application log (debug)
-  // Security fix #301: Removed VITE_LOG_ACCESS_TOKEN - JWT authentication is sufficient
-  const fetchLogPreview = useCallback(async () => {
-    setLogLoading(true);
-    setLogError(null);
-    try {
-      const response = await fetch(`${API_BASE}/api/harvest/logs?lines=200`, {
-        credentials: 'include',
-      });
-      if (!response.ok) {
-        throw new Error('Unable to load logs');
-      }
-      const data = await (response.json() as Promise<LogsResponse>);
-      setLogPreview(data.lines || []);
-    } catch (err) {
-      setLogPreview([]);
-      setLogError(err instanceof Error ? err.message : 'Failed to load log file');
-    } finally {
-      setLogLoading(false);
-    }
-  }, []);
-
-  // Save Network Discovery settings to API
-  const saveNetworkDiscoverySettings = useCallback(async () => {
-    setNetworkDiscoveryStatus('saving');
-    try {
-      const response = await fetch(`${API_BASE}/api/v1/shell/devices/settings`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify(networkDiscoverySettings),
-      });
-      if (response.ok) {
-        setNetworkDiscoveryStatus('saved');
-        setTimeout(() => setNetworkDiscoveryStatus('idle'), 2000);
-      } else {
-        setNetworkDiscoveryStatus('error');
-      }
-    } catch {
-      setNetworkDiscoveryStatus('error');
-    }
-  }, [networkDiscoverySettings]);
-
-  const saveSnmpSettings = useCallback(async () => {
-    setSnmpStatus('saving');
-    try {
-      const response = await fetch(`${API_BASE}/api/sap/snmp/settings`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify(snmpSettings),
-      });
-      if (response.ok) {
-        setSnmpStatus('saved');
-        setTimeout(() => setSnmpStatus('idle'), 2000);
-      } else {
-        setSnmpStatus('error');
-      }
-    } catch {
-      setSnmpStatus('error');
-    }
-  }, [snmpSettings]);
-  useEffect(() => {
-    if (isOpen) {
-      // Reset init refs on open
-      initialLoadRef.current = true;
-      thresholdsInitRef.current = true;
-      testsInitRef.current = true;
-      wifiInitRef.current = true;
-      linkInitRef.current = true;
-      cableTestInitRef.current = true;
-      networkDiscoveryInitRef.current = true;
-      snmpInitRef.current = true;
-      vulnInitRef.current = true;
-
-      fetchThresholds().catch(() => undefined);
-      fetchIpSettings().catch(() => undefined);
-      fetchTestsSettings().catch(() => undefined);
-      fetchWifiSettings().catch(() => undefined);
-      // FAB options, display options, and iperf settings come from SettingsContext
-      fetchNetworkDiscoverySettings().catch(() => undefined);
-      fetchSnmpSettings().catch(() => undefined);
-      fetchVulnSettings().catch(() => undefined);
-      fetchLinkSettings().catch(() => undefined);
-      fetchCableTestSettings().catch(() => undefined);
-      fetchSubnets().catch(() => undefined);
-
-      // Mark initial load as done after a short delay
-      setTimeout(() => {
-        initialLoadRef.current = false;
-        thresholdsInitRef.current = false;
-        testsInitRef.current = false;
-        wifiInitRef.current = false;
-        linkInitRef.current = false;
-        cableTestInitRef.current = false;
-        networkDiscoveryInitRef.current = false;
-        snmpInitRef.current = false;
-        vulnInitRef.current = false;
-      }, 500);
-    }
-  }, [
+  // Per-section fetch callbacks + open-time orchestration live in their hook
+  const { fetchIperfSuggestions, fetchLogPreview } = useSettingsDrawerLoaders({
     isOpen,
-    fetchThresholds,
-    fetchIpSettings,
-    fetchTestsSettings,
-    fetchWifiSettings,
-    fetchNetworkDiscoverySettings,
-    fetchSnmpSettings,
-    fetchVulnSettings,
-    fetchLinkSettings,
-    fetchCableTestSettings,
+    initRefs: {
+      initialLoadRef,
+      thresholdsInitRef,
+      testsInitRef,
+      wifiInitRef,
+      linkInitRef,
+      cableTestInitRef,
+      networkDiscoveryInitRef,
+      snmpInitRef,
+      vulnInitRef,
+    },
+    setThresholds,
+    setIpSettings,
+    setDnsInput,
+    setTestsSettings,
+    setIperfSuggestions,
+    setIperfSuggestionsStatus,
+    setIperfSuggestionsError,
+    setWifiSettings,
+    setNetworkDiscoverySettings,
+    setSnmpSettings,
+    setLinkSettings,
+    setCableTestSettings,
+    setLogPreview,
+    setLogLoading,
+    setLogError,
     fetchSubnets,
-  ]);
+    fetchVulnSettings,
+  });
 
-  const saveThresholds = useCallback(async () => {
-    setThresholdsStatus('saving');
-    try {
-      const response = await fetch(`${API_BASE}/api/settings`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({ thresholds }),
-      });
-      if (response.ok) {
-        setThresholdsStatus('saved');
-        setTimeout(() => setThresholdsStatus('idle'), 2000);
-      } else {
-        setThresholdsStatus('error');
-      }
-    } catch {
-      setThresholdsStatus('error');
-    }
-  }, [thresholds]);
+  // Per-section save callbacks live in their own hook
+  const {
+    saveThresholds,
+    saveTestsSettings,
+    saveWifiSettings,
+    saveLinkSettings,
+    saveCableTestSettings,
+    saveNetworkDiscoverySettings,
+    saveSnmpSettings,
+  } = useSettingsDrawerSavers({
+    thresholds,
+    setThresholdsStatus,
+    testsSettings,
+    setTestsStatus,
+    testsSettingsChangedRef,
+    wifiSettings,
+    setWifiStatus,
+    linkSettings,
+    setLinkStatus,
+    cableTestSettings,
+    setCableTestStatus,
+    networkDiscoverySettings,
+    setNetworkDiscoveryStatus,
+    snmpSettings,
+    setSnmpStatus,
+  });
 
   const saveIpSettings = async (): Promise<void> => {
     setSavingIp(true);
@@ -755,104 +417,6 @@ export const SettingsDrawer: React.MemoExoticComponent<
       setSavingIp(false);
     }
   };
-
-  const saveTestsSettings = useCallback(async () => {
-    setTestsStatus('saving');
-    try {
-      const payload = normalizeTestsSettingsForSave(testsSettings);
-      const response = await fetch(`${API_BASE}/api/health-checks/settings`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify(payload),
-      });
-      if (response.ok) {
-        setTestsStatus('saved');
-        setTimeout(() => setTestsStatus('idle'), 2000);
-        // Mark that test settings changed - event dispatched on drawer close
-        testsSettingsChangedRef.current = true;
-      } else {
-        setTestsStatus('error');
-      }
-    } catch {
-      setTestsStatus('error');
-    }
-  }, [testsSettings]);
-
-  const saveWifiSettings = useCallback(async () => {
-    setWifiStatus('saving');
-    try {
-      const response = await fetch(`${API_BASE}/api/canopy/wifi/settings`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({ interface: wifiSettings.interface }),
-      });
-      if (response.ok) {
-        setWifiStatus('saved');
-        setTimeout(() => setWifiStatus('idle'), 2000);
-      } else {
-        setWifiStatus('error');
-      }
-    } catch {
-      setWifiStatus('error');
-    }
-  }, [wifiSettings.interface]);
-
-  // Save link settings to backend (fixes #734)
-  const saveLinkSettings = useCallback(async () => {
-    setLinkStatus('saving');
-    try {
-      const response = await fetch(`${API_BASE}/api/settings/link`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          mode: linkSettings.mode,
-          availableModes: linkSettings.availableModes,
-        }),
-      });
-      if (response.ok) {
-        setLinkStatus('saved');
-        setTimeout(() => setLinkStatus('idle'), 2000);
-      } else {
-        setLinkStatus('error');
-      }
-    } catch {
-      setLinkStatus('error');
-    }
-  }, [linkSettings]);
-
-  // Save cable test settings to backend (fixes #740)
-  const saveCableTestSettings = useCallback(async () => {
-    setCableTestStatus('saving');
-    try {
-      const response = await fetch(`${API_BASE}/api/settings/cable`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          enabled: cableTestSettings.enabled,
-        }),
-      });
-      if (response.ok) {
-        setCableTestStatus('saved');
-        setTimeout(() => setCableTestStatus('idle'), 2000);
-      } else {
-        setCableTestStatus('error');
-      }
-    } catch {
-      setCableTestStatus('error');
-    }
-  }, [cableTestSettings]);
 
   // Debounced auto-save effects for every settings group
   useDebouncedAutoSave(saveThresholds, thresholdsInitRef, thresholdsTimerRef);

--- a/ui/src/components/settings/SettingsDrawer.tsx
+++ b/ui/src/components/settings/SettingsDrawer.tsx
@@ -30,7 +30,10 @@ import type React from 'react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSettings } from '../../contexts/useSettings';
+import { useDebouncedAutoSave } from '../../hooks/useDebouncedAutoSave';
+import { useSubnetSettings } from '../../hooks/useSubnetSettings';
 import { useTheme } from '../../hooks/useTheme';
+import { useVulnerabilitySettings } from '../../hooks/useVulnerabilitySettings';
 import { LogComponents, logger } from '../../lib/logger';
 import { button, cn, icon as iconTokens, layout, radius, spacing } from '../../styles/theme';
 import type {
@@ -42,32 +45,26 @@ import type {
   NetworkDiscoverySettings,
   SettingsThresholds,
   SnmpSettings as SnmpSettingsType,
-  SubnetConfig,
   TestsSettings,
-  VulnerabilityScanSettings,
   WiFiSettings as WiFiSettingsType,
 } from '../../types/settings';
-import { CollapsibleSection } from '../ui/CollapsibleSection';
-import { Network } from '../ui/icons';
+import { SettingsDrawerFooter } from './SettingsDrawerFooter';
+import { SettingsDrawerNetworkSection } from './SettingsDrawerNetworkSection';
 import { AppearanceSettings } from './sections/AppearanceSettings';
-import { AutoSaveIndicator } from './sections/AutoSaveIndicator';
 import { CableTestSettings } from './sections/CableTestSettings';
 import { ConfigBackupsSection } from './sections/ConfigBackupsSection';
 import { DiscoverySettings } from './sections/DiscoverySettings';
 import { DnsSettings } from './sections/DnsSettings';
 import { HealthChecksSettings } from './sections/HealthChecksSettings';
 import { LinkSettings } from './sections/LinkSettings';
-import { MtuControl } from './sections/MtuControl';
 import { PerformanceSettings } from './sections/PerformanceSettings';
 import { ThresholdsSettings } from './sections/ThresholdsSettings';
 import { UpdateSettings } from './sections/UpdateSettings';
-import { VlanControl } from './sections/VlanControl';
 import { VulnerabilitySettings } from './sections/VulnerabilitySettings';
 import { WiFiSettings } from './sections/WiFiSettings';
 import {
   INLINE_DEFAULT_CABLE_TEST_SETTINGS,
   INLINE_DEFAULT_LINK_SETTINGS,
-  INLINE_DEFAULT_VULNERABILITY_SETTINGS,
   normalizeTestsSettingsForSave,
   withIds,
 } from './settingsDrawerNormalizer';
@@ -260,16 +257,25 @@ export const SettingsDrawer: React.MemoExoticComponent<
     retries: 2,
     port: 161,
   });
-  // Additional subnets for scanning
-  const [subnets, setSubnets] = useState<SubnetConfig[]>([]);
-  const [newSubnetCidr, setNewSubnetCidr] = useState('');
-  const [newSubnetName, setNewSubnetName] = useState('');
-  const [subnetError, setSubnetError] = useState<string | null>(null);
+  // Subnet management lives in its own hook
+  const {
+    subnets,
+    newSubnetCidr,
+    setNewSubnetCidr,
+    newSubnetName,
+    setNewSubnetName,
+    subnetError,
+    setSubnetError,
+    subnetsStatus,
+    fetchSubnets,
+    addSubnet,
+    toggleSubnet,
+    deleteSubnet,
+  } = useSubnetSettings(isOpen);
   // Log preview (debug)
   const [logPreview, setLogPreview] = useState<string[]>([]);
   const [logLoading, setLogLoading] = useState(false);
   const [logError, setLogError] = useState<string | null>(null);
-  const [subnetsStatus, setSubnetsStatus] = useState<SaveStatus>('idle');
   // Auto-save status for each section
   type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
   const [thresholdsStatus, setThresholdsStatus] = useState<SaveStatus>('idle');
@@ -278,10 +284,15 @@ export const SettingsDrawer: React.MemoExoticComponent<
   const [linkStatus, setLinkStatus] = useState<SaveStatus>('idle');
   const [cableTestStatus, setCableTestStatus] = useState<SaveStatus>('idle');
   const [snmpStatus, setSnmpStatus] = useState<SaveStatus>('idle');
-  const [vulnSettings, setVulnSettings] = useState<VulnerabilityScanSettings>(
-    INLINE_DEFAULT_VULNERABILITY_SETTINGS,
-  );
-  const [vulnStatus, setVulnStatus] = useState<SaveStatus>('idle');
+  const {
+    vulnSettings,
+    setVulnSettings,
+    vulnStatus,
+    vulnInitRef,
+    vulnTimerRef,
+    fetchVulnSettings,
+    saveVulnSettings,
+  } = useVulnerabilitySettings();
   // Status for display, iperf comes from context (settingsStatus)
   const displayStatus = settingsStatus.display;
   const iperfStatus = settingsStatus.iperf;
@@ -297,7 +308,6 @@ export const SettingsDrawer: React.MemoExoticComponent<
   const cableTestInitRef = useRef(true);
   const networkDiscoveryInitRef = useRef(true);
   const snmpInitRef = useRef(true);
-  const vulnInitRef = useRef(true);
 
   // Debounce timers (fab, display, iperf now handled by context)
   const thresholdsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -307,7 +317,6 @@ export const SettingsDrawer: React.MemoExoticComponent<
   const cableTestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const networkDiscoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const snmpTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const vulnTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Legacy state (keep for IP settings which still needs manual apply)
   const [savingIp, setSavingIp] = useState(false);
@@ -569,21 +578,6 @@ export const SettingsDrawer: React.MemoExoticComponent<
     }
   }, []);
 
-  // Fetch configured subnets from API
-  const fetchSubnets = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_BASE}/api/v1/shell/devices/subnets`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await (response.json() as Promise<Record<string, unknown>>);
-        setSubnets(Array.isArray(data) ? data : []);
-      }
-    } catch (err) {
-      logger.error(LogComponents.Discovery, 'Failed to fetch subnets', err);
-    }
-  }, []);
-
   // Fetch a small tail of the application log (debug)
   // Security fix #301: Removed VITE_LOG_ACCESS_TOKEN - JWT authentication is sufficient
   const fetchLogPreview = useCallback(async () => {
@@ -605,111 +599,6 @@ export const SettingsDrawer: React.MemoExoticComponent<
       setLogLoading(false);
     }
   }, []);
-
-  // Fetch subnets when drawer opens
-  useEffect(() => {
-    if (isOpen) {
-      fetchSubnets().catch(() => undefined);
-    }
-  }, [isOpen, fetchSubnets]);
-
-  // Add a new subnet
-  const addSubnet = async (): Promise<void> => {
-    if (!newSubnetCidr.trim()) {
-      setSubnetError(t('network.cidrRequired'));
-      return;
-    }
-
-    setSubnetError(null);
-    setSubnetsStatus('saving');
-
-    try {
-      const response = await fetch(`${API_BASE}/api/v1/shell/devices/subnets`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          cidr: newSubnetCidr.trim(),
-          name: newSubnetName.trim() || newSubnetCidr.trim(),
-          enabled: true,
-        }),
-      });
-
-      if (response.ok) {
-        setNewSubnetCidr('');
-        setNewSubnetName('');
-        setSubnetsStatus('saved');
-        setTimeout(() => setSubnetsStatus('idle'), 2000);
-        await fetchSubnets();
-      } else {
-        // Handle both JSON and plain text error responses
-        const contentType = response.headers.get('content-type');
-        if (contentType?.includes('application/json')) {
-          const errorData = await (response.json() as Promise<{ error?: string }>);
-          setSubnetError(errorData.error || 'Failed to add subnet');
-        } else {
-          const errorText = await (response.text() as Promise<string>);
-          setSubnetError(errorText || 'Failed to add subnet');
-        }
-        setSubnetsStatus('error');
-      }
-    } catch (err) {
-      setSubnetError(err instanceof Error ? err.message : 'Network error adding subnet');
-      setSubnetsStatus('error');
-    }
-  };
-
-  // Toggle subnet enabled state
-  const toggleSubnet = async (cidr: string, enabled: boolean): Promise<void> => {
-    setSubnetsStatus('saving');
-    try {
-      const response = await fetch(`${API_BASE}/api/v1/shell/devices/subnets`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({ cidr, enabled }),
-      });
-
-      if (response.ok) {
-        setSubnetsStatus('saved');
-        setTimeout(() => setSubnetsStatus('idle'), 2000);
-        await fetchSubnets();
-      } else {
-        setSubnetsStatus('error');
-      }
-    } catch {
-      setSubnetsStatus('error');
-    }
-  };
-
-  // Delete a subnet
-  const deleteSubnet = async (cidr: string): Promise<void> => {
-    setSubnetsStatus('saving');
-    try {
-      // Backend expects CIDR as query parameter, not in body
-      const response = await fetch(
-        `${API_BASE}/api/v1/shell/devices/subnets?cidr=${encodeURIComponent(cidr)}`,
-        {
-          method: 'DELETE',
-          credentials: 'include',
-        },
-      );
-
-      if (response.ok) {
-        setSubnetsStatus('saved');
-        setTimeout(() => setSubnetsStatus('idle'), 2000);
-        await fetchSubnets();
-      } else {
-        setSubnetsStatus('error');
-      }
-    } catch {
-      setSubnetsStatus('error');
-    }
-  };
 
   // Save Network Discovery settings to API
   const saveNetworkDiscoverySettings = useCallback(async () => {
@@ -755,60 +644,6 @@ export const SettingsDrawer: React.MemoExoticComponent<
       setSnmpStatus('error');
     }
   }, [snmpSettings]);
-
-  // Fetch vulnerability scanner settings from API
-  const fetchVulnSettings = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_BASE}/api/v1/shell/vulnerabilities/settings`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await (response.json() as Promise<Record<string, unknown>>);
-        setVulnSettings({
-          enabled: data.enabled ?? false,
-          cveDatabase: data.cve_database ?? data.cveDatabase ?? 'nvd',
-          nvdApiKey: data.nvd_api_key ?? data.nvdApiKey ?? '',
-          updateInterval: data.update_interval ?? data.updateInterval ?? 86400,
-          severityThreshold: data.severity_threshold ?? data.severityThreshold ?? 'medium',
-          maxConcurrent: data.max_concurrent ?? data.maxConcurrent ?? 5,
-          autoScan: data.auto_scan ?? data.autoScan ?? false,
-        });
-      }
-    } catch (err) {
-      logger.error(LogComponents.CONFIG, 'Failed to fetch vulnerability settings', err);
-    }
-  }, []);
-
-  const saveVulnSettings = useCallback(async () => {
-    setVulnStatus('saving');
-    try {
-      const response = await fetch(`${API_BASE}/api/v1/shell/vulnerabilities/settings`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          enabled: vulnSettings.enabled,
-          cveDatabase: vulnSettings.cveDatabase,
-          nvdApiKey: vulnSettings.nvdApiKey,
-          updateInterval: vulnSettings.updateInterval,
-          severityThreshold: vulnSettings.severityThreshold,
-          maxConcurrent: vulnSettings.maxConcurrent,
-          autoScan: vulnSettings.autoScan,
-        }),
-      });
-      if (response.ok) {
-        setVulnStatus('saved');
-        setTimeout(() => setVulnStatus('idle'), 2000);
-      } else {
-        setVulnStatus('error');
-      }
-    } catch {
-      setVulnStatus('error');
-    }
-  }, [vulnSettings]);
-
   useEffect(() => {
     if (isOpen) {
       // Reset init refs on open
@@ -1019,151 +854,19 @@ export const SettingsDrawer: React.MemoExoticComponent<
     }
   }, [cableTestSettings]);
 
-  // Auto-save thresholds with debounce
-  useEffect(() => {
-    if (thresholdsInitRef.current) {
-      return;
-    }
-    if (thresholdsTimerRef.current) {
-      clearTimeout(thresholdsTimerRef.current);
-    }
-    thresholdsTimerRef.current = setTimeout(() => {
-      saveThresholds().catch(() => undefined);
-    }, 800);
-    return (): void => {
-      if (thresholdsTimerRef.current) {
-        clearTimeout(thresholdsTimerRef.current);
-      }
-    };
-  }, [saveThresholds]);
-
-  // Auto-save tests settings with debounce
-  useEffect(() => {
-    if (testsInitRef.current) {
-      return;
-    }
-    if (testsTimerRef.current) {
-      clearTimeout(testsTimerRef.current);
-    }
-    testsTimerRef.current = setTimeout(() => {
-      saveTestsSettings().catch(() => undefined);
-    }, 800);
-    return (): void => {
-      if (testsTimerRef.current) {
-        clearTimeout(testsTimerRef.current);
-      }
-    };
-  }, [saveTestsSettings]);
-
-  // Auto-save wifi settings with debounce
-  useEffect(() => {
-    if (wifiInitRef.current) {
-      return;
-    }
-    if (wifiTimerRef.current) {
-      clearTimeout(wifiTimerRef.current);
-    }
-    wifiTimerRef.current = setTimeout(() => {
-      saveWifiSettings().catch(() => undefined);
-    }, 800);
-    return (): void => {
-      if (wifiTimerRef.current) {
-        clearTimeout(wifiTimerRef.current);
-      }
-    };
-  }, [saveWifiSettings]);
-
-  // Auto-save link settings with debounce (fixes #734)
-  useEffect(() => {
-    if (linkInitRef.current) {
-      return;
-    }
-    if (linkTimerRef.current) {
-      clearTimeout(linkTimerRef.current);
-    }
-    linkTimerRef.current = setTimeout(() => {
-      saveLinkSettings().catch(() => undefined);
-    }, 800);
-    return (): void => {
-      if (linkTimerRef.current) {
-        clearTimeout(linkTimerRef.current);
-      }
-    };
-  }, [saveLinkSettings]);
-
-  // Auto-save cable test settings with debounce (fixes #740)
-  useEffect(() => {
-    if (cableTestInitRef.current) {
-      return;
-    }
-    if (cableTestTimerRef.current) {
-      clearTimeout(cableTestTimerRef.current);
-    }
-    cableTestTimerRef.current = setTimeout(() => {
-      saveCableTestSettings().catch(() => undefined);
-    }, 800);
-    return (): void => {
-      if (cableTestTimerRef.current) {
-        clearTimeout(cableTestTimerRef.current);
-      }
-    };
-  }, [saveCableTestSettings]);
-
-  // Display options and iperf settings auto-save is handled by SettingsContext
-
-  // Auto-save Network Discovery settings with debounce
-  useEffect(() => {
-    if (networkDiscoveryInitRef.current) {
-      return;
-    }
-    if (networkDiscoveryTimerRef.current) {
-      clearTimeout(networkDiscoveryTimerRef.current);
-    }
-    networkDiscoveryTimerRef.current = setTimeout(() => {
-      saveNetworkDiscoverySettings().catch(() => undefined);
-    }, 800);
-    return (): void => {
-      if (networkDiscoveryTimerRef.current) {
-        clearTimeout(networkDiscoveryTimerRef.current);
-      }
-    };
-  }, [saveNetworkDiscoverySettings]);
-
-  // Auto-save SNMP settings with debounce
-  useEffect(() => {
-    if (snmpInitRef.current) {
-      return;
-    }
-    if (snmpTimerRef.current) {
-      clearTimeout(snmpTimerRef.current);
-    }
-    snmpTimerRef.current = setTimeout(() => {
-      saveSnmpSettings().catch(() => undefined);
-    }, 800);
-    return (): void => {
-      if (snmpTimerRef.current) {
-        clearTimeout(snmpTimerRef.current);
-      }
-    };
-  }, [saveSnmpSettings]);
-
-  // Auto-save vulnerability settings with debounce
-  useEffect(() => {
-    if (vulnInitRef.current) {
-      return;
-    }
-    if (vulnTimerRef.current) {
-      clearTimeout(vulnTimerRef.current);
-    }
-    vulnTimerRef.current = setTimeout(() => {
-      saveVulnSettings().catch(() => undefined);
-    }, 800);
-    return (): void => {
-      if (vulnTimerRef.current) {
-        clearTimeout(vulnTimerRef.current);
-      }
-    };
-  }, [saveVulnSettings]);
+  // Debounced auto-save effects for every settings group
+  useDebouncedAutoSave(saveThresholds, thresholdsInitRef, thresholdsTimerRef);
+  useDebouncedAutoSave(saveTestsSettings, testsInitRef, testsTimerRef);
+  useDebouncedAutoSave(saveWifiSettings, wifiInitRef, wifiTimerRef);
+  useDebouncedAutoSave(saveLinkSettings, linkInitRef, linkTimerRef);
+  useDebouncedAutoSave(saveCableTestSettings, cableTestInitRef, cableTestTimerRef);
+  useDebouncedAutoSave(
+    saveNetworkDiscoverySettings,
+    networkDiscoveryInitRef,
+    networkDiscoveryTimerRef,
+  );
+  useDebouncedAutoSave(saveSnmpSettings, snmpInitRef, snmpTimerRef);
+  useDebouncedAutoSave(saveVulnSettings, vulnInitRef, vulnTimerRef);
 
   // Fixes #917: Master cleanup effect for all timer refs on unmount
   // Individual useEffects clean up on re-render, but this ensures cleanup on unmount
@@ -1325,269 +1028,19 @@ export const SettingsDrawer: React.MemoExoticComponent<
           />
 
           {/* Network Section - IP/DHCP config (third) */}
-          <CollapsibleSection
-            title={
-              <div class={layout.inline.default}>
-                <Network class={iconTokens.size.sm} />
-                <span>{t('sections.network')}</span>
-              </div>
-            }
-          >
-            {/* Network Configuration */}
-            <div class="stack">
-              <p class="section-title">{t('network.title')}</p>
-              {/* Mode Toggle */}
-              <div class={cn('grid grid-cols-2', spacing.gap.compact)}>
-                <button
-                  type="button"
-                  onClick={(): void => setIpSettings((prev) => ({ ...prev, mode: 'dhcp' }))}
-                  class={cn(
-                    spacing.tab,
-                    radius.md,
-                    'body-small font-medium transition-colors',
-                    ipSettings.mode === 'dhcp'
-                      ? 'bg-brand-primary text-text-inverse'
-                      : 'bg-surface-base border border-surface-border text-text-primary hover:bg-surface-hover',
-                  )}
-                >
-                  {t('network.dhcp')}
-                </button>
-                <button
-                  type="button"
-                  onClick={(): void => setIpSettings((prev) => ({ ...prev, mode: 'static' }))}
-                  class={cn(
-                    spacing.tab,
-                    radius.md,
-                    'body-small font-medium transition-colors',
-                    ipSettings.mode === 'static'
-                      ? 'bg-brand-primary text-text-inverse'
-                      : 'bg-surface-base border border-surface-border text-text-primary hover:bg-surface-hover',
-                  )}
-                >
-                  {t('network.static')}
-                </button>
-              </div>
-
-              {/* Static IP Fields */}
-              {ipSettings.mode === 'static' && (
-                <div
-                  class={cn('stack', spacing.padding.top.heading, 'border-t border-surface-border')}
-                >
-                  <div>
-                    <label for="static-ip-address" class="caption font-medium">
-                      {t('network.ipAddress')} *
-                    </label>
-                    <input
-                      id="static-ip-address"
-                      type="text"
-                      value={ipSettings.address}
-                      onChange={(
-                        e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-                      ): void =>
-                        setIpSettings((prev) => ({
-                          ...prev,
-                          address: e.target.value,
-                        }))
-                      }
-                      placeholder="192.168.1.100"
-                      class={cn(
-                        'w-full',
-                        spacing.margin.top.tight,
-                        spacing.chip.sm,
-                        'bg-surface-base border',
-                        radius.md,
-                        'body-small text-text-primary',
-                        ipSettings.address && !isValidIp(ipSettings.address)
-                          ? 'border-status-error'
-                          : 'border-surface-border',
-                      )}
-                    />
-                  </div>
-                  <div>
-                    <label for="static-subnet-mask" class="caption font-medium">
-                      {t('network.subnetMask')} *
-                    </label>
-                    <input
-                      id="static-subnet-mask"
-                      type="text"
-                      value={ipSettings.netmask}
-                      onChange={(
-                        e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-                      ): void =>
-                        setIpSettings((prev) => ({
-                          ...prev,
-                          netmask: e.target.value,
-                        }))
-                      }
-                      placeholder="24 or 255.255.255.0"
-                      class={cn(
-                        'w-full',
-                        spacing.margin.top.tight,
-                        spacing.chip.lg,
-                        'bg-surface-base border border-surface-border',
-                        radius.md,
-                        'body-small text-text-primary',
-                      )}
-                    />
-                  </div>
-                  <div>
-                    <label for="static-gateway" class="caption font-medium">
-                      {t('network.gateway')}
-                    </label>
-                    <input
-                      id="static-gateway"
-                      type="text"
-                      value={ipSettings.gateway}
-                      onChange={(
-                        e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-                      ): void =>
-                        setIpSettings((prev) => ({
-                          ...prev,
-                          gateway: e.target.value,
-                        }))
-                      }
-                      placeholder="192.168.1.1"
-                      class={cn(
-                        'w-full',
-                        spacing.margin.top.tight,
-                        spacing.chip.sm,
-                        'bg-surface-base border',
-                        radius.md,
-                        'body-small text-text-primary',
-                        ipSettings.gateway && !isValidIp(ipSettings.gateway)
-                          ? 'border-status-error'
-                          : 'border-surface-border',
-                      )}
-                    />
-                  </div>
-                  <div>
-                    <label for="static-dns-servers" class="caption font-medium">
-                      {t('network.dnsServers')}
-                    </label>
-                    <input
-                      id="static-dns-servers"
-                      type="text"
-                      value={dnsInput}
-                      onChange={(
-                        e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-                      ): void => setDnsInput(e.target.value)}
-                      placeholder="8.8.8.8, 8.8.4.4"
-                      class={cn(
-                        'w-full',
-                        spacing.margin.top.tight,
-                        spacing.chip.lg,
-                        'bg-surface-base border border-surface-border',
-                        radius.md,
-                        'body-small text-text-primary',
-                      )}
-                    />
-                  </div>
-                </div>
-              )}
-
-              {/* Apply Button */}
-              <button
-                type="button"
-                onClick={saveIpSettings}
-                disabled={savingIp || (ipSettings.mode === 'static' && !ipSettings.address)}
-                class={cn(
-                  'w-full',
-                  button.size.md,
-                  'bg-brand-primary text-text-inverse',
-                  radius.md,
-                  'font-medium hover:bg-brand-accent disabled:opacity-50 transition-colors',
-                )}
-              >
-                {savingIp ? t('network.applying') : t('network.applyIpSettings')}
-              </button>
-
-              {ipMessage ? (
-                <p
-                  class={cn(
-                    'caption text-center',
-                    ipMessage.includes('Failed') || ipMessage.includes('Error')
-                      ? 'text-status-error'
-                      : 'text-status-success',
-                  )}
-                >
-                  {ipMessage}
-                </p>
-              ) : null}
-
-              <p class="caption">{t('network.requiresRoot')}</p>
-            </div>
-
-            {/* Display Options */}
-            <div
-              class={cn(
-                'border-t border-surface-border',
-                spacing.padding.top.heading,
-                spacing.margin.top.heading,
-              )}
-            >
-              <p class={cn('caption font-medium', spacing.margin.bottom.inline)}>
-                {t('network.displayOptions')} <AutoSaveIndicator status={displayStatus} />
-              </p>
-              <div class="stack-sm">
-                {/* Show Public IP */}
-                <label
-                  class={cn(
-                    'flex items-center justify-between',
-                    spacing.pad.xs,
-                    'bg-surface-base',
-                    radius.md,
-                    'border border-surface-border',
-                  )}
-                >
-                  <div>
-                    <span class="body-small text-text-primary font-medium">
-                      {t('network.showPublicIp')}
-                    </span>
-                    <p class="caption text-text-muted">{t('network.displayInNetworkCard')}</p>
-                  </div>
-                  <input
-                    type="checkbox"
-                    checked={displayOptions.showPublicIp}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>): void =>
-                      setDisplayOptions((prev) => ({
-                        ...prev,
-                        showPublicIp: e.target.checked,
-                      }))
-                    }
-                    class={iconTokens.size.sm}
-                  />
-                </label>
-              </div>
-            </div>
-
-            {/* VLAN Configuration */}
-            <div
-              class={cn(
-                'border-t border-surface-border',
-                spacing.padding.top.heading,
-                spacing.margin.top.heading,
-              )}
-            >
-              <p class={cn('section-title', spacing.margin.bottom.inline)}>
-                {t('network.vlanTag')}
-              </p>
-              <VlanControl />
-            </div>
-
-            {/* MTU Configuration */}
-            <div
-              class={cn(
-                'border-t border-surface-border',
-                spacing.padding.top.heading,
-                spacing.margin.top.heading,
-              )}
-            >
-              <p class={cn('section-title', spacing.margin.bottom.inline)}>
-                {t('network.mtuSetting')}
-              </p>
-              <MtuControl />
-            </div>
-          </CollapsibleSection>
+          <SettingsDrawerNetworkSection
+            ipSettings={ipSettings}
+            setIpSettings={setIpSettings}
+            dnsInput={dnsInput}
+            setDnsInput={setDnsInput}
+            saveIpSettings={saveIpSettings}
+            savingIp={savingIp}
+            ipMessage={ipMessage}
+            displayOptions={displayOptions}
+            setDisplayOptions={setDisplayOptions}
+            displayStatus={displayStatus}
+            isValidIp={isValidIp}
+          />
 
           {/* WiFi Settings - only shown in WiFi mode (#754) */}
           {isWifi ? (
@@ -1680,95 +1133,13 @@ export const SettingsDrawer: React.MemoExoticComponent<
           {/* Updates Section (implements #862) */}
           <UpdateSettings currentVersion={version} />
 
-          {/* Logs (debug) */}
-          <section class={cn(spacing.padding.top.section, 'border-t border-surface-border')}>
-            <div class="flex items-start justify-between">
-              <div>
-                <h3 class="body-small font-medium text-text-muted">{t('logs.title')}</h3>
-                <p class="caption text-text-muted">{t('logs.description')}</p>
-              </div>
-              <button
-                type="button"
-                onClick={fetchLogPreview}
-                class={cn(
-                  'caption',
-                  spacing.chip.sm,
-                  'border border-surface-border',
-                  radius.md,
-                  'text-text-muted hover:text-text-primary hover:border-text-muted transition-colors',
-                )}
-              >
-                {logLoading ? t('logs.loading') : t('logs.view')}
-              </button>
-            </div>
-            {logError ? (
-              <p class={cn('caption text-status-error', spacing.margin.top.inline)}>{logError}</p>
-            ) : null}
-            {!logError && logPreview.length > 0 ? (
-              <pre
-                class={cn(
-                  spacing.margin.top.inline,
-                  'max-h-48 overflow-y-auto text-2xs leading-5 bg-surface-base border border-surface-border',
-                  radius.md,
-                  spacing.chip.lg,
-                  'text-text-primary whitespace-pre-wrap',
-                )}
-              >
-                {logPreview.join('\n')}
-              </pre>
-            ) : null}
-          </section>
-
-          {/* Export Section */}
-          <section class={cn(spacing.padding.top.section, 'border-t border-surface-border')}>
-            <h3 class={cn('body-small font-medium text-text-muted', spacing.margin.bottom.heading)}>
-              {t('export.title')}
-            </h3>
-            <a
-              href={`${API_BASE}/api/harvest/export`}
-              download="seed-export.json"
-              class={cn(
-                'w-full',
-                button.size.md,
-                'bg-surface-base border border-surface-border text-text-primary',
-                radius.md,
-                'font-medium hover:bg-surface-hover transition-colors flex items-center justify-center',
-                spacing.gap.compact,
-                'touch-manipulation',
-              )}
-            >
-              <svg
-                class={iconTokens.size.sm}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-                />
-              </svg>
-              {t('export.download')}
-            </a>
-            <p class={cn('caption text-text-muted', spacing.margin.top.inline)}>
-              {t('export.description')}
-            </p>
-          </section>
-
-          {/* About Section */}
-          <section class={cn(spacing.padding.top.section, 'border-t border-surface-border')}>
-            <h3 class={cn('body-small font-medium text-text-muted', spacing.margin.bottom.inline)}>
-              {t('about.title')}
-            </h3>
-            <p class="caption text-text-muted">
-              {t('about.appName')} {version}
-              <br />
-              {t('about.description')}
-            </p>
-          </section>
+          <SettingsDrawerFooter
+            version={version}
+            fetchLogPreview={fetchLogPreview}
+            logLoading={logLoading}
+            logError={logError}
+            logPreview={logPreview}
+          />
         </div>
       </div>
     </>

--- a/ui/src/components/settings/SettingsDrawer.tsx
+++ b/ui/src/components/settings/SettingsDrawer.tsx
@@ -47,7 +47,6 @@ import type {
   VulnerabilityScanSettings,
   WiFiSettings as WiFiSettingsType,
 } from '../../types/settings';
-import { generateId } from '../../utils/id';
 import { CollapsibleSection } from '../ui/CollapsibleSection';
 import { Network } from '../ui/icons';
 import { AppearanceSettings } from './sections/AppearanceSettings';
@@ -65,118 +64,15 @@ import { UpdateSettings } from './sections/UpdateSettings';
 import { VlanControl } from './sections/VlanControl';
 import { VulnerabilitySettings } from './sections/VulnerabilitySettings';
 import { WiFiSettings } from './sections/WiFiSettings';
-
-// Inline defaults - avoids deprecated imports while maintaining fallback behavior
-// The backend is the single source of truth; these are used only for initial state
-const INLINE_DEFAULT_LINK_SETTINGS: LinkSettingsType = {
-  mode: 'auto',
-  availableModes: [],
-};
-
-const INLINE_DEFAULT_CABLE_TEST_SETTINGS: CableTestSettingsType = {
-  enabled: true,
-};
-
-const INLINE_DEFAULT_VULNERABILITY_SETTINGS: VulnerabilityScanSettings = {
-  enabled: true,
-  cveDatabase: 'nvd',
-  nvdApiKey: '',
-  updateInterval: 86400,
-  severityThreshold: 'medium',
-  maxConcurrent: 5,
-  autoScan: true,
-};
+import {
+  INLINE_DEFAULT_CABLE_TEST_SETTINGS,
+  INLINE_DEFAULT_LINK_SETTINGS,
+  INLINE_DEFAULT_VULNERABILITY_SETTINGS,
+  normalizeTestsSettingsForSave,
+  withIds,
+} from './settingsDrawerNormalizer';
 
 const API_BASE: string = import.meta.env.VITE_API_BASE || '';
-
-// Utility: ensure every item in an array has a stable id for React keying/updating.
-const withIds = <T extends { id?: string }>(items: T[] = []): Array<T & { id: string }> =>
-  items.map((item) => ({ ...item, id: item.id ?? generateId() }));
-
-// Normalize tests/DNS settings payload before sending to the API.
-interface NormalizedTestsSettings {
-  dnsHostname: string;
-  dnsServers: Array<{ address: string; enabled: boolean }>;
-  pingTargets: Array<{ name: string; host: string; enabled: boolean }>;
-  tcpPorts: Array<{ name: string; host: string; port: number; enabled: boolean }>;
-  udpPorts: Array<{ name: string; host: string; port: number; enabled: boolean }>;
-  httpEndpoints: Array<{ name: string; url: string; expectedStatus: number; enabled: boolean }>;
-  runPerformance: boolean;
-  runSpeedtest: boolean;
-  runIperf: boolean;
-  runDiscovery: boolean;
-  speedtest: { serverId: string; autoRunOnLink: boolean };
-  iperf: { autoRunOnLink: boolean | undefined };
-}
-
-const normalizeTestsSettingsForSave = (settings: TestsSettings): NormalizedTestsSettings => {
-  const dnsHostname = settings.dnsHostname?.trim() || 'google.com';
-
-  const dnsServers = (settings.dnsServers || [])
-    .map((server) => ({
-      address: server.address.trim(),
-      enabled: server.enabled !== false,
-    }))
-    .filter((server) => server.address.length > 0);
-
-  const pingTargets = (settings.pingTargets || [])
-    .map((target) => ({
-      name: target.name?.trim() || target.host.trim(),
-      host: target.host.trim(),
-      enabled: target.enabled !== false,
-    }))
-    .filter((target) => target.host.length > 0);
-
-  const tcpPorts = (settings.tcpPorts || [])
-    .map((port) => ({
-      name: port.name?.trim() || port.host.trim(),
-      host: port.host.trim(),
-      port: typeof port.port === 'number' ? port.port : Number.parseInt(String(port.port), 10) || 0,
-      enabled: port.enabled !== false,
-    }))
-    .filter((port) => port.host.length > 0 && port.port > 0);
-
-  const udpPorts = (settings.udpPorts || [])
-    .map((port) => ({
-      name: port.name?.trim() || port.host.trim(),
-      host: port.host.trim(),
-      port: typeof port.port === 'number' ? port.port : Number.parseInt(String(port.port), 10) || 0,
-      enabled: port.enabled !== false,
-    }))
-    .filter((port) => port.host.length > 0 && port.port > 0);
-
-  const httpEndpoints = (settings.httpEndpoints || [])
-    .map((endpoint) => ({
-      name: endpoint.name?.trim() || endpoint.url.trim(),
-      url: endpoint.url.trim(),
-      expectedStatus:
-        typeof endpoint.expectedStatus === 'number' && endpoint.expectedStatus > 0
-          ? endpoint.expectedStatus
-          : 200,
-      enabled: endpoint.enabled !== false,
-    }))
-    .filter((endpoint) => endpoint.url.length > 0);
-
-  return {
-    dnsHostname,
-    dnsServers,
-    pingTargets,
-    tcpPorts,
-    udpPorts,
-    httpEndpoints,
-    runPerformance: settings.runPerformance !== false,
-    runSpeedtest: settings.runSpeedtest !== false,
-    runIperf: settings.runIperf !== false,
-    runDiscovery: settings.runDiscovery !== false,
-    speedtest: {
-      serverId: settings.speedtest?.serverId?.trim() || '',
-      autoRunOnLink: !!settings.speedtest?.autoRunOnLink,
-    },
-    iperf: {
-      autoRunOnLink: !!settings.iperf?.autoRunOnLink,
-    },
-  };
-};
 
 interface SettingsDrawerProps {
   isOpen: boolean;

--- a/ui/src/components/settings/SettingsDrawerFooter.tsx
+++ b/ui/src/components/settings/SettingsDrawerFooter.tsx
@@ -1,0 +1,121 @@
+/**
+ * SettingsDrawer footer: Logs (debug) viewer, Export download link,
+ * About blurb. Pulled out so SettingsDrawer.tsx can shrink.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { button, cn, icon as iconTokens, radius, spacing } from '../../styles/theme';
+
+const API_BASE: string = import.meta.env.VITE_API_BASE || '';
+
+interface SettingsDrawerFooterProps {
+  version: string;
+  fetchLogPreview: () => Promise<void> | void;
+  logLoading: boolean;
+  logError: string | null;
+  logPreview: string[];
+}
+
+export function SettingsDrawerFooter({
+  version,
+  fetchLogPreview,
+  logLoading,
+  logError,
+  logPreview,
+}: SettingsDrawerFooterProps): JSX.Element {
+  const { t } = useTranslation('settings');
+
+  return (
+    <>
+      {/* Logs (debug) */}
+      <section class={cn(spacing.padding.top.section, 'border-t border-surface-border')}>
+        <div class="flex items-start justify-between">
+          <div>
+            <h3 class="body-small font-medium text-text-muted">{t('logs.title')}</h3>
+            <p class="caption text-text-muted">{t('logs.description')}</p>
+          </div>
+          <button
+            type="button"
+            onClick={fetchLogPreview}
+            class={cn(
+              'caption',
+              spacing.chip.sm,
+              'border border-surface-border',
+              radius.md,
+              'text-text-muted hover:text-text-primary hover:border-text-muted transition-colors',
+            )}
+          >
+            {logLoading ? t('logs.loading') : t('logs.view')}
+          </button>
+        </div>
+        {logError ? (
+          <p class={cn('caption text-status-error', spacing.margin.top.inline)}>{logError}</p>
+        ) : null}
+        {!logError && logPreview.length > 0 ? (
+          <pre
+            class={cn(
+              spacing.margin.top.inline,
+              'max-h-48 overflow-y-auto text-2xs leading-5 bg-surface-base border border-surface-border',
+              radius.md,
+              spacing.chip.lg,
+              'text-text-primary whitespace-pre-wrap',
+            )}
+          >
+            {logPreview.join('\n')}
+          </pre>
+        ) : null}
+      </section>
+
+      {/* Export Section */}
+      <section class={cn(spacing.padding.top.section, 'border-t border-surface-border')}>
+        <h3 class={cn('body-small font-medium text-text-muted', spacing.margin.bottom.heading)}>
+          {t('export.title')}
+        </h3>
+        <a
+          href={`${API_BASE}/api/harvest/export`}
+          download="seed-export.json"
+          class={cn(
+            'w-full',
+            button.size.md,
+            'bg-surface-base border border-surface-border text-text-primary',
+            radius.md,
+            'font-medium hover:bg-surface-hover transition-colors flex items-center justify-center',
+            spacing.gap.compact,
+            'touch-manipulation',
+          )}
+        >
+          <svg
+            class={iconTokens.size.sm}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+            />
+          </svg>
+          {t('export.download')}
+        </a>
+        <p class={cn('caption text-text-muted', spacing.margin.top.inline)}>
+          {t('export.description')}
+        </p>
+      </section>
+
+      {/* About Section */}
+      <section class={cn(spacing.padding.top.section, 'border-t border-surface-border')}>
+        <h3 class={cn('body-small font-medium text-text-muted', spacing.margin.bottom.inline)}>
+          {t('about.title')}
+        </h3>
+        <p class="caption text-text-muted">
+          {t('about.appName')} {version}
+          <br />
+          {t('about.description')}
+        </p>
+      </section>
+    </>
+  );
+}

--- a/ui/src/components/settings/SettingsDrawerNetworkSection.tsx
+++ b/ui/src/components/settings/SettingsDrawerNetworkSection.tsx
@@ -1,0 +1,303 @@
+/**
+ * Network configuration sub-section of SettingsDrawer.
+ *
+ * Contains the IP mode toggle (DHCP/static), static IP fields, the
+ * apply button + status message, the public-IP display toggle, and
+ * the VLAN/MTU controls. Pulled out of SettingsDrawer so the main
+ * file stays manageable.
+ */
+
+import type React from 'react';
+import { useTranslation } from 'react-i18next';
+import { button, cn, icon as iconTokens, radius, spacing } from '../../styles/theme';
+import type { DisplayOptions, IpSettings, SaveStatus } from '../../types/settings';
+import { CollapsibleSection } from '../ui/CollapsibleSection';
+import { Network } from '../ui/icons';
+import { AutoSaveIndicator } from './sections/AutoSaveIndicator';
+import { MtuControl } from './sections/MtuControl';
+import { VlanControl } from './sections/VlanControl';
+
+interface SettingsDrawerNetworkSectionProps {
+  ipSettings: IpSettings;
+  setIpSettings: React.Dispatch<React.SetStateAction<IpSettings>>;
+  dnsInput: string;
+  setDnsInput: React.Dispatch<React.SetStateAction<string>>;
+  saveIpSettings: () => Promise<void>;
+  savingIp: boolean;
+  ipMessage: string;
+  displayOptions: DisplayOptions;
+  setDisplayOptions: React.Dispatch<React.SetStateAction<DisplayOptions>>;
+  displayStatus: SaveStatus;
+  isValidIp: (ip: string) => boolean;
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Renders five sub-blocks (mode toggle, static fields, apply, display options, VLAN/MTU); mirrors original inline structure
+export function SettingsDrawerNetworkSection({
+  ipSettings,
+  setIpSettings,
+  dnsInput,
+  setDnsInput,
+  saveIpSettings,
+  savingIp,
+  ipMessage,
+  displayOptions,
+  setDisplayOptions,
+  displayStatus,
+  isValidIp,
+}: SettingsDrawerNetworkSectionProps): JSX.Element {
+  const { t } = useTranslation('settings');
+
+  return (
+    <CollapsibleSection
+      title={
+        <div class={cn('flex items-center', spacing.gap.compact)}>
+          <Network class={iconTokens.size.sm} />
+          <span>{t('sections.network')}</span>
+        </div>
+      }
+    >
+      {/* Network Configuration */}
+      <div class="stack">
+        <p class="section-title">{t('network.title')}</p>
+        {/* Mode Toggle */}
+        <div class={cn('grid grid-cols-2', spacing.gap.compact)}>
+          <button
+            type="button"
+            onClick={(): void => setIpSettings((prev) => ({ ...prev, mode: 'dhcp' }))}
+            class={cn(
+              spacing.tab,
+              radius.md,
+              'body-small font-medium transition-colors',
+              ipSettings.mode === 'dhcp'
+                ? 'bg-brand-primary text-text-inverse'
+                : 'bg-surface-base border border-surface-border text-text-primary hover:bg-surface-hover',
+            )}
+          >
+            {t('network.dhcp')}
+          </button>
+          <button
+            type="button"
+            onClick={(): void => setIpSettings((prev) => ({ ...prev, mode: 'static' }))}
+            class={cn(
+              spacing.tab,
+              radius.md,
+              'body-small font-medium transition-colors',
+              ipSettings.mode === 'static'
+                ? 'bg-brand-primary text-text-inverse'
+                : 'bg-surface-base border border-surface-border text-text-primary hover:bg-surface-hover',
+            )}
+          >
+            {t('network.static')}
+          </button>
+        </div>
+
+        {/* Static IP Fields */}
+        {ipSettings.mode === 'static' && (
+          <div class={cn('stack', spacing.padding.top.heading, 'border-t border-surface-border')}>
+            <div>
+              <label for="static-ip-address" class="caption font-medium">
+                {t('network.ipAddress')} *
+              </label>
+              <input
+                id="static-ip-address"
+                type="text"
+                value={ipSettings.address}
+                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
+                  setIpSettings((prev) => ({
+                    ...prev,
+                    address: e.target.value,
+                  }))
+                }
+                placeholder="192.168.1.100"
+                class={cn(
+                  'w-full',
+                  spacing.margin.top.tight,
+                  spacing.chip.sm,
+                  'bg-surface-base border',
+                  radius.md,
+                  'body-small text-text-primary',
+                  ipSettings.address && !isValidIp(ipSettings.address)
+                    ? 'border-status-error'
+                    : 'border-surface-border',
+                )}
+              />
+            </div>
+            <div>
+              <label for="static-subnet-mask" class="caption font-medium">
+                {t('network.subnetMask')} *
+              </label>
+              <input
+                id="static-subnet-mask"
+                type="text"
+                value={ipSettings.netmask}
+                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
+                  setIpSettings((prev) => ({
+                    ...prev,
+                    netmask: e.target.value,
+                  }))
+                }
+                placeholder="24 or 255.255.255.0"
+                class={cn(
+                  'w-full',
+                  spacing.margin.top.tight,
+                  spacing.chip.lg,
+                  'bg-surface-base border border-surface-border',
+                  radius.md,
+                  'body-small text-text-primary',
+                )}
+              />
+            </div>
+            <div>
+              <label for="static-gateway" class="caption font-medium">
+                {t('network.gateway')}
+              </label>
+              <input
+                id="static-gateway"
+                type="text"
+                value={ipSettings.gateway}
+                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
+                  setIpSettings((prev) => ({
+                    ...prev,
+                    gateway: e.target.value,
+                  }))
+                }
+                placeholder="192.168.1.1"
+                class={cn(
+                  'w-full',
+                  spacing.margin.top.tight,
+                  spacing.chip.sm,
+                  'bg-surface-base border',
+                  radius.md,
+                  'body-small text-text-primary',
+                  ipSettings.gateway && !isValidIp(ipSettings.gateway)
+                    ? 'border-status-error'
+                    : 'border-surface-border',
+                )}
+              />
+            </div>
+            <div>
+              <label for="static-dns-servers" class="caption font-medium">
+                {t('network.dnsServers')}
+              </label>
+              <input
+                id="static-dns-servers"
+                type="text"
+                value={dnsInput}
+                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
+                  setDnsInput(e.target.value)
+                }
+                placeholder="8.8.8.8, 8.8.4.4"
+                class={cn(
+                  'w-full',
+                  spacing.margin.top.tight,
+                  spacing.chip.lg,
+                  'bg-surface-base border border-surface-border',
+                  radius.md,
+                  'body-small text-text-primary',
+                )}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Apply Button */}
+        <button
+          type="button"
+          onClick={saveIpSettings}
+          disabled={savingIp || (ipSettings.mode === 'static' && !ipSettings.address)}
+          class={cn(
+            'w-full',
+            button.size.md,
+            'bg-brand-primary text-text-inverse',
+            radius.md,
+            'font-medium hover:bg-brand-accent disabled:opacity-50 transition-colors',
+          )}
+        >
+          {savingIp ? t('network.applying') : t('network.applyIpSettings')}
+        </button>
+
+        {ipMessage ? (
+          <p
+            class={cn(
+              'caption text-center',
+              ipMessage.includes('Failed') || ipMessage.includes('Error')
+                ? 'text-status-error'
+                : 'text-status-success',
+            )}
+          >
+            {ipMessage}
+          </p>
+        ) : null}
+
+        <p class="caption">{t('network.requiresRoot')}</p>
+      </div>
+
+      {/* Display Options */}
+      <div
+        class={cn(
+          'border-t border-surface-border',
+          spacing.padding.top.heading,
+          spacing.margin.top.heading,
+        )}
+      >
+        <p class={cn('caption font-medium', spacing.margin.bottom.inline)}>
+          {t('network.displayOptions')} <AutoSaveIndicator status={displayStatus} />
+        </p>
+        <div class="stack-sm">
+          {/* Show Public IP */}
+          <label
+            class={cn(
+              'flex items-center justify-between',
+              spacing.pad.xs,
+              'bg-surface-base',
+              radius.md,
+              'border border-surface-border',
+            )}
+          >
+            <div>
+              <span class="body-small text-text-primary font-medium">
+                {t('network.showPublicIp')}
+              </span>
+              <p class="caption text-text-muted">{t('network.displayInNetworkCard')}</p>
+            </div>
+            <input
+              type="checkbox"
+              checked={displayOptions.showPublicIp}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>): void =>
+                setDisplayOptions((prev) => ({
+                  ...prev,
+                  showPublicIp: e.target.checked,
+                }))
+              }
+              class={iconTokens.size.sm}
+            />
+          </label>
+        </div>
+      </div>
+
+      {/* VLAN Configuration */}
+      <div
+        class={cn(
+          'border-t border-surface-border',
+          spacing.padding.top.heading,
+          spacing.margin.top.heading,
+        )}
+      >
+        <p class={cn('section-title', spacing.margin.bottom.inline)}>{t('network.vlanTag')}</p>
+        <VlanControl />
+      </div>
+
+      {/* MTU Configuration */}
+      <div
+        class={cn(
+          'border-t border-surface-border',
+          spacing.padding.top.heading,
+          spacing.margin.top.heading,
+        )}
+      >
+        <p class={cn('section-title', spacing.margin.bottom.inline)}>{t('network.mtuSetting')}</p>
+        <MtuControl />
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/ui/src/components/settings/settingsDrawerNormalizer.ts
+++ b/ui/src/components/settings/settingsDrawerNormalizer.ts
@@ -1,0 +1,122 @@
+/**
+ * Default-config constants and payload normaliser used by SettingsDrawer.
+ *
+ * Pulled out so the drawer file isn't carrying ~110 lines of pure data
+ * shape before its component definition.
+ */
+
+import type {
+  CableTestSettings as CableTestSettingsType,
+  LinkSettings as LinkSettingsType,
+  TestsSettings,
+  VulnerabilityScanSettings,
+} from '../../types/settings';
+import { generateId } from '../../utils/id';
+
+export const INLINE_DEFAULT_LINK_SETTINGS: LinkSettingsType = {
+  mode: 'auto',
+  availableModes: [],
+};
+
+export const INLINE_DEFAULT_CABLE_TEST_SETTINGS: CableTestSettingsType = {
+  enabled: true,
+};
+
+export const INLINE_DEFAULT_VULNERABILITY_SETTINGS: VulnerabilityScanSettings = {
+  enabled: true,
+  cveDatabase: 'nvd',
+  nvdApiKey: '',
+  updateInterval: 86400,
+  severityThreshold: 'medium',
+  maxConcurrent: 5,
+  autoScan: true,
+};
+
+// Utility: ensure every item in an array has a stable id for React keying/updating.
+export const withIds = <T extends { id?: string }>(items: T[] = []): Array<T & { id: string }> =>
+  items.map((item) => ({ ...item, id: item.id ?? generateId() }));
+
+// Normalize tests/DNS settings payload before sending to the API.
+export interface NormalizedTestsSettings {
+  dnsHostname: string;
+  dnsServers: Array<{ address: string; enabled: boolean }>;
+  pingTargets: Array<{ name: string; host: string; enabled: boolean }>;
+  tcpPorts: Array<{ name: string; host: string; port: number; enabled: boolean }>;
+  udpPorts: Array<{ name: string; host: string; port: number; enabled: boolean }>;
+  httpEndpoints: Array<{ name: string; url: string; expectedStatus: number; enabled: boolean }>;
+  runPerformance: boolean;
+  runSpeedtest: boolean;
+  runIperf: boolean;
+  runDiscovery: boolean;
+  speedtest: { serverId: string; autoRunOnLink: boolean };
+  iperf: { autoRunOnLink: boolean | undefined };
+}
+
+export const normalizeTestsSettingsForSave = (settings: TestsSettings): NormalizedTestsSettings => {
+  const dnsHostname = settings.dnsHostname?.trim() || 'google.com';
+
+  const dnsServers = (settings.dnsServers || [])
+    .map((server) => ({
+      address: server.address.trim(),
+      enabled: server.enabled !== false,
+    }))
+    .filter((server) => server.address.length > 0);
+
+  const pingTargets = (settings.pingTargets || [])
+    .map((target) => ({
+      name: target.name?.trim() || target.host.trim(),
+      host: target.host.trim(),
+      enabled: target.enabled !== false,
+    }))
+    .filter((target) => target.host.length > 0);
+
+  const tcpPorts = (settings.tcpPorts || [])
+    .map((port) => ({
+      name: port.name?.trim() || port.host.trim(),
+      host: port.host.trim(),
+      port: typeof port.port === 'number' ? port.port : Number.parseInt(String(port.port), 10) || 0,
+      enabled: port.enabled !== false,
+    }))
+    .filter((port) => port.host.length > 0 && port.port > 0);
+
+  const udpPorts = (settings.udpPorts || [])
+    .map((port) => ({
+      name: port.name?.trim() || port.host.trim(),
+      host: port.host.trim(),
+      port: typeof port.port === 'number' ? port.port : Number.parseInt(String(port.port), 10) || 0,
+      enabled: port.enabled !== false,
+    }))
+    .filter((port) => port.host.length > 0 && port.port > 0);
+
+  const httpEndpoints = (settings.httpEndpoints || [])
+    .map((endpoint) => ({
+      name: endpoint.name?.trim() || endpoint.url.trim(),
+      url: endpoint.url.trim(),
+      expectedStatus:
+        typeof endpoint.expectedStatus === 'number' && endpoint.expectedStatus > 0
+          ? endpoint.expectedStatus
+          : 200,
+      enabled: endpoint.enabled !== false,
+    }))
+    .filter((endpoint) => endpoint.url.length > 0);
+
+  return {
+    dnsHostname,
+    dnsServers,
+    pingTargets,
+    tcpPorts,
+    udpPorts,
+    httpEndpoints,
+    runPerformance: settings.runPerformance !== false,
+    runSpeedtest: settings.runSpeedtest !== false,
+    runIperf: settings.runIperf !== false,
+    runDiscovery: settings.runDiscovery !== false,
+    speedtest: {
+      serverId: settings.speedtest?.serverId?.trim() || '',
+      autoRunOnLink: !!settings.speedtest?.autoRunOnLink,
+    },
+    iperf: {
+      autoRunOnLink: !!settings.iperf?.autoRunOnLink,
+    },
+  };
+};

--- a/ui/src/hooks/useDebouncedAutoSave.ts
+++ b/ui/src/hooks/useDebouncedAutoSave.ts
@@ -1,0 +1,38 @@
+/**
+ * useDebouncedAutoSave
+ *
+ * Debounces a save callback by `delay` ms. Skips the very first invocation
+ * (controlled by `isInit`) so opening the drawer doesn't trigger a save
+ * before the fetched values have been seeded. Cleans up the timer on
+ * re-render and unmount.
+ */
+
+import type React from 'react';
+import { useEffect } from 'react';
+
+export function useDebouncedAutoSave(
+  saveFn: () => Promise<void> | void,
+  isInit: React.MutableRefObject<boolean>,
+  timerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>,
+  delay = 800,
+): void {
+  useEffect(() => {
+    if (isInit.current) {
+      return;
+    }
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => {
+      const result = saveFn();
+      if (result && typeof (result as Promise<void>).catch === 'function') {
+        (result as Promise<void>).catch(() => undefined);
+      }
+    }, delay);
+    return (): void => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [saveFn, isInit, timerRef, delay]);
+}

--- a/ui/src/hooks/useSettingsDrawerLoaders.ts
+++ b/ui/src/hooks/useSettingsDrawerLoaders.ts
@@ -1,0 +1,406 @@
+/**
+ * useSettingsDrawerLoaders
+ *
+ * Bundles every per-section fetch callback that SettingsDrawer used to
+ * declare inline (thresholds, IP, tests, iperf suggestions, wifi,
+ * network-discovery, snmp, link, cable, logs) and the open-time
+ * initial-load useEffect that fires them. The drawer passes in the
+ * relevant state setters and init refs; the hook owns the network
+ * calls and the on-open orchestration.
+ */
+
+import type React from 'react';
+import { useCallback, useEffect } from 'react';
+import { withIds } from '../components/settings/settingsDrawerNormalizer';
+import { LogComponents, logger } from '../lib/logger';
+import type {
+  CableTestSettings as CableTestSettingsType,
+  IperfSuggestion,
+  IpSettings,
+  LinkSettings as LinkSettingsType,
+  LogsResponse,
+  NetworkDiscoverySettings,
+  SettingsThresholds,
+  SnmpSettings as SnmpSettingsType,
+  TestsSettings,
+  WiFiSettings as WiFiSettingsType,
+} from '../types/settings';
+
+const API_BASE: string = import.meta.env.VITE_API_BASE || '';
+
+interface InitRefs {
+  initialLoadRef: React.MutableRefObject<boolean>;
+  thresholdsInitRef: React.MutableRefObject<boolean>;
+  testsInitRef: React.MutableRefObject<boolean>;
+  wifiInitRef: React.MutableRefObject<boolean>;
+  linkInitRef: React.MutableRefObject<boolean>;
+  cableTestInitRef: React.MutableRefObject<boolean>;
+  networkDiscoveryInitRef: React.MutableRefObject<boolean>;
+  snmpInitRef: React.MutableRefObject<boolean>;
+  vulnInitRef: React.MutableRefObject<boolean>;
+}
+
+interface UseSettingsDrawerLoadersArgs {
+  isOpen: boolean;
+  initRefs: InitRefs;
+  setThresholds: React.Dispatch<React.SetStateAction<SettingsThresholds>>;
+  setIpSettings: (s: IpSettings) => void;
+  setDnsInput: (value: string) => void;
+  setTestsSettings: (s: TestsSettings) => void;
+  setIperfSuggestions: (list: IperfSuggestion[]) => void;
+  setIperfSuggestionsStatus: (status: 'idle' | 'loading' | 'error') => void;
+  setIperfSuggestionsError: (msg: string | null) => void;
+  setWifiSettings: (s: WiFiSettingsType) => void;
+  setNetworkDiscoverySettings: (s: NetworkDiscoverySettings) => void;
+  setSnmpSettings: (s: SnmpSettingsType) => void;
+  setLinkSettings: (s: LinkSettingsType) => void;
+  setCableTestSettings: (s: CableTestSettingsType) => void;
+  setLogPreview: (lines: string[]) => void;
+  setLogLoading: (loading: boolean) => void;
+  setLogError: (msg: string | null) => void;
+  fetchSubnets: () => Promise<void>;
+  fetchVulnSettings: () => Promise<void>;
+}
+
+interface UseSettingsDrawerLoadersResult {
+  fetchIperfSuggestions: () => Promise<void>;
+  fetchLogPreview: () => Promise<void>;
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Aggregates ten per-section fetch callbacks and the open-time orchestration that previously lived inline in SettingsDrawer
+export function useSettingsDrawerLoaders({
+  isOpen,
+  initRefs,
+  setThresholds,
+  setIpSettings,
+  setDnsInput,
+  setTestsSettings,
+  setIperfSuggestions,
+  setIperfSuggestionsStatus,
+  setIperfSuggestionsError,
+  setWifiSettings,
+  setNetworkDiscoverySettings,
+  setSnmpSettings,
+  setLinkSettings,
+  setCableTestSettings,
+  setLogPreview,
+  setLogLoading,
+  setLogError,
+  fetchSubnets,
+  fetchVulnSettings,
+}: UseSettingsDrawerLoadersArgs): UseSettingsDrawerLoadersResult {
+  const fetchThresholds = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE}/api/settings`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await (response.json() as Promise<Record<string, unknown>>);
+        if (data.thresholds) {
+          setThresholds((prev) => ({ ...prev, ...data.thresholds }));
+        }
+      }
+    } catch (err) {
+      logger.error(LogComponents.CONFIG, 'Failed to fetch thresholds', err);
+    }
+  }, [setThresholds]);
+
+  const fetchIpSettings = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE}/api/ipconfig/settings`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await (response.json() as Promise<Record<string, unknown>>);
+        setIpSettings({
+          mode: data.mode || 'dhcp',
+          address: data.address || '',
+          netmask: data.netmask || '24',
+          gateway: data.gateway || '',
+          dns: data.dns || [],
+        });
+        setDnsInput((data.dns || []).join(', '));
+      }
+    } catch (err) {
+      logger.error(LogComponents.CONFIG, 'Failed to fetch IP settings', err);
+    }
+  }, [setIpSettings, setDnsInput]);
+
+  const fetchTestsSettings = useCallback(
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Reads many optional fields off the API payload; same shape as the original inline code
+    async () => {
+      try {
+        const response = await fetch(`${API_BASE}/api/health-checks/settings`, {
+          credentials: 'include',
+        });
+        if (response.ok) {
+          const data = await (response.json() as Promise<Record<string, unknown>>);
+          setTestsSettings({
+            dnsHostname: data.dnsHostname || 'google.com',
+            dnsServers: withIds(data.dnsServers || []).map((server) => ({
+              ...server,
+              enabled: server.enabled !== false,
+            })),
+            pingTargets: withIds(data.pingTargets || []).map((target) => ({
+              ...target,
+              enabled: target.enabled !== false,
+            })),
+            tcpPorts: withIds(data.tcpPorts || []).map((port) => ({
+              ...port,
+              port: port.port || 80,
+              enabled: port.enabled !== false,
+            })),
+            udpPorts: withIds(data.udpPorts || []).map((port) => ({
+              ...port,
+              port: port.port || 53,
+              enabled: port.enabled !== false,
+            })),
+            httpEndpoints: withIds(data.httpEndpoints || []).map((endpoint) => ({
+              ...endpoint,
+              expectedStatus: endpoint.expectedStatus || 200,
+              enabled: endpoint.enabled !== false,
+            })),
+            runPerformance: data.runPerformance ?? true,
+            runSpeedtest: data.runSpeedtest ?? true,
+            runIperf: data.runIperf ?? true,
+            runDiscovery: data.runDiscovery ?? true,
+            speedtest: {
+              serverId: data.speedtest?.serverId || '',
+              autoRunOnLink: data.speedtest?.autoRunOnLink ?? true,
+            },
+            iperf: {
+              autoRunOnLink: data.iperf?.autoRunOnLink,
+            },
+          });
+        }
+      } catch (err) {
+        logger.error(LogComponents.CONFIG, 'Failed to fetch tests settings', err);
+      }
+    },
+    [setTestsSettings],
+  );
+
+  const fetchIperfSuggestions = useCallback(async () => {
+    setIperfSuggestionsStatus('loading');
+    setIperfSuggestionsError(null);
+    try {
+      const response = await fetch(`${API_BASE}/api/sap/iperf/suggestions`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await (response.json() as Promise<Record<string, unknown>>);
+        setIperfSuggestions(Array.isArray(data) ? data : []);
+        setIperfSuggestionsStatus('idle');
+      } else {
+        setIperfSuggestionsStatus('error');
+        setIperfSuggestionsError('No iperf hosts found');
+      }
+    } catch (err) {
+      setIperfSuggestionsStatus('error');
+      setIperfSuggestionsError(err instanceof Error ? err.message : 'Failed to find iperf hosts');
+    }
+  }, [setIperfSuggestions, setIperfSuggestionsStatus, setIperfSuggestionsError]);
+
+  const fetchWifiSettings = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE}/api/canopy/wifi/settings`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await (response.json() as Promise<Record<string, unknown>>);
+        setWifiSettings({
+          interface: data.interface || '',
+          availableWifi: data.availableWifi || [],
+          isWireless: data.isWireless,
+        });
+      }
+    } catch (err) {
+      logger.error(LogComponents.Wifi, 'Failed to fetch WiFi settings', err);
+    }
+  }, [setWifiSettings]);
+
+  const fetchNetworkDiscoverySettings = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE}/api/v1/shell/devices/settings`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await (response.json() as Promise<Record<string, unknown>>);
+        setNetworkDiscoverySettings({
+          enabled: data.enabled ?? true,
+          arpScanWorkers: data.arpScanWorkers ?? 50,
+          pingTimeoutMs: data.pingTimeoutMs ?? 500,
+          scanTimeoutMs: data.scanTimeoutMs ?? 30000,
+          autoScan: data.autoScan ?? false,
+          scanIntervalMs: data.scanIntervalMs ?? 0,
+          ipv6Enabled: data.ipv6Enabled ?? true,
+          options: data.options ?? {
+            passiveProtocols: { lldp: true, cdp: true, edp: true, ndp: true },
+            arpScan: true,
+            icmpScan: true,
+            portScan: {
+              enabled: false,
+              preset: 'common',
+              tcpPorts: '22,80,443,8080-8100',
+              udpPorts: '53,123,161',
+              bannerTimeoutMs: 2000,
+            },
+            tcpProbe: { timeoutMs: 2000, workers: 20 },
+            traceroute: false,
+            snmpQuery: false,
+          },
+          timing: data.timing ?? {
+            probeIntervalMs: 75,
+            rescanIntervalMs: 600000,
+            workers: 50,
+          },
+          profiler: data.profiler ?? {
+            enabled: true,
+            timeoutMs: 2000,
+            maxConcurrent: 5,
+            quickPorts: [22, 80, 443, 8080],
+          },
+          fingerprinting: data.fingerprinting ?? {
+            enabled: false,
+            osDetection: false,
+            serviceProbes: false,
+          },
+        });
+      }
+    } catch (err) {
+      logger.error(LogComponents.Discovery, 'Failed to fetch network discovery settings', err);
+    }
+  }, [setNetworkDiscoverySettings]);
+
+  const fetchSnmpSettings = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE}/api/sap/snmp/settings`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await (response.json() as Promise<Record<string, unknown>>);
+        setSnmpSettings({
+          communities: data.communities ?? ['public'],
+          v3Credentials: data.v3Credentials ?? [],
+          timeout: data.timeout ?? 5000,
+          retries: data.retries ?? 2,
+          port: data.port ?? 161,
+        });
+      }
+    } catch (err) {
+      logger.error(LogComponents.CONFIG, 'Failed to fetch SNMP settings', err);
+    }
+  }, [setSnmpSettings]);
+
+  const fetchLinkSettings = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE}/api/settings/link`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await (response.json() as Promise<Record<string, unknown>>);
+        const mode = data.mode ?? (data.auto_negotiation ? 'auto' : `${data.speed}/${data.duplex}`);
+        setLinkSettings({
+          mode: mode,
+          availableModes: data.available_modes ?? [],
+        });
+      }
+    } catch (err) {
+      logger.error(LogComponents.CONFIG, 'Failed to fetch link settings', err);
+    }
+  }, [setLinkSettings]);
+
+  const fetchCableTestSettings = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE}/api/settings/cable`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await (response.json() as Promise<Record<string, unknown>>);
+        setCableTestSettings({
+          enabled: data.enabled ?? true,
+        });
+      }
+    } catch (err) {
+      logger.error(LogComponents.CONFIG, 'Failed to fetch cable test settings', err);
+    }
+  }, [setCableTestSettings]);
+
+  const fetchLogPreview = useCallback(async () => {
+    setLogLoading(true);
+    setLogError(null);
+    try {
+      const response = await fetch(`${API_BASE}/api/harvest/logs?lines=200`, {
+        credentials: 'include',
+      });
+      if (!response.ok) {
+        throw new Error('Unable to load logs');
+      }
+      const data = await (response.json() as Promise<LogsResponse>);
+      setLogPreview(data.lines || []);
+    } catch (err) {
+      setLogPreview([]);
+      setLogError(err instanceof Error ? err.message : 'Failed to load log file');
+    } finally {
+      setLogLoading(false);
+    }
+  }, [setLogPreview, setLogLoading, setLogError]);
+
+  // Open-time orchestration: reset init refs, fire every fetch, then
+  // clear init refs after a short delay so the auto-save hooks ignore
+  // the seeded values.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    initRefs.initialLoadRef.current = true;
+    initRefs.thresholdsInitRef.current = true;
+    initRefs.testsInitRef.current = true;
+    initRefs.wifiInitRef.current = true;
+    initRefs.linkInitRef.current = true;
+    initRefs.cableTestInitRef.current = true;
+    initRefs.networkDiscoveryInitRef.current = true;
+    initRefs.snmpInitRef.current = true;
+    initRefs.vulnInitRef.current = true;
+
+    fetchThresholds().catch(() => undefined);
+    fetchIpSettings().catch(() => undefined);
+    fetchTestsSettings().catch(() => undefined);
+    fetchWifiSettings().catch(() => undefined);
+    fetchNetworkDiscoverySettings().catch(() => undefined);
+    fetchSnmpSettings().catch(() => undefined);
+    fetchVulnSettings().catch(() => undefined);
+    fetchLinkSettings().catch(() => undefined);
+    fetchCableTestSettings().catch(() => undefined);
+    fetchSubnets().catch(() => undefined);
+
+    const timer = setTimeout(() => {
+      initRefs.initialLoadRef.current = false;
+      initRefs.thresholdsInitRef.current = false;
+      initRefs.testsInitRef.current = false;
+      initRefs.wifiInitRef.current = false;
+      initRefs.linkInitRef.current = false;
+      initRefs.cableTestInitRef.current = false;
+      initRefs.networkDiscoveryInitRef.current = false;
+      initRefs.snmpInitRef.current = false;
+      initRefs.vulnInitRef.current = false;
+    }, 500);
+
+    return (): void => clearTimeout(timer);
+  }, [
+    isOpen,
+    initRefs,
+    fetchThresholds,
+    fetchIpSettings,
+    fetchTestsSettings,
+    fetchWifiSettings,
+    fetchNetworkDiscoverySettings,
+    fetchSnmpSettings,
+    fetchVulnSettings,
+    fetchLinkSettings,
+    fetchCableTestSettings,
+    fetchSubnets,
+  ]);
+
+  return { fetchIperfSuggestions, fetchLogPreview };
+}

--- a/ui/src/hooks/useSettingsDrawerSavers.ts
+++ b/ui/src/hooks/useSettingsDrawerSavers.ts
@@ -1,0 +1,225 @@
+/**
+ * useSettingsDrawerSavers
+ *
+ * Bundles the per-section save callbacks that SettingsDrawer used to
+ * declare inline (thresholds, tests, wifi, link, cable, network
+ * discovery, snmp). The drawer keeps the state and status setters and
+ * passes them in; the hook owns the network calls.
+ */
+
+import type React from 'react';
+import { useCallback } from 'react';
+import { normalizeTestsSettingsForSave } from '../components/settings/settingsDrawerNormalizer';
+import type {
+  CableTestSettings as CableTestSettingsType,
+  LinkSettings as LinkSettingsType,
+  NetworkDiscoverySettings,
+  SaveStatus,
+  SettingsThresholds,
+  SnmpSettings as SnmpSettingsType,
+  TestsSettings,
+  WiFiSettings as WiFiSettingsType,
+} from '../types/settings';
+
+const API_BASE: string = import.meta.env.VITE_API_BASE || '';
+
+interface UseSettingsDrawerSaversArgs {
+  thresholds: SettingsThresholds;
+  setThresholdsStatus: (status: SaveStatus) => void;
+  testsSettings: TestsSettings;
+  setTestsStatus: (status: SaveStatus) => void;
+  testsSettingsChangedRef: React.MutableRefObject<boolean>;
+  wifiSettings: WiFiSettingsType;
+  setWifiStatus: (status: SaveStatus) => void;
+  linkSettings: LinkSettingsType;
+  setLinkStatus: (status: SaveStatus) => void;
+  cableTestSettings: CableTestSettingsType;
+  setCableTestStatus: (status: SaveStatus) => void;
+  networkDiscoverySettings: NetworkDiscoverySettings;
+  setNetworkDiscoveryStatus: (status: SaveStatus) => void;
+  snmpSettings: SnmpSettingsType;
+  setSnmpStatus: (status: SaveStatus) => void;
+}
+
+interface UseSettingsDrawerSaversResult {
+  saveThresholds: () => Promise<void>;
+  saveTestsSettings: () => Promise<void>;
+  saveWifiSettings: () => Promise<void>;
+  saveLinkSettings: () => Promise<void>;
+  saveCableTestSettings: () => Promise<void>;
+  saveNetworkDiscoverySettings: () => Promise<void>;
+  saveSnmpSettings: () => Promise<void>;
+}
+
+export function useSettingsDrawerSavers({
+  thresholds,
+  setThresholdsStatus,
+  testsSettings,
+  setTestsStatus,
+  testsSettingsChangedRef,
+  wifiSettings,
+  setWifiStatus,
+  linkSettings,
+  setLinkStatus,
+  cableTestSettings,
+  setCableTestStatus,
+  networkDiscoverySettings,
+  setNetworkDiscoveryStatus,
+  snmpSettings,
+  setSnmpStatus,
+}: UseSettingsDrawerSaversArgs): UseSettingsDrawerSaversResult {
+  const saveThresholds = useCallback(async () => {
+    setThresholdsStatus('saving');
+    try {
+      const response = await fetch(`${API_BASE}/api/settings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ thresholds }),
+      });
+      if (response.ok) {
+        setThresholdsStatus('saved');
+        setTimeout(() => setThresholdsStatus('idle'), 2000);
+      } else {
+        setThresholdsStatus('error');
+      }
+    } catch {
+      setThresholdsStatus('error');
+    }
+  }, [thresholds, setThresholdsStatus]);
+
+  const saveTestsSettings = useCallback(async () => {
+    setTestsStatus('saving');
+    try {
+      const payload = normalizeTestsSettingsForSave(testsSettings);
+      const response = await fetch(`${API_BASE}/api/health-checks/settings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+      });
+      if (response.ok) {
+        setTestsStatus('saved');
+        setTimeout(() => setTestsStatus('idle'), 2000);
+        testsSettingsChangedRef.current = true;
+      } else {
+        setTestsStatus('error');
+      }
+    } catch {
+      setTestsStatus('error');
+    }
+  }, [testsSettings, setTestsStatus, testsSettingsChangedRef]);
+
+  const saveWifiSettings = useCallback(async () => {
+    setWifiStatus('saving');
+    try {
+      const response = await fetch(`${API_BASE}/api/canopy/wifi/settings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ interface: wifiSettings.interface }),
+      });
+      if (response.ok) {
+        setWifiStatus('saved');
+        setTimeout(() => setWifiStatus('idle'), 2000);
+      } else {
+        setWifiStatus('error');
+      }
+    } catch {
+      setWifiStatus('error');
+    }
+  }, [wifiSettings.interface, setWifiStatus]);
+
+  const saveLinkSettings = useCallback(async () => {
+    setLinkStatus('saving');
+    try {
+      const response = await fetch(`${API_BASE}/api/settings/link`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          mode: linkSettings.mode,
+          availableModes: linkSettings.availableModes,
+        }),
+      });
+      if (response.ok) {
+        setLinkStatus('saved');
+        setTimeout(() => setLinkStatus('idle'), 2000);
+      } else {
+        setLinkStatus('error');
+      }
+    } catch {
+      setLinkStatus('error');
+    }
+  }, [linkSettings, setLinkStatus]);
+
+  const saveCableTestSettings = useCallback(async () => {
+    setCableTestStatus('saving');
+    try {
+      const response = await fetch(`${API_BASE}/api/settings/cable`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ enabled: cableTestSettings.enabled }),
+      });
+      if (response.ok) {
+        setCableTestStatus('saved');
+        setTimeout(() => setCableTestStatus('idle'), 2000);
+      } else {
+        setCableTestStatus('error');
+      }
+    } catch {
+      setCableTestStatus('error');
+    }
+  }, [cableTestSettings, setCableTestStatus]);
+
+  const saveNetworkDiscoverySettings = useCallback(async () => {
+    setNetworkDiscoveryStatus('saving');
+    try {
+      const response = await fetch(`${API_BASE}/api/v1/shell/devices/settings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(networkDiscoverySettings),
+      });
+      if (response.ok) {
+        setNetworkDiscoveryStatus('saved');
+        setTimeout(() => setNetworkDiscoveryStatus('idle'), 2000);
+      } else {
+        setNetworkDiscoveryStatus('error');
+      }
+    } catch {
+      setNetworkDiscoveryStatus('error');
+    }
+  }, [networkDiscoverySettings, setNetworkDiscoveryStatus]);
+
+  const saveSnmpSettings = useCallback(async () => {
+    setSnmpStatus('saving');
+    try {
+      const response = await fetch(`${API_BASE}/api/sap/snmp/settings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(snmpSettings),
+      });
+      if (response.ok) {
+        setSnmpStatus('saved');
+        setTimeout(() => setSnmpStatus('idle'), 2000);
+      } else {
+        setSnmpStatus('error');
+      }
+    } catch {
+      setSnmpStatus('error');
+    }
+  }, [snmpSettings, setSnmpStatus]);
+
+  return {
+    saveThresholds,
+    saveTestsSettings,
+    saveWifiSettings,
+    saveLinkSettings,
+    saveCableTestSettings,
+    saveNetworkDiscoverySettings,
+    saveSnmpSettings,
+  };
+}

--- a/ui/src/hooks/useSubnetSettings.ts
+++ b/ui/src/hooks/useSubnetSettings.ts
@@ -1,0 +1,173 @@
+/**
+ * useSubnetSettings
+ *
+ * Manages the list of configured network-discovery subnets on the
+ * /api/v1/shell/devices/subnets endpoint. Owns the subnet list state,
+ * the new-subnet form fields, the save-status, and the
+ * fetch/add/toggle/delete callbacks. Previously inline in
+ * SettingsDrawer.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LogComponents, logger } from '../lib/logger';
+import type { SaveStatus, SubnetConfig } from '../types/settings';
+
+const API_BASE: string = import.meta.env.VITE_API_BASE || '';
+
+interface UseSubnetSettingsResult {
+  subnets: SubnetConfig[];
+  newSubnetCidr: string;
+  setNewSubnetCidr: (value: string) => void;
+  newSubnetName: string;
+  setNewSubnetName: (value: string) => void;
+  subnetError: string | null;
+  setSubnetError: (value: string | null) => void;
+  subnetsStatus: SaveStatus;
+  fetchSubnets: () => Promise<void>;
+  addSubnet: () => Promise<void>;
+  toggleSubnet: (cidr: string, enabled: boolean) => Promise<void>;
+  deleteSubnet: (cidr: string) => Promise<void>;
+}
+
+export function useSubnetSettings(isOpen: boolean): UseSubnetSettingsResult {
+  const { t } = useTranslation('settings');
+  const [subnets, setSubnets] = useState<SubnetConfig[]>([]);
+  const [newSubnetCidr, setNewSubnetCidr] = useState('');
+  const [newSubnetName, setNewSubnetName] = useState('');
+  const [subnetError, setSubnetError] = useState<string | null>(null);
+  const [subnetsStatus, setSubnetsStatus] = useState<SaveStatus>('idle');
+
+  const fetchSubnets = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE}/api/v1/shell/devices/subnets`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await (response.json() as Promise<Record<string, unknown>>);
+        setSubnets(Array.isArray(data) ? data : []);
+      }
+    } catch (err) {
+      logger.error(LogComponents.Discovery, 'Failed to fetch subnets', err);
+    }
+  }, []);
+
+  // Fetch subnets when drawer opens
+  useEffect(() => {
+    if (isOpen) {
+      fetchSubnets().catch(() => undefined);
+    }
+  }, [isOpen, fetchSubnets]);
+
+  const addSubnet = useCallback(async (): Promise<void> => {
+    if (!newSubnetCidr.trim()) {
+      setSubnetError(t('network.cidrRequired'));
+      return;
+    }
+
+    setSubnetError(null);
+    setSubnetsStatus('saving');
+
+    try {
+      const response = await fetch(`${API_BASE}/api/v1/shell/devices/subnets`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          cidr: newSubnetCidr.trim(),
+          name: newSubnetName.trim() || newSubnetCidr.trim(),
+          enabled: true,
+        }),
+      });
+
+      if (response.ok) {
+        setNewSubnetCidr('');
+        setNewSubnetName('');
+        setSubnetsStatus('saved');
+        setTimeout(() => setSubnetsStatus('idle'), 2000);
+        await fetchSubnets();
+      } else {
+        // Handle both JSON and plain text error responses
+        const contentType = response.headers.get('content-type');
+        if (contentType?.includes('application/json')) {
+          const errorData = await (response.json() as Promise<{ error?: string }>);
+          setSubnetError(errorData.error || 'Failed to add subnet');
+        } else {
+          const errorText = await (response.text() as Promise<string>);
+          setSubnetError(errorText || 'Failed to add subnet');
+        }
+        setSubnetsStatus('error');
+      }
+    } catch (err) {
+      setSubnetError(err instanceof Error ? err.message : 'Network error adding subnet');
+      setSubnetsStatus('error');
+    }
+  }, [newSubnetCidr, newSubnetName, fetchSubnets, t]);
+
+  const toggleSubnet = useCallback(
+    async (cidr: string, enabled: boolean): Promise<void> => {
+      setSubnetsStatus('saving');
+      try {
+        const response = await fetch(`${API_BASE}/api/v1/shell/devices/subnets`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ cidr, enabled }),
+        });
+
+        if (response.ok) {
+          setSubnetsStatus('saved');
+          setTimeout(() => setSubnetsStatus('idle'), 2000);
+          await fetchSubnets();
+        } else {
+          setSubnetsStatus('error');
+        }
+      } catch {
+        setSubnetsStatus('error');
+      }
+    },
+    [fetchSubnets],
+  );
+
+  const deleteSubnet = useCallback(
+    async (cidr: string): Promise<void> => {
+      setSubnetsStatus('saving');
+      try {
+        // Backend expects CIDR as query parameter, not in body
+        const response = await fetch(
+          `${API_BASE}/api/v1/shell/devices/subnets?cidr=${encodeURIComponent(cidr)}`,
+          {
+            method: 'DELETE',
+            credentials: 'include',
+          },
+        );
+
+        if (response.ok) {
+          setSubnetsStatus('saved');
+          setTimeout(() => setSubnetsStatus('idle'), 2000);
+          await fetchSubnets();
+        } else {
+          setSubnetsStatus('error');
+        }
+      } catch {
+        setSubnetsStatus('error');
+      }
+    },
+    [fetchSubnets],
+  );
+
+  return {
+    subnets,
+    newSubnetCidr,
+    setNewSubnetCidr,
+    newSubnetName,
+    setNewSubnetName,
+    subnetError,
+    setSubnetError,
+    subnetsStatus,
+    fetchSubnets,
+    addSubnet,
+    toggleSubnet,
+    deleteSubnet,
+  };
+}

--- a/ui/src/hooks/useVulnerabilitySettings.ts
+++ b/ui/src/hooks/useVulnerabilitySettings.ts
@@ -1,0 +1,94 @@
+/**
+ * useVulnerabilitySettings
+ *
+ * Loads and saves CVE/vulnerability scanner settings from
+ * /api/v1/shell/vulnerabilities/settings. Owns the settings shape,
+ * the save-status, and the init/timer refs used by the drawer's
+ * debounced auto-save pattern.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { INLINE_DEFAULT_VULNERABILITY_SETTINGS } from '../components/settings/settingsDrawerNormalizer';
+import { LogComponents, logger } from '../lib/logger';
+import type { SaveStatus, VulnerabilityScanSettings } from '../types/settings';
+
+const API_BASE: string = import.meta.env.VITE_API_BASE || '';
+
+interface UseVulnerabilitySettingsResult {
+  vulnSettings: VulnerabilityScanSettings;
+  setVulnSettings: (value: VulnerabilityScanSettings) => void;
+  vulnStatus: SaveStatus;
+  vulnInitRef: React.MutableRefObject<boolean>;
+  vulnTimerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
+  fetchVulnSettings: () => Promise<void>;
+  saveVulnSettings: () => Promise<void>;
+}
+
+export function useVulnerabilitySettings(): UseVulnerabilitySettingsResult {
+  const [vulnSettings, setVulnSettings] = useState<VulnerabilityScanSettings>(
+    INLINE_DEFAULT_VULNERABILITY_SETTINGS,
+  );
+  const [vulnStatus, setVulnStatus] = useState<SaveStatus>('idle');
+  const vulnInitRef = useRef(true);
+  const vulnTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchVulnSettings = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE}/api/v1/shell/vulnerabilities/settings`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await (response.json() as Promise<Record<string, unknown>>);
+        setVulnSettings({
+          enabled: data.enabled ?? false,
+          cveDatabase: data.cve_database ?? data.cveDatabase ?? 'nvd',
+          nvdApiKey: data.nvd_api_key ?? data.nvdApiKey ?? '',
+          updateInterval: data.update_interval ?? data.updateInterval ?? 86400,
+          severityThreshold: data.severity_threshold ?? data.severityThreshold ?? 'medium',
+          maxConcurrent: data.max_concurrent ?? data.maxConcurrent ?? 5,
+          autoScan: data.auto_scan ?? data.autoScan ?? false,
+        });
+      }
+    } catch (err) {
+      logger.error(LogComponents.CONFIG, 'Failed to fetch vulnerability settings', err);
+    }
+  }, []);
+
+  const saveVulnSettings = useCallback(async () => {
+    setVulnStatus('saving');
+    try {
+      const response = await fetch(`${API_BASE}/api/v1/shell/vulnerabilities/settings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          enabled: vulnSettings.enabled,
+          cveDatabase: vulnSettings.cveDatabase,
+          nvdApiKey: vulnSettings.nvdApiKey,
+          updateInterval: vulnSettings.updateInterval,
+          severityThreshold: vulnSettings.severityThreshold,
+          maxConcurrent: vulnSettings.maxConcurrent,
+          autoScan: vulnSettings.autoScan,
+        }),
+      });
+      if (response.ok) {
+        setVulnStatus('saved');
+        setTimeout(() => setVulnStatus('idle'), 2000);
+      } else {
+        setVulnStatus('error');
+      }
+    } catch {
+      setVulnStatus('error');
+    }
+  }, [vulnSettings]);
+
+  return {
+    vulnSettings,
+    setVulnSettings,
+    vulnStatus,
+    vulnInitRef,
+    vulnTimerRef,
+    fetchVulnSettings,
+    saveVulnSettings,
+  };
+}


### PR DESCRIPTION
## Summary
- Drops \`ui/src/components/settings/SettingsDrawer.tsx\` from 1880 to 711 lines, clearing the 800-line red-flag budget.
- Eight sibling files now own the data orchestration, the auto-save pattern, and the inline JSX sub-panels.

## Files added
- \`settingsDrawerNormalizer.ts\` (~122) - default-config constants plus tests/DNS payload normaliser
- \`SettingsDrawerNetworkSection.tsx\` (~308) - IP mode toggle, static IP fields, apply button + status, display-options toggle, VLAN/MTU
- \`SettingsDrawerFooter.tsx\` (~110) - Logs (debug) viewer, Export download, About blurb
- \`hooks/useSubnetSettings.ts\` (~165) - subnet list state, form fields, fetch/add/toggle/delete plus open-time fetch effect
- \`hooks/useVulnerabilitySettings.ts\` (~85) - vuln scanner settings state plus fetch / save callbacks
- \`hooks/useDebouncedAutoSave.ts\` (~30) - shared hook replacing eight near-identical debounced-save useEffects
- \`hooks/useSettingsDrawerLoaders.ts\` (~400) - every per-section fetch callback plus the open-time initial-load orchestration
- \`hooks/useSettingsDrawerSavers.ts\` (~225) - seven section save callbacks (thresholds, tests, wifi, link, cable, network discovery, snmp)

The drawer keeps the section state objects but no longer owns the per-call networking. \`saveIpSettings\` stays inline because it's still manual-apply via the user-facing button. Pure relocation, no behavior change.

## Test plan
- [x] \`npx biome check\` clean on all files
- [x] \`npx vite build\` succeeds
- [x] \`scripts/check-file-size.sh\` no longer red-flags SettingsDrawer.tsx (warn at 711, under the 800 red-flag budget)