### PR TITLE
fix(survey): persist AirMapper-imported placements + criteria

### DIFF
--- a/internal/api/handlers_survey_floorplan.go
+++ b/internal/api/handlers_survey_floorplan.go
@@ -202,6 +202,63 @@ func (s *Server) updateSurveySettings(w http.ResponseWriter, r *http.Request) {
 	sendJSONResponse(w, logger, http.StatusOK, settingsUpdatedSurvey)
 }
 
+// UpdateSurveyImportedDataRequest is the payload for #727's imported-data
+// endpoint. Any field left nil is left unchanged on the survey; an empty
+// slice clears the corresponding list.
+type UpdateSurveyImportedDataRequest struct {
+	APLocations      []survey.APLocation        `json:"apLocations"`
+	ClientLocations  []survey.ClientLocation    `json:"clientLocations"`
+	PassFailCriteria []survey.PassFailCriterion `json:"passFailCriteria"`
+}
+
+// updateSurveyImportedData handles PUT /api/canopy/survey/imported-data?id=xxx.
+// Replaces the survey's AP/client placements and pass-fail criteria. This is
+// what the AirMapper import flow uses to persist parsed survey data so it
+// survives reload (#727).
+func (s *Server) updateSurveyImportedData(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+	localizer := i18n.FromRequest(r)
+	ctx := &surveyHandlerContext{w, logger, localizer}
+
+	if r.Method != http.MethodPut {
+		ctx.sendMethodNotAllowed()
+		return
+	}
+
+	id := r.URL.Query().Get("id")
+	if !isValidSurveyID(id) {
+		ctx.sendValidationError("errors.survey.invalidId")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, MaxBodySizeJSON)
+	var req UpdateSurveyImportedDataRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		logger.WarnContext(r.Context(), "Invalid imported-data body", "error", err)
+		ctx.sendBadRequestError("errors.api.invalidRequestBody")
+		return
+	}
+
+	update := survey.ImportedDataUpdate{
+		APLocations:      req.APLocations,
+		ClientLocations:  req.ClientLocations,
+		PassFailCriteria: req.PassFailCriteria,
+	}
+	if err := s.surveyManager().UpdateImportedData(id, update); err != nil {
+		logger.ErrorContext(r.Context(), "Failed to update imported data", "error", err)
+		ctx.sendBadRequestError("errors.survey.updateFailed")
+		return
+	}
+
+	updated, err := s.surveyManager().GetSurvey(id)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "Failed to get survey after imported-data update", "error", err)
+		ctx.sendInternalError("errors.survey.getSurveyFailed")
+		return
+	}
+	sendJSONResponse(w, logger, http.StatusOK, updated)
+}
+
 // importAirMapper handles POST /api/survey/import/airmapper.
 // It accepts a multipart form with an .amp file and returns parsed calibration,
 // floor plan, and pass/fail criteria data.

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -206,6 +206,7 @@ func (s *Server) setupCanopyRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/sample", s.addSurveySample)
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floorplan", s.updateSurveyFloorPlan)
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/settings", s.updateSurveySettings)
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/imported-data", s.updateSurveyImportedData)
 	s.mux.Handle(
 		APIVersionPrefix+"/canopy/survey/import/airmapper",
 		s.endpointRateLimiter().RateLimitMiddleware(http.HandlerFunc(s.importAirMapper)),

--- a/internal/canopy/survey/survey.go
+++ b/internal/canopy/survey/survey.go
@@ -218,6 +218,50 @@ type Survey struct {
 	Interface    string `json:"interface"`              // WiFi interface to use
 	IperfServer  string `json:"iperfServer,omitempty"`  // For throughput surveys
 	TestDuration int    `json:"testDuration,omitempty"` // seconds, for throughput tests
+
+	// Imported / placed data (#727). These are sourced from AirMapper imports
+	// or user placement in the planner and are persisted with the survey so
+	// they survive reload.
+	APLocations      []APLocation        `json:"apLocations,omitempty"`
+	ClientLocations  []ClientLocation    `json:"clientLocations,omitempty"`
+	PassFailCriteria []PassFailCriterion `json:"passFailCriteria,omitempty"`
+}
+
+// APLocation marks the floorplan-relative position of an access point. Sourced
+// from imported survey data or user placement.
+type APLocation struct {
+	ID       string `json:"id"` // Stable identifier (uuid)
+	X        int    `json:"x"`  // Pixel offset on the floor plan
+	Y        int    `json:"y"`  // Pixel offset on the floor plan
+	Label    string `json:"label,omitempty"`
+	BSSID    string `json:"bssid,omitempty"`
+	Vendor   string `json:"vendor,omitempty"`
+	Notes    string `json:"notes,omitempty"`
+	Imported bool   `json:"imported,omitempty"` // True when added by an importer
+}
+
+// ClientLocation marks the floorplan-relative position of a client/station.
+// Sourced from imported AirMapper data; the placement UI may add more later.
+type ClientLocation struct {
+	ID       string `json:"id"`
+	X        int    `json:"x"`
+	Y        int    `json:"y"`
+	Label    string `json:"label,omitempty"`
+	MAC      string `json:"mac,omitempty"`
+	Imported bool   `json:"imported,omitempty"`
+}
+
+// PassFailCriterion is a single threshold expression used to flag survey
+// samples as pass or fail. Mirrors the frontend PassFailCriterion shape.
+type PassFailCriterion struct {
+	Option   string  `json:"option"`           // Metric name (e.g. "rssi", "throughput")
+	Name     string  `json:"name,omitempty"`   // Display label
+	Limit    float64 `json:"limit"`            // Threshold value
+	Suffix   string  `json:"suffix,omitempty"` // Unit suffix (e.g. "dBm", "Mbps")
+	Enabled  bool    `json:"enabled"`
+	Mode     string  `json:"mode,omitempty"` // "gte" or "lte"
+	APCount  int     `json:"ap,omitempty"`   // For AP-density criteria
+	Imported bool    `json:"imported,omitempty"`
 }
 
 // GetActiveFloor returns the currently active floor for data collection.
@@ -499,6 +543,43 @@ func (m *Manager) UpdateSurveySettings(
 	}
 	survey.TestDuration = testDuration
 	survey.IperfServer = iperfServer
+	survey.UpdatedAt = time.Now()
+
+	return m.saveSurvey(survey)
+}
+
+// ImportedDataUpdate carries the slices a caller wants to replace on a survey.
+// Each field is optional; nil means "leave as-is". An empty (non-nil) slice
+// clears the corresponding survey field, which is the right behaviour when an
+// importer wants to fully replace the existing list.
+type ImportedDataUpdate struct {
+	APLocations      []APLocation
+	ClientLocations  []ClientLocation
+	PassFailCriteria []PassFailCriterion
+}
+
+// UpdateImportedData replaces the survey's imported-data fields (#727).
+// Callers (most notably the AirMapper import flow) use this to persist the
+// AP/client placements and pass-fail criteria that come back from the parser
+// so the data survives a page reload.
+func (m *Manager) UpdateImportedData(id string, update ImportedDataUpdate) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	survey, exists := m.surveys[id]
+	if !exists {
+		return fmt.Errorf("survey not found: %s", id)
+	}
+
+	if update.APLocations != nil {
+		survey.APLocations = update.APLocations
+	}
+	if update.ClientLocations != nil {
+		survey.ClientLocations = update.ClientLocations
+	}
+	if update.PassFailCriteria != nil {
+		survey.PassFailCriteria = update.PassFailCriteria
+	}
 	survey.UpdatedAt = time.Now()
 
 	return m.saveSurvey(survey)

--- a/ui/src/components/survey/SurveyViewFloorPlanPanel.tsx
+++ b/ui/src/components/survey/SurveyViewFloorPlanPanel.tsx
@@ -273,6 +273,8 @@ export function SurveyViewFloorPlanPanel({
                 }
               }
               samples={currentSamples}
+              // #727: render imported AP placements so they're not silently dropped.
+              apLocations={survey.apLocations}
               onPointClick={handlePointClick}
               interactive={
                 survey.status === 'in_progress' &&

--- a/ui/src/components/survey/useSurveyMutations.ts
+++ b/ui/src/components/survey/useSurveyMutations.ts
@@ -16,6 +16,73 @@ import type { ImportOptions } from './AirMapperImport';
 
 const API_BASE: string = import.meta.env.VITE_API_BASE || '';
 
+/** Stable id derived from index. Backend treats id as opaque. */
+function importedId(prefix: string, index: number): string {
+  return `${prefix}-imported-${index}`;
+}
+
+/**
+ * Pulls AP locations, client locations, and pass-fail criteria off the
+ * parsed AirMapper payload and shapes them for the survey/imported-data
+ * endpoint. Returns null when there's nothing to send so callers can
+ * short-circuit.
+ */
+function buildImportedDataPayload(data: AirMapperData): {
+  apLocations: Array<{ id: string; x: number; y: number; label?: string; imported: boolean }>;
+  clientLocations: Array<{ id: string; x: number; y: number; label?: string; imported: boolean }>;
+  passFailCriteria: Array<{
+    option: string;
+    name?: string;
+    limit: number;
+    suffix?: string;
+    enabled: boolean;
+    mode?: string;
+    ap?: number;
+    imported: boolean;
+  }>;
+} | null {
+  // .locations.passive carries AP positions in AirMapper passive surveys.
+  const apLocations = data.locations.passive.map((loc, idx) => ({
+    id: importedId('ap', idx),
+    x: Math.round(loc.x),
+    y: Math.round(loc.y),
+    label: loc.label || undefined,
+    imported: true,
+  }));
+
+  const clientLocations = data.locations.client.map((loc, idx) => ({
+    id: importedId('client', idx),
+    x: Math.round(loc.x),
+    y: Math.round(loc.y),
+    label: loc.label || undefined,
+    imported: true,
+  }));
+
+  // passFailCriteria lives on the raw backend response (when import went
+  // through the backend route). Be defensive about the shape since
+  // rawSerial is typed as unknown.
+  const raw = data.rawSerial as { passFailCriteria?: unknown } | undefined;
+  const rawCriteria = Array.isArray(raw?.passFailCriteria) ? raw.passFailCriteria : [];
+  const passFailCriteria = rawCriteria
+    .filter((c): c is Record<string, unknown> => typeof c === 'object' && c !== null)
+    .map((c) => ({
+      option: typeof c.option === 'string' ? c.option : '',
+      name: typeof c.name === 'string' ? c.name : undefined,
+      limit: typeof c.limit === 'number' ? c.limit : 0,
+      suffix: typeof c.suffix === 'string' ? c.suffix : undefined,
+      enabled: c.enabled !== false,
+      mode: typeof c.mode === 'string' ? c.mode : undefined,
+      ap: typeof c.ap === 'number' ? c.ap : undefined,
+      imported: true,
+    }))
+    .filter((c) => c.option !== '');
+
+  if (apLocations.length === 0 && clientLocations.length === 0 && passFailCriteria.length === 0) {
+    return null;
+  }
+  return { apLocations, clientLocations, passFailCriteria };
+}
+
 interface UseSurveyMutationsArgs {
   survey: Survey;
   setSurvey: (s: Survey) => void;
@@ -214,6 +281,27 @@ export function useSurveyMutations({
             scaleSource: 'imported',
             propagationM: data.calibration.propagationM,
           });
+        }
+
+        // Fixes #727: persist AP / client placements and pass-fail criteria
+        // from the parsed AirMapper data. Previously these were dropped on
+        // the floor (literally) and the user saw a floor plan with no markers.
+        const importedData = buildImportedDataPayload(data);
+        if (importedData) {
+          const dataRes = await fetch(
+            `${API_BASE}/api/canopy/survey/imported-data?id=${survey.id}`,
+            {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              credentials: 'include',
+              body: JSON.stringify(importedData),
+            },
+          );
+          if (dataRes.ok) {
+            const updated = await (dataRes.json() as Promise<Survey>);
+            setSurvey(updated);
+            onUpdate();
+          }
         }
 
         setShowImport(false);


### PR DESCRIPTION
Fixes #727.

## Root cause
The AirMapper import flow parsed AP locations, client locations, and pass-fail criteria from the .amp archive then **dropped them**. The user got a floor plan with no markers and no criteria — looked like the import had silently lost data, because it had.

Model gap: the backend \`Survey\` struct had no fields for the imported placements or criteria, no endpoint to persist them, and \`SurveyView\` never asked for them. The frontend \`handleAirMapperImport\` sent only floor-plan + calibration updates.

## Backend
- New types in \`internal/canopy/survey\`: \`APLocation\`, \`ClientLocation\`, \`PassFailCriterion\`.
- Three slice fields on \`Survey\` (each \`omitempty\`).
- \`Manager.UpdateImportedData\` replaces any combination of the three slices (nil = leave unchanged, empty = clear) and saves.
- New handler \`updateSurveyImportedData\` on \`PUT /api/v1/canopy/survey/imported-data?id=<surveyId>\`.

## Frontend
- \`useSurveyMutations.handleAirMapperImport\` now calls \`/survey/imported-data\` after the floor plan is in place, sending parsed AP positions, client positions, and pass-fail criteria. Each gets a stable id and \`imported: true\`.
- \`SurveyViewFloorPlanPanel\` passes \`survey.apLocations\` into \`FloorPlanCanvas\` so imported APs render as markers immediately.

## Out of scope (follow-up tracking suggested)
- Surfacing \`ApPlacementPanel\` + \`PassFailCriteriaPanel\` in SurveyView's side panel for in-app editing.
- Parsing the \`.SurveyResult\` binary measurements blob (TODO at \`airmapper_parser.go:142\`).

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/canopy/survey/... ./internal/api/...\` passes
- [x] \`npx biome check\` clean
- [x] \`npx vite build\` succeeds