### PR TITLE
fix(e2e): bypass login modal for non-auth specs and lift rate limit for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -793,6 +793,7 @@ jobs:
       - name: Start backend server
         env:
           SEED_CONFIG_PATH: ${{ runner.temp }}/seed/config.yaml
+          SEED_LOGIN_MAX_ATTEMPTS: "200"
         run: |
           mkdir -p data
           sudo setcap cap_net_raw=+ep ./seed || true
@@ -872,6 +873,7 @@ jobs:
       - name: Start backend server
         env:
           SEED_CONFIG_PATH: ${{ runner.temp }}/seed/config.yaml
+          SEED_LOGIN_MAX_ATTEMPTS: "200"
         run: |
           mkdir -p data
           sudo setcap cap_net_raw=+ep ./seed || true

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ ui/coverage/
 ui/dist/
 ui/node_modules/
 ui/playwright-report/
+ui/playwright/.auth/
 
 # Frontend build outputs (Vite builds directly to internal/api/ui)
 internal/api/ui/*

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -3,6 +3,8 @@ package api
 import (
 	"net"
 	"net/http"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -76,9 +78,21 @@ type RateLimitConfig struct {
 }
 
 // DefaultRateLimitConfig returns the default rate limiting configuration.
+// SEED_LOGIN_MAX_ATTEMPTS overrides MaxAttempts when set to a positive
+// integer; this is the documented escape hatch for E2E runs that
+// genuinely need to drive the real auth flow more than 5 times per
+// 15-minute window (auth.spec.ts + auth-complete.spec.ts cover XSS,
+// SQLi, brute-force, lockout, etc., and burn the default budget
+// before the rest of the suite gets a chance).
 func DefaultRateLimitConfig() RateLimitConfig {
+	maxAttempts := defaultMaxAttempts
+	if raw := os.Getenv("SEED_LOGIN_MAX_ATTEMPTS"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			maxAttempts = n
+		}
+	}
 	return RateLimitConfig{
-		MaxAttempts: defaultMaxAttempts,
+		MaxAttempts: maxAttempts,
 		Window:      rateLimitWindowMin * time.Minute,
 		BlockTime:   rateLimitWindowMin * time.Minute,
 	}

--- a/internal/netif/mock.go
+++ b/internal/netif/mock.go
@@ -8,6 +8,11 @@ const (
 	mockMTULoopback  = 65536
 	mockSpeedGigabit = 1000000000 // 1 Gbps
 	mockSpeedWiFi    = 866000000  // 866 Mbps (WiFi 5 AC)
+
+	// mockEth0 is the canonical mock ethernet interface name used as
+	// the default in DefaultMockConfig and as a map key for the same
+	// InterfaceInfo entry.
+	mockEth0 = "eth0"
 )
 
 // MockManagerConfig contains configuration for creating a mock network manager.
@@ -22,10 +27,10 @@ type MockManagerConfig struct {
 // with a single ethernet interface for testing.
 func DefaultMockConfig() MockManagerConfig {
 	return MockManagerConfig{
-		CurrentInterface: "eth0",
+		CurrentInterface: mockEth0,
 		Interfaces: map[string]*InterfaceInfo{
-			"eth0": {
-				Name:         "eth0",
+			mockEth0: {
+				Name:         mockEth0,
 				FriendlyName: "Ethernet 0",
 				Description:  "Mock Ethernet Interface",
 				Type:         InterfaceTypeEthernet,

--- a/internal/services/cable/cable.go
+++ b/internal/services/cable/cable.go
@@ -42,6 +42,17 @@ const (
 	Pin8 = 8
 )
 
+// RJ45 twisted-pair identifiers, expressed as the pin pair they
+// occupy in the 8P8C connector. These are stable across both T568A
+// and T568B wiring standards (the standards only differ in which
+// colour goes on which pin).
+const (
+	pair12 = "1-2"
+	pair36 = "3-6"
+	pair45 = "4-5"
+	pair78 = "7-8"
+)
+
 // MetersToFeetFactor is the conversion factor from meters to feet.
 // 1 meter = 3.28084 feet (exact definition: 1 foot = 0.3048 meters).
 const MetersToFeetFactor = 3.28084
@@ -140,14 +151,14 @@ func (t *Tester) GetLastResult() *TestResult {
 // T568A is primarily used in residential installations and crossover cables.
 func Get568APinout() []WirePinout {
 	return []WirePinout{
-		{Pin: Pin1, Color: "White/Green", Pair: "3-6"},
-		{Pin: Pin2, Color: "Green", Pair: "3-6"},
-		{Pin: Pin3, Color: "White/Orange", Pair: "1-2"},
-		{Pin: Pin4, Color: "Blue", Pair: "4-5"},
-		{Pin: Pin5, Color: "White/Blue", Pair: "4-5"},
-		{Pin: Pin6, Color: "Orange", Pair: "1-2"},
-		{Pin: Pin7, Color: "White/Brown", Pair: "7-8"},
-		{Pin: Pin8, Color: "Brown", Pair: "7-8"},
+		{Pin: Pin1, Color: "White/Green", Pair: pair36},
+		{Pin: Pin2, Color: "Green", Pair: pair36},
+		{Pin: Pin3, Color: "White/Orange", Pair: pair12},
+		{Pin: Pin4, Color: "Blue", Pair: pair45},
+		{Pin: Pin5, Color: "White/Blue", Pair: pair45},
+		{Pin: Pin6, Color: "Orange", Pair: pair12},
+		{Pin: Pin7, Color: "White/Brown", Pair: pair78},
+		{Pin: Pin8, Color: "Brown", Pair: pair78},
 	}
 }
 
@@ -155,14 +166,14 @@ func Get568APinout() []WirePinout {
 // T568B is the most common standard in commercial installations.
 func Get568BPinout() []WirePinout {
 	return []WirePinout{
-		{Pin: Pin1, Color: "White/Orange", Pair: "1-2"},
-		{Pin: Pin2, Color: "Orange", Pair: "1-2"},
-		{Pin: Pin3, Color: "White/Green", Pair: "3-6"},
-		{Pin: Pin4, Color: "Blue", Pair: "4-5"},
-		{Pin: Pin5, Color: "White/Blue", Pair: "4-5"},
-		{Pin: Pin6, Color: "Green", Pair: "3-6"},
-		{Pin: Pin7, Color: "White/Brown", Pair: "7-8"},
-		{Pin: Pin8, Color: "Brown", Pair: "7-8"},
+		{Pin: Pin1, Color: "White/Orange", Pair: pair12},
+		{Pin: Pin2, Color: "Orange", Pair: pair12},
+		{Pin: Pin3, Color: "White/Green", Pair: pair36},
+		{Pin: Pin4, Color: "Blue", Pair: pair45},
+		{Pin: Pin5, Color: "White/Blue", Pair: pair45},
+		{Pin: Pin6, Color: "Green", Pair: pair36},
+		{Pin: Pin7, Color: "White/Brown", Pair: pair78},
+		{Pin: Pin8, Color: "Brown", Pair: pair78},
 	}
 }
 

--- a/internal/services/discovery/cve_kev.go
+++ b/internal/services/discovery/cve_kev.go
@@ -279,9 +279,9 @@ func (kev *KEVProvider) EnrichVulnerabilities(vulns []Vulnerability) []Vulnerabi
 			vulns[i].DueDate = entry.DueDate
 
 			// Boost priority - any KEV entry should be treated as critical priority
-			if vulns[i].Severity != "CRITICAL" {
+			if vulns[i].Severity != severityCritical {
 				vulns[i].OriginalSeverity = vulns[i].Severity
-				vulns[i].Severity = "CRITICAL" // Escalate to critical due to active exploitation
+				vulns[i].Severity = severityCritical // Escalate due to active exploitation
 			}
 		}
 	}
@@ -360,8 +360,8 @@ func (kev *KEVProvider) entryToVulnerability(entry *KEVEntry) Vulnerability {
 	return Vulnerability{
 		CVEID:       entry.CVEID,
 		Description: entry.ShortDescription,
-		Severity:    "CRITICAL",      // All KEV entries are critical priority
-		Score:       kevMaxCVSSScore, // Max score for actively exploited
+		Severity:    severityCritical, // All KEV entries are critical priority
+		Score:       kevMaxCVSSScore,  // Max score for actively exploited
 		Published:   dateAdded,
 		References: []string{
 			fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", entry.CVEID),

--- a/internal/services/iperf/server_client_test.go
+++ b/internal/services/iperf/server_client_test.go
@@ -416,17 +416,27 @@ func TestGetVersionWithInstalledIperf(t *testing.T) {
 	t.Logf("Installed iperf3 version: %s", version)
 }
 
-// TestCheckInstalledReturnsConsistent tests consistency.
+// TestCheckInstalledReturnsConsistent verifies CheckInstalled is
+// idempotent against the package-level binary-path cache.
+//
+// This intentionally does NOT use t.Parallel: other tests in this
+// package call CheckInstalled / ExtractEmbeddedBinary in parallel
+// and mutate the same cache, so a parallel run here would observe a
+// "not found" result on the first call and a populated path on the
+// fifth call (or vice versa) — a real interleaving, not a logic bug
+// in CheckInstalled itself. Running serial + clearing the cache up-
+// front isolates this test from the rest of the package and pins the
+// invariant we actually care about: once the cache is set, repeated
+// calls return the same outcome.
 func TestCheckInstalledReturnsConsistent(t *testing.T) {
-	t.Parallel()
+	iperf.ClearIperfBinaryPath()
+	t.Cleanup(iperf.ClearIperfBinaryPath)
 
-	// Call multiple times
 	results := make([]error, 5)
 	for i := range results {
 		results[i] = iperf.CheckInstalled()
 	}
 
-	// All results should be consistent
 	first := results[0]
 	for i, r := range results {
 		if (first == nil) != (r == nil) {

--- a/ui/biome.json
+++ b/ui/biome.json
@@ -456,6 +456,9 @@
         "rules": {
           "nursery": {
             "useAwaitThenable": "off"
+          },
+          "suspicious": {
+            "noSkippedTests": "off"
           }
         }
       }

--- a/ui/e2e/auth-complete.spec.ts
+++ b/ui/e2e/auth-complete.spec.ts
@@ -14,7 +14,12 @@ import { expect, test } from '@playwright/test';
  *
  * These tests verify that authentication works correctly across all scenarios
  * and that sessions are properly managed throughout the application lifecycle.
+ *
+ * Opts out of the suite-wide authenticated storageState so each test
+ * starts from a clean unauthenticated context.
  */
+
+test.use({ storageState: { cookies: [], origins: [] } });
 
 test.describe('Complete Authentication Lifecycle', () => {
   test.beforeEach(async ({ page }) => {

--- a/ui/e2e/auth-complete.spec.ts
+++ b/ui/e2e/auth-complete.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { TEST_CREDENTIALS } from './helpers/auth';
 
 /**
  * Complete Authentication Lifecycle E2E Tests
@@ -64,8 +65,8 @@ test.describe('Complete Authentication Lifecycle', () => {
       await page.goto('/');
 
       // Login with valid credentials
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
 
       // Verify redirect to dashboard
@@ -81,7 +82,7 @@ test.describe('Complete Authentication Lifecycle', () => {
       await page.goto('/');
 
       // Attempt login with invalid credentials
-      await page.getByLabel(/username/i).fill('admin');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
       await page.getByLabel(/password/i).fill('wrongpassword');
       await page.getByRole('button', { name: /sign in|login/i }).click();
 
@@ -102,8 +103,8 @@ test.describe('Complete Authentication Lifecycle', () => {
     test.beforeEach(async ({ page }) => {
       // Login first for logout tests
       await page.goto('/');
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
       await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
         timeout: 10000,
@@ -232,8 +233,8 @@ test.describe('Complete Authentication Lifecycle', () => {
     test('should handle 401 unauthorized response gracefully', async ({ page }) => {
       // Login first
       await page.goto('/');
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
       await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
         timeout: 10000,
@@ -266,8 +267,8 @@ test.describe('Complete Authentication Lifecycle', () => {
     test('should allow re-login after session expiry', async ({ page }) => {
       // Login first
       await page.goto('/');
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
       await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
         timeout: 10000,
@@ -284,8 +285,8 @@ test.describe('Complete Authentication Lifecycle', () => {
       });
 
       // Login again
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
 
       // Should successfully login again
@@ -312,8 +313,8 @@ test.describe('Complete Authentication Lifecycle', () => {
     test('should allow access to protected routes when authenticated', async ({ page }) => {
       // Login
       await page.goto('/');
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
 
       // Should access dashboard
@@ -332,8 +333,8 @@ test.describe('Complete Authentication Lifecycle', () => {
     test('should persist authentication on page reload', async ({ page }) => {
       // Login
       await page.goto('/');
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
       await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
         timeout: 10000,
@@ -360,8 +361,8 @@ test.describe('Complete Authentication Lifecycle', () => {
 
       // Login
       await page.goto('/');
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
       await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
         timeout: 10000,
@@ -407,8 +408,8 @@ test.describe('Complete Authentication Lifecycle', () => {
 
       // Login
       await page.goto('/');
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
       await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
         timeout: 10000,
@@ -445,8 +446,8 @@ test.describe('Complete Authentication Lifecycle', () => {
       await rememberMe.check();
 
       // Login
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
       await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
         timeout: 10000,
@@ -479,8 +480,8 @@ test.describe('Complete Authentication Lifecycle', () => {
       await rememberMe.uncheck();
 
       // Login
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
       await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
         timeout: 10000,

--- a/ui/e2e/auth.spec.ts
+++ b/ui/e2e/auth.spec.ts
@@ -8,7 +8,12 @@ import { expect, test } from '@playwright/test';
  * - Login with valid credentials
  * - Login with invalid credentials shows error
  * - Logout clears session
+ *
+ * Opts out of the suite-wide authenticated storageState so each test
+ * starts from a clean unauthenticated context.
  */
+
+test.use({ storageState: { cookies: [], origins: [] } });
 
 test.describe('Authentication', () => {
   test.beforeEach(async ({ page }) => {

--- a/ui/e2e/auth.spec.ts
+++ b/ui/e2e/auth.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { TEST_CREDENTIALS } from './helpers/auth';
 
 /**
  * Authentication E2E Tests
@@ -50,9 +51,11 @@ test.describe('Authentication', () => {
   test('should login successfully with valid credentials', async ({ page }) => {
     await page.goto('/');
 
-    // Fill in valid credentials (default admin/seed)
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
+    // Provisioned in e2e/global-setup.ts; the wave-2 password policy
+    // rejects the legacy short "seed" literal, so the suite uses a
+    // shared strong passphrase from helpers/auth.ts.
+    await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+    await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
     await page.getByRole('button', { name: /sign in|login/i }).click();
 
     // Should redirect to dashboard

--- a/ui/e2e/cable-diagnostics.spec.ts
+++ b/ui/e2e/cable-diagnostics.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Cable Diagnostics E2E Tests
@@ -13,17 +14,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Cable Diagnostics', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -169,13 +161,8 @@ test.describe('Cable Diagnostics', () => {
 
 test.describe('Cable Card States', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -235,13 +222,8 @@ test.describe('Cable Card States', () => {
 
 test.describe('Cable Card Accessibility', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/card-lifecycle.spec.ts
+++ b/ui/e2e/card-lifecycle.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Card Lifecycle E2E Tests
@@ -30,17 +31,9 @@ import { expect, test } from '@playwright/test';
 test.describe('Card Lifecycle Tests', () => {
   // Helper to login before each test
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Login
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard
-    await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
+    await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
   });

--- a/ui/e2e/coverage-gaps.spec.ts
+++ b/ui/e2e/coverage-gaps.spec.ts
@@ -1,15 +1,10 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Coverage gaps', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -25,7 +20,9 @@ test.describe('Coverage gaps', () => {
   });
 
   test('opens log viewer modal', async ({ page }) => {
-    const logsCardTitle = page.locator('h3:has-text("System Logs"), h4:has-text("System Logs")').first();
+    const logsCardTitle = page
+      .locator('h3:has-text("System Logs"), h4:has-text("System Logs")')
+      .first();
     await expect(logsCardTitle).toBeVisible();
 
     const logsCard = logsCardTitle.locator('..').first();

--- a/ui/e2e/dashboard.spec.ts
+++ b/ui/e2e/dashboard.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Dashboard E2E Tests
@@ -13,17 +14,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Dashboard', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/dns-card.spec.ts
+++ b/ui/e2e/dns-card.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * DNS Card E2E Tests
@@ -15,13 +16,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('DNS Card', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -95,13 +91,8 @@ test.describe('DNS Card', () => {
 
 test.describe('DNS Settings', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -200,13 +191,8 @@ test.describe('DNS Settings', () => {
 
 test.describe('DNS Help', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/error-scenarios.spec.ts
+++ b/ui/e2e/error-scenarios.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { mockAuthenticated, TEST_CREDENTIALS } from './helpers/auth';
 
 /**
  * Comprehensive Error Scenario E2E Tests
@@ -61,8 +61,8 @@ test.describe('API Error Scenarios', () => {
         });
       });
 
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
 
       // Should show user-friendly error message
@@ -203,8 +203,8 @@ test.describe('API Error Scenarios', () => {
         await route.abort('timedout');
       });
 
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
+      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
       await page.getByRole('button', { name: /sign in|login/i }).click();
 
       // Should show timeout or error message
@@ -1118,8 +1118,8 @@ test.describe('Error Recovery Mechanisms', () => {
     });
 
     // First attempt
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
+    await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
+    await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
     await page.getByRole('button', { name: /sign in|login/i }).click();
 
     // Should show error

--- a/ui/e2e/error-scenarios.spec.ts
+++ b/ui/e2e/error-scenarios.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Comprehensive Error Scenario E2E Tests
@@ -37,14 +38,8 @@ import { expect, type Page, test } from '@playwright/test';
  * Helper: Login to the application
  */
 async function login(page: Page): Promise<void> {
+  await mockAuthenticated(page);
   await page.goto('/');
-  await page.evaluate(() => localStorage.clear());
-  await page.reload();
-
-  await page.getByLabel(/username/i).fill('admin');
-  await page.getByLabel(/password/i).fill('seed');
-  await page.getByRole('button', { name: /sign in|login/i }).click();
-
   await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
     timeout: 10000,
   });

--- a/ui/e2e/fab.spec.ts
+++ b/ui/e2e/fab.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * FAB (Floating Action Button) E2E Tests
@@ -14,17 +15,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('FAB - Run All Tests Flow', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/gateway.spec.ts
+++ b/ui/e2e/gateway.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Gateway E2E Tests
@@ -14,13 +15,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Gateway', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -146,13 +142,8 @@ test.describe('Gateway', () => {
 
 test.describe('Gateway Help', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/global-setup.ts
+++ b/ui/e2e/global-setup.ts
@@ -1,0 +1,72 @@
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { chromium, type FullConfig, request } from '@playwright/test';
+
+import { AUTH_STORAGE_STATE, TEST_CREDENTIALS } from './helpers/auth';
+
+/**
+ * One real login at suite start; every spec shares the resulting
+ * storageState (cookies + localStorage) via use.storageState in
+ * playwright.config.ts. This collapses ~436 login attempts down to
+ * exactly 1 — the per-IP login limiter
+ * (internal/api/ratelimit.go: defaultMaxAttempts = 5 / 15 min) is no
+ * longer a suite-wide cliff. auth.spec.ts and auth-complete.spec.ts
+ * opt back into a clean unauthenticated context with
+ * `test.use({ storageState: { cookies: [], origins: [] } })` so they
+ * still exercise the real form.
+ */
+async function globalSetup(config: FullConfig): Promise<void> {
+  const [project] = config.projects;
+  if (project === undefined) {
+    throw new Error('global-setup: no Playwright project configured');
+  }
+  const baseURL = project.use.baseURL ?? process.env.E2E_BASE_URL ?? 'http://localhost:5173';
+  const outPath = resolve(__dirname, '..', AUTH_STORAGE_STATE);
+
+  await mkdir(dirname(outPath), { recursive: true });
+
+  // POST directly to /api/auth/login instead of driving the form so
+  // global-setup does not need a full browser context just to capture
+  // a single cookie. The server sets the session cookie on the
+  // response; we hand the resulting cookies + an `authenticated` flag
+  // in localStorage to Playwright as the persisted storage state.
+  const apiContext = await request.newContext({
+    baseURL,
+    ignoreHTTPSErrors: true,
+  });
+  const response = await apiContext.post('/api/auth/login', {
+    headers: { 'Content-Type': 'application/json' },
+    data: {
+      username: TEST_CREDENTIALS.username,
+      password: TEST_CREDENTIALS.password,
+    },
+  });
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(
+      `global-setup: /api/auth/login returned ${response.status()}: ${body.slice(0, 200)}`,
+    );
+  }
+  const state = await apiContext.storageState({ path: outPath });
+  await apiContext.dispose();
+
+  // Some specs use a browser-only side check (no inflight fetch) so we
+  // also stash a "logged-in" flag in localStorage for the SPA origin.
+  // We get an origins entry by quickly opening the baseURL in a
+  // browser, writing the flag, and re-saving.
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    baseURL,
+    ignoreHTTPSErrors: true,
+    storageState: state,
+  });
+  const page = await context.newPage();
+  await page.goto('/');
+  await page.evaluate(() => {
+    window.localStorage.setItem('seed.authenticated', 'true');
+  });
+  await context.storageState({ path: outPath });
+  await browser.close();
+}
+
+export default globalSetup;

--- a/ui/e2e/global-setup.ts
+++ b/ui/e2e/global-setup.ts
@@ -1,8 +1,14 @@
 import { mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { chromium, type FullConfig, request } from '@playwright/test';
 
 import { AUTH_STORAGE_STATE, TEST_CREDENTIALS } from './helpers/auth';
+
+// ESM equivalent of __dirname; Playwright executes this file as ESM so
+// the CommonJS globals are not available.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 /**
  * One real login at suite start; every spec shares the resulting

--- a/ui/e2e/global-setup.ts
+++ b/ui/e2e/global-setup.ts
@@ -1,7 +1,7 @@
 import { mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { chromium, type FullConfig, request } from '@playwright/test';
+import { type APIRequestContext, chromium, type FullConfig, request } from '@playwright/test';
 
 import { AUTH_STORAGE_STATE, TEST_CREDENTIALS } from './helpers/auth';
 
@@ -20,6 +20,12 @@ const __dirname = dirname(__filename);
  * opt back into a clean unauthenticated context with
  * `test.use({ storageState: { cookies: [], origins: [] } })` so they
  * still exercise the real form.
+ *
+ * In CI the seed binary starts fresh each run, which means there is
+ * no admin user — the initial-setup wizard must complete before
+ * /api/v1/auth/login will accept any credentials. This script runs
+ * the setup-then-login flow once and persists the resulting session
+ * cookies as the suite's default storage state.
  */
 async function globalSetup(config: FullConfig): Promise<void> {
   const [project] = config.projects;
@@ -31,48 +37,97 @@ async function globalSetup(config: FullConfig): Promise<void> {
 
   await mkdir(dirname(outPath), { recursive: true });
 
-  // POST directly to /api/auth/login instead of driving the form so
-  // global-setup does not need a full browser context just to capture
-  // a single cookie. The server sets the session cookie on the
-  // response; we hand the resulting cookies + an `authenticated` flag
-  // in localStorage to Playwright as the persisted storage state.
   const apiContext = await request.newContext({
     baseURL,
     ignoreHTTPSErrors: true,
   });
-  const response = await apiContext.post('/api/auth/login', {
-    headers: { 'Content-Type': 'application/json' },
-    data: {
-      username: TEST_CREDENTIALS.username,
-      password: TEST_CREDENTIALS.password,
-    },
-  });
-  if (!response.ok()) {
-    const body = await response.text();
+
+  try {
+    await ensureSetupCompleted(apiContext);
+
+    const loginResponse = await apiContext.post('/api/v1/auth/login', {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        username: TEST_CREDENTIALS.username,
+        password: TEST_CREDENTIALS.password,
+      },
+    });
+    if (!loginResponse.ok()) {
+      const body = await loginResponse.text();
+      throw new Error(
+        `global-setup: /api/v1/auth/login returned ${loginResponse.status()}: ${body.slice(0, 200)}`,
+      );
+    }
+
+    await apiContext.storageState({ path: outPath });
+  } finally {
+    await apiContext.dispose();
+  }
+
+  // Attach a localStorage flag for the SPA origin so the in-app
+  // useAuth() hook's mount-time check doesn't flip the UI back to the
+  // login form before its /api/status probe lands.
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext({
+      baseURL,
+      ignoreHTTPSErrors: true,
+      storageState: outPath,
+    });
+    const page = await context.newPage();
+    await page.goto('/');
+    await page.evaluate(() => {
+      window.localStorage.setItem('seed.authenticated', 'true');
+    });
+    await context.storageState({ path: outPath });
+  } finally {
+    await browser.close();
+  }
+}
+
+/**
+ * Bring the seed backend into a logged-in-able state. On a fresh
+ * binary the admin password is unset and /api/v1/setup/status reports
+ * needsSetup=true with a one-time setupToken; POST the token plus the
+ * suite's well-known password to /api/v1/setup/complete. Idempotent
+ * — if setup is already complete the function returns without
+ * touching anything.
+ */
+async function ensureSetupCompleted(apiContext: APIRequestContext): Promise<void> {
+  const statusResponse = await apiContext.get('/api/v1/setup/status');
+  if (!statusResponse.ok()) {
+    const body = await statusResponse.text();
     throw new Error(
-      `global-setup: /api/auth/login returned ${response.status()}: ${body.slice(0, 200)}`,
+      `global-setup: /api/v1/setup/status returned ${statusResponse.status()}: ${body.slice(0, 200)}`,
     );
   }
-  const state = await apiContext.storageState({ path: outPath });
-  await apiContext.dispose();
+  const status = (await statusResponse.json()) as {
+    needsSetup: boolean;
+    setupToken?: string;
+    username?: string;
+  };
+  if (!status.needsSetup) {
+    return;
+  }
+  if (!status.setupToken) {
+    throw new Error(
+      'global-setup: setup status reports needsSetup=true but no setupToken returned',
+    );
+  }
 
-  // Some specs use a browser-only side check (no inflight fetch) so we
-  // also stash a "logged-in" flag in localStorage for the SPA origin.
-  // We get an origins entry by quickly opening the baseURL in a
-  // browser, writing the flag, and re-saving.
-  const browser = await chromium.launch();
-  const context = await browser.newContext({
-    baseURL,
-    ignoreHTTPSErrors: true,
-    storageState: state,
+  const completeResponse = await apiContext.post('/api/v1/setup/complete', {
+    headers: { 'Content-Type': 'application/json' },
+    data: {
+      password: TEST_CREDENTIALS.password,
+      setupToken: status.setupToken,
+    },
   });
-  const page = await context.newPage();
-  await page.goto('/');
-  await page.evaluate(() => {
-    window.localStorage.setItem('seed.authenticated', 'true');
-  });
-  await context.storageState({ path: outPath });
-  await browser.close();
+  if (!completeResponse.ok()) {
+    const body = await completeResponse.text();
+    throw new Error(
+      `global-setup: /api/v1/setup/complete returned ${completeResponse.status()}: ${body.slice(0, 200)}`,
+    );
+  }
 }
 
 export default globalSetup;

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -1,0 +1,72 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Shared E2E auth helpers.
+ *
+ * Wave 2 (#1047) tightened the login limiter to defaultMaxAttempts = 5
+ * per 15-minute window per IP (internal/api/ratelimit.go). With ~18
+ * spec files and ~436 tests each driving the real /api/auth/login in
+ * beforeEach, the suite blows through that budget after a handful of
+ * tests and subsequent specs land on a lockout — the login form stays
+ * mounted, shell clicks time out, and the whole E2E job runs out the
+ * 30-minute timeout. Specs that aren't actually testing the auth flow
+ * itself should call mockAuthenticated() instead of pounding the real
+ * endpoint.
+ */
+
+export const TEST_CREDENTIALS = {
+  username: 'admin',
+  password: 'seed',
+} as const;
+
+/**
+ * Skip the login form for tests whose subject is anything other than
+ * the authentication flow itself.
+ *
+ * Mocks the setup-status probe so the first-run wizard doesn't fire,
+ * mocks /api/status to return 200 so useAuth's mount-time session
+ * check hydrates isAuthenticated=true without driving the real login
+ * endpoint. Must be called before page.goto so the route handlers are
+ * registered before any navigation.
+ */
+export async function mockAuthenticated(page: Page): Promise<void> {
+  await page.route('**/api/setup/status', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ needsSetup: false, username: 'admin' }),
+    });
+  });
+  await page.route('**/api/status', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ authenticated: true, username: 'admin' }),
+    });
+  });
+}
+
+/**
+ * Drive the real login form. Reserve for specs that genuinely test
+ * the auth flow end-to-end (auth.spec.ts, auth-complete.spec.ts).
+ * Other specs should use mockAuthenticated() to avoid the rate-limit
+ * cliff.
+ */
+export async function loginViaUI(
+  page: Page,
+  creds: { username: string; password: string } = TEST_CREDENTIALS,
+): Promise<void> {
+  await page.route('**/api/setup/status', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ needsSetup: false, username: 'admin' }),
+    });
+  });
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await page.getByLabel(/username/i).fill(creds.username);
+  await page.getByLabel(/password/i).fill(creds.password);
+  await page.getByRole('button', { name: /sign in|login/i }).click();
+}

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -25,9 +25,19 @@ import type { Page } from '@playwright/test';
  * surface changes only require one edit.
  */
 
+/**
+ * Credentials the suite provisions in global-setup.ts.
+ *
+ * Wave 2 (#1047) enforces Argon2id + zxcvbn + HIBP on every password,
+ * so the legacy "seed" literal would be rejected by the setup wizard
+ * and login would never succeed. This value is long enough to clear
+ * zxcvbn's score-3 threshold and synthetic enough to stay out of the
+ * HIBP breach corpus; auth.spec.ts and auth-complete.spec.ts import
+ * this constant directly so the password is in one place.
+ */
 export const TEST_CREDENTIALS = {
   username: 'admin',
-  password: 'seed',
+  password: 'Seed-E2E-Strong-Passphrase-2026!', // gitleaks:allow — test fixture, provisioned in global-setup.ts
 } as const;
 
 /** Path (relative to ui/) where global-setup persists the storage state. */

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -4,14 +4,25 @@ import type { Page } from '@playwright/test';
  * Shared E2E auth helpers.
  *
  * Wave 2 (#1047) tightened the login limiter to defaultMaxAttempts = 5
- * per 15-minute window per IP (internal/api/ratelimit.go). With ~18
- * spec files and ~436 tests each driving the real /api/auth/login in
- * beforeEach, the suite blows through that budget after a handful of
- * tests and subsequent specs land on a lockout — the login form stays
- * mounted, shell clicks time out, and the whole E2E job runs out the
- * 30-minute timeout. Specs that aren't actually testing the auth flow
- * itself should call mockAuthenticated() instead of pounding the real
- * endpoint.
+ * per 15-minute window per IP (internal/api/ratelimit.go). With ~30
+ * specs and ~436 tests each driving the real /api/auth/login in
+ * beforeEach, the suite blew past the budget after a handful of tests
+ * and subsequent specs landed on a lockout.
+ *
+ * The fix is a single real login in e2e/global-setup.ts, persisted to
+ * AUTH_STORAGE_STATE and shared across every spec via Playwright's
+ * use.storageState. This collapses ~436 login attempts down to 1.
+ *
+ * Specs that genuinely test the auth flow (auth.spec.ts,
+ * auth-complete.spec.ts) opt out of the shared state with
+ * `test.use({ storageState: { cookies: [], origins: [] } })` and use
+ * loginViaUI() / their own flows.
+ *
+ * mockAuthenticated() still exists for specs that need to short-
+ * circuit the first-run setup wizard without driving the form — the
+ * storageState already covers auth, so this helper now only mocks
+ * /api/setup/status. Kept as a single call site so future setup-
+ * surface changes only require one edit.
  */
 
 export const TEST_CREDENTIALS = {
@@ -19,15 +30,14 @@ export const TEST_CREDENTIALS = {
   password: 'seed',
 } as const;
 
+/** Path (relative to ui/) where global-setup persists the storage state. */
+export const AUTH_STORAGE_STATE = 'playwright/.auth/user.json';
+
 /**
- * Skip the login form for tests whose subject is anything other than
- * the authentication flow itself.
+ * Skip the first-run setup wizard. Authentication is already handled
+ * by the shared storageState wired up in playwright.config.ts.
  *
- * Mocks the setup-status probe so the first-run wizard doesn't fire,
- * mocks /api/status to return 200 so useAuth's mount-time session
- * check hydrates isAuthenticated=true without driving the real login
- * endpoint. Must be called before page.goto so the route handlers are
- * registered before any navigation.
+ * Must be called before page.goto so the route handler is registered.
  */
 export async function mockAuthenticated(page: Page): Promise<void> {
   await page.route('**/api/setup/status', (route) => {
@@ -37,20 +47,12 @@ export async function mockAuthenticated(page: Page): Promise<void> {
       body: JSON.stringify({ needsSetup: false, username: 'admin' }),
     });
   });
-  await page.route('**/api/status', (route) => {
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ authenticated: true, username: 'admin' }),
-    });
-  });
 }
 
 /**
  * Drive the real login form. Reserve for specs that genuinely test
  * the auth flow end-to-end (auth.spec.ts, auth-complete.spec.ts).
- * Other specs should use mockAuthenticated() to avoid the rate-limit
- * cliff.
+ * Other specs inherit auth via the global-setup storageState.
  */
 export async function loginViaUI(
   page: Page,

--- a/ui/e2e/interface-switching.spec.ts
+++ b/ui/e2e/interface-switching.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Network Interface Switching E2E Tests
@@ -14,17 +15,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Network Interface Selection', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/iperf.spec.ts
+++ b/ui/e2e/iperf.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * iPerf E2E Tests
@@ -13,17 +14,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('iPerf Integration', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -301,13 +293,8 @@ test.describe('iPerf Integration', () => {
 
 test.describe('iPerf Test Execution', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/link-card.spec.ts
+++ b/ui/e2e/link-card.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Link Card E2E Tests
@@ -14,13 +15,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Link Card', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -120,13 +116,8 @@ test.describe('Link Card', () => {
 
 test.describe('Link Card Help', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -155,13 +146,8 @@ test.describe('Link Card Help', () => {
 
 test.describe('Link Card MTU Configuration', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/network-discovery-complete.spec.ts
+++ b/ui/e2e/network-discovery-complete.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Network Discovery Complete Flow E2E Tests
@@ -20,16 +21,8 @@ import { expect, type Page, test } from '@playwright/test';
  * Helper function to login and navigate to dashboard
  */
 async function loginAndNavigate(page: Page): Promise<void> {
+  await mockAuthenticated(page);
   await page.goto('/');
-  await page.evaluate(() => localStorage.clear());
-  await page.reload();
-
-  // Authenticate with valid credentials
-  await page.getByLabel(/username/i).fill('admin');
-  await page.getByLabel(/password/i).fill('seed');
-  await page.getByRole('button', { name: /sign in|login/i }).click();
-
-  // Wait for dashboard to load
   await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
     timeout: 10000,
   });

--- a/ui/e2e/network-discovery.spec.ts
+++ b/ui/e2e/network-discovery.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Network Discovery E2E Tests
@@ -13,17 +14,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Network Discovery', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/public-ip.spec.ts
+++ b/ui/e2e/public-ip.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Public IP E2E Tests
@@ -13,13 +14,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Public IP', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/responsive.spec.ts
+++ b/ui/e2e/responsive.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Responsive Layout E2E Tests
@@ -31,17 +32,9 @@ test.describe('Responsive Layout Tests', () => {
       // Set mobile viewport
       await page.setViewportSize({ width: 375, height: 667 });
 
+      await mockAuthenticated(page);
       await page.goto('/');
-      await page.evaluate(() => localStorage.clear());
-      await page.reload();
-
-      // Login
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
-      await page.getByRole('button', { name: /sign in|login/i }).click();
-
-      // Wait for dashboard
-      await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
+      await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
       });
     });
@@ -256,17 +249,9 @@ test.describe('Responsive Layout Tests', () => {
       // Set tablet viewport
       await page.setViewportSize({ width: 768, height: 1024 });
 
+      await mockAuthenticated(page);
       await page.goto('/');
-      await page.evaluate(() => localStorage.clear());
-      await page.reload();
-
-      // Login
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
-      await page.getByRole('button', { name: /sign in|login/i }).click();
-
-      // Wait for dashboard
-      await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
+      await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
       });
     });
@@ -400,17 +385,9 @@ test.describe('Responsive Layout Tests', () => {
       // Set desktop viewport
       await page.setViewportSize({ width: 1920, height: 1080 });
 
+      await mockAuthenticated(page);
       await page.goto('/');
-      await page.evaluate(() => localStorage.clear());
-      await page.reload();
-
-      // Login
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
-      await page.getByRole('button', { name: /sign in|login/i }).click();
-
-      // Wait for dashboard
-      await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
+      await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
       });
     });
@@ -585,15 +562,9 @@ test.describe('Responsive Layout Tests', () => {
     test('should maintain authentication across all viewports', async ({ page }) => {
       // Test on mobile
       await page.setViewportSize({ width: 375, height: 667 });
+      await mockAuthenticated(page);
       await page.goto('/');
-      await page.evaluate(() => localStorage.clear());
-      await page.reload();
-
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
-      await page.getByRole('button', { name: /sign in|login/i }).click();
-
-      await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
+      await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
       });
 
@@ -613,15 +584,9 @@ test.describe('Responsive Layout Tests', () => {
     test('should maintain theme preference across viewports', async ({ page }) => {
       // Login on desktop
       await page.setViewportSize({ width: 1920, height: 1080 });
+      await mockAuthenticated(page);
       await page.goto('/');
-      await page.evaluate(() => localStorage.clear());
-      await page.reload();
-
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
-      await page.getByRole('button', { name: /sign in|login/i }).click();
-
-      await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
+      await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
       });
 
@@ -677,15 +642,9 @@ test.describe('Responsive Layout Tests', () => {
     test('should display same card data across all viewports', async ({ page }) => {
       // Login on desktop
       await page.setViewportSize({ width: 1920, height: 1080 });
+      await mockAuthenticated(page);
       await page.goto('/');
-      await page.evaluate(() => localStorage.clear());
-      await page.reload();
-
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
-      await page.getByRole('button', { name: /sign in|login/i }).click();
-
-      await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
+      await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
       });
 
@@ -713,15 +672,9 @@ test.describe('Responsive Layout Tests', () => {
     test('should provide working settings across all viewports', async ({ page }) => {
       // Login
       await page.setViewportSize({ width: 1920, height: 1080 });
+      await mockAuthenticated(page);
       await page.goto('/');
-      await page.evaluate(() => localStorage.clear());
-      await page.reload();
-
-      await page.getByLabel(/username/i).fill('admin');
-      await page.getByLabel(/password/i).fill('seed');
-      await page.getByRole('button', { name: /sign in|login/i }).click();
-
-      await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
+      await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
       });
 

--- a/ui/e2e/settings.spec.ts
+++ b/ui/e2e/settings.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Settings E2E Tests
@@ -18,17 +19,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Settings', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -174,17 +166,8 @@ test.describe('Settings', () => {
  */
 test.describe('Settings CRUD Operations', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/setup-wizard.spec.ts
+++ b/ui/e2e/setup-wizard.spec.ts
@@ -116,7 +116,9 @@ test.describe('Setup Wizard', () => {
       // Setup is already complete; verify the app exposes the expected entry point.
       await expect(page.getByLabel(/username/i)).toBeVisible({ timeout: 5000 });
       await expect(page.getByLabel(/password/i)).toBeVisible({ timeout: 5000 });
-      await expect(page.getByRole('button', { name: /sign in|login/i })).toBeVisible({ timeout: 5000 });
+      await expect(page.getByRole('button', { name: /sign in|login/i })).toBeVisible({
+        timeout: 5000,
+      });
     }
   });
 });

--- a/ui/e2e/setup-wizard.spec.ts
+++ b/ui/e2e/setup-wizard.spec.ts
@@ -10,7 +10,12 @@ import { expect, test } from '@playwright/test';
  * - Completion flow
  *
  * Note: These tests may skip if setup is already complete
+ *
+ * Opts out of the suite-wide authenticated storageState so the wizard
+ * detection runs against a clean unauthenticated context.
  */
+
+test.use({ storageState: { cookies: [], origins: [] } });
 
 test.describe('Setup Wizard', () => {
   test.beforeEach(async ({ page }) => {

--- a/ui/e2e/snmp-settings.spec.ts
+++ b/ui/e2e/snmp-settings.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * SNMP Settings E2E Tests
@@ -14,17 +15,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('SNMP Settings', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -253,13 +245,8 @@ test.describe('SNMP Settings', () => {
 
 test.describe('SNMP Authentication', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -347,13 +334,8 @@ test.describe('SNMP Authentication', () => {
 
 test.describe('SNMP Test Connection', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/speed-test-complete.spec.ts
+++ b/ui/e2e/speed-test-complete.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Performance Testing E2E Tests - Complete Flow
@@ -13,17 +14,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Performance Testing - Complete Flow', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/speed-test.spec.ts
+++ b/ui/e2e/speed-test.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Speed Test E2E Tests
@@ -12,17 +13,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Speed Test', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/system-health.spec.ts
+++ b/ui/e2e/system-health.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * System Health E2E Tests
@@ -14,13 +15,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('System Health', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -137,13 +133,8 @@ test.describe('System Health', () => {
 
 test.describe('System Health Thresholds', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/theme-and-help.spec.ts
+++ b/ui/e2e/theme-and-help.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Theme Toggle and Help Modal E2E Tests
@@ -25,17 +26,9 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Theme Toggle and Help Modal', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Login
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard
-    await expect(page.getByRole('heading', { name: /link|dashboard/i })).toBeVisible({
+    await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
   });

--- a/ui/e2e/vlan.spec.ts
+++ b/ui/e2e/vlan.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * VLAN E2E Tests
@@ -14,13 +15,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('VLAN Information', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -95,13 +91,8 @@ test.describe('VLAN Information', () => {
 
 test.describe('VLAN Configuration', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -172,13 +163,8 @@ test.describe('VLAN Configuration', () => {
 
 test.describe('Switch Card Details', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });
@@ -218,13 +204,8 @@ test.describe('Switch Card Details', () => {
 
 test.describe('VLAN Help', () => {
   test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/vulnerabilities.spec.ts
+++ b/ui/e2e/vulnerabilities.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Vulnerability Scanning E2E Tests
@@ -12,17 +13,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Vulnerability Scanning', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/vulnerability-scanning-complete.spec.ts
+++ b/ui/e2e/vulnerability-scanning-complete.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Vulnerability Scanning Complete Flow E2E Tests
@@ -22,16 +23,8 @@ import { expect, type Page, test } from '@playwright/test';
  * Helper function to login and navigate to dashboard
  */
 async function loginAndNavigate(page: Page): Promise<void> {
+  await mockAuthenticated(page);
   await page.goto('/');
-  await page.evaluate(() => localStorage.clear());
-  await page.reload();
-
-  // Authenticate with valid credentials
-  await page.getByLabel(/username/i).fill('admin');
-  await page.getByLabel(/password/i).fill('seed');
-  await page.getByRole('button', { name: /sign in|login/i }).click();
-
-  // Wait for dashboard to load
   await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
     timeout: 10000,
   });

--- a/ui/e2e/wifi-survey-complete.spec.ts
+++ b/ui/e2e/wifi-survey-complete.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * Complete WiFi Survey Journey E2E Tests
@@ -146,17 +147,8 @@ function createMockSurveyWithSamples(
 
 test.describe('WiFi Survey - Complete User Journey', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/e2e/wifi-survey.spec.ts
+++ b/ui/e2e/wifi-survey.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { mockAuthenticated } from './helpers/auth';
 
 /**
  * WiFi Survey E2E Tests
@@ -13,17 +14,8 @@ import { expect, test } from '@playwright/test';
 
 test.describe('WiFi Survey', () => {
   test.beforeEach(async ({ page }) => {
-    // Login first
+    await mockAuthenticated(page);
     await page.goto('/');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-
-    // Authenticate
-    await page.getByLabel(/username/i).fill('admin');
-    await page.getByLabel(/password/i).fill('seed');
-    await page.getByRole('button', { name: /sign in|login/i }).click();
-
-    // Wait for dashboard to load
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
     });

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+import { AUTH_STORAGE_STATE } from './e2e/helpers/auth';
+
 /**
  * Playwright E2E Test Configuration
  *
@@ -25,6 +27,10 @@ export default defineConfig({
   expect: {
     timeout: 10000,
   },
+  // Single real login at suite start; persisted to AUTH_STORAGE_STATE
+  // and replayed into every test via use.storageState below. See
+  // e2e/global-setup.ts and the comment in e2e/helpers/auth.ts.
+  globalSetup: './e2e/global-setup.ts',
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['list'],
@@ -38,6 +44,11 @@ export default defineConfig({
     video: 'on-first-retry',
     // biome-ignore lint/style/useNamingConvention: Playwright API property
     ignoreHTTPSErrors: true,
+    // Cookies + localStorage captured by global-setup. Specs that
+    // need an unauthenticated context (auth.spec.ts,
+    // auth-complete.spec.ts, setup-wizard.spec.ts) override with
+    // test.use({ storageState: { cookies: [], origins: [] } }).
+    storageState: AUTH_STORAGE_STATE,
   },
   projects: [
     // Desktop browsers

--- a/ui/src/components/setup/SetupWizard.tsx
+++ b/ui/src/components/setup/SetupWizard.tsx
@@ -377,7 +377,7 @@ export function SetupWizard({
                   <button
                     type="button"
                     onClick={(): void => setShowPassword(!showPassword)}
-                    class="absolute right-2 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary"
+                    class="absolute right-2 top-1/2 -translate-y-1/2 flex h-6 w-6 items-center justify-center text-text-muted hover:text-text-primary"
                     aria-label={showPassword ? 'Hide password' : 'Show password'}
                   >
                     {showPassword ? (

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -163,7 +163,7 @@
   /* Text Colors - Inverted for dark backgrounds */
   --color-text-primary: #f8f8f8; /* Snow - main text */
   --color-text-secondary: #e5e5e5; /* Cloud - secondary text */
-  --color-text-muted: #999999; /* Silver - subtle text, captions */
+  --color-text-muted: #a3a3a3; /* Tailwind neutral-400; AA 4.5:1 vs #333 surface (#999 was 4.43, failed WCAG) */
   --color-text-accent: #81c784; /* Lighter Seed Green - links, highlights */
   --color-text-inverse: #1a1a1a; /* Midnight - text on colored backgrounds */
 


### PR DESCRIPTION
## Summary

Main CI has been failing on `Backend (race detector)` ← actually no — on E2E Browser Tests timing out at 30m — since Wave 2 (#1047) merged. This gates Release Please (`workflow_run` on CI `success`), so the open release PR #1045 is stuck on `v0.193.0` carrying only Wave 1 work. Wave 2 (Argon2id + HIBP) and Wave 3 (TOTP + WebAuthn) are landed in `main` but not visible in the release.

Root cause: every non-auth spec drives the real `/api/auth/login` form in `beforeEach`. Wave 2 tightened the login limiter to `defaultMaxAttempts = 5` per 15-minute window (`internal/api/ratelimit.go`). With 30 specs and 436 tests, the suite blows past the budget after a handful of tests — subsequent specs land on a lockout, the login form stays mounted, every shell click times out, and the whole E2E job runs out the 30-minute timeout. Same pattern as stem #232/#233/#234 hit.

Three-part fix:

1. **`ui/e2e/helpers/auth.ts`** — shared `mockAuthenticated(page)` that mocks `/api/setup/status` and `/api/status` so `useAuth`'s mount-time session check hydrates `isAuthenticated=true` without driving the real login endpoint. `loginViaUI(page)` for the few specs that genuinely need the form.
2. **Refactor 28 specs, 34 `beforeEach` blocks, plus the two `loginAndNavigate` helpers and `error-scenarios`** to use `mockAuthenticated`. `auth.spec.ts` and `auth-complete.spec.ts` keep driving the real form — they ARE the auth coverage.
3. **`SEED_LOGIN_MAX_ATTEMPTS`** env var on `DefaultRateLimitConfig` lets CI lift the budget for the auth specs themselves (XSS/SQLi/brute-force/lockout cases legitimately need ~15 logins). CI workflow sets it to `200` for the E2E backend only.

`ui/biome.json` grows a path-scoped exclusion for `noSkippedTests` on `e2e/**` — Playwright's `test.skip(condition, reason)` form is a legitimate runtime guard (skip when only one interface available, skip when remember-me feature absent) and biome can't tell those apart from accidental disable. Excluding the rule on `e2e/**` only.

## Test plan

- [x] `go test -race ./internal/api/...` — passes (rate-limiter unit tests still green).
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/api/...` — 0 issues.
- [x] `biome check ui/e2e/` — clean.
- [ ] CI green (especially E2E Browser Tests).

## Unblocks

Release Please #1045 → `v0.193.0` will then carry Waves 1-3 (TLS-by-default + Argon2id/HIBP + TOTP/WebAuthn).