### PR TITLE
fix(release): Replace broken SLSA generator with attest-build-provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,21 +259,49 @@ jobs:
           retention-days: 14
 
   # =========================================================================
-  # SLSA Level 3 provenance — runs only on real releases (not dry-run).
-  # The slsa-github-generator reusable workflow builds an in-toto
-  # attestation signed via Sigstore keyless OIDC and uploads it alongside
-  # the release artifacts.
+  # SLSA L3 provenance — runs only on real releases (not dry-run).
+  #
+  # Uses GitHub's first-party `actions/attest-build-provenance` rather than
+  # the slsa-github-generator reusable workflow. The latter (v2.1.0, the
+  # current latest as of 2026-05) has a known bug in its upload-assets
+  # step where UNTRUSTED_PATH is passed empty, causing the secure-download
+  # action to exit 1 and the `final` job to exit 27. attest-build-provenance
+  # produces the same SLSA L3 in-toto attestation (signed via Sigstore
+  # keyless OIDC), surfaces it on the release's GitHub Attestations panel,
+  # AND attaches the bundle file to the release as a downloadable asset.
   # =========================================================================
   provenance:
     name: SLSA provenance
     if: ${{ !inputs.dry_run }}
     needs: [goreleaser]
+    runs-on: ubuntu-latest
     permissions:
-      id-token: write   # for Sigstore OIDC
-      contents: write   # for uploading attestation to the release
-      actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
-    with:
-      base64-subjects: ${{ needs.goreleaser.outputs.hashes }}
-      upload-assets: true
-      provenance-name: seed-slsa-provenance.intoto.jsonl
+      id-token: write       # Sigstore OIDC signing
+      contents: write       # uploading the bundle to the release
+      attestations: write   # GitHub Attestations API
+    steps:
+      - name: Decode artifact subjects
+        id: subjects
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "${{ needs.goreleaser.outputs.hashes }}" | base64 -d > subjects.txt
+          echo "Subjects:"
+          cat subjects.txt
+
+      - name: Generate SLSA build-provenance attestation
+        id: attest
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-checksums: subjects.txt
+
+      - name: Attach attestation bundle to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp "${{ steps.attest.outputs.bundle-path }}" \
+             seed-slsa-provenance.intoto.jsonl
+          gh release upload "${GITHUB_REF_NAME}" \
+             seed-slsa-provenance.intoto.jsonl --clobber --repo "${GITHUB_REPOSITORY}"

--- a/ui/src/components/ui/Alert.stories.tsx
+++ b/ui/src/components/ui/Alert.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import type React from 'react';
+import { Alert } from './Alert';
+
+const meta: Meta<typeof Alert> = {
+  title: 'UI/Alert',
+  component: Alert,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Inline status message used for transient errors, warnings, and confirmations. Resolves through the shared status color tokens so dark/light parity comes for free.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['success', 'error', 'warning', 'info'],
+      description: 'Visual status — drives icon and color tokens.',
+    },
+    onDismiss: {
+      action: 'dismissed',
+      description: 'Optional callback. When provided, renders a close button.',
+    },
+  },
+  decorators: [
+    (StoryComponent: StoryFn): React.ReactElement => (
+      <div class="w-[440px]">
+        <StoryComponent />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Info: Story = {
+  args: {
+    status: 'info',
+    children: 'New firmware available for the gateway. Schedule an update during off-hours.',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    status: 'success',
+    children: 'DHCP lease renewed successfully on eth0.',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    status: 'warning',
+    children: 'Wi-Fi signal weak (-72 dBm). Consider relocating the access point.',
+  },
+};
+
+export const ErrorStatus: Story = {
+  name: 'Error',
+  args: {
+    status: 'error',
+    children: 'TCP port 8443 unreachable. Check the firewall rules.',
+  },
+};
+
+export const Dismissable: Story = {
+  args: {
+    status: 'info',
+    children: 'DNS resolution for 8.8.8.8 completed in 12ms.',
+    onDismiss: () => undefined,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div class="space-y-3">
+      <Alert status="info">Info: ARP cache contains 24 entries.</Alert>
+      <Alert status="success">Success: RFC 2544 benchmark passed.</Alert>
+      <Alert status="warning">Warning: UDP retransmits exceeded threshold.</Alert>
+      <Alert status="error">Error: IP route table inconsistent.</Alert>
+    </div>
+  ),
+};

--- a/ui/src/components/ui/Button.stories.tsx
+++ b/ui/src/components/ui/Button.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { Download, Plus, Trash2 } from 'lucide-react';
+import type React from 'react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'UI/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Canonical button primitive shared by seed/stem/niac. Variant + tone selects the surface; size scales padding and text.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'radio',
+      options: ['solid', 'outline', 'ghost', 'secondary'],
+      description: 'Visual surface.',
+    },
+    tone: {
+      control: 'select',
+      options: ['violet', 'red', 'green', 'blue', 'gray'],
+      description: 'Semantic color — violet is the brand default.',
+    },
+    size: {
+      control: 'radio',
+      options: ['xs', 'sm', 'md', 'lg'],
+      description: 'Padding/text size.',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Replaces leftIcon with a spinner and disables the button.',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+  },
+  decorators: [
+    (StoryComponent: StoryFn): React.ReactElement => (
+      <div class="p-2">
+        <StoryComponent />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    variant: 'solid',
+    tone: 'violet',
+    children: 'Run diagnostics',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+    tone: 'gray',
+    children: 'Cancel',
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    variant: 'ghost',
+    tone: 'violet',
+    children: 'View details',
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    variant: 'solid',
+    tone: 'red',
+    leftIcon: <Trash2 class="h-4 w-4" />,
+    children: 'Delete profile',
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    variant: 'outline',
+    tone: 'violet',
+    children: 'Outlined',
+  },
+};
+
+export const WithIcons: Story = {
+  args: {
+    variant: 'solid',
+    tone: 'green',
+    leftIcon: <Plus class="h-4 w-4" />,
+    children: 'Add server',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    variant: 'solid',
+    tone: 'violet',
+    loading: true,
+    children: 'Saving…',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    variant: 'solid',
+    tone: 'violet',
+    disabled: true,
+    children: 'Unavailable',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div class="space-y-4">
+      <div class="flex flex-wrap items-center gap-2">
+        <Button variant="solid" tone="violet">
+          Solid
+        </Button>
+        <Button variant="outline" tone="violet">
+          Outline
+        </Button>
+        <Button variant="ghost" tone="violet">
+          Ghost
+        </Button>
+        <Button variant="secondary" tone="gray">
+          Secondary
+        </Button>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <Button variant="solid" tone="green" leftIcon={<Download class="h-4 w-4" />}>
+          Success
+        </Button>
+        <Button variant="solid" tone="blue">
+          Info
+        </Button>
+        <Button variant="solid" tone="red">
+          Danger
+        </Button>
+        <Button variant="solid" tone="gray">
+          Neutral
+        </Button>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <Button size="xs">XS</Button>
+        <Button size="sm">Small</Button>
+        <Button size="md">Medium</Button>
+        <Button size="lg">Large</Button>
+      </div>
+    </div>
+  ),
+};

--- a/ui/src/components/ui/Combobox.stories.tsx
+++ b/ui/src/components/ui/Combobox.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import type React from 'react';
+import { useState } from 'react';
+import { Combobox } from './Combobox';
+
+interface Interface {
+  name: string;
+  speedMbps: number;
+}
+
+const interfaces: Interface[] = [
+  { name: 'eth0', speedMbps: 1000 },
+  { name: 'eth1', speedMbps: 1000 },
+  { name: 'wlan0', speedMbps: 866 },
+  { name: 'lo', speedMbps: 0 },
+];
+
+const meta: Meta<typeof Combobox<Interface>> = {
+  title: 'UI/Combobox',
+  component: Combobox<Interface>,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Generic typeahead select built on cmdk. Same look-and-feel as the command palette so navigation feels consistent.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (StoryComponent: StoryFn): React.ReactElement => (
+      <div class="w-[360px]">
+        <StoryComponent />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithOptions: Story = {
+  render: () => {
+    const [value, setValue] = useState<Interface | null>(null);
+    return (
+      <Combobox<Interface>
+        value={value}
+        onChange={setValue}
+        options={interfaces}
+        getKey={(o) => o.name}
+        getLabel={(o) =>
+          o.speedMbps > 0 ? `${o.name} (${o.speedMbps} Mbps)` : `${o.name} (loopback)`
+        }
+        placeholder="Select interface…"
+        ariaLabel="Network interface selector"
+      />
+    );
+  },
+};
+
+export const Preselected: Story = {
+  render: () => {
+    const [initialValue] = interfaces;
+    if (!initialValue) {
+      return <div>No interfaces available</div>;
+    }
+    const [value, setValue] = useState<Interface | null>(initialValue);
+    return (
+      <Combobox<Interface>
+        value={value}
+        onChange={setValue}
+        options={interfaces}
+        getKey={(o) => o.name}
+        getLabel={(o) => `${o.name} (${o.speedMbps} Mbps)`}
+        ariaLabel="Network interface selector"
+      />
+    );
+  },
+};
+
+export const Empty: Story = {
+  render: () => {
+    const [value, setValue] = useState<Interface | null>(null);
+    return (
+      <Combobox<Interface>
+        value={value}
+        onChange={setValue}
+        options={[]}
+        getKey={(o) => o.name}
+        getLabel={(o) => o.name}
+        placeholder="No interfaces detected"
+        emptyText="No network interfaces available."
+        ariaLabel="Network interface selector"
+      />
+    );
+  },
+};
+
+export const Disabled: Story = {
+  render: () => {
+    const [value, setValue] = useState<Interface | null>(null);
+    return (
+      <Combobox<Interface>
+        value={value}
+        onChange={setValue}
+        options={interfaces}
+        getKey={(o) => o.name}
+        getLabel={(o) => o.name}
+        placeholder="Locked"
+        ariaLabel="Network interface selector"
+        disabled={true}
+      />
+    );
+  },
+};

--- a/ui/src/components/ui/CommandPalette.stories.tsx
+++ b/ui/src/components/ui/CommandPalette.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { Activity, BookOpen, Home, Sparkles } from 'lucide-react';
+import type React from 'react';
+import { useState } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import type { SidebarNavGroup } from '../../ui/Sidebar';
+import { Button } from './Button';
+import { CommandPalette } from './CommandPalette';
+
+const navGroups: SidebarNavGroup[] = [
+  {
+    label: 'Modules',
+    items: [
+      { label: 'Roots', path: '/roots', icon: Home },
+      { label: 'Canopy', path: '/canopy', icon: Activity },
+      { label: 'Sap', path: '/sap', icon: Sparkles },
+    ],
+  },
+  {
+    label: 'Help',
+    items: [{ label: 'Documentation', path: '/help', icon: BookOpen }],
+  },
+];
+
+const meta: Meta<typeof CommandPalette> = {
+  title: 'UI/CommandPalette',
+  component: CommandPalette,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Keyboard-first command/navigation palette (cmdk). Opens on Cmd+K (macOS) / Ctrl+K (others). Populates with sidebar nav entries plus common actions.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (StoryComponent: StoryFn): React.ReactElement => (
+      <MemoryRouter>
+        <div class="min-h-[60vh] p-4">
+          <StoryComponent />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Closed: Story = {
+  render: () => (
+    <div class="space-y-3">
+      <p class="text-sm text-text-muted">
+        Press <kbd class="rounded border border-surface-border px-1.5 py-0.5">⌘K</kbd> /{' '}
+        <kbd class="rounded border border-surface-border px-1.5 py-0.5">Ctrl+K</kbd> to open.
+      </p>
+      <CommandPalette
+        groups={navGroups}
+        open={false}
+        onOpenChange={() => undefined}
+        onOpenSettings={() => undefined}
+        onOpenHelp={() => undefined}
+        onToggleTheme={() => undefined}
+        isDark={true}
+      />
+    </div>
+  ),
+};
+
+export const Open: Story = {
+  render: () => (
+    <CommandPalette
+      groups={navGroups}
+      open={true}
+      onOpenChange={() => undefined}
+      onOpenSettings={() => undefined}
+      onOpenHelp={() => undefined}
+      onToggleTheme={() => undefined}
+      isDark={true}
+    />
+  ),
+};
+
+export const Interactive: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <div class="space-y-3">
+        <Button onClick={() => setOpen(true)}>Open command palette</Button>
+        <CommandPalette
+          groups={navGroups}
+          open={open}
+          onOpenChange={setOpen}
+          onOpenSettings={() => undefined}
+          onOpenHelp={() => undefined}
+          onToggleTheme={() => undefined}
+          isDark={true}
+        />
+      </div>
+    );
+  },
+};
+
+export const WithExtraActions: Story = {
+  render: () => (
+    <CommandPalette
+      groups={navGroups}
+      open={true}
+      onOpenChange={() => undefined}
+      onOpenSettings={() => undefined}
+      onOpenHelp={() => undefined}
+      onToggleTheme={() => undefined}
+      isDark={false}
+      extraActions={[
+        {
+          id: 'run-rfc2544',
+          label: 'Run RFC 2544 benchmark',
+          hint: 'modules',
+          perform: () => undefined,
+        },
+        {
+          id: 'export-report',
+          label: 'Export Harvest report',
+          hint: 'reports',
+          perform: () => undefined,
+        },
+      ]}
+    />
+  ),
+};

--- a/ui/src/components/ui/ConfirmModal.stories.tsx
+++ b/ui/src/components/ui/ConfirmModal.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import type React from 'react';
+import { useState } from 'react';
+import { Button } from './Button';
+import { ConfirmModal } from './ConfirmModal';
+
+const meta: Meta<typeof ConfirmModal> = {
+  title: 'UI/ConfirmModal',
+  component: ConfirmModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'Confirmation dialog with a triangle icon and two buttons (cancel + confirm).',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (StoryComponent: StoryFn): React.ReactElement => (
+      <div class="min-h-[60vh] p-4">
+        <StoryComponent />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DestructiveOpen: Story = {
+  render: () => (
+    <ConfirmModal
+      isOpen={true}
+      onConfirm={() => undefined}
+      onCancel={() => undefined}
+      title="Delete profile?"
+      message="This will permanently remove the network profile and its history."
+      confirmLabel="Delete"
+      cancelLabel="Cancel"
+      confirmTone="red"
+    />
+  ),
+};
+
+export const InfoOpen: Story = {
+  render: () => (
+    <ConfirmModal
+      isOpen={true}
+      onConfirm={() => undefined}
+      onCancel={() => undefined}
+      title="Apply DHCP changes?"
+      message="The gateway will renew its lease. The interface may go down briefly."
+      confirmLabel="Apply"
+      cancelLabel="Cancel"
+      confirmTone="blue"
+    />
+  ),
+};
+
+export const SuccessOpen: Story = {
+  render: () => (
+    <ConfirmModal
+      isOpen={true}
+      onConfirm={() => undefined}
+      onCancel={() => undefined}
+      title="Start the RFC 2544 benchmark?"
+      message="This will run a 60-second throughput test on eth0."
+      confirmLabel="Start"
+      cancelLabel="Cancel"
+      confirmTone="green"
+    />
+  ),
+};
+
+export const Closed: Story = {
+  render: () => (
+    <ConfirmModal
+      isOpen={false}
+      onConfirm={() => undefined}
+      onCancel={() => undefined}
+      title="Hidden dialog"
+      message="This story documents the closed state — nothing should render."
+    />
+  ),
+};
+
+export const Interactive: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <div class="space-y-4">
+        <Button tone="red" onClick={() => setOpen(true)}>
+          Delete profile…
+        </Button>
+        <ConfirmModal
+          isOpen={open}
+          onConfirm={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+          title="Delete profile?"
+          message="This action cannot be undone."
+          confirmLabel="Delete"
+          confirmTone="red"
+        />
+      </div>
+    );
+  },
+};

--- a/ui/src/components/ui/Input.stories.tsx
+++ b/ui/src/components/ui/Input.stories.tsx
@@ -1,0 +1,182 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { Lock, Mail, Search } from 'lucide-react';
+import type React from 'react';
+import { useState } from 'react';
+import {
+  Checkbox,
+  FormGroup,
+  FormSection,
+  Input,
+  SearchInput,
+  Select,
+  Textarea,
+  Toggle,
+} from './Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'UI/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Form primitives: text input, textarea, select, checkbox, toggle, and search input. All share the same focus ring and color tokens.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    error: { control: 'text' },
+    hint: { control: 'text' },
+    disabled: { control: 'boolean' },
+  },
+  decorators: [
+    (StoryComponent: StoryFn): React.ReactElement => (
+      <div class="w-[360px]">
+        <StoryComponent />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: 'Server hostname',
+    placeholder: 'example.local',
+  },
+};
+
+export const WithHint: Story = {
+  args: {
+    label: 'IP address',
+    placeholder: '192.168.1.1',
+    hint: 'Enter the IPv4 address of the gateway.',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'you@example.com',
+    error: 'Email is required.',
+    defaultValue: '',
+  },
+};
+
+export const WithLeftIcon: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'you@example.com',
+    leftIcon: <Mail class="h-4 w-4" />,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Locked field',
+    defaultValue: 'cannot edit',
+    disabled: true,
+    leftIcon: <Lock class="h-4 w-4" />,
+  },
+};
+
+export const TextareaExample: Story = {
+  name: 'Textarea',
+  render: () => (
+    <Textarea
+      label="Notes"
+      placeholder="Describe the network topology…"
+      hint="Markdown supported."
+    />
+  ),
+};
+
+export const SelectExample: Story = {
+  name: 'Select',
+  render: () => (
+    <Select
+      label="Test protocol"
+      placeholder="Choose protocol"
+      options={[
+        { value: 'tcp', label: 'TCP' },
+        { value: 'udp', label: 'UDP' },
+        { value: 'icmp', label: 'ICMP' },
+      ]}
+    />
+  ),
+};
+
+export const CheckboxExample: Story = {
+  name: 'Checkbox',
+  render: () => {
+    const [checked, setChecked] = useState(false);
+    return (
+      <Checkbox
+        label="Enable deep packet inspection"
+        description="Inspects TCP/UDP headers in addition to flow stats."
+        checked={checked}
+        onChange={(e) => setChecked(e.target.checked)}
+      />
+    );
+  },
+};
+
+export const ToggleExample: Story = {
+  name: 'Toggle',
+  render: () => {
+    const [enabled, setEnabled] = useState(true);
+    return (
+      <Toggle
+        label="Auto-refresh dashboard"
+        description="Polls the server every 5 seconds."
+        checked={enabled}
+        onChange={(e) => setEnabled(e.target.checked)}
+      />
+    );
+  },
+};
+
+export const SearchInputExample: Story = {
+  name: 'SearchInput',
+  render: () => {
+    const [query, setQuery] = useState('');
+    return (
+      <SearchInput
+        label="Find host"
+        placeholder="Search by hostname or IP…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onClear={() => setQuery('')}
+        leftIcon={<Search class="h-4 w-4" />}
+      />
+    );
+  },
+};
+
+export const FormLayout: Story = {
+  name: 'Form layout',
+  render: () => (
+    <FormSection
+      title="Network profile"
+      description="DHCP, DNS, and ARP settings for this interface."
+    >
+      <FormGroup>
+        <Input label="Profile name" placeholder="Office gateway" />
+        <Input label="Gateway IP" placeholder="192.168.1.1" hint="IPv4 only." />
+        <Select
+          label="Mode"
+          options={[
+            { value: 'dhcp', label: 'DHCP' },
+            { value: 'static', label: 'Static' },
+          ]}
+        />
+      </FormGroup>
+    </FormSection>
+  ),
+};

--- a/ui/src/components/ui/InputModal.stories.tsx
+++ b/ui/src/components/ui/InputModal.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import type React from 'react';
+import { useState } from 'react';
+import { Button } from './Button';
+import { InputModal } from './InputModal';
+
+const meta: Meta<typeof InputModal> = {
+  title: 'UI/InputModal',
+  component: InputModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Single-field prompt dialog. Submits on Enter, cancels on Escape. Focuses and selects the field on open.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (StoryComponent: StoryFn): React.ReactElement => (
+      <div class="min-h-[60vh] p-4">
+        <StoryComponent />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {
+  render: () => (
+    <InputModal
+      isOpen={true}
+      onSubmit={() => undefined}
+      onCancel={() => undefined}
+      title="Rename profile"
+      message="Pick a new name for this network profile."
+      placeholder="Office gateway"
+      defaultValue="Office gateway"
+      submitLabel="Save"
+    />
+  ),
+};
+
+export const Closed: Story = {
+  render: () => (
+    <InputModal
+      isOpen={false}
+      onSubmit={() => undefined}
+      onCancel={() => undefined}
+      title="Hidden"
+      message="Nothing should render in the closed state."
+    />
+  ),
+};
+
+export const DangerTone: Story = {
+  render: () => (
+    <InputModal
+      isOpen={true}
+      onSubmit={() => undefined}
+      onCancel={() => undefined}
+      title="Type DELETE to confirm"
+      message="This will permanently remove the IP route table. Type DELETE to proceed."
+      placeholder="DELETE"
+      submitLabel="Delete"
+      submitTone="red"
+    />
+  ),
+};
+
+export const Interactive: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    const [name, setName] = useState('Office gateway');
+    return (
+      <div class="space-y-3">
+        <Button onClick={() => setOpen(true)}>Rename profile…</Button>
+        <p class="text-sm text-text-muted">Current name: {name}</p>
+        <InputModal
+          isOpen={open}
+          onSubmit={(value) => {
+            setName(value);
+            setOpen(false);
+          }}
+          onCancel={() => setOpen(false)}
+          title="Rename profile"
+          message="Pick a new name."
+          defaultValue={name}
+        />
+      </div>
+    );
+  },
+};

--- a/ui/src/components/ui/Modal.stories.tsx
+++ b/ui/src/components/ui/Modal.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import type React from 'react';
+import { useState } from 'react';
+import { Button } from './Button';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from './Modal';
+
+const meta: Meta<typeof Modal> = {
+  title: 'UI/Modal',
+  component: Modal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Base modal primitive with focus trap, backdrop click and Escape close, and ModalHeader/Body/Footer slots.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg', 'xl', 'full'],
+    },
+    showCloseButton: { control: 'boolean' },
+    closeOnBackdropClick: { control: 'boolean' },
+    closeOnEscape: { control: 'boolean' },
+  },
+  decorators: [
+    (StoryComponent: StoryFn): React.ReactElement => (
+      <div class="min-h-[60vh] p-4">
+        <StoryComponent />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {
+  render: () => (
+    <Modal isOpen={true} onClose={() => undefined} title="Modal title" size="md">
+      <p class="text-text-secondary">
+        Modal body. Tab is trapped inside the dialog; Escape closes when closeOnEscape is on.
+      </p>
+    </Modal>
+  ),
+};
+
+export const Closed: Story = {
+  render: () => (
+    <Modal isOpen={false} onClose={() => undefined} title="Hidden">
+      <p>Nothing should render in the closed state.</p>
+    </Modal>
+  ),
+};
+
+export const WithSlots: Story = {
+  name: 'With ModalHeader/Body/Footer',
+  render: () => (
+    <Modal isOpen={true} onClose={() => undefined} size="lg">
+      <ModalHeader>
+        <h2 class="text-lg font-semibold text-text-primary">Edit DHCP profile</h2>
+        <p class="text-sm text-text-muted">Changes apply to all interfaces using this profile.</p>
+      </ModalHeader>
+      <ModalBody>
+        <p class="text-text-secondary">
+          DNS, ARP, and TCP/UDP defaults are inherited unless overridden per interface.
+        </p>
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="outline" onClick={() => undefined}>
+          Cancel
+        </Button>
+        <Button onClick={() => undefined}>Save</Button>
+      </ModalFooter>
+    </Modal>
+  ),
+};
+
+export const Interactive: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <div class="space-y-3">
+        <Button onClick={() => setOpen(true)}>Open modal</Button>
+        <Modal isOpen={open} onClose={() => setOpen(false)} title="Hello" size="md">
+          <p class="text-text-secondary">Click the backdrop or press Escape to close.</p>
+          <div class="mt-4 flex justify-end">
+            <Button onClick={() => setOpen(false)}>Close</Button>
+          </div>
+        </Modal>
+      </div>
+    );
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <Modal isOpen={true} onClose={() => undefined} title="Full size modal" size="full">
+      <p class="text-text-secondary">
+        Use size=&quot;full&quot; for content-heavy dialogs (reports, log viewers).
+      </p>
+    </Modal>
+  ),
+};

--- a/ui/src/components/ui/Tag.stories.tsx
+++ b/ui/src/components/ui/Tag.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import type React from 'react';
+import { Tag } from './Tag';
+
+const meta: Meta<typeof Tag> = {
+  title: 'UI/Tag',
+  component: Tag,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Inline label/badge primitive. Color scheme maps to the shared status + brand tokens, so dark/light parity is automatic.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    colorScheme: {
+      control: 'select',
+      options: ['gray', 'red', 'green', 'blue', 'yellow', 'purple', 'violet', 'cyan'],
+    },
+  },
+  decorators: [
+    (StoryComponent: StoryFn): React.ReactElement => (
+      <div class="p-2">
+        <StoryComponent />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Tag',
+  },
+};
+
+export const Green: Story = {
+  args: {
+    colorScheme: 'green',
+    children: 'Online',
+  },
+};
+
+export const Red: Story = {
+  args: {
+    colorScheme: 'red',
+    children: 'Failed',
+  },
+};
+
+export const Yellow: Story = {
+  args: {
+    colorScheme: 'yellow',
+    children: 'Warning',
+  },
+};
+
+export const Blue: Story = {
+  args: {
+    colorScheme: 'blue',
+    children: 'Info',
+  },
+};
+
+export const AllColors: Story = {
+  render: () => (
+    <div class="flex flex-wrap items-center gap-2">
+      <Tag colorScheme="gray">Gray</Tag>
+      <Tag colorScheme="red">Red</Tag>
+      <Tag colorScheme="green">Green</Tag>
+      <Tag colorScheme="blue">Blue</Tag>
+      <Tag colorScheme="yellow">Yellow</Tag>
+      <Tag colorScheme="purple">Purple</Tag>
+      <Tag colorScheme="violet">Violet</Tag>
+      <Tag colorScheme="cyan">Cyan</Tag>
+    </div>
+  ),
+};
+
+export const NetworkStatuses: Story = {
+  render: () => (
+    <div class="flex flex-wrap items-center gap-2">
+      <Tag colorScheme="green">DHCP active</Tag>
+      <Tag colorScheme="blue">DNS resolving</Tag>
+      <Tag colorScheme="yellow">ARP slow</Tag>
+      <Tag colorScheme="red">TCP timeout</Tag>
+      <Tag colorScheme="cyan">UDP healthy</Tag>
+      <Tag colorScheme="violet">WiFi connected</Tag>
+    </div>
+  ),
+};

--- a/ui/src/components/ui/Typography.stories.tsx
+++ b/ui/src/components/ui/Typography.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import type React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AccentLink, Caption, H1, H2, H3, H4, P, SmallText } from './Typography';
+
+const meta: Meta<typeof H1> = {
+  title: 'UI/Typography',
+  component: H1,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Canonical heading and body text primitives. Use these instead of ad-hoc class strings so the app stays visually consistent.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (StoryComponent: StoryFn): React.ReactElement => (
+      <MemoryRouter>
+        <div class="w-[480px]">
+          <StoryComponent />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Heading1: Story = {
+  render: () => <H1>The Seed</H1>,
+};
+
+export const Heading2: Story = {
+  render: () => <H2>Network diagnostics</H2>,
+};
+
+export const Heading3: Story = {
+  render: () => <H3>DHCP lease summary</H3>,
+};
+
+export const Heading4: Story = {
+  render: () => <H4>Interface eth0</H4>,
+};
+
+export const Paragraph: Story = {
+  render: () => (
+    <P>
+      The Roots module analyses path quality across the discovered topology using TCP, UDP, and ICMP
+      probes. Results are persisted to SQLite and exposed via the REST API.
+    </P>
+  ),
+};
+
+export const SmallTextStory: Story = {
+  name: 'SmallText',
+  render: () => <SmallText>Last scan: 12 seconds ago</SmallText>,
+};
+
+export const CaptionStory: Story = {
+  name: 'Caption',
+  render: () => <Caption>Sourced from RFC 2544 baseline measurements.</Caption>,
+};
+
+export const LinkVariants: Story = {
+  name: 'AccentLink',
+  render: () => (
+    <div class="space-y-3">
+      <div>
+        <AccentLink href="https://example.com">External link (href)</AccentLink>
+      </div>
+      <div>
+        <AccentLink to="/roots">Internal link (react-router)</AccentLink>
+      </div>
+      <div>
+        <AccentLink onClick={() => undefined}>Button-styled link</AccentLink>
+      </div>
+    </div>
+  ),
+};
+
+export const Hierarchy: Story = {
+  render: () => (
+    <div class="space-y-4">
+      <H1>The Seed</H1>
+      <H2>Modules</H2>
+      <P>Five modules cover the full network diagnostics surface:</P>
+      <div class="space-y-2">
+        <H3>Roots — path analysis</H3>
+        <P>Hop-by-hop latency, jitter, and loss measurements over TCP/UDP/ICMP.</P>
+        <SmallText>RFC 2544 baseline supported.</SmallText>
+      </div>
+      <div class="space-y-2">
+        <H3>Canopy — Wi-Fi planning</H3>
+        <P>RF coverage and capacity planning informed by IEEE 802.11 telemetry.</P>
+      </div>
+      <Caption>Last updated 5 minutes ago.</Caption>
+    </div>
+  ),
+};


### PR DESCRIPTION
Fixes the SLSA provenance / final exit-27 failure on every release. The slsa-github-generator v2.1.0 reusable workflow has a bug where UNTRUSTED_PATH is passed empty to the secure-download composite action, causing the upload-assets step to silently fail and the provenance bundle never to attach to the release. Replaced with GitHub's first-party actions/attest-build-provenance@v2 which produces the same SLSA L3 in-toto attestation and uploads it as both a GitHub-native attestation and a release asset.

Verify against v0.190.0/v0.191.0 — both have 0 SLSA assets currently. After this merges + the next release cycle, .intoto.jsonl will appear.

## Test plan
- [ ] CI: all required checks pass
- [ ] After merge: trigger next release, verify seed-slsa-provenance.intoto.jsonl attached