### PR TITLE
fix(lint): Disable noShadow in stories (Storybook decorator convention)

### DIFF
--- a/ui/biome.json
+++ b/ui/biome.json
@@ -465,6 +465,19 @@
     },
     {
       "includes": [
+        "**/*.stories.ts",
+        "**/*.stories.tsx"
+      ],
+      "linter": {
+        "rules": {
+          "nursery": {
+            "noShadow": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": [
         "**/scripts/**",
         "**/cli/**"
       ],


### PR DESCRIPTION
## Summary

Unblocks #1058 (and any future PR that touches stories). The biome 2.4.10 pin we just landed now actually runs noShadow analysis (the broken 2.4.15 was crashing before reaching it), and surfaces 19 violations across our story files. All 19 are the same pattern — Storybook decorator's \`Story\` parameter shadowing the imported \`Story\` type:

\`\`\`tsx
import type { Decorator } from '@storybook/react-vite';
decorators: [
  (Story: Parameters<Decorator>[0]) => (  // ← shadows the import 'Story'
    <div className="w-[440px]"><Story /></div>
  ),
],
\`\`\`

This is the conventional Storybook pattern — every Storybook example online uses \`Story\` as the parameter name. Rather than rewrite all 19 against the upstream convention, scope noShadow off for \`**/*.stories.{ts,tsx}\` (in addition to the existing test + e2e overrides for noisy rules).

## Verification

\`npm run lint\` clean (304 files, no fixes applied).

## Unblocks

- seed #1058 (E2E smoke split — currently failing on these same 19 errors after the rebase)
- All future PRs that touch stories