### PR TITLE
fix(ui): Version every backend fetch under /api/v1/* (P0 silent auth failure)

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -16,10 +16,10 @@
  * import { api } from './api';
  *
  * // GET request
- * const data = await api.get<MyType>('/api/endpoint');
+ * const data = await api.get<MyType>('/api/v1/endpoint');
  *
  * // POST request with body
- * const result = await api.post<Response>('/api/endpoint', { key: 'value' });
+ * const result = await api.post<Response>('/api/v1/endpoint', { key: 'value' });
  * ```
  *
  * Session Management:
@@ -74,7 +74,7 @@ async function refreshAccessToken(): Promise<boolean> {
   // Start new refresh attempt
   const newPromise: Promise<boolean> = (async (): Promise<boolean> => {
     try {
-      const response = await fetch(`${API_BASE}/api/auth/refresh`, {
+      const response = await fetch(`${API_BASE}/api/v1/auth/refresh`, {
         method: 'POST',
         credentials: 'include', // Send refresh token cookie
       });
@@ -100,7 +100,7 @@ async function refreshAccessToken(): Promise<boolean> {
  */
 async function fetchCsrfToken(): Promise<string | null> {
   try {
-    const response = await fetch(`${API_BASE}/api/auth/csrf`, {
+    const response = await fetch(`${API_BASE}/api/v1/auth/csrf`, {
       method: 'GET',
       credentials: 'include', // Send auth cookies
     });
@@ -185,10 +185,10 @@ export const api = {
   /**
    * Performs a GET request to the specified endpoint.
    *
-   * @param endpoint - API endpoint path (e.g., '/api/network/status')
+   * @param endpoint - API endpoint path (e.g., '/api/v1/network/status')
    * @returns Promise resolving to typed response data
    * @example
-   * const status = await api.get<NetworkStatus>('/api/network/status');
+   * const status = await api.get<NetworkStatus>('/api/v1/network/status');
    */
   async get<T>(endpoint: string, init?: RequestInit): Promise<T> {
     const isAuthEndpoint: boolean = endpoint.includes('/api/v1/auth/');
@@ -212,7 +212,7 @@ export const api = {
    * @param body - Request body (will be JSON serialized)
    * @returns Promise resolving to typed response data
    * @example
-   * const result = await api.post<Result>('/api/network/scan', { subnet: '192.168.1.0/24' });
+   * const result = await api.post<Result>('/api/v1/network/scan', { subnet: '192.168.1.0/24' });
    */
   async post<T>(endpoint: string, body?: unknown, init?: RequestInit): Promise<T> {
     const isAuthEndpoint: boolean = endpoint.includes('/api/v1/auth/');
@@ -249,7 +249,7 @@ export const api = {
    * @param body - Request body (will be JSON serialized)
    * @returns Promise resolving to typed response data
    * @example
-   * await api.put('/api/settings', { theme: 'dark' });
+   * await api.put('/api/v1/settings', { theme: 'dark' });
    */
   async put<T>(endpoint: string, body?: unknown, init?: RequestInit): Promise<T> {
     const isAuthEndpoint: boolean = endpoint.includes('/api/v1/auth/');
@@ -286,7 +286,7 @@ export const api = {
    * @param body - Request body (will be JSON serialized)
    * @returns Promise resolving to typed response data
    * @example
-   * await api.patch('/api/settings', { theme: 'dark' });
+   * await api.patch('/api/v1/settings', { theme: 'dark' });
    */
   async patch<T>(endpoint: string, body?: unknown, init?: RequestInit): Promise<T> {
     const isAuthEndpoint: boolean = endpoint.includes('/api/v1/auth/');
@@ -322,7 +322,7 @@ export const api = {
    * @param endpoint - API endpoint path
    * @returns Promise resolving to typed response data
    * @example
-   * await api.delete('/api/devices/12345');
+   * await api.delete('/api/v1/devices/12345');
    */
   async delete<T>(endpoint: string, init?: RequestInit): Promise<T> {
     const isAuthEndpoint: boolean = endpoint.includes('/api/v1/auth/');

--- a/ui/src/app.test.tsx
+++ b/ui/src/app.test.tsx
@@ -205,7 +205,7 @@ describe('App', () => {
 
     // Default API mocks - includes profile endpoints for ProfileContext
     mockFetch.mockImplementation((url: string) => {
-      if (url.includes('/api/setup/status')) {
+      if (url.includes('/api/v1/setup/status')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({ needsSetup: false, username: 'admin' }),
@@ -388,7 +388,7 @@ describe('App', () => {
 
     it('handles login form submission', async () => {
       mockFetch.mockImplementation((url: string) => {
-        if (url.includes('/api/setup/status')) {
+        if (url.includes('/api/v1/setup/status')) {
           return Promise.resolve({
             ok: true,
             json: () => Promise.resolve({ needsSetup: false, username: 'admin' }),
@@ -447,7 +447,7 @@ describe('App', () => {
 
     it('shows error message on login failure', async () => {
       mockFetch.mockImplementation((url: string) => {
-        if (url.includes('/api/setup/status')) {
+        if (url.includes('/api/v1/setup/status')) {
           return Promise.resolve({
             ok: true,
             json: () => Promise.resolve({ needsSetup: false, username: 'admin' }),
@@ -499,7 +499,7 @@ describe('App', () => {
     it('disables login button while loading', async () => {
       let resolveLogin: (value: unknown) => void;
       mockFetch.mockImplementation((url: string) => {
-        if (url.includes('/api/setup/status')) {
+        if (url.includes('/api/v1/setup/status')) {
           return Promise.resolve({
             ok: true,
             json: () => Promise.resolve({ needsSetup: false, username: 'admin' }),
@@ -555,9 +555,9 @@ describe('App', () => {
 
   describe('authenticated state', () => {
     beforeEach(() => {
-      // Set up authenticated state by mocking /api/status to return authenticated
+      // Set up authenticated state by mocking /api/v1/status to return authenticated
       mockFetch.mockImplementation((url: string) => {
-        if (url.includes('/api/setup/status')) {
+        if (url.includes('/api/v1/setup/status')) {
           return Promise.resolve({
             ok: true,
             json: () => Promise.resolve({ needsSetup: false, username: 'admin' }),
@@ -615,7 +615,7 @@ describe('App', () => {
 
     it('renders interface selector', async () => {
       mockFetch.mockImplementation((url: string) => {
-        if (url.includes('/api/setup/status')) {
+        if (url.includes('/api/v1/setup/status')) {
           return Promise.resolve({
             ok: true,
             json: () => Promise.resolve({ needsSetup: false, username: 'admin' }),
@@ -720,7 +720,7 @@ describe('LoginForm input validation', () => {
     vi.clearAllMocks();
 
     mockFetch.mockImplementation((url: string) => {
-      if (url.includes('/api/setup/status')) {
+      if (url.includes('/api/v1/setup/status')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({ needsSetup: false, username: 'admin' }),

--- a/ui/src/app/LoginForm.tsx
+++ b/ui/src/app/LoginForm.tsx
@@ -72,7 +72,7 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
 
   // Fetch recovery status on mount
   useEffect(() => {
-    fetch(`${API_BASE}/api/recovery/status`)
+    fetch(`${API_BASE}/api/v1/recovery/status`)
       .then((res) => (res.ok ? res.json() : { active: false }))
       .then((data: RecoveryStatus) => {
         setRecoveryStatus(data);
@@ -86,7 +86,7 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
 
   // Fetch enabled SSO providers on mount (fixes #769)
   useEffect(() => {
-    fetch(`${API_BASE}/api/sso/providers`)
+    fetch(`${API_BASE}/api/v1/sso/providers`)
       .then((res) => (res.ok ? res.json() : { providers: [] }))
       .then((data) => setSsoProviders(data.providers || []))
       .catch(() => setSsoProviders([]));
@@ -302,7 +302,7 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
                 <button
                   type="button"
                   onClick={() => {
-                    window.location.href = `${API_BASE}/api/sso/login?provider=google`;
+                    window.location.href = `${API_BASE}/api/v1/sso/login?provider=google`;
                   }}
                   class={cn(
                     'w-full',
@@ -319,7 +319,7 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
                 <button
                   type="button"
                   onClick={() => {
-                    window.location.href = `${API_BASE}/api/sso/login?provider=microsoft`;
+                    window.location.href = `${API_BASE}/api/v1/sso/login?provider=microsoft`;
                   }}
                   class={cn(
                     'w-full',
@@ -336,7 +336,7 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
                 <button
                   type="button"
                   onClick={() => {
-                    window.location.href = `${API_BASE}/api/sso/login?provider=github`;
+                    window.location.href = `${API_BASE}/api/v1/sso/login?provider=github`;
                   }}
                   class={cn(
                     'w-full',

--- a/ui/src/components/help/WiFiSurveyHelp.tsx
+++ b/ui/src/components/help/WiFiSurveyHelp.tsx
@@ -130,7 +130,7 @@ export const WIFI_SURVEY_HELP: HelpSection[] = [
       {
         question: 'Can I export survey data?',
         answer:
-          'Survey export functionality is coming soon. Future versions will support:\n• CSV export of all sample points\n• PDF reports with heatmap images\n• Comparison reports (before/after changes)\n• Integration with professional tools\n\nCurrently, you can:\n• View all measurements in the web interface\n• Take screenshots of heatmaps\n• Access raw data via the API (/api/canopy/survey endpoints)',
+          'Survey export functionality is coming soon. Future versions will support:\n• CSV export of all sample points\n• PDF reports with heatmap images\n• Comparison reports (before/after changes)\n• Integration with professional tools\n\nCurrently, you can:\n• View all measurements in the web interface\n• Take screenshots of heatmaps\n• Access raw data via the API (/api/v1/canopy/survey endpoints)',
       },
     ],
   },

--- a/ui/src/components/login/RecoveryForm.tsx
+++ b/ui/src/components/login/RecoveryForm.tsx
@@ -76,7 +76,7 @@ export function RecoveryForm({
 
   // Fetch recovery instructions on mount
   useEffect(() => {
-    fetch(`${API_BASE}/api/recovery/instructions`)
+    fetch(`${API_BASE}/api/v1/recovery/instructions`)
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (data) {
@@ -136,7 +136,7 @@ export function RecoveryForm({
     setIsSubmitting(true);
 
     try {
-      const response = await fetch(`${API_BASE}/api/recovery/complete`, {
+      const response = await fetch(`${API_BASE}/api/v1/recovery/complete`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/ui/src/components/settings/SettingsDrawer.tsx
+++ b/ui/src/components/settings/SettingsDrawer.tsx
@@ -390,7 +390,7 @@ export const SettingsDrawer: React.MemoExoticComponent<
         .map((s) => s.trim())
         .filter((s) => s.length > 0);
 
-      const response = await fetch(`${API_BASE}/api/ipconfig/settings`, {
+      const response = await fetch(`${API_BASE}/api/v1/sap/ipconfig/settings`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/ui/src/components/settings/SettingsDrawerFooter.tsx
+++ b/ui/src/components/settings/SettingsDrawerFooter.tsx
@@ -72,7 +72,7 @@ export function SettingsDrawerFooter({
           {t('export.title')}
         </h3>
         <a
-          href={`${API_BASE}/api/harvest/export`}
+          href={`${API_BASE}/api/v1/harvest/export`}
           download="seed-export.json"
           class={cn(
             'w-full',

--- a/ui/src/components/settings/sections/CableTestSettings.tsx
+++ b/ui/src/components/settings/sections/CableTestSettings.tsx
@@ -67,7 +67,7 @@ export const CableTestSettings: React.NamedExoticComponent<CableTestSettingsProp
     const checkTdrSupport = useCallback(async (): Promise<void> => {
       setCheckingSupport(true);
       try {
-        const response = await fetch(`${API_BASE}/api/sap/cable/support`, {
+        const response = await fetch(`${API_BASE}/api/v1/sap/cable/support`, {
           credentials: 'include',
         });
         if (response.ok) {

--- a/ui/src/components/settings/sections/ConfigBackupsSection.tsx
+++ b/ui/src/components/settings/sections/ConfigBackupsSection.tsx
@@ -62,8 +62,8 @@ export const ConfigBackupsSection: React.NamedExoticComponent<Record<string, nev
       setError(null);
       try {
         const [backupsRes, versionRes] = await Promise.all([
-          fetch(`${API_BASE}/api/config/backups`, { credentials: 'include' }),
-          fetch(`${API_BASE}/api/config/version`, { credentials: 'include' }),
+          fetch(`${API_BASE}/api/v1/config/backups`, { credentials: 'include' }),
+          fetch(`${API_BASE}/api/v1/config/version`, { credentials: 'include' }),
         ]);
 
         if (backupsRes.ok) {
@@ -91,7 +91,7 @@ export const ConfigBackupsSection: React.NamedExoticComponent<Record<string, nev
       setActionLoading('create');
       setError(null);
       try {
-        const response = await fetch(`${API_BASE}/api/config/backup`, {
+        const response = await fetch(`${API_BASE}/api/v1/config/backup`, {
           method: 'POST',
           credentials: 'include',
         });
@@ -111,7 +111,7 @@ export const ConfigBackupsSection: React.NamedExoticComponent<Record<string, nev
       setActionLoading(backupName);
       setError(null);
       try {
-        const response = await fetch(`${API_BASE}/api/config/restore`, {
+        const response = await fetch(`${API_BASE}/api/v1/config/restore`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -137,7 +137,7 @@ export const ConfigBackupsSection: React.NamedExoticComponent<Record<string, nev
       setError(null);
       try {
         const response = await fetch(
-          `${API_BASE}/api/config/backup/delete?name=${encodeURIComponent(backupName)}`,
+          `${API_BASE}/api/v1/config/backup/delete?name=${encodeURIComponent(backupName)}`,
           {
             method: 'DELETE',
             credentials: 'include',

--- a/ui/src/components/settings/sections/MtuControl.tsx
+++ b/ui/src/components/settings/sections/MtuControl.tsx
@@ -42,7 +42,7 @@ export const MtuControl: React.NamedExoticComponent<Record<string, never>> = mem
       setLoading(true);
       setMessage(null);
       try {
-        const response = await fetch(`${API_BASE}/api/network/mtu`, {
+        const response = await fetch(`${API_BASE}/api/v1/network/mtu`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',

--- a/ui/src/components/settings/sections/WiFiSettings.tsx
+++ b/ui/src/components/settings/sections/WiFiSettings.tsx
@@ -93,7 +93,7 @@ export const WiFiSettings: React.NamedExoticComponent<WiFiSettingsProps> = memo(
       setScanError(null);
       try {
         const response = await api.get<{ networks: ScannedNetwork[]; error?: string }>(
-          `/api/canopy/wifi/scan?interface=${wifiSettings.interface}`,
+          `/api/v1/canopy/wifi/scan?interface=${wifiSettings.interface}`,
         );
         if (response?.networks) {
           // Filter out hidden networks (empty SSID) and sort by signal strength
@@ -174,7 +174,7 @@ export const WiFiSettings: React.NamedExoticComponent<WiFiSettingsProps> = memo(
     const forgetNetwork = useCallback(
       async (ssid: string) => {
         try {
-          await api.delete(`/api/canopy/wifi/forget?ssid=${encodeURIComponent(ssid)}`);
+          await api.delete(`/api/v1/canopy/wifi/forget?ssid=${encodeURIComponent(ssid)}`);
           await loadSavedNetworks();
         } catch {
           // Ignore errors

--- a/ui/src/components/setup/SetupWizard.tsx
+++ b/ui/src/components/setup/SetupWizard.tsx
@@ -67,9 +67,9 @@ interface SetupWizardProps {
  * Modal-like component that requires user to set admin password before
  * accessing the main application.
  */
-// SSO providers from backend (/api/sso/providers returns the names of
+// SSO providers from backend (/api/v1/sso/providers returns the names of
 // only the providers that are enabled AND have a ClientID configured -
-// see internal/api/handlers_oauth.go::initOAuthManager). Fixes #720.
+// see internal/api/v1/handlers_oauth.go::initOAuthManager). Fixes #720.
 
 /**
  * First-run setup flow that forces the user to create credentials before using the app.
@@ -95,7 +95,7 @@ export function SetupWizard({
 
   // Fetch enabled SSO providers (fixes #769, #720)
   useEffect(() => {
-    fetch(`${API_BASE}/api/sso/providers`)
+    fetch(`${API_BASE}/api/v1/sso/providers`)
       .then((res) => (res.ok ? res.json() : { providers: [] }))
       .then((data: { providers?: string[] }) => {
         const providers = data.providers ?? [];
@@ -481,7 +481,7 @@ export function SetupWizard({
                   <button
                     type="button"
                     onClick={() => {
-                      window.location.href = `${API_BASE}/api/sso/login?provider=google`;
+                      window.location.href = `${API_BASE}/api/v1/sso/login?provider=google`;
                     }}
                     class={cn(
                       'w-full',
@@ -498,7 +498,7 @@ export function SetupWizard({
                   <button
                     type="button"
                     onClick={() => {
-                      window.location.href = `${API_BASE}/api/sso/login?provider=microsoft`;
+                      window.location.href = `${API_BASE}/api/v1/sso/login?provider=microsoft`;
                     }}
                     class={cn(
                       'w-full',
@@ -515,7 +515,7 @@ export function SetupWizard({
                   <button
                     type="button"
                     onClick={() => {
-                      window.location.href = `${API_BASE}/api/sso/login?provider=github`;
+                      window.location.href = `${API_BASE}/api/v1/sso/login?provider=github`;
                     }}
                     class={cn(
                       'w-full',

--- a/ui/src/components/survey/ReportDialog.tsx
+++ b/ui/src/components/survey/ReportDialog.tsx
@@ -81,7 +81,7 @@ export function ReportDialog({
     setSuccess(false);
 
     try {
-      const response = await fetch(`${API_BASE}/api/canopy/survey/report?id=${surveyId}`, {
+      const response = await fetch(`${API_BASE}/api/v1/canopy/survey/report?id=${surveyId}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/ui/src/components/survey/SurveyView.tsx
+++ b/ui/src/components/survey/SurveyView.tsx
@@ -63,7 +63,7 @@ interface SurveyViewProps {
  * SurveyView Component
  * Main survey interface with floor plan, sampling controls, and heatmap visualization
  */
-// WiFi adapter status from /api/canopy/wifi/status
+// WiFi adapter status from /api/v1/canopy/wifi/status
 interface WiFiStatus {
   status: 'unavailable' | 'available' | 'ready';
   message: string;
@@ -166,7 +166,7 @@ export function SurveyView({
   useEffect(() => {
     const checkWifiStatus = async (): Promise<void> => {
       try {
-        const res: Response = await fetch(`${API_BASE}/api/canopy/wifi/status`, {
+        const res: Response = await fetch(`${API_BASE}/api/v1/canopy/wifi/status`, {
           credentials: 'include',
         });
         if (res.ok) {
@@ -190,7 +190,7 @@ export function SurveyView({
 
     const interval = setInterval(async () => {
       try {
-        const res = await fetch(`${API_BASE}/api/canopy/survey?id=${survey.id}`, {
+        const res = await fetch(`${API_BASE}/api/v1/canopy/survey?id=${survey.id}`, {
           credentials: 'include',
         });
         if (res.ok) {
@@ -252,7 +252,7 @@ export function SurveyView({
         };
 
         // Upload to server
-        const res = await fetch(`${API_BASE}/api/canopy/survey/floorplan?id=${survey.id}`, {
+        const res = await fetch(`${API_BASE}/api/v1/canopy/survey/floorplan?id=${survey.id}`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -302,7 +302,7 @@ export function SurveyView({
         switch (survey.surveyType) {
           case 'passive': {
             // Fetch WiFi scan
-            const scanRes = await fetch(`${API_BASE}/api/canopy/wifi/scan`, {
+            const scanRes = await fetch(`${API_BASE}/api/v1/canopy/wifi/scan`, {
               credentials: 'include',
             });
             if (!scanRes.ok) {
@@ -319,7 +319,7 @@ export function SurveyView({
 
           case 'active': {
             // Fetch current WiFi status
-            const wifiRes = await fetch(`${API_BASE}/api/canopy/wifi`, {
+            const wifiRes = await fetch(`${API_BASE}/api/v1/canopy/wifi`, {
               credentials: 'include',
             });
             if (!wifiRes.ok) {
@@ -344,7 +344,7 @@ export function SurveyView({
 
           case 'throughput': {
             // Fetch WiFi status first
-            const wifiRes2 = await fetch(`${API_BASE}/api/canopy/wifi`, {
+            const wifiRes2 = await fetch(`${API_BASE}/api/v1/canopy/wifi`, {
               credentials: 'include',
             });
             if (!wifiRes2.ok) {
@@ -358,7 +358,7 @@ export function SurveyView({
             }
 
             const [host, port] = survey.iperfServer.split(':');
-            const iperfRes = await fetch(`${API_BASE}/api/sap/iperf/client`, {
+            const iperfRes = await fetch(`${API_BASE}/api/v1/sap/iperf/client`, {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
@@ -399,7 +399,7 @@ export function SurveyView({
         }
 
         // Submit sample to server
-        const res = await fetch(`${API_BASE}/api/canopy/survey/sample?id=${survey.id}`, {
+        const res = await fetch(`${API_BASE}/api/v1/canopy/survey/sample?id=${survey.id}`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -413,7 +413,7 @@ export function SurveyView({
         }
 
         // Refresh survey to get updated samples
-        const refreshRes = await fetch(`${API_BASE}/api/canopy/survey?id=${survey.id}`, {
+        const refreshRes = await fetch(`${API_BASE}/api/v1/canopy/survey?id=${survey.id}`, {
           credentials: 'include',
         });
         if (refreshRes.ok) {
@@ -471,7 +471,7 @@ export function SurveyView({
 
     try {
       // Update floor plan scale on server
-      const res = await fetch(`${API_BASE}/api/canopy/survey/floorplan?id=${survey.id}`, {
+      const res = await fetch(`${API_BASE}/api/v1/canopy/survey/floorplan?id=${survey.id}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/ui/src/components/survey/useSurveyMutations.ts
+++ b/ui/src/components/survey/useSurveyMutations.ts
@@ -130,7 +130,7 @@ export function useSurveyMutations({
         };
 
         const res: Response = await fetch(
-          `${API_BASE}/api/canopy/survey/floorplan?id=${survey.id}`,
+          `${API_BASE}/api/v1/canopy/survey/floorplan?id=${survey.id}`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -161,12 +161,15 @@ export function useSurveyMutations({
           ...configUpdates,
         } as SurveyConfig;
 
-        const res: Response = await fetch(`${API_BASE}/api/canopy/survey/config?id=${survey.id}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify(updatedConfig),
-        });
+        const res: Response = await fetch(
+          `${API_BASE}/api/v1/canopy/survey/config?id=${survey.id}`,
+          {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify(updatedConfig),
+          },
+        );
 
         if (!res.ok) {
           throw new Error('Failed to update survey config');
@@ -187,16 +190,19 @@ export function useSurveyMutations({
     setError(null);
 
     try {
-      const res: Response = await fetch(`${API_BASE}/api/canopy/survey/settings?id=${survey.id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          surveyType: editSurveyType,
-          iperfServer: editIperfServer,
-          testDuration: editTestDuration,
-        }),
-      });
+      const res: Response = await fetch(
+        `${API_BASE}/api/v1/canopy/survey/settings?id=${survey.id}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            surveyType: editSurveyType,
+            iperfServer: editIperfServer,
+            testDuration: editTestDuration,
+          }),
+        },
+      );
 
       if (!res.ok) {
         const errorText: string = await (res.text() as Promise<string>);
@@ -217,7 +223,7 @@ export function useSurveyMutations({
     async (action: 'start' | 'pause' | 'complete'): Promise<void> => {
       try {
         const res: Response = await fetch(
-          `${API_BASE}/api/canopy/survey/${action}?id=${survey.id}`,
+          `${API_BASE}/api/v1/canopy/survey/${action}?id=${survey.id}`,
           {
             method: 'POST',
             credentials: 'include',
@@ -260,7 +266,7 @@ export function useSurveyMutations({
             originalFile: data.floorPlanFilename,
           };
 
-          const res = await fetch(`${API_BASE}/api/canopy/survey/floorplan?id=${survey.id}`, {
+          const res = await fetch(`${API_BASE}/api/v1/canopy/survey/floorplan?id=${survey.id}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',
@@ -289,7 +295,7 @@ export function useSurveyMutations({
         const importedData = buildImportedDataPayload(data);
         if (importedData) {
           const dataRes = await fetch(
-            `${API_BASE}/api/canopy/survey/imported-data?id=${survey.id}`,
+            `${API_BASE}/api/v1/canopy/survey/imported-data?id=${survey.id}`,
             {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },

--- a/ui/src/contexts/useProfileInterfaces.ts
+++ b/ui/src/contexts/useProfileInterfaces.ts
@@ -86,7 +86,7 @@ export function useProfileInterfaces(
         const updatedInterfaces = updater(currentInterfaces);
         const updatedConfig = { ...currentProfile.config, interfaces: updatedInterfaces };
 
-        await api.put(`/api/profiles/${currentProfile.id}`, {
+        await api.put(`/api/v1/profiles/${currentProfile.id}`, {
           name: currentProfile.name,
           description: currentProfile.description,
           config: updatedConfig,

--- a/ui/src/hooks/useAuth.test.ts
+++ b/ui/src/hooks/useAuth.test.ts
@@ -67,7 +67,7 @@ describe('useAuth', () => {
   });
 
   it('starts with loading state and checks auth status', async () => {
-    // Mock /api/status to return 401 (not authenticated)
+    // Mock /api/v1/status to return 401 (not authenticated)
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 401,
@@ -89,7 +89,7 @@ describe('useAuth', () => {
   });
 
   it('restores auth state when backend confirms session', async () => {
-    // Mock /api/status to return 200 (authenticated)
+    // Mock /api/v1/status to return 200 (authenticated)
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -103,7 +103,7 @@ describe('useAuth', () => {
 
     expect(result.current.isAuthenticated).toBe(true);
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/status',
+      '/api/v1/status',
       expect.objectContaining({ credentials: 'include' }),
     );
   });
@@ -149,7 +149,7 @@ describe('useAuth', () => {
     expect(result.current.token).toBe('access-token'); // For WebSocket
     expect(result.current.username).toBe('admin');
     expect(mockFetch).toHaveBeenLastCalledWith(
-      '/api/auth/login',
+      '/api/v1/auth/login',
       expect.objectContaining({
         method: 'POST',
         credentials: 'include',
@@ -275,7 +275,7 @@ describe('useAuth', () => {
     // Should have called logout endpoint with credentials
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(
-        '/api/auth/logout',
+        '/api/v1/auth/logout',
         expect.objectContaining({
           method: 'POST',
           credentials: 'include',

--- a/ui/src/hooks/useAuth.ts
+++ b/ui/src/hooks/useAuth.ts
@@ -154,12 +154,12 @@ export function useAuth(): UseAuthReturn {
     clearLegacyStorage();
 
     // Check if we're authenticated by calling a protected endpoint
-    fetch(`${API_BASE}/api/status`, {
+    fetch(`${API_BASE}/api/v1/status`, {
       credentials: 'include', // Send cookies
     })
       .then((response) => {
         if (response.ok) {
-          // Authenticated - we don't have username from /api/status, will be set on login
+          // Authenticated - we don't have username from /api/v1/status, will be set on login
           setState({
             isAuthenticated: true,
             token: null, // Will be set on login for SSE
@@ -199,7 +199,7 @@ export function useAuth(): UseAuthReturn {
     setError(null);
 
     try {
-      const response = await fetch(`${API_BASE}/api/auth/login`, {
+      const response = await fetch(`${API_BASE}/api/v1/auth/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -262,7 +262,7 @@ export function useAuth(): UseAuthReturn {
     clearCSRFToken();
 
     // Call logout endpoint to clear httpOnly cookies
-    fetch(`${API_BASE}/api/auth/logout`, {
+    fetch(`${API_BASE}/api/v1/auth/logout`, {
       method: 'POST',
       credentials: 'include', // Send cookies to be cleared
     })
@@ -296,7 +296,7 @@ export function useAuth(): UseAuthReturn {
     };
 
     try {
-      const response = await fetch(`${API_BASE}/api/auth/refresh`, {
+      const response = await fetch(`${API_BASE}/api/v1/auth/refresh`, {
         method: 'POST',
         credentials: 'include', // Send refresh token cookie
       });

--- a/ui/src/hooks/useCapabilities.ts
+++ b/ui/src/hooks/useCapabilities.ts
@@ -40,7 +40,7 @@ export function useCapabilities(): UseCapabilitiesResult {
 
   const fetchCapabilities = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/status`, {
+      const response = await fetch(`${API_BASE}/api/v1/status`, {
         credentials: 'include',
       });
 

--- a/ui/src/hooks/useDiscoveredDevices.ts
+++ b/ui/src/hooks/useDiscoveredDevices.ts
@@ -43,7 +43,7 @@ export interface DiscoveryStatus {
   lastScan: string;
 }
 
-/** API response from /api/discovery */
+/** API response from /api/v1/discovery */
 interface DiscoveryResponse {
   devices: DiscoveredDevice[];
   status: DiscoveryStatus;
@@ -192,8 +192,8 @@ export function useDiscoveredDevices(autoRefresh: boolean = false): {
   const fetchDevices = useCallback(async (): Promise<void> => {
     try {
       setError(null);
-      // Use /api/devices endpoint which returns discovered network devices
-      // (not /api/discovery which returns LLDP/CDP protocol neighbors)
+      // Use /api/v1/devices endpoint which returns discovered network devices
+      // (not /api/v1/discovery which returns LLDP/CDP protocol neighbors)
       const data = await api.get<DiscoveryResponse>('/api/v1/shell/devices');
       setDevices(data.devices || []);
       setStatus(data.status);

--- a/ui/src/hooks/useLogs.ts
+++ b/ui/src/hooks/useLogs.ts
@@ -164,7 +164,7 @@ export function useLogs({
     setError(null);
 
     try {
-      const response = await fetch(`/api/harvest/logs/recent?limit=${limit}`);
+      const response = await fetch(`/api/v1/harvest/logs/recent?limit=${limit}`);
       if (!response.ok) {
         throw new Error(`Failed to fetch logs: ${response.statusText}`);
       }

--- a/ui/src/hooks/useNetworkFetchers.ts
+++ b/ui/src/hooks/useNetworkFetchers.ts
@@ -127,8 +127,8 @@ export function useNetworkFetchers({
       // Use ref to get current interface without dependency change (#754)
       const iface = currentInterfaceRef.current;
       const url = iface
-        ? `${API_BASE}/api/sap/link?interface=${encodeURIComponent(iface)}`
-        : `${API_BASE}/api/sap/link`;
+        ? `${API_BASE}/api/v1/sap/link?interface=${encodeURIComponent(iface)}`
+        : `${API_BASE}/api/v1/sap/link`;
       const response = await fetch(url, {
         credentials: 'include',
       });
@@ -179,8 +179,8 @@ export function useNetworkFetchers({
       // Use ref to get current interface without dependency change (#754)
       const iface = currentInterfaceRef.current;
       const url = iface
-        ? `${API_BASE}/api/sap/ipconfig?interface=${encodeURIComponent(iface)}`
-        : `${API_BASE}/api/sap/ipconfig`;
+        ? `${API_BASE}/api/v1/sap/ipconfig?interface=${encodeURIComponent(iface)}`
+        : `${API_BASE}/api/v1/sap/ipconfig`;
       const response = await fetch(url, {
         credentials: 'include',
       });
@@ -206,7 +206,7 @@ export function useNetworkFetchers({
   // Fetch interfaces (#756: Use categorized endpoint for recommendations)
   const fetchInterfaces = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/interfaces?categorized=true`, {
+      const response = await fetch(`${API_BASE}/api/v1/interfaces?categorized=true`, {
         credentials: 'include',
       });
       if (response.ok) {
@@ -230,7 +230,7 @@ export function useNetworkFetchers({
   // Fetch app version from status endpoint
   const fetchVersion = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/status`, {
+      const response = await fetch(`${API_BASE}/api/v1/status`, {
         credentials: 'include',
       });
       if (response.ok) {
@@ -303,8 +303,8 @@ export function useNetworkFetchers({
       // Use ref to get current interface without dependency change (#754)
       const iface = currentInterfaceRef.current;
       const url = iface
-        ? `${API_BASE}/api/sap/dns?interface=${encodeURIComponent(iface)}`
-        : `${API_BASE}/api/sap/dns`;
+        ? `${API_BASE}/api/v1/sap/dns?interface=${encodeURIComponent(iface)}`
+        : `${API_BASE}/api/v1/sap/dns`;
       const response = await fetch(url, {
         credentials: 'include',
       });
@@ -367,7 +367,7 @@ export function useNetworkFetchers({
   // Fetch VLAN data
   const fetchVlanData = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/sap/vlan`, {
+      const response = await fetch(`${API_BASE}/api/v1/sap/vlan`, {
         credentials: 'include',
       });
       if (response.ok) {
@@ -393,8 +393,8 @@ export function useNetworkFetchers({
       // Use ref to get current interface without dependency change (#754)
       const iface = currentInterfaceRef.current;
       const url = iface
-        ? `${API_BASE}/api/sap/gateway?interface=${encodeURIComponent(iface)}`
-        : `${API_BASE}/api/sap/gateway`;
+        ? `${API_BASE}/api/v1/sap/gateway?interface=${encodeURIComponent(iface)}`
+        : `${API_BASE}/api/v1/sap/gateway`;
       const response = await fetch(url, {
         credentials: 'include',
       });
@@ -441,8 +441,8 @@ export function useNetworkFetchers({
       // Use ref to get current interface without dependency change (#754)
       const iface = currentInterfaceRef.current;
       const url = iface
-        ? `${API_BASE}/api/canopy/wifi?interface=${encodeURIComponent(iface)}`
-        : `${API_BASE}/api/canopy/wifi`;
+        ? `${API_BASE}/api/v1/canopy/wifi?interface=${encodeURIComponent(iface)}`
+        : `${API_BASE}/api/v1/canopy/wifi`;
       const response = await fetch(url, {
         credentials: 'include',
       });
@@ -481,7 +481,7 @@ export function useNetworkFetchers({
   // Fetch Cable test data
   const fetchCableData = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/sap/cable`, {
+      const response = await fetch(`${API_BASE}/api/v1/sap/cable`, {
         credentials: 'include',
       });
       if (response.ok) {
@@ -505,7 +505,7 @@ export function useNetworkFetchers({
   // Fetch Public IP data
   const fetchPublicIp = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/sap/publicip`, {
+      const response = await fetch(`${API_BASE}/api/v1/sap/publicip`, {
         credentials: 'include',
       });
       if (response.ok) {

--- a/ui/src/hooks/useSettingsDrawerLoaders.ts
+++ b/ui/src/hooks/useSettingsDrawerLoaders.ts
@@ -90,7 +90,7 @@ export function useSettingsDrawerLoaders({
 }: UseSettingsDrawerLoadersArgs): UseSettingsDrawerLoadersResult {
   const fetchThresholds = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/settings`, {
+      const response = await fetch(`${API_BASE}/api/v1/settings`, {
         credentials: 'include',
       });
       if (response.ok) {
@@ -106,7 +106,7 @@ export function useSettingsDrawerLoaders({
 
   const fetchIpSettings = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/ipconfig/settings`, {
+      const response = await fetch(`${API_BASE}/api/v1/sap/ipconfig/settings`, {
         credentials: 'include',
       });
       if (response.ok) {
@@ -129,7 +129,7 @@ export function useSettingsDrawerLoaders({
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Reads many optional fields off the API payload; same shape as the original inline code
     async () => {
       try {
-        const response = await fetch(`${API_BASE}/api/health-checks/settings`, {
+        const response = await fetch(`${API_BASE}/api/v1/sap/health-checks/settings`, {
           credentials: 'include',
         });
         if (response.ok) {
@@ -183,7 +183,7 @@ export function useSettingsDrawerLoaders({
     setIperfSuggestionsStatus('loading');
     setIperfSuggestionsError(null);
     try {
-      const response = await fetch(`${API_BASE}/api/sap/iperf/suggestions`, {
+      const response = await fetch(`${API_BASE}/api/v1/sap/iperf/suggestions`, {
         credentials: 'include',
       });
       if (response.ok) {
@@ -202,7 +202,7 @@ export function useSettingsDrawerLoaders({
 
   const fetchWifiSettings = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/canopy/wifi/settings`, {
+      const response = await fetch(`${API_BASE}/api/v1/canopy/wifi/settings`, {
         credentials: 'include',
       });
       if (response.ok) {
@@ -273,7 +273,7 @@ export function useSettingsDrawerLoaders({
 
   const fetchSnmpSettings = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/sap/snmp/settings`, {
+      const response = await fetch(`${API_BASE}/api/v1/sap/snmp/settings`, {
         credentials: 'include',
       });
       if (response.ok) {
@@ -293,7 +293,7 @@ export function useSettingsDrawerLoaders({
 
   const fetchLinkSettings = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/settings/link`, {
+      const response = await fetch(`${API_BASE}/api/v1/settings/link`, {
         credentials: 'include',
       });
       if (response.ok) {
@@ -311,7 +311,7 @@ export function useSettingsDrawerLoaders({
 
   const fetchCableTestSettings = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/settings/cable`, {
+      const response = await fetch(`${API_BASE}/api/v1/settings/cable`, {
         credentials: 'include',
       });
       if (response.ok) {
@@ -329,7 +329,7 @@ export function useSettingsDrawerLoaders({
     setLogLoading(true);
     setLogError(null);
     try {
-      const response = await fetch(`${API_BASE}/api/harvest/logs?lines=200`, {
+      const response = await fetch(`${API_BASE}/api/v1/harvest/logs?lines=200`, {
         credentials: 'include',
       });
       if (!response.ok) {

--- a/ui/src/hooks/useSettingsDrawerSavers.ts
+++ b/ui/src/hooks/useSettingsDrawerSavers.ts
@@ -71,7 +71,7 @@ export function useSettingsDrawerSavers({
   const saveThresholds = useCallback(async () => {
     setThresholdsStatus('saving');
     try {
-      const response = await fetch(`${API_BASE}/api/settings`, {
+      const response = await fetch(`${API_BASE}/api/v1/settings`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -92,7 +92,7 @@ export function useSettingsDrawerSavers({
     setTestsStatus('saving');
     try {
       const payload = normalizeTestsSettingsForSave(testsSettings);
-      const response = await fetch(`${API_BASE}/api/health-checks/settings`, {
+      const response = await fetch(`${API_BASE}/api/v1/sap/health-checks/settings`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -113,7 +113,7 @@ export function useSettingsDrawerSavers({
   const saveWifiSettings = useCallback(async () => {
     setWifiStatus('saving');
     try {
-      const response = await fetch(`${API_BASE}/api/canopy/wifi/settings`, {
+      const response = await fetch(`${API_BASE}/api/v1/canopy/wifi/settings`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -133,7 +133,7 @@ export function useSettingsDrawerSavers({
   const saveLinkSettings = useCallback(async () => {
     setLinkStatus('saving');
     try {
-      const response = await fetch(`${API_BASE}/api/settings/link`, {
+      const response = await fetch(`${API_BASE}/api/v1/settings/link`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -156,7 +156,7 @@ export function useSettingsDrawerSavers({
   const saveCableTestSettings = useCallback(async () => {
     setCableTestStatus('saving');
     try {
-      const response = await fetch(`${API_BASE}/api/settings/cable`, {
+      const response = await fetch(`${API_BASE}/api/v1/settings/cable`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -196,7 +196,7 @@ export function useSettingsDrawerSavers({
   const saveSnmpSettings = useCallback(async () => {
     setSnmpStatus('saving');
     try {
-      const response = await fetch(`${API_BASE}/api/sap/snmp/settings`, {
+      const response = await fetch(`${API_BASE}/api/v1/sap/snmp/settings`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/ui/src/hooks/useSurvey.ts
+++ b/ui/src/hooks/useSurvey.ts
@@ -579,7 +579,7 @@ export function useSurvey(): {
     setError(null);
     try {
       const params = new URLSearchParams({ id });
-      return await api.get<Survey>(`/api/canopy/survey?${params.toString()}`);
+      return await api.get<Survey>(`/api/v1/canopy/survey?${params.toString()}`);
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : 'Failed to get survey';
       setError(errorMsg);
@@ -605,7 +605,7 @@ export function useSurvey(): {
       setError(null);
       try {
         const params = new URLSearchParams({ id });
-        await api.delete(`/api/canopy/survey/delete?${params.toString()}`);
+        await api.delete(`/api/v1/canopy/survey/delete?${params.toString()}`);
         await listSurveys(); // Refresh list
         logger.info(LogComponents.Survey, 'Survey deleted successfully', {
           surveyId: id,
@@ -636,7 +636,7 @@ export function useSurvey(): {
       setError(null);
       try {
         const params = new URLSearchParams({ id });
-        await api.post(`/api/canopy/survey/start?${params.toString()}`);
+        await api.post(`/api/v1/canopy/survey/start?${params.toString()}`);
         await listSurveys(); // Refresh list
         logger.info(LogComponents.Survey, 'Survey started', { surveyId: id });
       } catch (err) {
@@ -665,7 +665,7 @@ export function useSurvey(): {
       setError(null);
       try {
         const params = new URLSearchParams({ id });
-        await api.post(`/api/canopy/survey/pause?${params.toString()}`);
+        await api.post(`/api/v1/canopy/survey/pause?${params.toString()}`);
         await listSurveys(); // Refresh list
         logger.info(LogComponents.Survey, 'Survey paused', { surveyId: id });
       } catch (err) {
@@ -694,7 +694,7 @@ export function useSurvey(): {
       setError(null);
       try {
         const params = new URLSearchParams({ id });
-        await api.post(`/api/canopy/survey/complete?${params.toString()}`);
+        await api.post(`/api/v1/canopy/survey/complete?${params.toString()}`);
         await listSurveys(); // Refresh list
         logger.info(LogComponents.Survey, 'Survey completed', { surveyId: id });
       } catch (err) {
@@ -742,7 +742,7 @@ export function useSurvey(): {
       setError(null);
       try {
         const params = new URLSearchParams({ id });
-        await api.post(`/api/canopy/survey/sample?${params.toString()}`, {
+        await api.post(`/api/v1/canopy/survey/sample?${params.toString()}`, {
           x,
           y,
           sampleData,
@@ -791,7 +791,7 @@ export function useSurvey(): {
     setError(null);
     try {
       const params = new URLSearchParams({ id });
-      await api.post(`/api/canopy/survey/floorplan?${params.toString()}`, floorPlan);
+      await api.post(`/api/v1/canopy/survey/floorplan?${params.toString()}`, floorPlan);
       logger.info(LogComponents.Survey, 'Floor plan updated', {
         surveyId: id,
         dimensions: { width: floorPlan.width, height: floorPlan.height },

--- a/ui/src/types/defaults.ts
+++ b/ui/src/types/defaults.ts
@@ -236,7 +236,7 @@ export interface VulnerabilityDefaults {
 }
 
 // ============================================================================
-// Complete Default Settings (from /api/settings/defaults)
+// Complete Default Settings (from /api/v1/settings/defaults)
 // ============================================================================
 
 export interface DefaultSettings {

--- a/ui/src/types/settings.ts
+++ b/ui/src/types/settings.ts
@@ -491,7 +491,7 @@ export interface LogsResponse {
 //
 // DEPRECATED: These constants are now fallbacks only.
 // The single source of truth for defaults is the backend API:
-//   GET /api/settings/defaults
+//   GET /api/v1/settings/defaults
 //
 // Use the useDefaults() hook from "../hooks/useDefaults" to get defaults.
 // These constants will be removed in a future version.

--- a/ui/src/utils/airmapper.ts
+++ b/ui/src/utils/airmapper.ts
@@ -381,7 +381,7 @@ export async function importAirMapperViaBackend(
   formData.append('file', file);
 
   try {
-    const response = await fetch(`${API_BASE}/api/canopy/survey/import/airmapper`, {
+    const response = await fetch(`${API_BASE}/api/v1/canopy/survey/import/airmapper`, {
       method: 'POST',
       headers: authHeaders,
       body: formData,


### PR DESCRIPTION
## Summary

**P0 production bug.** The seed backend registers every JSON API route under the `APIVersionPrefix` constant (`/api/v1`) in `internal/api/server_routes.go`. The UI has been calling bare `/api/*` paths across nearly the entire surface — **87+ fetch sites in 26 files** — including the auth flow itself: `useAuth.ts` hit `/api/auth/login` and `/api/status`, both of which the server doesn't register. Requests fell through to the SPA catch-all in `server_spa.go`, which returns `index.html`, and the JSON parser then choked on HTML.

**End-user impact:** silent login failure. Users get a generic "Login failed" / "Network error" toast and have no way to tell the path is the problem. The E2E suite caught it the moment we wired up `globalSetup` + `storageState` in #1049 — every spec hit the broken `useAuth.ts` mount-time probe and bounced back to the login form.

## What changed

Mechanical rewrite across 26 files: prepend `/v1/` to every bare `/api/*` fetch URL. Two segments that moved under the SAP module (`/api/ipconfig/settings`, `/api/health-checks/settings`) are remapped to `/api/v1/sap/ipconfig/settings` and `/api/v1/sap/health-checks/settings` respectively. JSDoc examples in `api/client.ts` that demonstrated the broken pattern were rewritten too so future code doesn't propagate it.

## Why the bug has been quiet

- **No Vite proxy** (`ui/vite.config.ts`) — dev runs hit the backend directly and would have failed too.
- **Path-filtered E2E job** hadn't actually exercised the auth surface in months — the only test that did was `auth.spec.ts` and its "valid credentials" assertion was generic enough to mask the underlying 200-with-HTML response.
- **`MfaCard.tsx`** (introduced in Wave 3) used the correctly-versioned paths from the start, which is what surfaced the inconsistency once we started actually reading the code.

## Verification

- [x] `grep -rE "['\"\`]/api/[a-z]"` in `ui/src/` excluding `/api/v1` and `/api/events` returns zero non-v1 matches.
- [x] Cross-checked every UI path against `internal/api/server_routes.go` route registrations.
- [x] `biome check src/` clean.
- [x] `tsc` errors are pre-existing `fab.tsx`/`Fab.tsx` casing collision, unrelated.
- [ ] CI green.

## Unblocks

Seed PR #1049 (E2E refactor) — every spec that authenticates was timing out because the UI couldn't actually log in. With this landed, the globalSetup + storageState work in #1049 should flow naturally.

This is the actual user-facing P0 in the seed `v0.193.0` stack; #1049 is the test-infra companion.