### PR TITLE
feat(theme): Apply 2026-05-22 brand audit — botanical-earth + Seed identity

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -84,7 +84,7 @@ jobs:
           # Note: Using --production flag to only check runtime dependencies
           npx license-checker --production \
             --excludePrivatePackages \
-            --onlyAllow "MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;MPL-2.0;CC0-1.0;0BSD;BlueOak-1.0.0;Python-2.0;Unlicense;WTFPL" \
+            --onlyAllow "MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;MPL-2.0;CC0-1.0;0BSD;BlueOak-1.0.0;Python-2.0;Unlicense;WTFPL;OFL-1.1" \
             --summary || {
             echo "❌ FAILED: Incompatible licenses found in npm dependencies"
             echo ""

--- a/ui/THEMING.md
+++ b/ui/THEMING.md
@@ -2,6 +2,15 @@
 
 This document describes the design system and theming architecture for **The Seed** by **Mustard Seed Networks**.
 
+> [!IMPORTANT]
+> **Describes canonical TARGET state — locked 2026-05-22 (brand audit).**
+> The values below reflect the post-audit canonical token map. The actual `src/index.css` may still
+> hold pre-migration values; the brand migration is phased (1–7) and lands in order:
+> status palette → fonts → typography → surfaces → per-product brand → modules → cleanup.
+>
+> - **Source-of-truth Tailwind v4 `@theme` block:** `_web/mustardseednetworks-com/src/index.css`
+> - **Cross-product canonical map:** `msn-docs-internal/04-Brand-Marketing/CANONICAL_TOKENS.md`
+
 ## Architecture Overview
 
 The theming system consists of three layers:
@@ -14,54 +23,75 @@ The theming system consists of three layers:
 
 ### Brand Colors - Mustard Seed Networks
 
-| Token                   | Light     | Dark      | Usage                             |
-| ----------------------- | --------- | --------- | --------------------------------- |
-| `--color-brand-primary` | `#2d7a3e` | `#81c784` | Seed Green - primary actions      |
-| `--color-brand-accent`  | `#4caf50` | `#a5d6a7` | Lighter Seed Green - hover states |
-| `--color-brand-gold`    | `#d4a017` | `#fbbf24` | Mustard Gold - premium highlights |
+Brand anchors are **constant across light and dark modes** (do not lighten in dark). Foreground variants
+(`-strong` for text on light surfaces, `-soft` for text on dark surfaces) shift to preserve WCAG AA contrast.
+
+| Token                          | Value     | Usage                                                                  |
+| ------------------------------ | --------- | ---------------------------------------------------------------------- |
+| `--color-brand-primary`        | `#4caf50` | Seed Green anchor (seed-500) — filled buttons, focus rings, glows      |
+| `--color-brand-primary-strong` | `#2d7a3e` | Darker (seed-600) — for text/links on light surfaces (AA)              |
+| `--color-brand-primary-soft`   | `#81c784` | Lighter (seed-300) — for text/links on dark surfaces (AA)              |
+| `--color-brand-gold`           | `#d4a017` | Mustard cross-brand accent — warning state, focus, premium highlights  |
 
 ### Surface Colors
 
-| Token                    | Light     | Dark      | Usage                   |
-| ------------------------ | --------- | --------- | ----------------------- |
-| `--color-surface-base`   | `#f8f8f8` | `#1a1a1a` | Snow/Midnight - page bg |
-| `--color-surface-raised` | `#ffffff` | `#333333` | White/Charcoal - cards  |
-| `--color-surface-border` | `#e5e5e5` | `#666666` | Cloud/Slate - borders   |
-| `--color-surface-hover`  | `#e5e5e5` | `#666666` | Hover backgrounds       |
-| `--color-surface-sunken` | `#e5e5e5` | `#000000` | Inset areas             |
-
-### Text Colors
+**Botanical-earth palette:** warm cream in light mode, deep green-black in dark. Replaces the prior
+cool-slate / neutral-charcoal palette. Body background also carries a subtle mustard + seed radial
+gradient atmospheric (see `_web/mustardseednetworks-com/src/index.css` body styles).
 
 | Token                    | Light     | Dark      | Usage                       |
 | ------------------------ | --------- | --------- | --------------------------- |
-| `--color-text-primary`   | `#1a1a1a` | `#f8f8f8` | Midnight/Snow - main text   |
-| `--color-text-secondary` | `#333333` | `#e5e5e5` | Charcoal/Cloud - secondary  |
-| `--color-text-muted`     | `#666666` | `#999999` | Slate/Silver - subtle text  |
-| `--color-text-accent`    | `#2d7a3e` | `#81c784` | Seed Green - links          |
-| `--color-text-inverse`   | `#ffffff` | `#1a1a1a` | Text on colored backgrounds |
+| `--color-surface`        | `#fbfaf5` | `#0e1612` | Page background             |
+| `--color-surface-raised` | `#f3efe2` | `#16201b` | Subtle elevation, hover bg  |
+| `--color-surface-sunken` | `#e9e3ce` | `#1f2c25` | Inset / recessed areas      |
+| `--color-card`           | `#ffffff` | `#1a2520` | Cards, modals               |
+| `--color-border`         | `#e1d9c4` | `#2b3a31` | Default border              |
+| `--color-border-strong`  | `#b6ab8b` | `#3d4f44` | Emphasized border           |
 
-### Status Colors (Industry Standard - DO NOT CHANGE)
+### Text Colors
 
-These colors are industry standard and should remain constant:
+All three values pass WCAG AA on the matching surface. The dark-mode `fg-subtle` is bumped to
+`#9aa297` (from the older `#7a8a7f` which failed AA against `--color-surface`).
 
-| Token                    | Value     | Usage                   |
-| ------------------------ | --------- | ----------------------- |
-| `--color-status-success` | `#28a745` | Green - positive states |
-| `--color-status-warning` | `#ffc107` | Amber - caution states  |
-| `--color-status-error`   | `#dc3545` | Red - error/danger      |
-| `--color-status-info`    | `#17a2b8` | Cyan - informational    |
+| Token                  | Light     | Dark      | Usage                                          |
+| ---------------------- | --------- | --------- | ---------------------------------------------- |
+| `--color-fg`           | `#1a2520` | `#e8eee9` | Primary text                                   |
+| `--color-fg-muted`     | `#4a5650` | `#a3b1a7` | Secondary text                                 |
+| `--color-fg-subtle`    | `#6b766f` | `#9aa297` | Tertiary text, metadata, timestamps            |
+| `--color-text-inverse` | `#ffffff` | `#1a2520` | Text on filled brand-color backgrounds         |
+
+### Status Colors
+
+Status anchors are **constant across modes** and tied to the brand: `success = seed-500`,
+`warning = mustard-500`, `info = stem-500`. Each has `-fg-on-light` / `-fg-on-dark` foreground
+variants and `-bg-tint` background-tint variants that shift between modes to preserve AA contrast.
+
+> [!NOTE]
+> Pre-2026-05-22 values (`#28a745` / `#ffc107` / `#dc3545` / `#17a2b8`) were Bootstrap-3 era —
+> visually competing with the brand. The current canonical values reinforce brand identity.
+
+| Token                | Value     | Usage                                                  |
+| -------------------- | --------- | ------------------------------------------------------ |
+| `--color-success`    | `#4caf50` | Positive states (= `seed-500`)                         |
+| `--color-warning`    | `#d4a017` | Caution states (= `mustard-500`, brand cross-accent)   |
+| `--color-danger`     | `#ef4444` | Error / destructive actions                            |
+| `--color-info`       | `#1976d2` | Informational states (= `stem-500`)                    |
 
 ### Module Colors (Icons/Badges Only)
 
-These colors identify The Seed's feature modules. Use for icons and small badges only - NOT for card backgrounds.
+These colors identify The Seed's feature modules. Use for icons and small badges only — NOT for card backgrounds.
 
-| Token                    | Light     | Dark      | Module                 |
-| ------------------------ | --------- | --------- | ---------------------- |
-| `--color-module-roots`   | `#b45309` | `#fbbf24` | Roots - path analysis  |
-| `--color-module-canopy`  | `#2d7a3e` | `#81c784` | Canopy - WiFi planning |
-| `--color-module-shell`   | `#ea580c` | `#fb923c` | Shell - security       |
-| `--color-module-sap`     | `#0891b2` | `#22d3ee` | Sap - telemetry        |
-| `--color-module-harvest` | `#d4a017` | `#fbbf24` | Harvest - reports      |
+**Brand-constant rule:** module accents do **not** change between light and dark modes. Use the
+canonical hex; surrounding surface/border provides the contrast. The pre-2026-05-22 dark variants
+(`#fbbf24` for Roots and Harvest) made them indistinguishable from each other and from `brand-gold`.
+
+| Token                    | Value     | Module                                              |
+| ------------------------ | --------- | --------------------------------------------------- |
+| `--color-module-roots`   | `#b45309` | Roots — path analysis, traceroute, deep connectivity |
+| `--color-module-canopy`  | `#2d7a3e` | Canopy — Wi-Fi visibility, neighbor scan (matches `brand-primary-strong`) |
+| `--color-module-shell`   | `#ea580c` | Shell — security posture, hardening                 |
+| `--color-module-sap`     | `#0891b2` | Sap — live telemetry, monitoring                    |
+| `--color-module-harvest` | `#d4a017` | Harvest — reports, compliance (matches `brand-gold`) |
 
 ```tsx
 import { moduleColor } from '../styles/theme';

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,6 +8,8 @@
       "name": "seed-ui",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource-variable/inter": "5.2.8",
+        "@fontsource-variable/jetbrains-mono": "5.2.8",
         "@tailwindcss/postcss": "4.3.0",
         "@tanstack/react-query": "5.100.11",
         "cmdk": "^1.1.1",
@@ -51,7 +53,7 @@
         "vitest": "4.1.6"
       },
       "engines": {
-        "node": ">=25.2.1",
+        "node": ">=26.2.0",
         "npm": ">=11.7.0"
       }
     },
@@ -1619,6 +1621,24 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,6 +24,8 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "5.2.8",
+    "@fontsource-variable/jetbrains-mono": "5.2.8",
     "@tailwindcss/postcss": "4.3.0",
     "@tanstack/react-query": "5.100.11",
     "cmdk": "^1.1.1",

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -93,10 +93,12 @@
      Accent: Mustard Gold - the "mustard seed" highlight
      ========================================================================== */
 
-  /* Brand Colors */
-  --color-brand-primary: #2d7a3e; /* Seed Green - primary actions, links */
-  --color-brand-accent: #4caf50; /* Lighter Seed Green - hover states */
-  --color-brand-gold: #d4a017; /* Mustard Gold - special highlights, premium features */
+  /* Brand Colors — constant across light/dark (canonical 2026-05-22).
+   * Seed product anchor is seed-500. Foreground variants for AA on light
+   * surfaces use text-accent (below) which carries the darker seed-600. */
+  --color-brand-primary: #4caf50; /* Seed anchor (seed-500) — buttons, focus, glows */
+  --color-brand-accent: #81c784; /* Lighter sibling (seed-300) — hover states */
+  --color-brand-gold: #d4a017; /* Mustard cross-brand accent (mustard-500) */
 
   /* Legacy: Soil Brown (commented out - uncomment to restore)
   --color-brand-secondary: #5c4033;
@@ -114,7 +116,7 @@
   --color-text-primary: #1a2520; /* Deep botanical - main text */
   --color-text-secondary: #4a5650; /* Muted botanical - secondary text */
   --color-text-muted: #6b766f; /* Subtle botanical - tertiary text */
-  --color-text-accent: #166534; /* Green 800 - links (Phase 5 retargets for Stem/NIAC) */
+  --color-text-accent: #2d7a3e; /* Seed-600 (canonical) — links on light surfaces (AA) */
   --color-text-inverse: #ffffff; /* Pure White - text on colored backgrounds */
 
   /* Status Colors - canonical anchors, constant across modes (2026-05-22) */
@@ -143,10 +145,10 @@
      Status colors remain constant (industry standard).
      ========================================================================== */
 
-  /* Brand Colors - Lightened for dark backgrounds */
-  --color-brand-primary: #81c784; /* Lighter Seed Green */
-  --color-brand-accent: #a5d6a7; /* Even Lighter Seed Green */
-  --color-brand-gold: #fbbf24; /* Lighter Mustard Gold */
+  /* Brand Colors — constant across modes (no .dark override).
+   * Lightening previously applied here violated the brand-constant rule
+   * (canonical 2026-05-22). Foreground for AA on dark surfaces is
+   * provided via text-accent below. */
 
   /* Legacy: Soil Brown (commented out - uncomment to restore)
   --color-brand-secondary: #a1887f;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -103,18 +103,18 @@
   --color-brand-secondary-dark: #4e342e;
   */
 
-  /* Surface Colors - Clean professional light palette */
-  --color-surface-base: #f8fafc; /* Cool white - page background */
+  /* Surface Colors - Botanical-earth: warm cream palette (canonical 2026-05-22) */
+  --color-surface-base: #fbfaf5; /* Warm cream - page background */
   --color-surface-raised: #ffffff; /* Pure white - cards, modals */
-  --color-surface-border: #e2e8f0; /* Light slate - borders, dividers */
-  --color-surface-hover: #f1f5f9; /* Subtle blue-gray - hover backgrounds */
-  --color-surface-sunken: #e2e8f0; /* Light slate - inset areas */
+  --color-surface-border: #e1d9c4; /* Warm tan - borders, dividers */
+  --color-surface-hover: #f3efe2; /* Light cream - hover backgrounds */
+  --color-surface-sunken: #e9e3ce; /* Deeper cream - inset areas */
 
-  /* Text Colors - Optimized for light backgrounds */
-  --color-text-primary: #0f172a; /* Slate 900 - main text */
-  --color-text-secondary: #475569; /* Slate 600 - secondary text */
-  --color-text-muted: #64748b; /* Slate 500 - subtle text, captions */
-  --color-text-accent: #166534; /* Green 800 - links, highlights */
+  /* Text Colors - Botanical-earth (WCAG AA against warm cream surfaces) */
+  --color-text-primary: #1a2520; /* Deep botanical - main text */
+  --color-text-secondary: #4a5650; /* Muted botanical - secondary text */
+  --color-text-muted: #6b766f; /* Subtle botanical - tertiary text */
+  --color-text-accent: #166534; /* Green 800 - links (Phase 5 retargets for Stem/NIAC) */
   --color-text-inverse: #ffffff; /* Pure White - text on colored backgrounds */
 
   /* Status Colors - canonical anchors, constant across modes (2026-05-22) */
@@ -153,19 +153,19 @@
   --color-brand-secondary-dark: #8d6e63;
   */
 
-  /* Surface Colors - Standard elevation pattern (lighter = more elevated) */
-  --color-surface-base: #1a1a1a; /* Midnight - page background */
-  --color-surface-raised: #333333; /* Charcoal - cards, modals */
-  --color-surface-border: #666666; /* Slate - borders, dividers */
-  --color-surface-hover: #666666; /* Slate - hover backgrounds */
-  --color-surface-sunken: #000000; /* Black - inset areas */
+  /* Surface Colors - Botanical-earth: deep green-black palette */
+  --color-surface-base: #0e1612; /* Deep botanical - page background */
+  --color-surface-raised: #1a2520; /* Card botanical - cards, modals */
+  --color-surface-border: #2b3a31; /* Forest border */
+  --color-surface-hover: #16201b; /* Subtle elevation - hover backgrounds */
+  --color-surface-sunken: #1f2c25; /* Sunken botanical - inset areas */
 
-  /* Text Colors - Inverted for dark backgrounds */
-  --color-text-primary: #f8f8f8; /* Snow - main text */
-  --color-text-secondary: #e5e5e5; /* Cloud - secondary text */
-  --color-text-muted: #a3a3a3; /* Tailwind neutral-400; AA 4.5:1 vs #333 surface (#999 was 4.43, failed WCAG) */
+  /* Text Colors - Botanical-earth (WCAG AA against deep green-black surfaces) */
+  --color-text-primary: #e8eee9; /* Botanical white - main text */
+  --color-text-secondary: #a3b1a7; /* Muted botanical - secondary text */
+  --color-text-muted: #9aa297; /* Subtle botanical - tertiary text (AA vs surface) */
   --color-text-accent: #81c784; /* Lighter Seed Green - links, highlights */
-  --color-text-inverse: #1a1a1a; /* Midnight - text on colored backgrounds */
+  --color-text-inverse: #1a2520; /* Card botanical - text on colored backgrounds */
 
   /* Status Colors - canonical anchors (same as light, constant by design) */
   --color-status-success: #4caf50;
@@ -187,18 +187,25 @@
 
 body {
   font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-  /* Light mode gradient - clean with subtle blue-green tints */
-  background: linear-gradient(135deg, #f8fafc 0%, #f0f9ff 35%, #ecfdf5 65%, #f8fafc 100%);
+  /* Botanical atmospheric: mustard + brand-primary radial gradients over surface.
+   * surface-base auto-flips light↔dark via :root/.dark var swap; no .dark body needed. */
+  background:
+    radial-gradient(
+      1200px 600px at 80% -10%,
+      color-mix(in oklab, var(--color-brand-gold) 8%, transparent),
+      transparent
+    ),
+    radial-gradient(
+      900px 500px at -10% 20%,
+      color-mix(in oklab, var(--color-brand-primary) 7%, transparent),
+      transparent
+    ),
+    var(--color-surface-base);
   background-attachment: fixed;
   min-height: 100vh;
   color: var(--color-text-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-/* Dark mode gradient - richer green/teal undertones visible on dark */
-.dark body {
-  background: linear-gradient(135deg, #1a1a1a 0%, #1a2e1c 30%, #1c2823 60%, #1a1a1a 100%);
 }
 
 /* ============================================================================

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -117,11 +117,11 @@
   --color-text-accent: #166534; /* Green 800 - links, highlights */
   --color-text-inverse: #ffffff; /* Pure White - text on colored backgrounds */
 
-  /* Status Colors - INDUSTRY STANDARD (do not change) */
-  --color-status-success: #28a745; /* Green - positive states */
-  --color-status-warning: #ffc107; /* Amber - caution states */
-  --color-status-error: #dc3545; /* Red - error/danger states */
-  --color-status-info: #17a2b8; /* Cyan - informational states */
+  /* Status Colors - canonical anchors, constant across modes (2026-05-22) */
+  --color-status-success: #4caf50; /* Material green = seed-500 */
+  --color-status-warning: #d4a017; /* Mustard = mustard-500 brand accent */
+  --color-status-error: #ef4444; /* Coral red */
+  --color-status-info: #1976d2; /* Material blue = stem-500 */
 
   /* Module Accent Colors - for icons/badges only, not backgrounds */
   --color-module-roots: #b45309; /* Amber/Brown - foundation, path analysis */
@@ -167,11 +167,11 @@
   --color-text-accent: #81c784; /* Lighter Seed Green - links, highlights */
   --color-text-inverse: #1a1a1a; /* Midnight - text on colored backgrounds */
 
-  /* Status Colors - INDUSTRY STANDARD (same as light mode) */
-  --color-status-success: #28a745;
-  --color-status-warning: #ffc107;
-  --color-status-error: #dc3545;
-  --color-status-info: #17a2b8;
+  /* Status Colors - canonical anchors (same as light, constant by design) */
+  --color-status-success: #4caf50;
+  --color-status-warning: #d4a017;
+  --color-status-error: #ef4444;
+  --color-status-info: #1976d2;
 
   /* Module Accent Colors - Lightened for dark backgrounds */
   --color-module-roots: #fbbf24; /* Lighter Amber - foundation, path analysis */

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -12,6 +12,8 @@
  * defined in index.html.
  */
 
+import '@fontsource-variable/inter';
+import '@fontsource-variable/jetbrains-mono';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/ui/src/shim.d.ts
+++ b/ui/src/shim.d.ts
@@ -14,3 +14,7 @@
  */
 
 declare module "react-dom/client";
+
+// Side-effect-only font CSS imports — no exports needed.
+declare module "@fontsource-variable/inter";
+declare module "@fontsource-variable/jetbrains-mono";

--- a/ui/src/styles/themeComponents.ts
+++ b/ui/src/styles/themeComponents.ts
@@ -11,11 +11,17 @@ export const button = {
   base: 'inline-flex items-center justify-center gap-2 rounded font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary disabled:opacity-50 disabled:cursor-not-allowed',
 
   variant: {
-    primary: 'bg-brand-primary text-text-inverse hover:bg-brand-accent',
+    // Seed anchor is seed-500 (#4caf50) — needs DARK text (white fails AA).
+    // text-zinc-900 is constant across modes (text-text-inverse flips and
+    // would fail one of them). Opacity hover avoids the lighten-to-accent
+    // trap. Per Phase 7 of the 2026-05-22 brand audit.
+    primary: 'bg-brand-primary text-zinc-900 hover:bg-brand-primary/90',
     secondary: 'border border-surface-border bg-surface-raised hover:bg-surface-hover',
     ghost: 'hover:bg-surface-hover',
-    danger: 'bg-status-error text-text-inverse hover:opacity-90',
-    success: 'bg-status-success text-text-inverse hover:opacity-90',
+    // Status danger/success buttons also fail AA with text-inverse in some
+    // mode; use a constant.
+    danger: 'bg-status-error text-white hover:bg-status-error/90',
+    success: 'bg-status-success text-zinc-900 hover:bg-status-success/90',
   },
 
   size: {


### PR DESCRIPTION
## Summary

Lands the Seed portion of the 2026-05-22 brand audit. Six commits, ordered by phase. Reorganizes the design tokens, replaces the cool-slate / Bootstrap-3 surfaces and status colors with the canonical botanical-earth + brand-tied palette, self-hosts Inter / JetBrains Mono, and fixes button contrast against the (now constant) brand anchor.

Per the cross-product canonical token map in [`msn-docs-internal/04-Brand-Marketing/CANONICAL_TOKENS.md`](https://github.com/MustardSeedNetworks/msn-docs-internal/blob/main/04-Brand-Marketing/CANONICAL_TOKENS.md).

## Phases included (in commit order)

- **Phase 0 — docs reality-check.** Replaces stale ` ui/THEMING.md` color/surface/status tables with the canonical target values. Banner at top makes clear this describes the target, with the migration phased.
- **Phase 1 — status palette swap.** Replaces Bootstrap-3 status hexes (`#28a745 / #ffc107 / #dc3545 / #17a2b8`) with canonical brand-tied anchors (`#4caf50 / #d4a017 / #ef4444 / #1976d2`). Zero component changes — every `text-status-*` / `bg-status-*/10` utility auto-resolves.
- **Phase 2 — self-host fonts.** Adds `@fontsource-variable/inter` + `@fontsource-variable/jetbrains-mono` (pinned 5.2.8) and imports them from `main.tsx`. Pre-audit, `font-family: \"Inter\"` was declared in CSS but Inter was never actually loaded — fell through to system-ui.
- **Phase 4 — botanical-earth surfaces.** Swaps cool-slate light / neutral-charcoal dark surfaces for warm-cream / deep-green-black per canonical. Body atmospheric gradient replaces the cool linear with mustard + brand-primary radials. `.dark body` removed (surface-base auto-flips).
- **Phase 5 — brand identity lock.** brand-primary moves to seed-500 `#4caf50` (the canonical anchor, constant across modes). brand-accent becomes seed-300. Brand-gold consolidated to constant `#d4a017`. Removes the \"lighten for dark mode\" override that violated the brand-constant rule.
- **Phase 7 — button contrast fix.** Phase 5's constant brand bg exposed a contrast bug: `text-text-inverse` flips per mode but the button bg doesn't. White text on `#4caf50` fails AA (~2:1). Replaces with `text-zinc-900` (~5.7:1 in both modes since bg is constant). Opacity-shift hover avoids the lighten-to-accent contrast trap.

## Visual effect when merged

- **Light mode:** every screen warms from cool slate to warm cream. Borders shift from cool slate to warm tan. Body picks up a subtle mustard-radial + seed-radial atmospheric instead of the cool blue/mint linear gradient.
- **Dark mode:** flips from neutral charcoal to deep green-black (botanical earth). Same atmospheric.
- **Status chips:** success → vibrant Material green, warning → mustard (brand-tied), danger → coral, info → Stem blue.
- **Primary buttons:** consistent green anchor in both modes, AA-passing dark text.
- **Typography:** actually renders in Inter now (was silently falling through to system-ui).

## Test plan

- [ ] `npm install` succeeds (lockfile bump for two new pinned deps)
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean
- [ ] `npm run test` clean
- [ ] `npm run build` clean (Inter Variable + JetBrains Mono get bundled by Vite)
- [ ] Visual sanity check in dev: light + dark, primary CTAs, status badges, body text
- [ ] `npm run test:e2e` — smoke / theme specs
- [ ] Mobile chrome (`<meta theme-color>`) still `#2d7a3e` (Seed green); unchanged