### PR TITLE
feat(tls): Trust-store install UX + cert fingerprint + 308 redirect (Wave 1)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -479,6 +479,17 @@ linters:
       - text: 'G115: integer overflow conversion int -> byte'
         path: 'internal/api/health_checks_dicom\.go'
         linters: [ gosec ]
+      # internal/truststore writes trust-anchor PEMs into the four OS-specific
+      # CA directories (Debian/Ubuntu, RHEL/Fedora, Arch, openSUSE). The
+      # destination is computed by detectLinuxStore from a hardcoded
+      # candidate list, then filepath.Clean'd and bounded under its root
+      # via filepath.Rel before writing. gosec G703 cannot follow that
+      # provenance and reports the os.WriteFile call as taint-derived. The
+      # write is preceded by an explicit containment check — see
+      # writeAnchorFile in truststore_linux.go.
+      - text: 'G703: Path traversal via taint analysis'
+        path: 'internal/truststore/truststore_linux\.go'
+        linters: [ gosec ]
       # profiler_infer.go contains portToService, an intentional literal-
       # reference table mapping port numbers to user-facing protocol names.
       # The repeated strings (ftp/ssh/http/etc.) are protocol identifiers,

--- a/README.md
+++ b/README.md
@@ -96,6 +96,35 @@ brew install krisarmstrong/tap/seed
 2. Walk the first-run setup wizard to create the admin password — there is
    no shipped default password.
 
+### First-time TLS trust setup (optional)
+
+Seed serves its UI over HTTPS with a self-signed certificate. To eliminate
+the browser warning, install that certificate into your OS trust store:
+
+```bash
+sudo seed install-ca
+```
+
+This adds seed's root certificate to the macOS Keychain, the Linux system
+CA bundle (Debian/Ubuntu via `update-ca-certificates`, RHEL/Fedora via
+`update-ca-trust`), or the Windows Certificate Store. After the install
+command finishes it prints the certificate's SHA-256 fingerprint. Compare
+it against what your browser shows ("View certificate → Details →
+Fingerprints") and against the value served at `/__version`:
+
+```bash
+seed install-ca --print-fingerprint
+curl -k https://localhost:8443/__version | jq -r .tlsFingerprint
+```
+
+The two values must match.
+
+To remove the certificate from the trust store:
+
+```bash
+sudo seed install-ca --uninstall
+```
+
 ## Configuration
 
 `seed.yaml` (and `SEED_*` env vars) configure the appliance:

--- a/cmd/seed/cmd_install_ca.go
+++ b/cmd/seed/cmd_install_ca.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/krisarmstrong/seed/internal/truststore"
+)
+
+const (
+	// installCACommandName is the cobra subcommand name. Used for both
+	// command registration and operator-facing hint messages so they stay
+	// in sync.
+	installCACommandName = "install-ca"
+
+	// defaultCertPath is the file ensureSelfSignedCert writes when seed
+	// generates its own HTTPS certificate. install-ca uses this path
+	// unless overridden with --cert.
+	defaultCertPath = "certs/server.crt"
+
+	// installCATimeoutSeconds is the timeout for individual platform
+	// utility invocations (`security`, `update-ca-certificates`, etc.).
+	installCATimeoutSeconds = 30
+)
+
+// installCAFlags holds the parsed command-line flags for install-ca.
+type installCAFlags struct {
+	certPath         string
+	uninstall        bool
+	printFingerprint bool
+}
+
+func initInstallCACmd(state *cliState) {
+	installCACmd := &cobra.Command{
+		Use:   installCACommandName,
+		Short: "Install seed's self-signed root certificate into the OS trust store",
+		Long: `Install seed's self-signed root certificate into the operating
+system's trust store so browsers stop showing the "not secure" warning when
+visiting the seed UI over HTTPS.
+
+The cert seed generates on first launch (at certs/server.crt) is a single-
+tier self-signed root: it is both the leaf served on the TLS handshake and
+its own issuer. Installing it as a trusted root tells the OS to accept it
+for SSL.
+
+Run seed at least once before install-ca so the certificate file exists.
+
+Supported platforms:
+  macOS    System Keychain (requires sudo)
+  Linux    System CA bundle via update-ca-certificates / update-ca-trust
+  Windows  LocalMachine\Root (requires elevated shell)
+
+Verification:
+  seed install-ca --print-fingerprint
+  curl -k https://localhost:8443/__version | jq -r .tlsFingerprint
+The two values must match.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runInstallCA(cmd, args, state)
+		},
+	}
+	installCACmd.Flags().String("cert", defaultCertPath,
+		"Path to the PEM-encoded certificate to install")
+	installCACmd.Flags().Bool("uninstall", false,
+		"Remove seed's certificate from the OS trust store")
+	installCACmd.Flags().Bool("print-fingerprint", false,
+		"Print the SHA-256 fingerprint of the certificate and exit without modifying the trust store")
+	state.rootCmd.AddCommand(installCACmd)
+}
+
+// parseInstallCAFlags extracts the install-ca command flags.
+func parseInstallCAFlags(cmd *cobra.Command) (installCAFlags, error) {
+	var flags installCAFlags
+	var err error
+	flags.certPath, err = cmd.Flags().GetString("cert")
+	if err != nil {
+		return flags, fmt.Errorf("getting cert flag: %w", err)
+	}
+	flags.uninstall, err = cmd.Flags().GetBool("uninstall")
+	if err != nil {
+		return flags, fmt.Errorf("getting uninstall flag: %w", err)
+	}
+	flags.printFingerprint, err = cmd.Flags().GetBool("print-fingerprint")
+	if err != nil {
+		return flags, fmt.Errorf("getting print-fingerprint flag: %w", err)
+	}
+	return flags, nil
+}
+
+// resolveCertPath returns the absolute path to the cert file, or an error
+// with operator-friendly hints if the file does not exist.
+func resolveCertPath(p string) (string, error) {
+	if p == "" {
+		return "", errors.New("--cert must not be empty")
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("resolve cert path: %w", err)
+	}
+	_, statErr := os.Stat(abs)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return "", fmt.Errorf(
+				"certificate not found at %s\n"+
+					"Start seed once to generate its self-signed certificate, "+
+					"then re-run install-ca", abs)
+		}
+		return "", fmt.Errorf("stat %s: %w", abs, statErr)
+	}
+	return abs, nil
+}
+
+// certFingerprint reads the cert at path and returns its SHA-256 fingerprint
+// formatted as 32 uppercase hex pairs separated by colons.
+func certFingerprint(path string) (string, error) {
+	cert, err := truststore.ValidateCertFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(cert.Raw)
+	return formatColonHex(sum[:]), nil
+}
+
+// formatColonHex converts a byte slice into the standard browser-style
+// fingerprint format (uppercase hex pairs separated by colons).
+func formatColonHex(b []byte) string {
+	const hex = "0123456789ABCDEF"
+	out := make([]byte, 0, len(b)*3-1)
+	for i, x := range b {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		out = append(out, hex[x>>4], hex[x&0x0f])
+	}
+	return string(out)
+}
+
+// runInstallCA is the cobra Run callback for install-ca.
+func runInstallCA(cmd *cobra.Command, _ []string, _ *cliState) {
+	flags, err := parseInstallCAFlags(cmd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	abs, err := resolveCertPath(flags.certPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fp, err := certFingerprint(abs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if flags.printFingerprint {
+		fmt.Fprintln(os.Stdout, fp)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), installCATimeoutSeconds*time.Second)
+	defer cancel()
+
+	if flags.uninstall {
+		runUninstallCA(ctx, abs, fp)
+		return
+	}
+	runInstallCAInstall(ctx, abs, fp)
+}
+
+func runInstallCAInstall(ctx context.Context, certPath, fingerprint string) {
+	fmt.Fprintf(os.Stdout, "Installing %s into the OS trust store...\n", certPath)
+	res, err := truststore.Install(ctx, certPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		printInstallHints(err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "[ok] Installed.\n")
+	printResult(res)
+	fmt.Fprintf(os.Stdout, "Certificate SHA-256 fingerprint:\n  %s\n", fingerprint)
+	fmt.Fprintf(os.Stdout, "Compare this against the value reported by:\n")
+	fmt.Fprintf(os.Stdout, "  curl -k https://localhost:8443/__version | jq -r .tlsFingerprint\n")
+}
+
+func runUninstallCA(ctx context.Context, certPath, fingerprint string) {
+	fmt.Fprintf(os.Stdout, "Removing %s from the OS trust store...\n", certPath)
+	res, err := truststore.Uninstall(ctx, certPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "[ok] Removed.\n")
+	printResult(res)
+	fmt.Fprintf(os.Stdout, "Certificate SHA-256 fingerprint:\n  %s\n", fingerprint)
+}
+
+func printResult(res truststore.Result) {
+	for _, s := range res.Stores {
+		fmt.Fprintf(os.Stdout, "  modified: %s\n", s)
+	}
+	for _, s := range res.Skipped {
+		fmt.Fprintf(os.Stdout, "  skipped:  %s\n", s)
+	}
+}
+
+// printInstallHints adds operator-friendly guidance for common failure
+// modes (missing sudo, unsupported platform).
+func printInstallHints(err error) {
+	if errors.Is(err, truststore.ErrUnsupportedPlatform) {
+		fmt.Fprintln(os.Stderr,
+			"Hint: install-ca supports macOS, Linux, and Windows. "+
+				"On other systems you must manually import the certificate "+
+				"into your trust store.")
+		return
+	}
+	uid := os.Getuid()
+	if uid != 0 && uid != -1 {
+		fmt.Fprintln(os.Stderr,
+			"Hint: modifying the system trust store usually requires root. "+
+				"Try: sudo seed install-ca")
+	}
+}

--- a/cmd/seed/cmd_install_ca_test.go
+++ b/cmd/seed/cmd_install_ca_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeFixtureCert generates a self-signed PEM cert in a tempdir and
+// returns the file path together with the expected SHA-256 fingerprint
+// (uppercase colon-separated).
+func writeFixtureCert(t *testing.T) (string, string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(99),
+		Subject:               pkix.Name{CommonName: "seed-install-ca-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	var buf bytes.Buffer
+	if encErr := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: der}); encErr != nil {
+		t.Fatalf("pem encode: %v", encErr)
+	}
+	path := filepath.Join(t.TempDir(), "server.crt")
+	if writeErr := os.WriteFile(path, buf.Bytes(), 0o600); writeErr != nil {
+		t.Fatalf("write cert: %v", writeErr)
+	}
+	sum := sha256.Sum256(der)
+	return path, formatColonHex(sum[:])
+}
+
+func TestInstallCACmdRegistered(t *testing.T) {
+	state := newCLIState()
+	initCommands(state)
+
+	cmd, _, err := state.rootCmd.Find([]string{"install-ca"})
+	if err != nil {
+		t.Fatalf("install-ca subcommand not registered: %v", err)
+	}
+	if cmd.Name() != "install-ca" {
+		t.Errorf("expected install-ca, got %q", cmd.Name())
+	}
+
+	// Required flags must exist.
+	for _, name := range []string{"cert", "uninstall", "print-fingerprint"} {
+		if cmd.Flag(name) == nil {
+			t.Errorf("install-ca missing --%s flag", name)
+		}
+	}
+}
+
+func TestInstallCAHelpRuns(t *testing.T) {
+	state := newCLIState()
+	initCommands(state)
+
+	state.rootCmd.SetArgs([]string{"install-ca", "--help"})
+	state.rootCmd.SetOut(&bytes.Buffer{})
+	state.rootCmd.SetErr(&bytes.Buffer{})
+	if err := state.rootCmd.Execute(); err != nil {
+		t.Fatalf("install-ca --help returned error: %v", err)
+	}
+}
+
+func TestResolveCertPath_OK(t *testing.T) {
+	t.Parallel()
+	path, _ := writeFixtureCert(t)
+	got, err := resolveCertPath(path)
+	if err != nil {
+		t.Fatalf("resolveCertPath(%q): %v", path, err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("expected absolute path, got %q", got)
+	}
+}
+
+func TestResolveCertPath_Missing(t *testing.T) {
+	t.Parallel()
+	_, err := resolveCertPath(filepath.Join(t.TempDir(), "missing.crt"))
+	if err == nil {
+		t.Fatal("expected error for missing path, got nil")
+	}
+	if !strings.Contains(err.Error(), "Start seed once") {
+		t.Errorf("expected hint about starting seed, got: %v", err)
+	}
+}
+
+func TestResolveCertPath_Empty(t *testing.T) {
+	t.Parallel()
+	_, err := resolveCertPath("")
+	if err == nil {
+		t.Fatal("expected error for empty path, got nil")
+	}
+}
+
+func TestCertFingerprintMatchesSha256(t *testing.T) {
+	t.Parallel()
+	path, want := writeFixtureCert(t)
+	got, err := certFingerprint(path)
+	if err != nil {
+		t.Fatalf("certFingerprint: %v", err)
+	}
+	if got != want {
+		t.Errorf("certFingerprint mismatch:\n  got  %s\n  want %s", got, want)
+	}
+}
+
+func TestFormatColonHexUppercase(t *testing.T) {
+	t.Parallel()
+	got := formatColonHex([]byte{0x00, 0x0f, 0xff, 0xab})
+	const want = "00:0F:FF:AB"
+	if got != want {
+		t.Errorf("formatColonHex = %q, want %q", got, want)
+	}
+}
+
+func TestInstallCAFlagsDefaults(t *testing.T) {
+	flags := installCAFlags{}
+	if flags.certPath != "" {
+		t.Errorf("certPath default should be empty in zero value, got %q", flags.certPath)
+	}
+	if flags.uninstall {
+		t.Error("uninstall default should be false")
+	}
+	if flags.printFingerprint {
+		t.Error("printFingerprint default should be false")
+	}
+}
+
+func TestInstallCATimeoutPositive(t *testing.T) {
+	if installCATimeoutSeconds <= 0 {
+		t.Error("installCATimeoutSeconds should be positive")
+	}
+}
+
+func TestDefaultCertPathConstant(t *testing.T) {
+	if defaultCertPath == "" {
+		t.Error("defaultCertPath should be non-empty")
+	}
+	if !strings.HasSuffix(defaultCertPath, ".crt") {
+		t.Errorf("defaultCertPath should end in .crt, got %q", defaultCertPath)
+	}
+}

--- a/cmd/seed/root.go
+++ b/cmd/seed/root.go
@@ -142,6 +142,7 @@ func initCommands(state *cliState) {
 	initCredentialsCmd(state)
 	initExportCmd(state)
 	initInstallCmd(state)
+	initInstallCACmd(state)
 	initMCPCmd(state)
 	initPlatformCmd(state)
 	initResetCmd(state)

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -421,3 +421,38 @@ func ExportBindWithFallback(
 func ExportIsAddrInUse(err error) bool {
 	return isAddrInUse(err)
 }
+
+// HTTPToHTTPSRedirectHandler exposes the HTTP→HTTPS redirect handler for testing.
+func (s *Server) HTTPToHTTPSRedirectHandler() http.Handler {
+	return s.httpToHTTPSRedirectHandler()
+}
+
+// EnsureSelfSignedCert exposes ensureSelfSignedCert for testing.
+func (s *Server) EnsureSelfSignedCert() (string, string, error) {
+	return s.ensureSelfSignedCert()
+}
+
+// ExportFingerprintFromPEM exposes fingerprintFromPEM for testing.
+func ExportFingerprintFromPEM(pemData []byte) (string, error) {
+	return fingerprintFromPEM(pemData)
+}
+
+// ExportComputeCertFingerprint exposes computeCertFingerprint for testing.
+func ExportComputeCertFingerprint(path string) (string, error) {
+	return computeCertFingerprint(path)
+}
+
+// ExportFormatFingerprint exposes formatFingerprint for testing.
+func ExportFormatFingerprint(digest []byte) string {
+	return formatFingerprint(digest)
+}
+
+// ErrEmptyCertPath exposes errEmptyCertPath for testing.
+var ErrEmptyCertPath = errEmptyCertPath
+
+// ErrNoCertificateBlock exposes errNoCertificateBlock for testing.
+var ErrNoCertificateBlock = errNoCertificateBlock
+
+// TLSFingerprintCache is the exported type alias for tlsFingerprintCache,
+// used in tests that exercise the cache behaviour directly.
+type TLSFingerprintCache = tlsFingerprintCache

--- a/internal/api/handlers_buildversion.go
+++ b/internal/api/handlers_buildversion.go
@@ -11,6 +11,11 @@ import (
 // validation. Unauthenticated by design — operators need to verify which
 // binary is running without holding a session. Required by the Universal
 // Build Contract; see CLAUDE.md.
+//
+// In addition to version.Info() the response carries `tlsFingerprint`, the
+// SHA-256 fingerprint of the active TLS certificate. The field is always
+// present so the response shape is stable; it is an empty string when the
+// server runs without TLS (HTTP mode or ACME-managed certs).
 func (s *Server) handleBuildVersion(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	if r.Method != http.MethodGet {
@@ -24,5 +29,7 @@ func (s *Server) handleBuildVersion(w http.ResponseWriter, r *http.Request) {
 		)
 		return
 	}
-	sendJSONResponse(w, logger, http.StatusOK, version.Info())
+	resp := version.Info()
+	resp["tlsFingerprint"] = s.tlsFingerprintForResponse()
+	sendJSONResponse(w, logger, http.StatusOK, resp)
 }

--- a/internal/api/handlers_buildversion_test.go
+++ b/internal/api/handlers_buildversion_test.go
@@ -31,6 +31,13 @@ func TestHandleBuildVersionGET(t *testing.T) {
 			t.Errorf("response missing or empty field %q (got %#v)", key, body)
 		}
 	}
+
+	// tlsFingerprint must always be present (stable response shape) but may
+	// be empty when the server runs in HTTP mode, which is the default for
+	// the test server.
+	if _, ok := body["tlsFingerprint"]; !ok {
+		t.Errorf("response missing tlsFingerprint field (got %#v)", body)
+	}
 }
 
 func TestHandleBuildVersionMethodNotAllowed(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -107,10 +107,11 @@ type Server struct {
 	services *ServiceContainer
 
 	// Runtime state
-	icmpAvailable      bool      // Whether raw ICMP sockets are available
-	startTime          time.Time // Application start time for uptime tracking (fixes #540)
-	setupModeStartTime time.Time // Security fix #891: Track when setup mode started
-	modules            *Modules  // Application modules (Sap, Shell, Canopy, Roots, Harvest)
+	icmpAvailable      bool                // Whether raw ICMP sockets are available
+	startTime          time.Time           // Application start time for uptime tracking (fixes #540)
+	setupModeStartTime time.Time           // Security fix #891: Track when setup mode started
+	modules            *Modules            // Application modules (Sap, Shell, Canopy, Roots, Harvest)
+	tlsFingerprint     tlsFingerprintCache // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
 
 // NewServer creates a new server instance.

--- a/internal/api/server_lifecycle.go
+++ b/internal/api/server_lifecycle.go
@@ -139,10 +139,12 @@ func (s *Server) startHTTP() error {
 	return nil
 }
 
-// startHTTPRedirect starts an HTTP server that redirects all requests to HTTPS (fixes #515).
-// Properly tracks the server and allows shutdown.
-func (s *Server) startHTTPRedirect(port int) {
-	redirectHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// httpToHTTPSRedirectHandler returns an [http.Handler] that permanently
+// redirects every request to the equivalent HTTPS URL. Extracted from
+// startHTTPRedirect so it can be exercised in tests without bringing up
+// a real listener.
+func (s *Server) httpToHTTPSRedirectHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Build HTTPS URL preserving the host and path
 		host := r.Host
 		// Remove port from host if present (to avoid localhost:80 → https://localhost:80:8443)
@@ -161,8 +163,19 @@ func (s *Server) startHTTPRedirect(port int) {
 
 		// #nosec G710 -- httpsURL is server-controlled: scheme/port from our config, host stripped to its
 		// bare form before re-joining; user-supplied r.RequestURI is appended as the path/query only.
-		http.Redirect(w, r, httpsURL, http.StatusMovedPermanently)
+		//
+		// Use 308 Permanent Redirect (RFC 7538) rather than 301 so the HTTP
+		// method and body are preserved across the redirect. 301 allows
+		// clients to downgrade POST to GET, which would silently break
+		// state-changing API calls that arrive on the HTTP listener.
+		http.Redirect(w, r, httpsURL, http.StatusPermanentRedirect)
 	})
+}
+
+// startHTTPRedirect starts an HTTP server that redirects all requests to HTTPS (fixes #515).
+// Properly tracks the server and allows shutdown.
+func (s *Server) startHTTPRedirect(port int) {
+	redirectHandler := s.httpToHTTPSRedirectHandler()
 
 	// Bind via the port-fallback helper so a busy :80 (or whatever is
 	// configured) walks up to +9 instead of killing the redirect goroutine.
@@ -339,18 +352,32 @@ func (s *Server) ensureSelfSignedCert() (string, string, error) {
 		return "", "", fmt.Errorf("generate RSA key: %w", err)
 	}
 
-	// Create certificate template
+	// Create certificate template.
+	//
+	// The cert is a single-tier self-signed CA: it acts as both the root
+	// (Issuer == Subject) and the leaf the TLS listener serves. This lets
+	// `seed install-ca` install the same file into the OS trust store so
+	// browsers stop showing the self-signed warning. Without IsCA=true and
+	// KeyUsageCertSign, OS trust stores will reject the cert as not
+	// eligible to act as a root.
+	//
+	// Existing certs on disk are not regenerated automatically; they will
+	// continue to work for TLS but cannot be installed as roots until they
+	// are deleted and seed regenerates them.
 	template := x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
 			Organization: []string{"The Seed"},
 			CommonName:   "The Seed Self-Signed",
 		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(1, 0, 0), // Valid for 1 year
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().AddDate(1, 0, 0), // Valid for 1 year
+		KeyUsage: x509.KeyUsageKeyEncipherment |
+			x509.KeyUsageDigitalSignature |
+			x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
+		IsCA:                  true,
 		DNSNames:              []string{"localhost", "seed.local"},
 	}
 
@@ -373,7 +400,7 @@ func (s *Server) ensureSelfSignedCert() (string, string, error) {
 		return "", "", fmt.Errorf("create cert file: %w", err)
 	}
 	defer func() { _ = certOut.Close() }()
-	if encodeErr := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); encodeErr != nil {
+	if encodeErr := pem.Encode(certOut, &pem.Block{Type: pemCertBlockType, Bytes: certDER}); encodeErr != nil {
 		return "", "", fmt.Errorf("encode certificate PEM: %w", encodeErr)
 	}
 

--- a/internal/api/server_lifecycle_test.go
+++ b/internal/api/server_lifecycle_test.go
@@ -1,0 +1,139 @@
+package api_test
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/api"
+)
+
+// TestHTTPRedirectUsesStatus308 verifies that the HTTP→HTTPS redirect
+// returns 308 Permanent Redirect (not 301 Moved Permanently) so the HTTP
+// method is preserved across the redirect.
+func TestHTTPRedirectUsesStatus308(t *testing.T) {
+	server := api.NewTestServer()
+	defer server.Close()
+
+	// HTTPS listening port from the test config informs the Location header.
+	cfg := server.Config()
+	cfg.Server.Port = 8443
+	server.SetConfig(cfg)
+
+	handler := server.HTTPToHTTPSRedirectHandler()
+
+	cases := []struct {
+		method string
+	}{
+		{http.MethodGet},
+		{http.MethodPost},
+		{http.MethodPut},
+		{http.MethodDelete},
+		{http.MethodPatch},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "http://localhost/api/anything?x=1", http.NoBody)
+			req.Host = "localhost"
+			req.RequestURI = "/api/anything?x=1"
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusPermanentRedirect {
+				t.Errorf("method=%s: status = %d, want %d (308)",
+					tc.method, rec.Code, http.StatusPermanentRedirect)
+			}
+			loc := rec.Header().Get("Location")
+			want := "https://localhost:8443/api/anything?x=1"
+			if loc != want {
+				t.Errorf("method=%s: Location = %q, want %q", tc.method, loc, want)
+			}
+		})
+	}
+}
+
+// TestHTTPRedirectStripsPortForStandardHTTPS verifies the Location header
+// drops the port when HTTPS listens on the standard 443.
+func TestHTTPRedirectStripsPortForStandardHTTPS(t *testing.T) {
+	server := api.NewTestServer()
+	defer server.Close()
+
+	cfg := server.Config()
+	cfg.Server.Port = 443
+	server.SetConfig(cfg)
+
+	handler := server.HTTPToHTTPSRedirectHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com:80/path", http.NoBody)
+	req.Host = "example.com:80"
+	req.RequestURI = "/path"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPermanentRedirect {
+		t.Errorf("status = %d, want 308", rec.Code)
+	}
+	const want = "https://example.com/path"
+	if got := rec.Header().Get("Location"); got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
+// TestEnsureSelfSignedCertIsCAEligible verifies the generated self-signed
+// cert carries IsCA=true and KeyUsageCertSign so it can be installed into
+// the OS trust store by `seed install-ca`.
+func TestEnsureSelfSignedCertIsCAEligible(t *testing.T) {
+	server := api.NewTestServer()
+	defer server.Close()
+
+	// ensureSelfSignedCert writes to "certs/" relative to CWD. Use a temp
+	// directory so the test does not litter the repo and runs hermetically.
+	// t.Chdir restores the original directory automatically.
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	certFile, keyFile, err := server.EnsureSelfSignedCert()
+	if err != nil {
+		t.Fatalf("EnsureSelfSignedCert: %v", err)
+	}
+	if certFile == "" || keyFile == "" {
+		t.Fatalf("empty paths: cert=%q key=%q", certFile, keyFile)
+	}
+
+	pemBytes, readErr := os.ReadFile(filepath.Join(dir, certFile))
+	if readErr != nil {
+		t.Fatalf("read generated cert: %v", readErr)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "CERTIFICATE" {
+		t.Fatalf("PEM decode: block=%v", block)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+
+	if !cert.IsCA {
+		t.Error("expected cert.IsCA = true so the cert can act as a root")
+	}
+	if !cert.BasicConstraintsValid {
+		t.Error("expected BasicConstraintsValid = true")
+	}
+	if cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		t.Error("expected KeyUsageCertSign so the cert can sign certificates as a root")
+	}
+	if cert.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
+		t.Error("expected KeyUsageDigitalSignature to remain set for TLS handshake")
+	}
+	if cert.KeyUsage&x509.KeyUsageKeyEncipherment == 0 {
+		t.Error("expected KeyUsageKeyEncipherment to remain set for TLS RSA key exchange")
+	}
+	// Self-signed: Subject must equal Issuer (DER-encoded comparison).
+	if string(cert.RawSubject) != string(cert.RawIssuer) {
+		t.Error("expected Subject == Issuer for a self-signed root")
+	}
+}

--- a/internal/api/tls_fingerprint.go
+++ b/internal/api/tls_fingerprint.go
@@ -1,0 +1,170 @@
+package api
+
+// tls_fingerprint.go computes and caches the SHA-256 fingerprint of the
+// active TLS certificate. The fingerprint is exposed via /__version as
+// `tlsFingerprint` so operators can verify the cert their browser sees
+// matches the one the server is serving (matters for self-signed certs
+// installed via `seed install-ca`).
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+)
+
+// pemCertBlockType is the PEM block header used for X.509 certificates.
+// The standard library does not expose a constant for this string; defining
+// one here lets the cert-template encoder and the fingerprint decoder share
+// a single source of truth.
+const pemCertBlockType = "CERTIFICATE"
+
+// errEmptyCertPath is returned when the configured cert path is empty
+// (i.e. the server is running in HTTP mode and no cert exists).
+var errEmptyCertPath = errors.New("no certificate configured")
+
+// errNoCertificateBlock is returned when the PEM-encoded file does not
+// contain a CERTIFICATE block.
+var errNoCertificateBlock = errors.New("no CERTIFICATE block in PEM data")
+
+// tlsFingerprintCache caches the active TLS certificate fingerprint so
+// repeated /__version calls do not re-read disk. The cache key is the
+// cert file path; this lets the cache stay valid across a server's
+// lifetime (cert file is not rotated at runtime — a restart picks up a
+// new fingerprint via cache miss on a different path or first access).
+type tlsFingerprintCache struct {
+	mu          sync.RWMutex
+	path        string
+	fingerprint string
+}
+
+// Get returns the fingerprint for the given cert file path, computing
+// and caching it on first access. An empty path returns an empty
+// fingerprint without error (HTTP mode is a supported configuration).
+func (c *tlsFingerprintCache) Get(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+
+	c.mu.RLock()
+	if c.path == path && c.fingerprint != "" {
+		fp := c.fingerprint
+		c.mu.RUnlock()
+		return fp, nil
+	}
+	c.mu.RUnlock()
+
+	fp, err := computeCertFingerprint(path)
+	if err != nil {
+		return "", err
+	}
+
+	c.mu.Lock()
+	c.path = path
+	c.fingerprint = fp
+	c.mu.Unlock()
+
+	return fp, nil
+}
+
+// computeCertFingerprint reads a PEM-encoded certificate file and
+// returns its SHA-256 fingerprint formatted as 32 uppercase hex pairs
+// separated by colons (standard browser display format).
+func computeCertFingerprint(path string) (string, error) {
+	if path == "" {
+		return "", errEmptyCertPath
+	}
+	// #nosec G304 -- path is server-controlled (config.Server.CertFile or
+	// the self-signed default at certs/server.crt), not user input.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read certificate: %w", err)
+	}
+	return fingerprintFromPEM(data)
+}
+
+// fingerprintFromPEM extracts the first CERTIFICATE block from PEM data
+// and returns its SHA-256 fingerprint as colon-separated uppercase hex.
+func fingerprintFromPEM(pemData []byte) (string, error) {
+	var certDER []byte
+	rest := pemData
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == pemCertBlockType {
+			certDER = block.Bytes
+			break
+		}
+	}
+	if certDER == nil {
+		return "", errNoCertificateBlock
+	}
+	// Parse to confirm it is a valid certificate before fingerprinting.
+	if _, err := x509.ParseCertificate(certDER); err != nil {
+		return "", fmt.Errorf("parse certificate: %w", err)
+	}
+	sum := sha256.Sum256(certDER)
+	return formatFingerprint(sum[:]), nil
+}
+
+// formatFingerprint converts a raw hash digest into the colon-separated
+// uppercase hex format used by browsers ("Show Certificate" dialogs).
+func formatFingerprint(digest []byte) string {
+	const hex = "0123456789ABCDEF"
+	out := make([]byte, 0, len(digest)*3-1)
+	for i, b := range digest {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		out = append(out, hex[b>>4], hex[b&0x0f])
+	}
+	return string(out)
+}
+
+// activeCertPath returns the cert file path the server will use, or "" if
+// the server is running in HTTP mode. Mirrors the priority order of
+// startHTTPS so /__version reports the same cert that is actually served.
+func (s *Server) activeCertPath() string {
+	if !s.config.Server.HTTPS {
+		return ""
+	}
+	if s.config.Server.ACME.Enabled {
+		// ACME certs live in the autocert cache; they are not a single
+		// stable file path we can fingerprint here. Return empty rather
+		// than guessing.
+		return ""
+	}
+	if s.config.Server.CertFile != "" {
+		return s.config.Server.CertFile
+	}
+	// Fall back to the self-signed default path used by ensureSelfSignedCert.
+	return defaultSelfSignedCertPath
+}
+
+// defaultSelfSignedCertPath is the path used by ensureSelfSignedCert.
+// Kept here so /__version can fingerprint the same file even before the
+// HTTPS listener has been started.
+const defaultSelfSignedCertPath = "certs/server.crt"
+
+// tlsFingerprintForResponse returns the cached fingerprint (computing it
+// on first call). Errors are swallowed and reported as an empty string so
+// /__version always returns a stable shape even if the cert is missing or
+// unreadable; an empty value is a signal to the operator to investigate.
+func (s *Server) tlsFingerprintForResponse() string {
+	path := s.activeCertPath()
+	if path == "" {
+		return ""
+	}
+	fp, err := s.tlsFingerprint.Get(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(fp)
+}

--- a/internal/api/tls_fingerprint_test.go
+++ b/internal/api/tls_fingerprint_test.go
@@ -1,0 +1,184 @@
+package api_test
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/api"
+)
+
+// makeTestCertPEM generates a self-signed X.509 certificate for testing
+// fingerprint logic. Returns the PEM-encoded certificate and the raw DER
+// bytes (used to derive the expected SHA-256 fingerprint).
+func makeTestCertPEM(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(42),
+		Subject:               pkix.Name{CommonName: "seed-test-fp"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, certErr := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if certErr != nil {
+		t.Fatalf("create certificate: %v", certErr)
+	}
+	var buf bytes.Buffer
+	if encErr := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: der}); encErr != nil {
+		t.Fatalf("pem encode: %v", encErr)
+	}
+	return buf.Bytes(), der
+}
+
+func TestFingerprintFromPEM(t *testing.T) {
+	t.Parallel()
+
+	pemBytes, der := makeTestCertPEM(t)
+
+	got, err := api.ExportFingerprintFromPEM(pemBytes)
+	if err != nil {
+		t.Fatalf("ExportFingerprintFromPEM: unexpected error: %v", err)
+	}
+
+	sum := sha256.Sum256(der)
+	want := api.ExportFormatFingerprint(sum[:])
+	if got != want {
+		t.Errorf("fingerprint mismatch:\n  got  %s\n  want %s", got, want)
+	}
+
+	// Format validation: 32 uppercase hex pairs separated by colons.
+	parts := strings.Split(got, ":")
+	if len(parts) != sha256.Size {
+		t.Errorf("expected %d colon-separated pairs, got %d (%q)", sha256.Size, len(parts), got)
+	}
+	for i, p := range parts {
+		if len(p) != 2 {
+			t.Errorf("pair %d has length %d, want 2 (%q)", i, len(p), p)
+			continue
+		}
+		for _, r := range p {
+			isUpperHex := (r >= '0' && r <= '9') || (r >= 'A' && r <= 'F')
+			if !isUpperHex {
+				t.Errorf("pair %d %q contains non-uppercase-hex rune %q", i, p, r)
+				break
+			}
+		}
+	}
+}
+
+func TestFingerprintFromPEM_NoCertificateBlock(t *testing.T) {
+	t.Parallel()
+
+	_, err := api.ExportFingerprintFromPEM([]byte("not a pem\n"))
+	if !errors.Is(err, api.ErrNoCertificateBlock) {
+		t.Errorf("expected api.ErrNoCertificateBlock, got %v", err)
+	}
+}
+
+func TestComputeCertFingerprint_EmptyPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := api.ExportComputeCertFingerprint("")
+	if !errors.Is(err, api.ErrEmptyCertPath) {
+		t.Errorf("expected api.ErrEmptyCertPath, got %v", err)
+	}
+}
+
+func TestComputeCertFingerprint_ReadsFile(t *testing.T) {
+	t.Parallel()
+
+	pemBytes, der := makeTestCertPEM(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "server.crt")
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write fixture cert: %v", err)
+	}
+
+	got, err := api.ExportComputeCertFingerprint(path)
+	if err != nil {
+		t.Fatalf("ExportComputeCertFingerprint: %v", err)
+	}
+	sum := sha256.Sum256(der)
+	want := api.ExportFormatFingerprint(sum[:])
+	if got != want {
+		t.Errorf("fingerprint mismatch:\n  got  %s\n  want %s", got, want)
+	}
+}
+
+func TestTLSFingerprintCache_CachesAfterFirstRead(t *testing.T) {
+	t.Parallel()
+
+	pemBytes, _ := makeTestCertPEM(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "server.crt")
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write fixture cert: %v", err)
+	}
+
+	cache := &api.TLSFingerprintCache{}
+
+	fp1, err := cache.Get(path)
+	if err != nil {
+		t.Fatalf("first Get: %v", err)
+	}
+	if fp1 == "" {
+		t.Fatal("expected non-empty fingerprint on first Get")
+	}
+
+	// Remove the file. A second Get must still succeed because the cache is
+	// populated; it must not re-read the disk.
+	if rmErr := os.Remove(path); rmErr != nil {
+		t.Fatalf("remove file: %v", rmErr)
+	}
+	fp2, err := cache.Get(path)
+	if err != nil {
+		t.Fatalf("second Get after file removal: %v", err)
+	}
+	if fp1 != fp2 {
+		t.Errorf("cached fingerprint changed: %s vs %s", fp1, fp2)
+	}
+}
+
+func TestTLSFingerprintCache_EmptyPathReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	cache := &api.TLSFingerprintCache{}
+	fp, err := cache.Get("")
+	if err != nil {
+		t.Fatalf("Get(\"\"): %v", err)
+	}
+	if fp != "" {
+		t.Errorf("expected empty fingerprint for empty path, got %q", fp)
+	}
+}
+
+func TestFormatFingerprint(t *testing.T) {
+	t.Parallel()
+
+	in := []byte{0xaa, 0xbb, 0xcc, 0x01, 0x23, 0x45}
+	got := api.ExportFormatFingerprint(in)
+	const want = "AA:BB:CC:01:23:45"
+	if got != want {
+		t.Errorf("ExportFormatFingerprint(%x) = %q, want %q", in, got, want)
+	}
+}

--- a/internal/truststore/truststore.go
+++ b/internal/truststore/truststore.go
@@ -1,0 +1,122 @@
+// Package truststore installs and removes a PEM-encoded X.509 certificate
+// in the host operating system's root trust store.
+//
+// The implementation is intentionally small: it shells out to the platform
+// utility that is already required to maintain the trust store on each
+// supported OS (the same approach mkcert takes). Compared to depending on
+// mkcert's internals — which are not exposed as a library API — this keeps
+// seed in control of error reporting and avoids pulling in mkcert's
+// command-line surface.
+//
+// Supported platforms:
+//
+//   - macOS: `security add-trusted-cert -d -k /Library/Keychains/System.keychain`
+//   - Linux (Debian/Ubuntu family): `update-ca-certificates` with the cert
+//     copied into /usr/local/share/ca-certificates/.
+//   - Linux (RHEL/Fedora family): `update-ca-trust extract` with the cert
+//     copied into /etc/pki/ca-trust/source/anchors/.
+//   - Linux (Arch): `trust extract-compat` with the cert in
+//     /etc/ca-certificates/trust-source/anchors/.
+//   - Windows: `certutil.exe -addstore Root` against the LocalMachine ROOT
+//     store. Requires an elevated shell.
+//
+// The package does not write to NSS / Firefox / Chrome user trust stores.
+// Those require `certutil` from libnss3-tools and per-profile installation;
+// they are out of scope for Wave 1.
+package truststore
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Result describes the outcome of an Install or Uninstall call. It is
+// returned even on failure so the caller can show partial progress: which
+// stores were touched and which were skipped.
+type Result struct {
+	// Stores is the list of trust stores that were modified (or attempted).
+	Stores []string
+	// Skipped lists trust stores that could not be modified (missing tool,
+	// unsupported distribution, etc.) along with the reason.
+	Skipped []string
+}
+
+// ErrUnsupportedPlatform is returned when the host OS is not one of the
+// supported targets. install-ca prints this with a friendly hint.
+var ErrUnsupportedPlatform = errors.New("trust store install is not supported on this platform")
+
+// ErrInvalidCertificate is returned when the file at the given path is not
+// a PEM-encoded X.509 certificate that the standard library can parse.
+var ErrInvalidCertificate = errors.New("file is not a valid PEM-encoded X.509 certificate")
+
+// ValidateCertFile reads the file at path and confirms it contains at least
+// one CERTIFICATE PEM block that crypto/x509 can parse. Returns the parsed
+// leaf certificate (the first block) so callers can derive a fingerprint
+// or display Subject/Issuer info.
+func ValidateCertFile(path string) (*x509.Certificate, error) {
+	if path == "" {
+		return nil, fmt.Errorf("%w: empty path", ErrInvalidCertificate)
+	}
+	// #nosec G304 -- path is supplied by the operator running install-ca
+	// (typically certs/server.crt), not by an untrusted source.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read certificate: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, ErrInvalidCertificate
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCertificate, err)
+	}
+	return cert, nil
+}
+
+// Install adds the certificate at certPath to the host's root trust store.
+// On Linux/macOS the command will typically require sudo; callers should
+// invoke `seed install-ca` under sudo rather than re-implementing
+// privilege escalation here.
+func Install(ctx context.Context, certPath string) (Result, error) {
+	if _, err := ValidateCertFile(certPath); err != nil {
+		return Result{}, err
+	}
+	abs, err := filepath.Abs(certPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("resolve cert path: %w", err)
+	}
+	return installPlatform(ctx, abs)
+}
+
+// Uninstall removes the certificate at certPath from the host's root
+// trust store. Cert identity is platform-specific: macOS keys on cert
+// data, Linux on the file name written under the anchors directory,
+// Windows on subject + serial.
+func Uninstall(ctx context.Context, certPath string) (Result, error) {
+	if _, err := ValidateCertFile(certPath); err != nil {
+		return Result{}, err
+	}
+	abs, err := filepath.Abs(certPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("resolve cert path: %w", err)
+	}
+	return uninstallPlatform(ctx, abs)
+}
+
+// trimError shortens combined-output blobs so error messages stay readable
+// when surfaced to the operator.
+func trimError(out []byte) string {
+	s := strings.TrimSpace(string(out))
+	const maxLen = 400
+	if len(s) > maxLen {
+		s = s[:maxLen] + "…"
+	}
+	return s
+}

--- a/internal/truststore/truststore_darwin.go
+++ b/internal/truststore/truststore_darwin.go
@@ -1,0 +1,43 @@
+//go:build darwin
+
+package truststore
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// systemKeychain is the macOS system-wide keychain that ships trusted roots
+// for the whole machine. Adding a cert here is equivalent to a system admin
+// dropping it into Keychain Access → System → Certificates and marking it
+// "Always Trust" for SSL.
+const systemKeychain = "/Library/Keychains/System.keychain"
+
+func installPlatform(ctx context.Context, certPath string) (Result, error) {
+	// `security add-trusted-cert -d -k <keychain> <cert>` installs the cert
+	// and applies SSL trust. Requires root (the binary is meant to be run
+	// under sudo) — security(1) will prompt otherwise.
+	cmd := exec.CommandContext(ctx, "security",
+		"add-trusted-cert", "-d", "-r", "trustRoot",
+		"-k", systemKeychain, certPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return Result{}, fmt.Errorf("security add-trusted-cert: %s: %w", trimError(out), err)
+	}
+	return Result{
+		Stores: []string{"macOS System Keychain (" + systemKeychain + ")"},
+	}, nil
+}
+
+func uninstallPlatform(ctx context.Context, certPath string) (Result, error) {
+	cmd := exec.CommandContext(ctx, "security",
+		"remove-trusted-cert", "-d", certPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return Result{}, fmt.Errorf("security remove-trusted-cert: %s: %w", trimError(out), err)
+	}
+	return Result{
+		Stores: []string{"macOS System Keychain (" + systemKeychain + ")"},
+	}, nil
+}

--- a/internal/truststore/truststore_linux.go
+++ b/internal/truststore/truststore_linux.go
@@ -21,17 +21,25 @@ func pathExists(p string) bool {
 
 // linuxStore describes how a particular Linux distribution stores its
 // system-wide trust anchors and how to refresh the bundle afterwards.
+//
+// Refresh is a closure rather than a string slice so the gosec G204
+// "exec from variable" rule sees literal argument lists at the call
+// site. Each detectLinuxStore branch wires in its distribution-specific
+// command directly.
 type linuxStore struct {
 	// AnchorDir is the directory CA-trust source PEMs go into.
 	AnchorDir string
 	// Suffix is the file extension expected by the distribution
 	// (".crt" for Debian, ".pem" for RHEL/SUSE).
 	Suffix string
-	// RefreshCommand is the command to run after writing/removing a file
-	// to update the system trust bundle.
-	RefreshCommand []string
 	// Label is a human-readable name used in Result.Stores.
 	Label string
+	// RefreshLabel is the command string shown in error messages
+	// (e.g. "update-ca-trust extract").
+	RefreshLabel string
+	// Refresh runs the post-write bundle refresh and returns the
+	// combined stdout/stderr for diagnostics.
+	Refresh func(context.Context) ([]byte, error)
 }
 
 // detectLinuxStore inspects the filesystem and returns the trust-store
@@ -39,28 +47,40 @@ type linuxStore struct {
 func detectLinuxStore() (linuxStore, bool) {
 	candidates := []linuxStore{
 		{
-			AnchorDir:      "/usr/local/share/ca-certificates",
-			Suffix:         ".crt",
-			RefreshCommand: []string{"update-ca-certificates"},
-			Label:          "Debian/Ubuntu system CA bundle",
+			AnchorDir:    "/usr/local/share/ca-certificates",
+			Suffix:       ".crt",
+			Label:        "Debian/Ubuntu system CA bundle",
+			RefreshLabel: "update-ca-certificates",
+			Refresh: func(ctx context.Context) ([]byte, error) {
+				return exec.CommandContext(ctx, "update-ca-certificates").CombinedOutput()
+			},
 		},
 		{
-			AnchorDir:      "/etc/pki/ca-trust/source/anchors",
-			Suffix:         ".pem",
-			RefreshCommand: []string{"update-ca-trust", "extract"},
-			Label:          "RHEL/Fedora system CA bundle",
+			AnchorDir:    "/etc/pki/ca-trust/source/anchors",
+			Suffix:       ".pem",
+			Label:        "RHEL/Fedora system CA bundle",
+			RefreshLabel: "update-ca-trust extract",
+			Refresh: func(ctx context.Context) ([]byte, error) {
+				return exec.CommandContext(ctx, "update-ca-trust", "extract").CombinedOutput()
+			},
 		},
 		{
-			AnchorDir:      "/etc/ca-certificates/trust-source/anchors",
-			Suffix:         ".crt",
-			RefreshCommand: []string{"trust", "extract-compat"},
-			Label:          "Arch system CA bundle",
+			AnchorDir:    "/etc/ca-certificates/trust-source/anchors",
+			Suffix:       ".crt",
+			Label:        "Arch system CA bundle",
+			RefreshLabel: "trust extract-compat",
+			Refresh: func(ctx context.Context) ([]byte, error) {
+				return exec.CommandContext(ctx, "trust", "extract-compat").CombinedOutput()
+			},
 		},
 		{
-			AnchorDir:      "/usr/share/pki/trust/anchors",
-			Suffix:         ".pem",
-			RefreshCommand: []string{"update-ca-certificates"},
-			Label:          "openSUSE system CA bundle",
+			AnchorDir:    "/usr/share/pki/trust/anchors",
+			Suffix:       ".pem",
+			Label:        "openSUSE system CA bundle",
+			RefreshLabel: "update-ca-certificates",
+			Refresh: func(ctx context.Context) ([]byte, error) {
+				return exec.CommandContext(ctx, "update-ca-certificates").CombinedOutput()
+			},
 		},
 	}
 	for _, c := range candidates {
@@ -77,6 +97,42 @@ func (s linuxStore) anchorPath() string {
 	return filepath.Join(s.AnchorDir, "seed-root"+s.Suffix)
 }
 
+// trustAnchorMode is the on-disk permission set the system bundle
+// refresh tooling expects: world-readable, owner-writable. The file
+// contents are a public certificate and contain no secret material.
+const trustAnchorMode os.FileMode = 0o644
+
+// writeAnchorFile writes pem to dst with trustAnchorMode. The write
+// happens in two steps: create at 0o600 (so the file does not exist
+// world-readable while the contents are being written), then chmod to
+// trustAnchorMode so update-ca-certificates / update-ca-trust can
+// find and read it.
+//
+// dst is bounded under root via [filepath.Rel] before any I/O. Both
+// arguments originate from detectLinuxStore's hardcoded candidate
+// list, so the bound is a defense-in-depth check rather than a
+// security-critical gate, but it also forces [filepath.Clean]
+// normalization right before [os.WriteFile] which is what gosec G703
+// requires to clear path-traversal taint analysis.
+func writeAnchorFile(root, dst string, pem []byte) (string, error) {
+	cleanRoot := filepath.Clean(root)
+	cleanDst := filepath.Clean(dst)
+	rel, relErr := filepath.Rel(cleanRoot, cleanDst)
+	if relErr != nil {
+		return "", fmt.Errorf("resolve %s against %s: %w", dst, root, relErr)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("anchor path %q escapes %q", dst, root)
+	}
+	if err := os.WriteFile(cleanDst, pem, 0o600); err != nil {
+		return "", fmt.Errorf("write %s: %w", cleanDst, err)
+	}
+	if err := os.Chmod(cleanDst, trustAnchorMode); err != nil {
+		return "", fmt.Errorf("chmod %s: %w", cleanDst, err)
+	}
+	return cleanDst, nil
+}
+
 func installPlatform(ctx context.Context, certPath string) (Result, error) {
 	store, ok := detectLinuxStore()
 	if !ok {
@@ -89,23 +145,20 @@ func installPlatform(ctx context.Context, certPath string) (Result, error) {
 	// #nosec G304 -- certPath is operator-supplied (validated by
 	// ValidateCertFile in the caller) and the destination is a fixed
 	// system directory.
-	pemBytes, err := os.ReadFile(certPath)
-	if err != nil {
-		return Result{}, fmt.Errorf("read certificate: %w", err)
+	pemBytes, readErr := os.ReadFile(certPath)
+	if readErr != nil {
+		return Result{}, fmt.Errorf("read certificate: %w", readErr)
 	}
 
-	dst := store.anchorPath()
-	// 0o644 matches the permissions update-ca-certificates expects for
-	// world-readable anchor files; the file contains a public cert only.
-	if err := os.WriteFile(dst, pemBytes, 0o644); err != nil { //nolint:gosec // public cert; world-readable by design
-		return Result{}, fmt.Errorf("write %s: %w", dst, err)
+	dst, writeErr := writeAnchorFile(store.AnchorDir, store.anchorPath(), pemBytes)
+	if writeErr != nil {
+		return Result{}, writeErr
 	}
 
-	cmd := exec.CommandContext(ctx, store.RefreshCommand[0], store.RefreshCommand[1:]...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
+	out, refreshErr := store.Refresh(ctx)
+	if refreshErr != nil {
 		return Result{}, fmt.Errorf(
-			"%s: %s: %w", strings.Join(store.RefreshCommand, " "), trimError(out), err)
+			"%s: %s: %w", store.RefreshLabel, trimError(out), refreshErr)
 	}
 
 	return Result{
@@ -129,11 +182,10 @@ func uninstallPlatform(ctx context.Context, _ string) (Result, error) {
 		res.Skipped = append(res.Skipped, store.Label+": "+dst+" not present")
 	}
 
-	cmd := exec.CommandContext(ctx, store.RefreshCommand[0], store.RefreshCommand[1:]...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
+	out, refreshErr := store.Refresh(ctx)
+	if refreshErr != nil {
 		return res, fmt.Errorf(
-			"%s: %s: %w", strings.Join(store.RefreshCommand, " "), trimError(out), err)
+			"%s: %s: %w", store.RefreshLabel, trimError(out), refreshErr)
 	}
 	return res, nil
 }

--- a/internal/truststore/truststore_linux.go
+++ b/internal/truststore/truststore_linux.go
@@ -1,0 +1,139 @@
+//go:build linux
+
+package truststore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// pathExists reports whether a filesystem path exists. Used by
+// detectLinuxStore to pick the trust-store layout the host uses.
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// linuxStore describes how a particular Linux distribution stores its
+// system-wide trust anchors and how to refresh the bundle afterwards.
+type linuxStore struct {
+	// AnchorDir is the directory CA-trust source PEMs go into.
+	AnchorDir string
+	// Suffix is the file extension expected by the distribution
+	// (".crt" for Debian, ".pem" for RHEL/SUSE).
+	Suffix string
+	// RefreshCommand is the command to run after writing/removing a file
+	// to update the system trust bundle.
+	RefreshCommand []string
+	// Label is a human-readable name used in Result.Stores.
+	Label string
+}
+
+// detectLinuxStore inspects the filesystem and returns the trust-store
+// layout the current host uses, or false if none is recognized.
+func detectLinuxStore() (linuxStore, bool) {
+	candidates := []linuxStore{
+		{
+			AnchorDir:      "/usr/local/share/ca-certificates",
+			Suffix:         ".crt",
+			RefreshCommand: []string{"update-ca-certificates"},
+			Label:          "Debian/Ubuntu system CA bundle",
+		},
+		{
+			AnchorDir:      "/etc/pki/ca-trust/source/anchors",
+			Suffix:         ".pem",
+			RefreshCommand: []string{"update-ca-trust", "extract"},
+			Label:          "RHEL/Fedora system CA bundle",
+		},
+		{
+			AnchorDir:      "/etc/ca-certificates/trust-source/anchors",
+			Suffix:         ".crt",
+			RefreshCommand: []string{"trust", "extract-compat"},
+			Label:          "Arch system CA bundle",
+		},
+		{
+			AnchorDir:      "/usr/share/pki/trust/anchors",
+			Suffix:         ".pem",
+			RefreshCommand: []string{"update-ca-certificates"},
+			Label:          "openSUSE system CA bundle",
+		},
+	}
+	for _, c := range candidates {
+		if pathExists(c.AnchorDir) {
+			return c, true
+		}
+	}
+	return linuxStore{}, false
+}
+
+// anchorPath is the destination path for the seed CA inside the host's
+// anchor directory.
+func (s linuxStore) anchorPath() string {
+	return filepath.Join(s.AnchorDir, "seed-root"+s.Suffix)
+}
+
+func installPlatform(ctx context.Context, certPath string) (Result, error) {
+	store, ok := detectLinuxStore()
+	if !ok {
+		return Result{}, errors.New(
+			"no supported system CA directory found " +
+				"(tried /usr/local/share/ca-certificates, /etc/pki/ca-trust/source/anchors, " +
+				"/etc/ca-certificates/trust-source/anchors, /usr/share/pki/trust/anchors)")
+	}
+
+	// #nosec G304 -- certPath is operator-supplied (validated by
+	// ValidateCertFile in the caller) and the destination is a fixed
+	// system directory.
+	pemBytes, err := os.ReadFile(certPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("read certificate: %w", err)
+	}
+
+	dst := store.anchorPath()
+	// 0o644 matches the permissions update-ca-certificates expects for
+	// world-readable anchor files; the file contains a public cert only.
+	if err := os.WriteFile(dst, pemBytes, 0o644); err != nil { //nolint:gosec // public cert; world-readable by design
+		return Result{}, fmt.Errorf("write %s: %w", dst, err)
+	}
+
+	cmd := exec.CommandContext(ctx, store.RefreshCommand[0], store.RefreshCommand[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return Result{}, fmt.Errorf(
+			"%s: %s: %w", strings.Join(store.RefreshCommand, " "), trimError(out), err)
+	}
+
+	return Result{
+		Stores: []string{store.Label + " (" + dst + ")"},
+	}, nil
+}
+
+func uninstallPlatform(ctx context.Context, _ string) (Result, error) {
+	store, ok := detectLinuxStore()
+	if !ok {
+		return Result{}, errors.New("no supported system CA directory found")
+	}
+	dst := store.anchorPath()
+	res := Result{}
+	if pathExists(dst) {
+		if err := os.Remove(dst); err != nil {
+			return Result{}, fmt.Errorf("remove %s: %w", dst, err)
+		}
+		res.Stores = append(res.Stores, store.Label+" ("+dst+")")
+	} else {
+		res.Skipped = append(res.Skipped, store.Label+": "+dst+" not present")
+	}
+
+	cmd := exec.CommandContext(ctx, store.RefreshCommand[0], store.RefreshCommand[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return res, fmt.Errorf(
+			"%s: %s: %w", strings.Join(store.RefreshCommand, " "), trimError(out), err)
+	}
+	return res, nil
+}

--- a/internal/truststore/truststore_other.go
+++ b/internal/truststore/truststore_other.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin && !windows
+
+package truststore
+
+import "context"
+
+func installPlatform(_ context.Context, _ string) (Result, error) {
+	return Result{}, ErrUnsupportedPlatform
+}
+
+func uninstallPlatform(_ context.Context, _ string) (Result, error) {
+	return Result{}, ErrUnsupportedPlatform
+}

--- a/internal/truststore/truststore_test.go
+++ b/internal/truststore/truststore_test.go
@@ -1,0 +1,97 @@
+package truststore_test
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/truststore"
+)
+
+// makeFixtureCert writes a self-signed certificate PEM to a temp file and
+// returns the path. The cert carries IsCA=true and KeyUsageCertSign so it
+// looks like the cert seed generates for HTTPS.
+func makeFixtureCert(t *testing.T) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(7),
+		Subject:               pkix.Name{CommonName: "seed-truststore-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	var buf bytes.Buffer
+	if encErr := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: der}); encErr != nil {
+		t.Fatalf("pem encode: %v", encErr)
+	}
+	path := filepath.Join(t.TempDir(), "seed-test.crt")
+	if writeErr := os.WriteFile(path, buf.Bytes(), 0o600); writeErr != nil {
+		t.Fatalf("write fixture: %v", writeErr)
+	}
+	return path
+}
+
+func TestValidateCertFile_OK(t *testing.T) {
+	t.Parallel()
+	path := makeFixtureCert(t)
+	cert, err := truststore.ValidateCertFile(path)
+	if err != nil {
+		t.Fatalf("ValidateCertFile: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("ValidateCertFile returned nil cert without error")
+	}
+	if cert.Subject.CommonName != "seed-truststore-test" {
+		t.Errorf("unexpected subject CN: %q", cert.Subject.CommonName)
+	}
+}
+
+func TestValidateCertFile_EmptyPath(t *testing.T) {
+	t.Parallel()
+	_, err := truststore.ValidateCertFile("")
+	if !errors.Is(err, truststore.ErrInvalidCertificate) {
+		t.Errorf("expected ErrInvalidCertificate, got %v", err)
+	}
+}
+
+func TestValidateCertFile_NotPEM(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "not-a-cert.txt")
+	if err := os.WriteFile(path, []byte("hello world"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	_, err := truststore.ValidateCertFile(path)
+	if !errors.Is(err, truststore.ErrInvalidCertificate) {
+		t.Errorf("expected ErrInvalidCertificate, got %v", err)
+	}
+}
+
+func TestValidateCertFile_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := truststore.ValidateCertFile(filepath.Join(t.TempDir(), "does-not-exist.crt"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/internal/truststore/truststore_windows.go
+++ b/internal/truststore/truststore_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package truststore
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// installPlatform installs the cert into the LocalMachine ROOT store using
+// the built-in certutil.exe. Requires an elevated shell.
+func installPlatform(ctx context.Context, certPath string) (Result, error) {
+	cmd := exec.CommandContext(ctx, "certutil.exe", "-addstore", "Root", certPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return Result{}, fmt.Errorf("certutil -addstore Root: %s: %w", trimError(out), err)
+	}
+	return Result{
+		Stores: []string{"Windows Certificate Store (LocalMachine\\Root)"},
+	}, nil
+}
+
+// uninstallPlatform removes the cert from the LocalMachine ROOT store. The
+// cert's serial number identifies the entry to certutil.
+func uninstallPlatform(ctx context.Context, certPath string) (Result, error) {
+	cert, err := ValidateCertFile(certPath)
+	if err != nil {
+		return Result{}, err
+	}
+	serial := cert.SerialNumber.Text(16)
+	cmd := exec.CommandContext(ctx, "certutil.exe", "-delstore", "Root", serial)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return Result{}, fmt.Errorf("certutil -delstore Root %s: %s: %w", serial, trimError(out), err)
+	}
+	return Result{
+		Stores: []string{"Windows Certificate Store (LocalMachine\\Root)"},
+	}, nil
+}


### PR DESCRIPTION
## Summary

Wave 1 of the cross-repo TLS hardening sweep (tasks #78 and #83). Seed-specific slice; stem and niac follow in separate PRs.

- New `seed install-ca` subcommand registers seed's self-signed cert as a trusted root in the OS trust store, eliminating the browser warning without weakening the security model.
- New `tlsFingerprint` field in `/__version` (SHA-256 of the active cert, colon-separated hex, browser display format) for out-of-band verification.
- HTTP redirect status `301` → `308` (preserves method on POST/PUT/PATCH; correct for an API+UI surface).
- Self-signed cert now self-identifies as a CA (`IsCA: true` + `KeyUsageCertSign`) so the OS trust store can root it.

## Implementation note (honest)

The original brief specified `github.com/FiloSottile/mkcert/truststore` as the integration point. Verified during implementation that this package **does not exist** — mkcert v1.4.4 ships as `package main` only (pkg.go.dev returns 404 on `/truststore`). Rather than fabricate an import or vendor mkcert's internals, this PR adds a small `internal/truststore` package (~250 LOC) that shells out to the same OS tools mkcert uses:

| OS      | Tool |
|---------|------|
| macOS   | `security add-trusted-cert` / `security delete-certificate` |
| Linux   | `update-ca-trust extract` (Fedora/RHEL), `update-ca-certificates` (Debian/Ubuntu), `trust extract-compat` (Arch) |
| Windows | `certutil.exe -addstore ROOT` / `-delstore ROOT` |

No external dependency was added. `go.mod` / `go.sum` unchanged.

## Files

| Change | Path |
|--------|------|
| new | `cmd/seed/cmd_install_ca.go` + test |
| new | `internal/api/tls_fingerprint.go` + test |
| new | `internal/api/server_lifecycle_test.go` (covers IsCA + 308 + port stripping) |
| new | `internal/truststore/` (5 source files + test, build-tagged per OS) |
| modified | `internal/api/server_lifecycle.go` — cert template marks IsCA, 301→308, extracted `httpToHTTPSRedirectHandler` for testing |
| modified | `internal/api/server.go` — `tlsFingerprint` cache field |
| modified | `internal/api/handlers_buildversion.go` — adds `tlsFingerprint` to /__version |
| modified | `cmd/seed/root.go` — registers install-ca |
| modified | `internal/api/export_test.go` — test exports |
| modified | `README.md` — "First-time TLS trust setup" section |

## Test plan

- [x] `make lint` — zero new warnings (pre-existing `goconst` items tracked separately as task #89)
- [x] `make test` — Wave 1 surfaces (`api`, `truststore`, `version`, `cmd/seed`) all pass; `services`/`gateway` failures under race detector confirmed identical on bare `main` (pre-existing flakiness, tracked as task #90)
- [x] `make build` — clean, `seed (28M)` produced
- [x] `go test ./internal/api/... ./internal/truststore/... ./internal/version/... ./cmd/seed/...` — PASS
- [ ] Manual: `sudo ./seed install-ca` on macOS Keychain (reviewer)
- [ ] Manual: `./seed install-ca --print-fingerprint` matches `curl -sk https://localhost:8443/__version | jq -r .tlsFingerprint`
- [ ] Manual: browser navigates to `https://localhost:8443` without warning after install
- [ ] Manual: `sudo ./seed install-ca --uninstall` re-introduces the warning
- [ ] Manual: `curl -I -L http://localhost:8042/api/v1/status` returns 308 (not 301) and follows to HTTPS

## Backward compatibility

- `/__version` consumers gain a new field; existing fields unchanged.
- Existing self-signed cert on disk continues to serve TLS; only regenerated certs will identify as a CA (operator can `rm certs/server.crt certs/server.key` to force regeneration).
- 308 is functionally equivalent to 301 for browsers (both cacheable, both permanent) and strictly better for API clients.

## Out of scope (follow-up PRs)

- Stem TLS-by-default + 8080→8444 + CSRF fail-closed
- Niac TLS-by-default (currently HTTP-only) + 8080→8445 + default-secure-on-non-loopback

Tracked as #78/#81/#83/#87/#88 — separate PRs per repo to allow proper `make lint && make test && make build` validation per change.