### PR TITLE
fix(survey): client-side validation for ids, coords, floorplan size

### DIFF
--- a/ui/src/hooks/useSurvey.ts
+++ b/ui/src/hooks/useSurvey.ts
@@ -34,6 +34,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import { api } from '../api';
 import { LogComponents, logger } from '../lib/logger';
+import {
+  validateCoordinates,
+  validateCreateSurvey,
+  validateFloorPlan,
+  validateSurveyId,
+} from '../lib/surveyValidation';
 
 /** Survey data collection mode */
 export type SurveyType = 'passive' | 'active' | 'throughput';
@@ -524,6 +530,18 @@ export function useSurvey(): {
 
   const createSurvey = useCallback(
     async (request: CreateSurveyRequest): Promise<Survey> => {
+      // Fixes #725: validate before sending so we don't push malformed
+      // payloads at the backend and can surface a clear field-specific error.
+      const check = validateCreateSurvey(request);
+      if (!check.ok) {
+        setError(check.error);
+        logger.warn(LogComponents.Survey, 'Rejected createSurvey - validation failed', {
+          error: check.error,
+          field: check.field,
+        });
+        throw new Error(check.error);
+      }
+
       setLoading(true);
       setError(null);
       try {
@@ -552,6 +570,11 @@ export function useSurvey(): {
   );
 
   const getSurvey = useCallback(async (id: string): Promise<Survey> => {
+    const check = validateSurveyId(id);
+    if (!check.ok) {
+      setError(check.error);
+      throw new Error(check.error);
+    }
     setLoading(true);
     setError(null);
     try {
@@ -573,6 +596,11 @@ export function useSurvey(): {
 
   const deleteSurvey = useCallback(
     async (id: string) => {
+      const check = validateSurveyId(id);
+      if (!check.ok) {
+        setError(check.error);
+        return;
+      }
       setLoading(true);
       setError(null);
       try {
@@ -599,6 +627,11 @@ export function useSurvey(): {
 
   const startSurvey = useCallback(
     async (id: string) => {
+      const check = validateSurveyId(id);
+      if (!check.ok) {
+        setError(check.error);
+        return;
+      }
       setLoading(true);
       setError(null);
       try {
@@ -623,6 +656,11 @@ export function useSurvey(): {
 
   const pauseSurvey = useCallback(
     async (id: string) => {
+      const check = validateSurveyId(id);
+      if (!check.ok) {
+        setError(check.error);
+        return;
+      }
       setLoading(true);
       setError(null);
       try {
@@ -647,6 +685,11 @@ export function useSurvey(): {
 
   const completeSurvey = useCallback(
     async (id: string) => {
+      const check = validateSurveyId(id);
+      if (!check.ok) {
+        setError(check.error);
+        return;
+      }
       setLoading(true);
       setError(null);
       try {
@@ -676,6 +719,25 @@ export function useSurvey(): {
       y: number,
       sampleData: PassiveSample | ActiveSample | ThroughputSample,
     ) => {
+      const idCheck = validateSurveyId(id);
+      if (!idCheck.ok) {
+        setError(idCheck.error);
+        return;
+      }
+      // Fixes #725: reject non-finite or negative coordinates before submission.
+      // (Bounds vs floor-plan extent are enforced at the canvas layer.)
+      const coordCheck = validateCoordinates(x, y);
+      if (!coordCheck.ok) {
+        setError(coordCheck.error);
+        logger.warn(LogComponents.Survey, 'Rejected sample - coordinate validation failed', {
+          surveyId: id,
+          x,
+          y,
+          error: coordCheck.error,
+        });
+        return;
+      }
+
       setLoading(true);
       setError(null);
       try {
@@ -707,6 +769,24 @@ export function useSurvey(): {
   );
 
   const updateFloorPlan = useCallback(async (id: string, floorPlan: FloorPlan) => {
+    const idCheck = validateSurveyId(id);
+    if (!idCheck.ok) {
+      setError(idCheck.error);
+      return;
+    }
+    // Fixes #725: enforce max dimensions / payload size before sending.
+    const planCheck = validateFloorPlan(floorPlan);
+    if (!planCheck.ok) {
+      setError(planCheck.error);
+      logger.warn(LogComponents.Survey, 'Rejected updateFloorPlan - validation failed', {
+        surveyId: id,
+        error: planCheck.error,
+        field: planCheck.field,
+        dimensions: { width: floorPlan.width, height: floorPlan.height },
+      });
+      return;
+    }
+
     setLoading(true);
     setError(null);
     try {

--- a/ui/src/lib/surveyValidation.ts
+++ b/ui/src/lib/surveyValidation.ts
@@ -1,0 +1,145 @@
+/**
+ * Client-side validation for survey API requests (fixes #725).
+ *
+ * Centralises the rules so every useSurvey callsite enforces the same
+ * constraints before sending data over the wire. On failure each helper
+ * returns a stable error code (caller maps to a localised string) plus
+ * the offending field name where useful, so the UI can surface clear
+ * messages instead of generic 4xx responses from the backend.
+ */
+
+export const SURVEY_ID_MAX_LEN = 128;
+export const SURVEY_NAME_MAX_LEN = 256;
+
+/** PNG/JPEG max pixel dimension that all major browsers/decoders accept. */
+export const FLOORPLAN_MAX_DIMENSION_PX = 16_384;
+
+/** Maximum raw image bytes accepted client-side before submission. */
+export const FLOORPLAN_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+
+/** Minimum valid scale (meters per pixel). Below this is almost certainly a bug. */
+export const FLOORPLAN_MIN_SCALE_M = 0.0001;
+export const FLOORPLAN_MAX_SCALE_M = 100;
+
+/**
+ * Result type used by every validator. `ok=true` means safe to send.
+ * `error` is a stable string code; callers translate / display it.
+ */
+export type ValidationResult = { ok: true } | { ok: false; error: string; field?: string };
+
+const VALID_ID_RE = /^[A-Za-z0-9._-]+$/;
+
+export function validateSurveyId(id: string | undefined | null): ValidationResult {
+  if (!id) {
+    return { ok: false, error: 'survey.id.empty', field: 'id' };
+  }
+  if (id.length > SURVEY_ID_MAX_LEN) {
+    return { ok: false, error: 'survey.id.tooLong', field: 'id' };
+  }
+  if (!VALID_ID_RE.test(id)) {
+    return { ok: false, error: 'survey.id.invalidChars', field: 'id' };
+  }
+  return { ok: true };
+}
+
+export function validateCoordinate(value: number, axis: 'x' | 'y', max?: number): ValidationResult {
+  if (!Number.isFinite(value)) {
+    return { ok: false, error: 'survey.coord.notFinite', field: axis };
+  }
+  if (value < 0) {
+    return { ok: false, error: 'survey.coord.negative', field: axis };
+  }
+  if (max !== undefined && value > max) {
+    return { ok: false, error: 'survey.coord.outOfBounds', field: axis };
+  }
+  return { ok: true };
+}
+
+/**
+ * Validate a sample's (x, y) within an optional floor-plan extent.
+ * Pass the floorPlan if available so out-of-bounds is caught before
+ * the click ever reaches the backend.
+ */
+export function validateCoordinates(
+  x: number,
+  y: number,
+  bounds?: { width: number; height: number },
+): ValidationResult {
+  const xCheck = validateCoordinate(x, 'x', bounds?.width);
+  if (!xCheck.ok) {
+    return xCheck;
+  }
+  return validateCoordinate(y, 'y', bounds?.height);
+}
+
+interface FloorPlanLike {
+  imageData?: string;
+  width: number;
+  height: number;
+  scaleM: number;
+}
+
+/**
+ * Estimate decoded byte size of a base-64 data URL or raw base-64 string.
+ * Avoids decoding the full image just to measure it.
+ */
+function approximateBase64Bytes(data: string): number {
+  const payload = data.startsWith('data:') ? data.slice(data.indexOf(',') + 1) : data;
+  // base64 inflates by 4/3; subtract padding chars.
+  let padding = 0;
+  if (payload.endsWith('==')) {
+    padding = 2;
+  } else if (payload.endsWith('=')) {
+    padding = 1;
+  }
+  return Math.floor((payload.length * 3) / 4) - padding;
+}
+
+export function validateFloorPlan(plan: FloorPlanLike): ValidationResult {
+  if (!Number.isFinite(plan.width) || plan.width <= 0) {
+    return { ok: false, error: 'survey.floorPlan.widthInvalid', field: 'width' };
+  }
+  if (!Number.isFinite(plan.height) || plan.height <= 0) {
+    return { ok: false, error: 'survey.floorPlan.heightInvalid', field: 'height' };
+  }
+  if (plan.width > FLOORPLAN_MAX_DIMENSION_PX || plan.height > FLOORPLAN_MAX_DIMENSION_PX) {
+    return { ok: false, error: 'survey.floorPlan.tooLarge', field: 'dimensions' };
+  }
+  if (
+    !Number.isFinite(plan.scaleM) ||
+    plan.scaleM < FLOORPLAN_MIN_SCALE_M ||
+    plan.scaleM > FLOORPLAN_MAX_SCALE_M
+  ) {
+    return { ok: false, error: 'survey.floorPlan.scaleInvalid', field: 'scaleM' };
+  }
+  if (plan.imageData && approximateBase64Bytes(plan.imageData) > FLOORPLAN_MAX_BYTES) {
+    return { ok: false, error: 'survey.floorPlan.imageTooLarge', field: 'imageData' };
+  }
+  return { ok: true };
+}
+
+interface CreateSurveyLike {
+  name?: string;
+  surveyType?: string;
+  interface?: string;
+  iperfServer?: string;
+}
+
+export function validateCreateSurvey(req: CreateSurveyLike): ValidationResult {
+  if (!req.name?.trim()) {
+    return { ok: false, error: 'survey.create.nameRequired', field: 'name' };
+  }
+  if (req.name.length > SURVEY_NAME_MAX_LEN) {
+    return { ok: false, error: 'survey.create.nameTooLong', field: 'name' };
+  }
+  if (!req.surveyType) {
+    return { ok: false, error: 'survey.create.typeRequired', field: 'surveyType' };
+  }
+  if (!req.interface?.trim()) {
+    return { ok: false, error: 'survey.create.interfaceRequired', field: 'interface' };
+  }
+  if (req.surveyType === 'throughput' && !req.iperfServer?.trim()) {
+    return { ok: false, error: 'survey.create.iperfServerRequired', field: 'iperfServer' };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
Fixes #725.

## Summary
Every \`useSurvey\` callsite forwarded survey ids, coordinates, and floor-plan payloads to the backend without validation. Empty ids, NaN/negative coordinates, and very large floorplan blobs went out unchecked — generic 4xx responses + inflated DoS surface.

## Changes
New \`ui/src/lib/surveyValidation.ts\` with:

| Helper | Rules |
|---|---|
| \`validateSurveyId\` | non-empty, \`<=128\` chars, \`[A-Za-z0-9._-]\` |
| \`validateCoordinate(s)\` | finite, non-negative, optional max bound |
| \`validateFloorPlan\` | dims \`>0\` and \`<=16384px\`; \`scaleM\` finite in \`[0.0001, 100]\` m/px; decoded image bytes \`<=10MB\` |
| \`validateCreateSurvey\` | required name (\`<=256\`), surveyType, interface, plus \`iperfServer\` when type=\`throughput\` |

\`useSurvey\` now runs the matching validator before every fetch in \`createSurvey\`, \`getSurvey\`, \`deleteSurvey\`, \`startSurvey\`, \`pauseSurvey\`, \`completeSurvey\`, \`addSample\`, and \`updateFloorPlan\`. On failure it sets a stable error code on state, logs structured context, and short-circuits before any HTTP request.

The module is reusable from survey UI surfaces (FloorPlanCanvas, AirMapperImport, etc.) for inline form validation in follow-ups.

## Test plan
- [x] \`npx biome check\` clean on both files
- [x] \`npx vite build\` succeeds
- [x] \`go build ./...\` clean