### PR TITLE
chore(ci): expand E2E to full Playwright suite (#64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,7 +814,7 @@ jobs:
         working-directory: ui
         env:
           E2E_BASE_URL: https://localhost:8443
-        run: npx playwright test e2e/smoke.spec.ts e2e/setup-wizard.spec.ts --project=chromium --reporter=html
+        run: npx playwright test --project=chromium --reporter=html
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary
- Switch CI's Playwright invocation from the smoke + setup-wizard subset to the full e2e/ suite.
- Brings seed's E2E coverage in line with niac-go, which already runs all specs in CI.
- Suite is advisory (not required for merge per #73's branch-protection update), so newly-surfaced flakes or drifted selectors will not block the merge queue.

## Why
Most spec files in ui/e2e/ were unused by CI - they only ran locally. Running them in CI surfaces drift early so it can be triaged in a follow-up audit.

## Test plan
- [ ] CI runs all specs in ui/e2e/ against the locally-started backend
- [ ] E2E job is reported as non-required (advisory) per #73
- [ ] Any failing specs are captured for a follow-up triage task (#64 follow-up)

Refs #64