### PR TITLE
fix(ci): Add target_tag input to SLSA backfill (#75 follow-up)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,10 @@ on:
         description: "Backfill: skip build, recompute subjects from the existing release's checksums.txt, attest + upload bundle"
         type: boolean
         default: false
+      target_tag:
+        description: "Backfill target tag (e.g. v0.190.0). Required when provenance_only=true — workflow_dispatch must be issued against main since older tags don't have these inputs."
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -286,10 +290,18 @@ jobs:
       - name: Download checksums.txt from existing release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # When provenance_only is invoked via workflow_dispatch on the
+          # main branch, GITHUB_REF_NAME is "main", not the tag we want.
+          # The target_tag input carries the real tag.
+          TARGET_TAG: ${{ inputs.target_tag }}
         shell: bash
         run: |
           set -euo pipefail
-          gh release download "${GITHUB_REF_NAME}" \
+          if [ -z "$TARGET_TAG" ]; then
+            echo "::error::provenance_only=true requires target_tag to identify which existing release to attest"
+            exit 1
+          fi
+          gh release download "$TARGET_TAG" \
             --repo "${GITHUB_REPOSITORY}" \
             --pattern 'checksums.txt' \
             --dir .
@@ -359,10 +371,14 @@ jobs:
       - name: Attach attestation bundle to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # On a tag-push trigger GITHUB_REF_NAME is the tag itself.
+          # On a backfill dispatch (provenance_only=true from main),
+          # target_tag carries the real tag instead.
+          TARGET_TAG: ${{ inputs.target_tag || github.ref_name }}
         shell: bash
         run: |
           set -euo pipefail
           cp "${{ steps.attest.outputs.bundle-path }}" \
              seed-slsa-provenance.intoto.jsonl
-          gh release upload "${GITHUB_REF_NAME}" \
+          gh release upload "$TARGET_TAG" \
              seed-slsa-provenance.intoto.jsonl --clobber --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,12 @@
 #     SLSA L3 provenance
 #   - workflow_dispatch with dry_run=true: snapshot only — no publish, no
 #     signing, no provenance; artifacts uploaded for inspection
+#   - workflow_dispatch with provenance_only=true (ref=<existing tag>):
+#     skips goreleaser entirely, recomputes artifact subjects from the
+#     already-published checksums.txt on that tag's GitHub release, then
+#     runs attest-build-provenance + uploads the .intoto.jsonl. Used to
+#     retroactively attest tags that shipped before the provenance job
+#     existed. provenance_only takes precedence over dry_run.
 #
 # Toolchain notes:
 #   The goreleaser-cross Docker image ships:
@@ -38,6 +44,10 @@ on:
         description: "Snapshot build only — do not publish or sign"
         type: boolean
         default: true
+      provenance_only:
+        description: "Backfill: skip build, recompute subjects from the existing release's checksums.txt, attest + upload bundle"
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -55,6 +65,7 @@ jobs:
   # =========================================================================
   build-iperf3:
     name: Build iperf3 (${{ matrix.arch }})
+    if: ${{ !inputs.provenance_only }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -106,6 +117,7 @@ jobs:
   # =========================================================================
   build-ui:
     name: Build UI
+    if: ${{ !inputs.provenance_only }}
     runs-on: ubuntu-latest
     outputs:
       ui_hash: ${{ steps.ui-hash.outputs.hash }}
@@ -145,6 +157,7 @@ jobs:
   # =========================================================================
   goreleaser:
     name: goreleaser ${{ inputs.dry_run && '(snapshot)' || '(release)' }}
+    if: ${{ !inputs.provenance_only }}
     runs-on: ubuntu-latest
     needs: [build-iperf3, build-ui]
     container:
@@ -254,7 +267,50 @@ jobs:
           retention-days: 14
 
   # =========================================================================
-  # SLSA L3 provenance — runs only on real releases (not dry-run).
+  # SLSA provenance backfill — recomputes the subject list from a tag's
+  # already-published checksums.txt instead of running goreleaser. Used
+  # to retroactively attest tags that shipped before the provenance job
+  # existed (issue #75). Only fires under workflow_dispatch with
+  # provenance_only=true; on a push or normal dispatch this job is
+  # skipped and the regular `goreleaser` job feeds the provenance job.
+  # =========================================================================
+  goreleaser-backfill-hashes:
+    name: goreleaser (backfill subjects from existing release)
+    if: ${{ inputs.provenance_only }}
+    runs-on: ubuntu-latest
+    outputs:
+      # Same base64-subjects contract as the goreleaser job's `hashes`
+      # output. Provenance job picks whichever upstream produced one.
+      hashes: ${{ steps.hashes.outputs.hashes }}
+    steps:
+      - name: Download checksums.txt from existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release download "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern 'checksums.txt' \
+            --dir .
+          echo "checksums.txt contents:"
+          cat checksums.txt
+
+      - name: Convert checksums.txt to base64 subjects
+        id: hashes
+        shell: bash
+        run: |
+          # checksums.txt is the standard goreleaser format:
+          #   <sha256>  <filename>
+          # The attest-build-provenance `subject-checksums` input takes
+          # exactly that format. We base64-encode here so the output
+          # contract matches the goreleaser job's `hashes` output.
+          set -euo pipefail
+          hashes=$(base64 -w0 < checksums.txt)
+          echo "hashes=${hashes}" >> "$GITHUB_OUTPUT"
+
+  # =========================================================================
+  # SLSA L3 provenance — runs on real releases (not dry-run).
   #
   # Uses GitHub's first-party `actions/attest-build-provenance` rather than
   # the slsa-github-generator reusable workflow. The latter (v2.1.0, the
@@ -264,11 +320,19 @@ jobs:
   # produces the same SLSA L3 in-toto attestation (signed via Sigstore
   # keyless OIDC), surfaces it on the release's GitHub Attestations panel,
   # AND attaches the bundle file to the release as a downloadable asset.
+  #
+  # Two upstream paths feed this job (only one runs per invocation):
+  #   - normal release:  needs.goreleaser produces subjects from artifacts.json
+  #   - provenance_only: needs.goreleaser-backfill-hashes produces subjects
+  #                      from the existing release's checksums.txt
   # =========================================================================
   provenance:
     name: SLSA provenance
-    if: ${{ !inputs.dry_run }}
-    needs: [goreleaser]
+    # Skip on dry-run snapshots; require one of the two upstreams to have
+    # succeeded. `!cancelled()` lets this job run even though one of the
+    # two `needs` is intentionally skipped per dispatch path.
+    if: ${{ !inputs.dry_run && !cancelled() && (needs.goreleaser.result == 'success' || needs.goreleaser-backfill-hashes.result == 'success') }}
+    needs: [goreleaser, goreleaser-backfill-hashes]
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # Sigstore OIDC signing
@@ -280,7 +344,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "${{ needs.goreleaser.outputs.hashes }}" | base64 -d > subjects.txt
+          # Pick whichever upstream ran. The unused one is empty.
+          echo "${{ needs.goreleaser.outputs.hashes || needs.goreleaser-backfill-hashes.outputs.hashes }}" \
+            | base64 -d > subjects.txt
           echo "Subjects:"
           cat subjects.txt
 

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
 
 	"github.com/krisarmstrong/seed/internal/auth"
@@ -405,4 +406,18 @@ type ExportEngineDiscoveryResponse = EngineDiscoveryResponse
 // GetEngine returns the discovery engine for testing.
 func (s *Server) GetEngine() any {
 	return s.services.Discovery.Engine
+}
+
+// ExportBindWithFallback exposes bindWithFallback for testing.
+func ExportBindWithFallback(
+	ctx context.Context,
+	host string,
+	port int,
+) (net.Listener, int, error) {
+	return bindWithFallback(ctx, host, port)
+}
+
+// ExportIsAddrInUse exposes isAddrInUse for testing.
+func ExportIsAddrInUse(err error) bool {
+	return isAddrInUse(err)
 }

--- a/internal/api/server_lifecycle.go
+++ b/internal/api/server_lifecycle.go
@@ -121,10 +121,20 @@ func (s *Server) Start() error {
 }
 
 // startHTTP starts the server in HTTP mode.
+//
+// Uses bindWithFallback so that a busy canonical port falls back to
+// port+1..+9 instead of failing outright. The actual bound port is
+// reflected back into s.httpServer.Addr so /__version and log lines
+// match reality (fixes #69).
 func (s *Server) startHTTP() error {
-	logging.GetLogger().Info("Starting HTTP server", "addr", s.httpServer.Addr)
-	if err := s.httpServer.ListenAndServe(); err != nil {
+	ln, actualPort, err := bindWithFallback(context.Background(), "", s.config.Server.Port)
+	if err != nil {
 		return fmt.Errorf("http server: %w", err)
+	}
+	s.httpServer.Addr = fmt.Sprintf(":%d", actualPort)
+	logging.GetLogger().Info("Starting HTTP server", "addr", s.httpServer.Addr)
+	if serveErr := s.httpServer.Serve(ln); serveErr != nil {
+		return fmt.Errorf("http server: %w", serveErr)
 	}
 	return nil
 }
@@ -154,7 +164,18 @@ func (s *Server) startHTTPRedirect(port int) {
 		http.Redirect(w, r, httpsURL, http.StatusMovedPermanently)
 	})
 
-	addr := fmt.Sprintf(":%d", port)
+	// Bind via the port-fallback helper so a busy :80 (or whatever is
+	// configured) walks up to +9 instead of killing the redirect goroutine.
+	ln, actualPort, bindErr := bindWithFallback(context.Background(), "", port)
+	if bindErr != nil {
+		logging.GetLogger().Error("HTTP redirect server bind failed", "error", bindErr)
+		if s.redirectServerErr == nil {
+			s.redirectServerErr = make(chan error, 1)
+		}
+		s.redirectServerErr <- bindErr
+		return
+	}
+	addr := fmt.Sprintf(":%d", actualPort)
 	logging.GetLogger().Info("Starting HTTP→HTTPS redirect server", "addr", addr)
 
 	// Store redirect server for proper shutdown (fixes #515)
@@ -171,7 +192,7 @@ func (s *Server) startHTTPRedirect(port int) {
 	}
 
 	// Run server and report errors
-	err := s.redirectServer.ListenAndServe()
+	err := s.redirectServer.Serve(ln)
 	if err != nil && err != http.ErrServerClosed {
 		logging.GetLogger().Error("HTTP redirect server error", "error", err)
 		s.redirectServerErr <- err
@@ -213,9 +234,15 @@ func (s *Server) startHTTPS() error {
 	}
 	s.httpServer.TLSConfig = tlsConfig
 
+	ln, actualPort, bindErr := bindWithFallback(context.Background(), "", s.config.Server.Port)
+	if bindErr != nil {
+		return fmt.Errorf("https server: %w", bindErr)
+	}
+	s.httpServer.Addr = fmt.Sprintf(":%d", actualPort)
+
 	logging.GetLogger().
 		Info("Starting HTTPS server", "addr", s.httpServer.Addr, "tls_version", "1.3")
-	if err := s.httpServer.ListenAndServeTLS(certFile, keyFile); err != nil {
+	if err := s.httpServer.ServeTLS(ln, certFile, keyFile); err != nil {
 		return fmt.Errorf("https server: %w", err)
 	}
 	return nil
@@ -275,8 +302,14 @@ func (s *Server) startHTTPSWithACME() error {
 		}
 	}()
 
-	// ListenAndServeTLS with empty cert/key paths uses GetCertificate from TLSConfig
-	if err := s.httpServer.ListenAndServeTLS("", ""); err != nil {
+	ln, actualPort, bindErr := bindWithFallback(context.Background(), "", s.config.Server.Port)
+	if bindErr != nil {
+		return fmt.Errorf("https server with ACME: %w", bindErr)
+	}
+	s.httpServer.Addr = fmt.Sprintf(":%d", actualPort)
+
+	// ServeTLS with empty cert/key paths uses GetCertificate from TLSConfig.
+	if err := s.httpServer.ServeTLS(ln, "", ""); err != nil {
 		return fmt.Errorf("https server with ACME: %w", err)
 	}
 	return nil

--- a/internal/api/server_port_fallback.go
+++ b/internal/api/server_port_fallback.go
@@ -1,0 +1,89 @@
+package api
+
+// server_port_fallback.go provides bindWithFallback, a helper that opens a
+// TCP listener on a desired port and walks +1..+9 if the canonical port
+// is already in use. This keeps `seed` runnable for developers who have
+// another service squatting on 8443 without changing the documented
+// default port (see #69).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"syscall"
+
+	"github.com/krisarmstrong/seed/internal/logging"
+)
+
+// portFallbackMaxOffset is the maximum offset above the requested port that
+// bindWithFallback will probe. Probes are requested..requested+portFallbackMaxOffset.
+const portFallbackMaxOffset = 9
+
+// bindWithFallback opens a TCP listener on host:port. If that port is in
+// use it walks ports+1..+portFallbackMaxOffset and returns the first
+// listener that binds, logging a WARN with the requested and actual port.
+//
+// Non-EADDRINUSE errors are returned immediately — the caller must treat
+// them as fatal (permission denied, invalid address, etc.).
+//
+// The caller is responsible for closing the returned listener (typically
+// by passing it to [http.Server.Serve] / [http.Server.ServeTLS], which
+// close on shutdown).
+func bindWithFallback(ctx context.Context, host string, port int) (net.Listener, int, error) {
+	var lc net.ListenConfig
+	for offset := 0; offset <= portFallbackMaxOffset; offset++ {
+		actual := port + offset
+		addr := net.JoinHostPort(host, strconv.Itoa(actual))
+		ln, err := lc.Listen(ctx, "tcp", addr)
+		if err == nil {
+			if offset > 0 {
+				logging.GetLogger().Warn(
+					"requested port is in use, bound fallback port instead",
+					"requested", port,
+					"bound", actual,
+				)
+			}
+			return ln, actual, nil
+		}
+		if !isAddrInUse(err) {
+			return nil, 0, fmt.Errorf("bind %s: %w", addr, err)
+		}
+	}
+	return nil, 0, fmt.Errorf(
+		"bind %s:%d and +1..+%d all in use",
+		host, port, portFallbackMaxOffset,
+	)
+}
+
+// isAddrInUse reports whether err indicates the address-in-use condition.
+// It checks [syscall.EADDRINUSE] via [errors.Is] (works on Linux/macOS) and
+// falls back to a string match for platforms whose listener wrapping does
+// not unwrap to the syscall errno.
+func isAddrInUse(err error) bool {
+	if errors.Is(err, syscall.EADDRINUSE) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Err != nil {
+		return containsAddrInUse(opErr.Err.Error())
+	}
+	return false
+}
+
+// containsAddrInUse looks for the canonical address-in-use substring.
+// Split out so it can be unit-tested independently of platform errno
+// behaviour.
+func containsAddrInUse(msg string) bool {
+	const needle = "address already in use"
+	if len(msg) < len(needle) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(msg); i++ {
+		if msg[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/server_port_fallback.go
+++ b/internal/api/server_port_fallback.go
@@ -39,7 +39,8 @@ func bindWithFallback(ctx context.Context, host string, port int) (net.Listener,
 		ln, err := lc.Listen(ctx, "tcp", addr)
 		if err == nil {
 			if offset > 0 {
-				logging.GetLogger().Warn(
+				logging.WarnContext(
+					ctx,
 					"requested port is in use, bound fallback port instead",
 					"requested", port,
 					"bound", actual,

--- a/internal/api/server_port_fallback_test.go
+++ b/internal/api/server_port_fallback_test.go
@@ -1,0 +1,75 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/api"
+)
+
+// TestBindWithFallback_FreePort confirms a free port is bound at offset 0.
+func TestBindWithFallback_FreePort(t *testing.T) {
+	// Grab an ephemeral port, close immediately so it's free again.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	port := probe.Addr().(*net.TCPAddr).Port
+	_ = probe.Close()
+
+	ln, bound, err := api.ExportBindWithFallback(context.Background(), "127.0.0.1", port)
+	if err != nil {
+		t.Fatalf("bindWithFallback returned error: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	if bound != port {
+		t.Fatalf("expected bound port %d, got %d", port, bound)
+	}
+	if !strings.HasSuffix(ln.Addr().String(), ":"+strconv.Itoa(port)) {
+		t.Fatalf("listener bound to unexpected address %s", ln.Addr().String())
+	}
+}
+
+// TestBindWithFallback_FallsBackOneStep grabs a port, holds it open, then
+// expects bindWithFallback to land on requested+1.
+func TestBindWithFallback_FallsBackOneStep(t *testing.T) {
+	hold, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("hold listen: %v", err)
+	}
+	defer func() { _ = hold.Close() }()
+
+	taken := hold.Addr().(*net.TCPAddr).Port
+	// Ask for the same port — should fall back to taken+1.
+	ln, bound, err := api.ExportBindWithFallback(context.Background(), "127.0.0.1", taken)
+	if err != nil {
+		t.Fatalf("bindWithFallback fell through: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	if bound != taken+1 {
+		t.Fatalf("expected fallback to port %d, got %d", taken+1, bound)
+	}
+}
+
+// TestIsAddrInUse_RecognisesSyscall confirms isAddrInUse matches a wrapped
+// EADDRINUSE.
+func TestIsAddrInUse_RecognisesSyscall(t *testing.T) {
+	wrapped := &net.OpError{Op: "listen", Err: syscall.EADDRINUSE}
+	if !api.ExportIsAddrInUse(wrapped) {
+		t.Fatalf("expected isAddrInUse to match EADDRINUSE")
+	}
+}
+
+// TestIsAddrInUse_RejectsOtherErrors ensures unrelated errors don't match.
+func TestIsAddrInUse_RejectsOtherErrors(t *testing.T) {
+	if api.ExportIsAddrInUse(errors.New("some unrelated failure")) {
+		t.Fatalf("expected isAddrInUse to reject unrelated error")
+	}
+}


### PR DESCRIPTION
Follow-up to #75. The previous design dispatched against the tag ref but GH parses workflow_dispatch inputs from the workflow file AT THAT REF — older tags don't have provenance_only, so every backfill dispatch returned HTTP 422. Fix: add target_tag input + dispatch from main.