### PR TITLE
fix(netif): drop hardcoded interface fallbacks, auto-detect at constructor time

### DIFF
--- a/internal/canopy/services.go
+++ b/internal/canopy/services.go
@@ -9,11 +9,27 @@ import (
 	"github.com/krisarmstrong/seed/internal/canopy/wifi"
 	"github.com/krisarmstrong/seed/internal/config"
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/netif"
 	"github.com/krisarmstrong/seed/internal/services/iperf"
 )
 
-// DefaultInterface is the default network interface to use when none is configured.
+// DefaultInterface is the last-ditch fallback interface name when both config
+// and live auto-detection fail to provide one (#572). Prefer
+// netif.AutoDetectInterfaceName("wifi") over this constant.
 const DefaultInterface = "wlan0"
+
+// resolveWiFiInterface picks the WiFi interface name: config first, then live
+// auto-detection (preferring a wifi-typed interface), then DefaultInterface as
+// a last-ditch fallback.
+func resolveWiFiInterface(cfg *config.Config) string {
+	if iface, ok := cfg.GetActiveInterface(); ok && iface != "" {
+		return iface
+	}
+	if iface := netif.AutoDetectInterfaceName("wifi"); iface != "" {
+		return iface
+	}
+	return DefaultInterface
+}
 
 // Channel utilization constants.
 const (
@@ -62,10 +78,7 @@ type WiFiService struct {
 
 // NewWiFiService creates a new WiFi service.
 func NewWiFiService(cfg *config.Config) *WiFiService {
-	iface, ok := cfg.GetActiveInterface()
-	if !ok || iface == "" {
-		iface = DefaultInterface
-	}
+	iface := resolveWiFiInterface(cfg)
 
 	return &WiFiService{
 		cfg:     cfg,
@@ -101,10 +114,7 @@ func (s *WiFiService) Scan(_ context.Context) (*ScanResult, error) {
 	}
 
 	// Get active interface name
-	iface, _ := s.cfg.GetActiveInterface()
-	if iface == "" {
-		iface = DefaultInterface
-	}
+	iface := resolveWiFiInterface(s.cfg)
 
 	// Convert to canopy types
 	result := &ScanResult{
@@ -207,10 +217,7 @@ func (s *SurveyService) Create(_ context.Context, name, description string) (*Su
 		return nil, ErrNotInitialized
 	}
 
-	iface, ok := s.cfg.GetActiveInterface()
-	if !ok || iface == "" {
-		iface = DefaultInterface
-	}
+	iface := resolveWiFiInterface(s.cfg)
 
 	// Create using the underlying manager
 	surveyObj, err := s.manager.CreateSurvey(name, description, iface, survey.TypePassive)

--- a/internal/netif/autodetect.go
+++ b/internal/netif/autodetect.go
@@ -1,0 +1,37 @@
+package netif
+
+import (
+	"github.com/krisarmstrong/seed/internal/netif/detection"
+)
+
+// AutoDetectInterfaceName returns the name of the highest-scoring live interface.
+//
+// preferType, if non-empty, filters to interfaces of that type ("ethernet",
+// "wifi", "fiber"). When no interface matches the preferred type, the call
+// falls back to the global best-scoring interface so callers always get a
+// usable name when one exists on the system.
+//
+// Returns "" when the system has no non-loopback interface or the underlying
+// detector returns an error. Callers should treat "" as "use a hardcoded
+// last-ditch default" rather than as an error.
+//
+// This is intended as a constructor-time helper for services that need a
+// reasonable interface name before the live netif.Manager is wired up.
+// Replaces hardcoded "eth0"/"wlan0" fallbacks (#572).
+func AutoDetectInterfaceName(preferType string) string {
+	det := detection.NewDetector()
+	scores, err := det.DetectAll()
+	if err != nil || len(scores) == 0 {
+		return ""
+	}
+
+	if preferType != "" {
+		for _, s := range scores {
+			if s.Type == preferType {
+				return s.Name
+			}
+		}
+	}
+
+	return scores[0].Name
+}

--- a/internal/netif/interfaces_darwin.go
+++ b/internal/netif/interfaces_darwin.go
@@ -83,18 +83,13 @@ func configureDHCPPlatform(iface string) error {
 }
 
 // getNetworkServiceName gets the macOS network service name for an interface.
+//
+// Always queries `networksetup -listnetworkserviceorder` rather than relying on
+// hardcoded en0/en1 → service-name mappings: on Mac hardware en0 is sometimes
+// Wi-Fi (laptops without Ethernet) and en1 is sometimes a USB Ethernet adapter,
+// so any static mapping is wrong on some machines (#572).
 func getNetworkServiceName(iface string) (string, error) {
-	// Common mappings
-	serviceNames := map[string]string{
-		"en0": "Ethernet",
-		"en1": "Wi-Fi",
-	}
-
-	if name, ok := serviceNames[iface]; ok {
-		return name, nil
-	}
-
-	// Try to find the service by listing all
+	// Look up the live service order
 	ctx, cancel := context.WithTimeout(context.Background(), ifconfigTimeoutSeconds*time.Second)
 	defer cancel()
 	output, err := exec.CommandContext(ctx, "networksetup", "-listnetworkserviceorder").Output()
@@ -129,7 +124,6 @@ func setMTUPlatform(iface string, mtu int) error {
 	// Use ifconfig to set MTU
 	ctx, cancel := context.WithTimeout(context.Background(), ifconfigTimeoutSeconds*time.Second)
 	defer cancel()
-	//nolint:gosec // G204: ifconfig is a known macOS system binary, args are validated
 	if runErr := exec.CommandContext(ctx, "ifconfig", iface, "mtu", strconv.Itoa(mtu)).Run(); runErr != nil {
 		return fmt.Errorf("failed to set MTU: %w", runErr)
 	}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -19,8 +19,23 @@ import (
 	"github.com/krisarmstrong/seed/internal/services/vlan"
 )
 
-// DefaultInterface is the default network interface to use when none is configured.
+// DefaultInterface is the last-ditch fallback interface name when both config
+// and live auto-detection fail to provide one (#572). Prefer resolveInterface
+// over reading this constant directly.
 const DefaultInterface = "eth0"
+
+// resolveInterface picks the interface name: config first, then live
+// auto-detection (preferring ethernet), then DefaultInterface as a last-ditch
+// fallback.
+func resolveInterface(cfg *config.Config) string {
+	if iface, ok := cfg.GetActiveInterface(); ok && iface != "" {
+		return iface
+	}
+	if iface := netif.AutoDetectInterfaceName("ethernet"); iface != "" {
+		return iface
+	}
+	return DefaultInterface
+}
 
 // InterfaceStateWaitMs is the time in milliseconds to wait for initial interface state detection.
 const InterfaceStateWaitMs = 100
@@ -51,11 +66,8 @@ func NewLinkService(cfg *config.Config) *LinkService {
 func (s *LinkService) Start(ctx context.Context) error {
 	_, s.cancel = context.WithCancel(ctx)
 
-	// Get active interface from config
-	iface, ok := s.cfg.GetActiveInterface()
-	if !ok || iface == "" {
-		iface = DefaultInterface
-	}
+	// Get active interface (config → auto-detect → fallback)
+	iface := resolveInterface(s.cfg)
 
 	// Create network manager for interface enumeration
 	var err error
@@ -539,10 +551,7 @@ type VLANService struct {
 
 // NewVLANService creates a new VLAN service.
 func NewVLANService(cfg *config.Config) *VLANService {
-	iface, ok := cfg.GetActiveInterface()
-	if !ok || iface == "" {
-		iface = DefaultInterface
-	}
+	iface := resolveInterface(cfg)
 	return &VLANService{
 		cfg:            cfg,
 		manager:        vlan.NewManager(iface),
@@ -587,10 +596,7 @@ func (s *VLANService) List(_ context.Context) ([]VLANConfig, error) {
 	}
 
 	// Get active interface for config
-	activeIface, _ := s.cfg.GetActiveInterface()
-	if activeIface == "" {
-		activeIface = DefaultInterface
-	}
+	activeIface := resolveInterface(s.cfg)
 
 	configs := make([]VLANConfig, 0)
 

--- a/internal/services/shell/services.go
+++ b/internal/services/shell/services.go
@@ -8,11 +8,27 @@ import (
 	"github.com/krisarmstrong/seed/internal/config"
 	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/dhcp"
+	"github.com/krisarmstrong/seed/internal/netif"
 	"github.com/krisarmstrong/seed/internal/services/discovery"
 )
 
-// DefaultInterface is the default network interface to use when none is configured.
+// DefaultInterface is the last-ditch fallback interface name when both config
+// and live auto-detection fail to provide one (#572). Prefer resolveInterface
+// over reading this constant directly.
 const DefaultInterface = "eth0"
+
+// resolveInterface picks the interface name: config first, then live
+// auto-detection (preferring ethernet), then DefaultInterface as a last-ditch
+// fallback.
+func resolveInterface(cfg *config.Config) string {
+	if iface, ok := cfg.GetActiveInterface(); ok && iface != "" {
+		return iface
+	}
+	if iface := netif.AutoDetectInterfaceName("ethernet"); iface != "" {
+		return iface
+	}
+	return DefaultInterface
+}
 
 // perfectSecurityScore is the baseline score before any vulnerability deductions (100%).
 const perfectSecurityScore = 100
@@ -31,10 +47,7 @@ type DiscoveryService struct {
 
 // NewDiscoveryService creates a new discovery service.
 func NewDiscoveryService(cfg *config.Config, db *database.DB) *DiscoveryService {
-	iface, ok := cfg.GetActiveInterface()
-	if !ok || iface == "" {
-		iface = DefaultInterface
-	}
+	iface := resolveInterface(cfg)
 
 	return &DiscoveryService{
 		cfg:     cfg,
@@ -364,10 +377,7 @@ type RogueService struct {
 
 // NewRogueService creates a new rogue detection service.
 func NewRogueService(cfg *config.Config) *RogueService {
-	iface, ok := cfg.GetActiveInterface()
-	if !ok || iface == "" {
-		iface = DefaultInterface
-	}
+	iface := resolveInterface(cfg)
 
 	detectorCfg := &dhcp.RogueDetectorConfig{
 		Interface:        iface,


### PR DESCRIPTION
Fixes #572.

## Why
Service constructors fell straight through to \`\"eth0\"\`/\`\"wlan0\"\` whenever config had no active interface. On Linux predictable names (\`enp3s0\`, \`wlp2s0\`) and on Mac laptops without built-in Ethernet (where \`en0\` is Wi-Fi), those defaults are wrong. The existing \`netif/detection\` scorer was never consulted at constructor time.

## What

### New helper
- \`netif.AutoDetectInterfaceName(preferType)\` — standalone package-level helper, returns the best-scoring live interface (optionally filtered to \`\"ethernet\"\` or \`\"wifi\"\`). Empty string means \"no interface\" so callers can fall through to the hardcoded last-ditch default.

### Resolver cascades
Each service now goes \`config → autodetect → DefaultInterface\`:
- \`canopy.NewWiFiService\` / \`SurveyService.Create\` / \`WiFiService.Scan\` — prefer \`wifi\`.
- \`services.NewLinkService\` / \`NewVLANService\` / \`VLANService.List\` — prefer \`ethernet\`.
- \`shell.NewDiscoveryService\` / \`NewRogueService\` — prefer \`ethernet\`.

### macOS service-name lookup
\`getNetworkServiceName\` no longer carries a hardcoded \`en0 → Ethernet\` / \`en1 → Wi-Fi\` map. en0 is the Wi-Fi interface on Macs without built-in Ethernet, and en1 is often a USB adapter, so the static mapping was wrong on real hardware. Always queries \`networksetup -listnetworkserviceorder\` now.

### DefaultInterface constants
Kept for compatibility with existing tests in \`services_test.go\` / \`module_test.go\`, but their doc comments now point at the new resolver helpers and label them as last-ditch fallback only.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/netif/... ./internal/canopy/... ./internal/services/...\` — all pass
- [x] \`golangci-lint run ./internal/netif/...\` clean
- [x] Pre-commit hook passes