### PR TITLE
fix(auth): clear stale state, gate setup completion, match SSO contract

### DIFF
--- a/ui/src/components/setup/SetupWizard.tsx
+++ b/ui/src/components/setup/SetupWizard.tsx
@@ -64,11 +64,9 @@ interface SetupWizardProps {
  * Modal-like component that requires user to set admin password before
  * accessing the main application.
  */
-// SSO provider info from backend
-interface SsoProvider {
-  name: string;
-  enabled: boolean;
-}
+// SSO providers from backend (/api/sso/providers returns the names of
+// only the providers that are enabled AND have a ClientID configured -
+// see internal/api/handlers_oauth.go::initOAuthManager). Fixes #720.
 
 /**
  * First-run setup flow that forces the user to create credentials before using the app.
@@ -89,13 +87,13 @@ export function SetupWizard({
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [ssoProviders, setSsoProviders] = useState<SsoProvider[]>([]);
+  const [ssoProviders, setSsoProviders] = useState<string[]>([]);
 
-  // Fetch enabled SSO providers (fixes #769)
+  // Fetch enabled SSO providers (fixes #769, #720)
   useEffect(() => {
     fetch(`${API_BASE}/api/sso/providers`)
       .then((res) => (res.ok ? res.json() : { providers: [] }))
-      .then((data) => setSsoProviders(data.providers || []))
+      .then((data: { providers?: string[] }) => setSsoProviders(data.providers ?? []))
       .catch(() => setSsoProviders([]));
   }, []);
 
@@ -107,12 +105,14 @@ export function SetupWizard({
     }
   }, [passwordMode, suggestedPassword]);
 
-  // Helper to check if a provider is enabled
+  // Helper to check if a provider is enabled. The backend only lists
+  // providers that have Enabled=true AND a non-empty ClientID, so
+  // presence in the list is sufficient (#720).
   const isProviderEnabled = (name: string): boolean =>
-    ssoProviders.some((p) => p.name.toLowerCase() === name.toLowerCase() && p.enabled);
+    ssoProviders.some((p) => p.toLowerCase() === name.toLowerCase());
 
   // Check if any SSO provider is enabled
-  const hasEnabledSso = ssoProviders.some((p) => p.enabled);
+  const hasEnabledSso = ssoProviders.length > 0;
 
   const handleCopyPassword = async (): Promise<void> => {
     if (suggestedPassword) {
@@ -175,9 +175,10 @@ export function SetupWizard({
       const loginSuccess = await onLogin(username, password);
 
       if (!loginSuccess) {
+        // Fixes #719: do not exit the wizard when auto-login fails - the user
+        // would land in the main UI unauthenticated. Keep the wizard open with
+        // the error visible so they can retry or surface the real failure.
         setError(t('errors.loginFailed'));
-        // Still call onComplete to exit setup wizard
-        onComplete();
         return;
       }
 

--- a/ui/src/hooks/useAuth.ts
+++ b/ui/src/hooks/useAuth.ts
@@ -287,6 +287,14 @@ export function useAuth(): UseAuthReturn {
    * This is used by WebSocket to get a fresh token for reconnection.
    */
   const refreshToken = useCallback(async (): Promise<string | null> => {
+    // Fixes #718: any refresh-failure path must drop auth state so the UI
+    // doesn't keep showing an authenticated session with a stale token.
+    const clearAuthState = (): void => {
+      setState({ isAuthenticated: false, token: null, username: null });
+      setConnected(false);
+      clearCSRFToken();
+    };
+
     try {
       const response = await fetch(`${API_BASE}/api/auth/refresh`, {
         method: 'POST',
@@ -297,6 +305,7 @@ export function useAuth(): UseAuthReturn {
         logger.warn(LogComponents.Auth, 'Token refresh failed', {
           status: response.status,
         });
+        clearAuthState();
         return null;
       }
 
@@ -312,6 +321,7 @@ export function useAuth(): UseAuthReturn {
       return data.token;
     } catch (err) {
       logger.error(LogComponents.Auth, 'Token refresh error', err);
+      clearAuthState();
       return null;
     }
   }, []);


### PR DESCRIPTION
Fixes #718, #719, #720 — three related auth/setup defects in one PR.

## Summary

### #718 — Token refresh failure left UI authenticated
\`refreshToken()\` in \`useAuth.ts\` kept \`isAuthenticated=true\` and the last access token when \`/api/auth/refresh\` failed. The UI and WebSocket continued operating with stale credentials → repeated 401s and a false authenticated state. Both the \`!response.ok\` branch and the catch branch now drop auth state and CSRF token before returning null.

### #719 — Setup wizard completed when auto-login failed
\`SetupWizard.handleSubmit()\` called \`onComplete()\` even when the post-setup auto-login returned false, dropping the user into the main UI unauthenticated. The wizard now stays open and surfaces the error.

### #720 — SSO providers contract mismatch
Backend returns \`{ providers: string[] }\`. UI typed it as \`{ name, enabled }[]\` and read \`.name\` / \`.enabled\` — both undefined on a string. \`hasEnabledSso\` was permanently false, the SSO section never rendered (Microsoft "missing"), and any direct hit at \`/sso/login\` fell through to \`GetProvider\`'s "Invalid provider" error. UI now uses the string list directly; \`initOAuthManager\` already filters to providers that are Enabled AND have a ClientID, so presence in the list is sufficient.

## Test plan
- [x] \`npx biome check\` clean on both files
- [x] \`npx vite build\` succeeds
- [x] \`go build ./...\` succeeds
- [x] \`go vet ./...\` clean