### PR TITLE
feat: Graceful port fallback when canonical port is in use (#69)

### DIFF
--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
 
 	"github.com/krisarmstrong/seed/internal/auth"
@@ -405,4 +406,18 @@ type ExportEngineDiscoveryResponse = EngineDiscoveryResponse
 // GetEngine returns the discovery engine for testing.
 func (s *Server) GetEngine() any {
 	return s.services.Discovery.Engine
+}
+
+// ExportBindWithFallback exposes bindWithFallback for testing.
+func ExportBindWithFallback(
+	ctx context.Context,
+	host string,
+	port int,
+) (net.Listener, int, error) {
+	return bindWithFallback(ctx, host, port)
+}
+
+// ExportIsAddrInUse exposes isAddrInUse for testing.
+func ExportIsAddrInUse(err error) bool {
+	return isAddrInUse(err)
 }

--- a/internal/api/server_lifecycle.go
+++ b/internal/api/server_lifecycle.go
@@ -121,10 +121,20 @@ func (s *Server) Start() error {
 }
 
 // startHTTP starts the server in HTTP mode.
+//
+// Uses bindWithFallback so that a busy canonical port falls back to
+// port+1..+9 instead of failing outright. The actual bound port is
+// reflected back into s.httpServer.Addr so /__version and log lines
+// match reality (fixes #69).
 func (s *Server) startHTTP() error {
-	logging.GetLogger().Info("Starting HTTP server", "addr", s.httpServer.Addr)
-	if err := s.httpServer.ListenAndServe(); err != nil {
+	ln, actualPort, err := bindWithFallback(context.Background(), "", s.config.Server.Port)
+	if err != nil {
 		return fmt.Errorf("http server: %w", err)
+	}
+	s.httpServer.Addr = fmt.Sprintf(":%d", actualPort)
+	logging.GetLogger().Info("Starting HTTP server", "addr", s.httpServer.Addr)
+	if serveErr := s.httpServer.Serve(ln); serveErr != nil {
+		return fmt.Errorf("http server: %w", serveErr)
 	}
 	return nil
 }
@@ -154,7 +164,18 @@ func (s *Server) startHTTPRedirect(port int) {
 		http.Redirect(w, r, httpsURL, http.StatusMovedPermanently)
 	})
 
-	addr := fmt.Sprintf(":%d", port)
+	// Bind via the port-fallback helper so a busy :80 (or whatever is
+	// configured) walks up to +9 instead of killing the redirect goroutine.
+	ln, actualPort, bindErr := bindWithFallback(context.Background(), "", port)
+	if bindErr != nil {
+		logging.GetLogger().Error("HTTP redirect server bind failed", "error", bindErr)
+		if s.redirectServerErr == nil {
+			s.redirectServerErr = make(chan error, 1)
+		}
+		s.redirectServerErr <- bindErr
+		return
+	}
+	addr := fmt.Sprintf(":%d", actualPort)
 	logging.GetLogger().Info("Starting HTTP→HTTPS redirect server", "addr", addr)
 
 	// Store redirect server for proper shutdown (fixes #515)
@@ -171,7 +192,7 @@ func (s *Server) startHTTPRedirect(port int) {
 	}
 
 	// Run server and report errors
-	err := s.redirectServer.ListenAndServe()
+	err := s.redirectServer.Serve(ln)
 	if err != nil && err != http.ErrServerClosed {
 		logging.GetLogger().Error("HTTP redirect server error", "error", err)
 		s.redirectServerErr <- err
@@ -213,9 +234,15 @@ func (s *Server) startHTTPS() error {
 	}
 	s.httpServer.TLSConfig = tlsConfig
 
+	ln, actualPort, bindErr := bindWithFallback(context.Background(), "", s.config.Server.Port)
+	if bindErr != nil {
+		return fmt.Errorf("https server: %w", bindErr)
+	}
+	s.httpServer.Addr = fmt.Sprintf(":%d", actualPort)
+
 	logging.GetLogger().
 		Info("Starting HTTPS server", "addr", s.httpServer.Addr, "tls_version", "1.3")
-	if err := s.httpServer.ListenAndServeTLS(certFile, keyFile); err != nil {
+	if err := s.httpServer.ServeTLS(ln, certFile, keyFile); err != nil {
 		return fmt.Errorf("https server: %w", err)
 	}
 	return nil
@@ -275,8 +302,14 @@ func (s *Server) startHTTPSWithACME() error {
 		}
 	}()
 
-	// ListenAndServeTLS with empty cert/key paths uses GetCertificate from TLSConfig
-	if err := s.httpServer.ListenAndServeTLS("", ""); err != nil {
+	ln, actualPort, bindErr := bindWithFallback(context.Background(), "", s.config.Server.Port)
+	if bindErr != nil {
+		return fmt.Errorf("https server with ACME: %w", bindErr)
+	}
+	s.httpServer.Addr = fmt.Sprintf(":%d", actualPort)
+
+	// ServeTLS with empty cert/key paths uses GetCertificate from TLSConfig.
+	if err := s.httpServer.ServeTLS(ln, "", ""); err != nil {
 		return fmt.Errorf("https server with ACME: %w", err)
 	}
 	return nil

--- a/internal/api/server_port_fallback.go
+++ b/internal/api/server_port_fallback.go
@@ -1,0 +1,89 @@
+package api
+
+// server_port_fallback.go provides bindWithFallback, a helper that opens a
+// TCP listener on a desired port and walks +1..+9 if the canonical port
+// is already in use. This keeps `seed` runnable for developers who have
+// another service squatting on 8443 without changing the documented
+// default port (see #69).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"syscall"
+
+	"github.com/krisarmstrong/seed/internal/logging"
+)
+
+// portFallbackMaxOffset is the maximum offset above the requested port that
+// bindWithFallback will probe. Probes are requested..requested+portFallbackMaxOffset.
+const portFallbackMaxOffset = 9
+
+// bindWithFallback opens a TCP listener on host:port. If that port is in
+// use it walks ports+1..+portFallbackMaxOffset and returns the first
+// listener that binds, logging a WARN with the requested and actual port.
+//
+// Non-EADDRINUSE errors are returned immediately — the caller must treat
+// them as fatal (permission denied, invalid address, etc.).
+//
+// The caller is responsible for closing the returned listener (typically
+// by passing it to [http.Server.Serve] / [http.Server.ServeTLS], which
+// close on shutdown).
+func bindWithFallback(ctx context.Context, host string, port int) (net.Listener, int, error) {
+	var lc net.ListenConfig
+	for offset := 0; offset <= portFallbackMaxOffset; offset++ {
+		actual := port + offset
+		addr := net.JoinHostPort(host, strconv.Itoa(actual))
+		ln, err := lc.Listen(ctx, "tcp", addr)
+		if err == nil {
+			if offset > 0 {
+				logging.GetLogger().Warn(
+					"requested port is in use, bound fallback port instead",
+					"requested", port,
+					"bound", actual,
+				)
+			}
+			return ln, actual, nil
+		}
+		if !isAddrInUse(err) {
+			return nil, 0, fmt.Errorf("bind %s: %w", addr, err)
+		}
+	}
+	return nil, 0, fmt.Errorf(
+		"bind %s:%d and +1..+%d all in use",
+		host, port, portFallbackMaxOffset,
+	)
+}
+
+// isAddrInUse reports whether err indicates the address-in-use condition.
+// It checks [syscall.EADDRINUSE] via [errors.Is] (works on Linux/macOS) and
+// falls back to a string match for platforms whose listener wrapping does
+// not unwrap to the syscall errno.
+func isAddrInUse(err error) bool {
+	if errors.Is(err, syscall.EADDRINUSE) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Err != nil {
+		return containsAddrInUse(opErr.Err.Error())
+	}
+	return false
+}
+
+// containsAddrInUse looks for the canonical address-in-use substring.
+// Split out so it can be unit-tested independently of platform errno
+// behaviour.
+func containsAddrInUse(msg string) bool {
+	const needle = "address already in use"
+	if len(msg) < len(needle) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(msg); i++ {
+		if msg[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/server_port_fallback.go
+++ b/internal/api/server_port_fallback.go
@@ -39,7 +39,8 @@ func bindWithFallback(ctx context.Context, host string, port int) (net.Listener,
 		ln, err := lc.Listen(ctx, "tcp", addr)
 		if err == nil {
 			if offset > 0 {
-				logging.GetLogger().Warn(
+				logging.WarnContext(
+					ctx,
 					"requested port is in use, bound fallback port instead",
 					"requested", port,
 					"bound", actual,

--- a/internal/api/server_port_fallback_test.go
+++ b/internal/api/server_port_fallback_test.go
@@ -1,0 +1,75 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/api"
+)
+
+// TestBindWithFallback_FreePort confirms a free port is bound at offset 0.
+func TestBindWithFallback_FreePort(t *testing.T) {
+	// Grab an ephemeral port, close immediately so it's free again.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	port := probe.Addr().(*net.TCPAddr).Port
+	_ = probe.Close()
+
+	ln, bound, err := api.ExportBindWithFallback(context.Background(), "127.0.0.1", port)
+	if err != nil {
+		t.Fatalf("bindWithFallback returned error: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	if bound != port {
+		t.Fatalf("expected bound port %d, got %d", port, bound)
+	}
+	if !strings.HasSuffix(ln.Addr().String(), ":"+strconv.Itoa(port)) {
+		t.Fatalf("listener bound to unexpected address %s", ln.Addr().String())
+	}
+}
+
+// TestBindWithFallback_FallsBackOneStep grabs a port, holds it open, then
+// expects bindWithFallback to land on requested+1.
+func TestBindWithFallback_FallsBackOneStep(t *testing.T) {
+	hold, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("hold listen: %v", err)
+	}
+	defer func() { _ = hold.Close() }()
+
+	taken := hold.Addr().(*net.TCPAddr).Port
+	// Ask for the same port — should fall back to taken+1.
+	ln, bound, err := api.ExportBindWithFallback(context.Background(), "127.0.0.1", taken)
+	if err != nil {
+		t.Fatalf("bindWithFallback fell through: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	if bound != taken+1 {
+		t.Fatalf("expected fallback to port %d, got %d", taken+1, bound)
+	}
+}
+
+// TestIsAddrInUse_RecognisesSyscall confirms isAddrInUse matches a wrapped
+// EADDRINUSE.
+func TestIsAddrInUse_RecognisesSyscall(t *testing.T) {
+	wrapped := &net.OpError{Op: "listen", Err: syscall.EADDRINUSE}
+	if !api.ExportIsAddrInUse(wrapped) {
+		t.Fatalf("expected isAddrInUse to match EADDRINUSE")
+	}
+}
+
+// TestIsAddrInUse_RejectsOtherErrors ensures unrelated errors don't match.
+func TestIsAddrInUse_RejectsOtherErrors(t *testing.T) {
+	if api.ExportIsAddrInUse(errors.New("some unrelated failure")) {
+		t.Fatalf("expected isAddrInUse to reject unrelated error")
+	}
+}


### PR DESCRIPTION
Implements #69. bindWithFallback helper probes the canonical HTTP/HTTPS port and walks +1..+9 on EADDRINUSE with a structured WARN. Non-bind-conflict errors stay fatal. Graceful shutdown unchanged.