### PR TITLE
perf(e2e): Bump CI workers 1->2 and retries 2->1 (#1072)

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -21,8 +21,15 @@ export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // retries 1 (not 2) — one retry is enough to dodge transient flakes; the
+  //   second retry was costing ~30s × N flaky tests with no incremental signal.
+  // workers 2 in CI (was 1) — GH Actions runners are 4-vCPU; 1 worker wastes
+  //   75% of the box and is the biggest single driver of the 30-min full-suite
+  //   runtime we're trying to fix (issue #1072). Two workers run safely against
+  //   our single-instance backend without state interference today; bump to 4
+  //   once we've audited tests that mutate global server state.
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
   timeout: 30000,
   expect: {
     timeout: 10000,


### PR DESCRIPTION
## Summary

First quick win on issue #1072 (E2E Browser Tests 30-min timeout). Two single-line config tweaks expected to cut full-suite wall time by roughly half:

| Setting | Before | After | Why |
|---|---|---|---|
| \`workers\` (CI) | \`1\` | \`2\` | GH Actions runners are 4-vCPU; 1 worker wastes 75% of the box. **Biggest single driver** of the 30-min runtime. |
| \`retries\` (CI) | \`2\` | \`1\` | One retry is enough to dodge transient flakes; the second retry was costing ~30s × N flaky tests with no incremental signal. |

Both stem + niac have the same anti-pattern; sibling PRs landing on each.

## Why not workers: 4 (the runner's full capacity)

\`workers: 2\` is conservative — our single-instance backend can hit state interference with too many parallel writers (settings drawer mutations, profile switches, etc.). Bumping to 2 is a no-risk start. Audit interference patterns then push to 4 in a follow-up.

## Why not 0 retries

A genuine transient flake (network, server cold-start race) shouldn't fail a PR; \`retries: 1\` keeps that safety net. But \`retries: 2\` means a hard-failing test wastes \`30s × 3 = 90s\` per occurrence with the same signal as a single failure.

## Follow-up work tracked in #1072

- Audit + replace 387 \`waitForTimeout()\` calls with event-based waits (~7.7 min of pure sleep waste per run)
- Add Playwright sharding (\`--shard 1/4\` across 4 jobs) for further parallelism
- Quarantine routinely-flaky specs into a nightly tier

## Verification

Mechanical config change. CI will validate the actual wall-time improvement on the next E2E run.