### PR TITLE
fix(setup): Point wizard at /api/v1/setup/* (fixes wizard not appearing)

### DIFF
--- a/ui/src/components/setup/SetupWizard.tsx
+++ b/ui/src/components/setup/SetupWizard.tsx
@@ -14,7 +14,7 @@
  * Flow:
  * 1. User enters password (or accepts suggested password)
  * 2. Confirms password matches
- * 3. SetupWizard sends POST /api/setup/complete with new password
+ * 3. SetupWizard sends POST /api/v1/setup/complete with new password
  * 4. Server hashes and stores password
  * 5. Component automatically logs in user
  * 6. Calls onComplete callback to exit setup flow
@@ -175,7 +175,7 @@ export function SetupWizard({
     try {
       // Step 1: Complete setup (set password on server)
       // Security fix #724, #758: Include the one-time setup token to prevent CSRF attacks
-      const response = await fetch(`${API_BASE}/api/setup/complete`, {
+      const response = await fetch(`${API_BASE}/api/v1/setup/complete`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/ui/src/components/setup/setupApi.ts
+++ b/ui/src/components/setup/setupApi.ts
@@ -8,7 +8,7 @@
 const API_BASE: string = import.meta.env.VITE_API_BASE || '';
 
 /**
- * Response from /api/setup/status endpoint
+ * Response from /api/v1/setup/status endpoint
  */
 export interface SetupStatusResponse {
   needsSetup: boolean; // True if initial setup is required
@@ -19,10 +19,13 @@ export interface SetupStatusResponse {
 
 /**
  * Checks if initial setup is required by querying the API status endpoint.
+ * Backend mounts this at /api/v1/setup/status (the unversioned /api/setup/...
+ * path returns 401 from the auth catch-all middleware and the wizard never
+ * fires — root cause of the "wizard doesn't appear" symptom on v0.191.x).
  */
 export async function checkSetupStatus(): Promise<SetupStatusResponse> {
   try {
-    const response = await fetch(`${API_BASE}/api/setup/status`);
+    const response = await fetch(`${API_BASE}/api/v1/setup/status`);
     if (response.ok) {
       return response.json() as Promise<SetupStatusResponse>;
     }


### PR DESCRIPTION
Setup wizard never appeared on fresh installs because setupApi.checkSetupStatus() hits /api/setup/status but the backend mounts the route at /api/v1/setup/status (APIVersionPrefix). Unversioned path → auth catch-all → 401 → silent fallback to needsSetup:false → no wizard. Fix both the status check and the complete POST.