### PR TITLE
feat(api): add personal-access tokens for programmatic API access (Pro tier)

### DIFF
--- a/internal/api/handlers_api_tokens.go
+++ b/internal/api/handlers_api_tokens.go
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+// handlers_api_tokens.go implements the personal-access-token surface
+// added in Phase D-2 of LICENSE_STRATEGY: API tokens for programmatic
+// access (scripts, monitoring, CI). Minting requires the Pro tier;
+// listing / revoking is available to any authenticated user for their
+// own tokens.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/i18n"
+	"github.com/krisarmstrong/seed/internal/license"
+	"github.com/krisarmstrong/seed/internal/logging"
+)
+
+// APITokenPrefix is the visible prefix that distinguishes a Seed
+// personal-access token from a JWT or other Bearer value.
+const APITokenPrefix = "sd_pat_"
+
+// apiTokenIDLength is the random byte count for token IDs (16 bytes →
+// 32 hex chars). Small enough to be friendly, large enough to avoid
+// any collision risk over the lifetime of the deployment.
+const apiTokenIDLength = 16
+
+// apiTokenSecretLength is the random byte count for the secret portion
+// of the token (32 bytes → 64 hex chars → ~256 bits of entropy).
+const apiTokenSecretLength = 32
+
+// apiTokenDisplayPrefix is how many chars of the plaintext token are
+// retained in the DB so the UI can identify it without revealing it.
+// "sd_pat_" (7) + first 5 chars of the secret = 12.
+const apiTokenDisplayPrefix = 12
+
+// apiTokenNameMaxLen caps the user-supplied token label length. The
+// limit keeps DB rows compact and prevents UI overflow.
+const apiTokenNameMaxLen = 64
+
+// MintTokenRequest is the body of POST /api/v1/tokens.
+type MintTokenRequest struct {
+	Name string `json:"name"`
+}
+
+// MintTokenResponse is returned by POST /api/v1/tokens. The Token
+// field contains the plaintext value and is shown ONLY at creation —
+// it is never persisted in plaintext form.
+type MintTokenResponse struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Token     string    `json:"token"`
+	Prefix    string    `json:"prefix"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// TokenListItem is a sanitized projection of APITokenRecord for the
+// list endpoint — never contains the plaintext token or the hash.
+type TokenListItem struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	Prefix     string    `json:"prefix"`
+	CreatedAt  time.Time `json:"createdAt"`
+	LastUsedAt time.Time `json:"lastUsedAt,omitzero"`
+	RevokedAt  time.Time `json:"revokedAt,omitzero"`
+}
+
+// handleAPITokens routes /api/v1/tokens (POST = mint, GET = list).
+func (s *Server) handleAPITokens(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		s.handleAPITokenMint(w, r)
+	case http.MethodGet:
+		s.handleAPITokenList(w, r)
+	default:
+		writeAPITokenError(w, r, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed,
+			"Method not allowed")
+	}
+}
+
+// handleAPITokenByID routes /api/v1/tokens/<id> (DELETE = revoke).
+func (s *Server) handleAPITokenByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeAPITokenError(w, r, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed,
+			"Method not allowed")
+		return
+	}
+	s.handleAPITokenRevoke(w, r)
+}
+
+func (s *Server) handleAPITokenMint(w http.ResponseWriter, r *http.Request) {
+	username := usernameFromContext(r)
+	if username == "" {
+		writeAPITokenError(w, r, http.StatusUnauthorized, ErrCodeUnauthorized,
+			"Authentication required")
+		return
+	}
+
+	if !s.licenseAllowsAPITokens() {
+		writeAPITokenError(w, r, http.StatusPaymentRequired, "TIER_TOO_LOW",
+			"API token minting requires the Pro tier. "+
+				"Start a Pro trial with `seed license trial` or activate a Pro key.")
+		return
+	}
+
+	repo := s.services.Auth.APITokens
+	if repo == nil {
+		writeAPITokenError(w, r, http.StatusServiceUnavailable, ErrCodeServiceUnavail,
+			"API token storage is not available")
+		return
+	}
+
+	var req MintTokenRequest
+	if decErr := json.NewDecoder(r.Body).Decode(&req); decErr != nil {
+		writeAPITokenError(w, r, http.StatusBadRequest, ErrCodeBadRequest,
+			"Invalid JSON body")
+		return
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" {
+		writeAPITokenError(w, r, http.StatusBadRequest, ErrCodeValidation,
+			"`name` is required")
+		return
+	}
+	if len(req.Name) > apiTokenNameMaxLen {
+		writeAPITokenError(w, r, http.StatusBadRequest, ErrCodeValidation,
+			"`name` must be 64 characters or fewer")
+		return
+	}
+
+	id, secret, mintErr := mintTokenMaterial()
+	if mintErr != nil {
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal,
+			"Failed to generate token material")
+		return
+	}
+	plaintext := APITokenPrefix + secret
+	rec := database.APITokenRecord{
+		ID:            id,
+		OwnerUsername: username,
+		Name:          req.Name,
+		TokenHash:     hashAPIToken(plaintext),
+		Prefix:        plaintext[:apiTokenDisplayPrefix],
+		CreatedAt:     time.Now().UTC(),
+	}
+	if insertErr := repo.Insert(r.Context(), rec); insertErr != nil {
+		logger := logging.FromContext(r.Context())
+		logger.ErrorContext(r.Context(), "failed to insert api token", "error", insertErr)
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal,
+			"Failed to persist token")
+		return
+	}
+
+	sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusCreated, MintTokenResponse{
+		ID:        rec.ID,
+		Name:      rec.Name,
+		Token:     plaintext,
+		Prefix:    rec.Prefix,
+		CreatedAt: rec.CreatedAt,
+	})
+}
+
+func (s *Server) handleAPITokenList(w http.ResponseWriter, r *http.Request) {
+	username := usernameFromContext(r)
+	if username == "" {
+		writeAPITokenError(w, r, http.StatusUnauthorized, ErrCodeUnauthorized,
+			"Authentication required")
+		return
+	}
+
+	repo := s.services.Auth.APITokens
+	if repo == nil {
+		sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusOK,
+			[]TokenListItem{})
+		return
+	}
+
+	rows, err := repo.ListByOwner(r.Context(), username)
+	if err != nil {
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal,
+			"Failed to list tokens")
+		return
+	}
+	out := make([]TokenListItem, 0, len(rows))
+	for _, t := range rows {
+		out = append(out, TokenListItem{
+			ID:         t.ID,
+			Name:       t.Name,
+			Prefix:     t.Prefix,
+			CreatedAt:  t.CreatedAt,
+			LastUsedAt: t.LastUsedAt,
+			RevokedAt:  t.RevokedAt,
+		})
+	}
+	sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusOK, out)
+}
+
+func (s *Server) handleAPITokenRevoke(w http.ResponseWriter, r *http.Request) {
+	username := usernameFromContext(r)
+	if username == "" {
+		writeAPITokenError(w, r, http.StatusUnauthorized, ErrCodeUnauthorized,
+			"Authentication required")
+		return
+	}
+
+	id := strings.TrimPrefix(r.URL.Path, APIVersionPrefix+"/tokens/")
+	if id == "" || strings.ContainsRune(id, '/') {
+		writeAPITokenError(w, r, http.StatusBadRequest, ErrCodeBadRequest,
+			"Token ID is required in path")
+		return
+	}
+
+	repo := s.services.Auth.APITokens
+	if repo == nil {
+		writeAPITokenError(w, r, http.StatusServiceUnavailable, ErrCodeServiceUnavail,
+			"API token storage is not available")
+		return
+	}
+	if err := repo.Revoke(r.Context(), id, username); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeAPITokenError(w, r, http.StatusNotFound, ErrCodeNotFound,
+				"Token not found or already revoked")
+			return
+		}
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal,
+			"Failed to revoke token")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// licenseAllowsAPITokens reports whether the active license tier is
+// allowed to mint API tokens. Pro grants it; trial mode (which grants
+// Pro-equivalent features) grants it. Free / Starter do not.
+//
+// A nil license manager is treated as "license disabled" (developer
+// builds, tests) and permits minting so the feature stays usable
+// without forcing a license setup.
+func (s *Server) licenseAllowsAPITokens() bool {
+	mgr := s.services.Auth.License
+	if mgr == nil {
+		return true
+	}
+	st := mgr.GetState()
+	if st == nil {
+		return false
+	}
+	return st.IsTrialMode || st.Tier >= license.TierPro
+}
+
+// mintTokenMaterial returns (id, secret, err). The ID is a hex string
+// used as the public handle; the secret is the high-entropy portion
+// appended to APITokenPrefix to form the plaintext.
+func mintTokenMaterial() (string, string, error) {
+	idBytes := make([]byte, apiTokenIDLength)
+	if _, err := rand.Read(idBytes); err != nil {
+		return "", "", err
+	}
+	secretBytes := make([]byte, apiTokenSecretLength)
+	if _, err := rand.Read(secretBytes); err != nil {
+		return "", "", err
+	}
+	return hex.EncodeToString(idBytes), hex.EncodeToString(secretBytes), nil
+}
+
+// hashAPIToken returns the SHA-256 hex digest of the plaintext token.
+// We use SHA-256 (not bcrypt/argon) because tokens are high-entropy
+// random values; the goal is "DB compromise doesn't yield usable
+// tokens," not slowing down password guessing.
+func hashAPIToken(plaintext string) string {
+	sum := sha256.Sum256([]byte(plaintext))
+	return hex.EncodeToString(sum[:])
+}
+
+// resolveAPIToken returns the owning username for the given plaintext
+// token, or "" if no active token matches. Token's last_used_at is
+// touched on a successful lookup (best-effort; failures are logged
+// but do not block the request).
+func resolveAPIToken(ctx context.Context, repo *database.APITokenRepository, plaintext string) string {
+	if repo == nil || !strings.HasPrefix(plaintext, APITokenPrefix) {
+		return ""
+	}
+	rec, err := repo.FindActiveByHash(ctx, hashAPIToken(plaintext))
+	if err != nil {
+		return ""
+	}
+	if touchErr := repo.TouchLastUsed(ctx, rec.ID); touchErr != nil {
+		logging.GetLogger().WarnContext(ctx, "failed to update api token last_used_at",
+			"token_id", rec.ID, "error", touchErr)
+	}
+	return rec.OwnerUsername
+}
+
+// apiTokenMiddleware sits in front of the existing JWT auth middleware.
+// If the request carries `Authorization: Bearer sd_pat_...`, it looks
+// up the token, sets X-Username, and forwards to `next` so downstream
+// handlers see an authenticated user. Otherwise it falls through to
+// `next` unchanged, letting the JWT middleware handle the request.
+func apiTokenMiddleware(repo *database.APITokenRepository, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only attempt token auth for API paths; static assets and
+		// auth endpoints are handled by the existing JWT bypass.
+		if !strings.HasPrefix(r.URL.Path, APIVersionPrefix) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		authz := r.Header.Get("Authorization")
+		if authz == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		const bearer = "Bearer "
+		if !strings.HasPrefix(authz, bearer) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		token := strings.TrimPrefix(authz, bearer)
+		if !strings.HasPrefix(token, APITokenPrefix) {
+			// Not a PAT — let the JWT middleware handle it.
+			next.ServeHTTP(w, r)
+			return
+		}
+		owner := resolveAPIToken(r.Context(), repo, token)
+		if owner == "" {
+			writeAPITokenError(w, r, http.StatusUnauthorized, ErrCodeUnauthorized,
+				"Invalid or revoked API token")
+			return
+		}
+		ctx := logging.WithUserID(r.Context(), owner)
+		r.Header.Set("X-Username", owner)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// writeAPITokenError is a thin wrapper around sendErrorResponseWithDetails
+// that pulls the logger + localizer from the request context.
+func writeAPITokenError(w http.ResponseWriter, r *http.Request, status int, code, message string) {
+	logger := logging.FromContext(r.Context())
+	_ = i18n.FromRequest(r) // reserved for future localization
+	sendErrorResponseWithDetails(w, logger, status, code, message, "")
+}

--- a/internal/api/handlers_api_tokens_internal_test.go
+++ b/internal/api/handlers_api_tokens_internal_test.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/license"
+)
+
+// apiTokenTestSetup wires up the minimum surface needed by the
+// token handlers: a temp SQLite DB + license manager rooted at a
+// tmpdir so test runs don't touch the developer's real license.
+func apiTokenTestSetup(t *testing.T) (*Server, *license.Manager) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp(t.TempDir(), "seed-token-*.db")
+	if err != nil {
+		t.Fatalf("temp db file: %v", err)
+	}
+	tmpPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() { _ = os.Remove(tmpPath) })
+
+	db, openErr := database.Open(tmpPath)
+	if openErr != nil {
+		t.Fatalf("open db: %v", openErr)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	licenseDir := t.TempDir()
+	mgr, mgrErr := license.NewManagerWithDir(licenseDir)
+	if mgrErr != nil {
+		t.Fatalf("license manager: %v", mgrErr)
+	}
+
+	s := &Server{
+		mux:      http.NewServeMux(),
+		services: NewServiceContainer(),
+	}
+	s.services.Database.DB = db
+	s.services.Auth.APITokens = database.NewAPITokenRepository(db)
+	s.services.Auth.License = mgr
+	return s, mgr
+}
+
+func newAuthedRequest(method, path string, body []byte, username string) *http.Request {
+	var bodyReader *bytes.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	var req *http.Request
+	if bodyReader != nil {
+		req = httptest.NewRequest(method, path, bodyReader)
+	} else {
+		req = httptest.NewRequest(method, path, http.NoBody)
+	}
+	// X-Username is the contract between the JWT/token middleware and
+	// downstream handlers; setting it directly bypasses the middleware
+	// for unit tests, which is what we want here.
+	req.Header.Set("X-Username", username)
+	return req
+}
+
+func TestMintRequiresPro_NoLicense(t *testing.T) {
+	t.Parallel()
+	s, _ := apiTokenTestSetup(t)
+	// No StartTrial → license state is nil → licenseAllowsAPITokens=false.
+
+	body, _ := json.Marshal(MintTokenRequest{Name: "ci"})
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/tokens", body, "alice")
+	w := httptest.NewRecorder()
+	s.handleAPITokens(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("status = %d, want 402; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMintRequiresPro_TrialAllowed(t *testing.T) {
+	t.Parallel()
+	s, mgr := apiTokenTestSetup(t)
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+
+	body, _ := json.Marshal(MintTokenRequest{Name: "ci-bot"})
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/tokens", body, "alice")
+	w := httptest.NewRecorder()
+	s.handleAPITokens(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", w.Code, w.Body.String())
+	}
+	var out MintTokenResponse
+	if err := json.NewDecoder(w.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.HasPrefix(out.Token, APITokenPrefix) {
+		t.Errorf("token missing prefix: %q", out.Token)
+	}
+	if out.Prefix == "" || !strings.HasPrefix(out.Token, out.Prefix) {
+		t.Errorf("prefix mismatch: token=%q prefix=%q", out.Token, out.Prefix)
+	}
+}
+
+func TestMintRejectsEmptyName(t *testing.T) {
+	t.Parallel()
+	s, mgr := apiTokenTestSetup(t)
+	mgr.StartTrial()
+
+	body, _ := json.Marshal(MintTokenRequest{Name: "   "})
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/tokens", body, "alice")
+	w := httptest.NewRecorder()
+	s.handleAPITokens(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMintRequiresAuthentication(t *testing.T) {
+	t.Parallel()
+	s, mgr := apiTokenTestSetup(t)
+	mgr.StartTrial()
+
+	body, _ := json.Marshal(MintTokenRequest{Name: "no-user"})
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/tokens", body, "")
+	w := httptest.NewRecorder()
+	s.handleAPITokens(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestListAndRevokeRoundTrip(t *testing.T) {
+	t.Parallel()
+	s, mgr := apiTokenTestSetup(t)
+	mgr.StartTrial()
+
+	// Mint.
+	body, _ := json.Marshal(MintTokenRequest{Name: "tok1"})
+	w := httptest.NewRecorder()
+	s.handleAPITokens(w, newAuthedRequest(http.MethodPost, APIVersionPrefix+"/tokens", body, "alice"))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("mint failed: %d %s", w.Code, w.Body.String())
+	}
+	var minted MintTokenResponse
+	_ = json.NewDecoder(w.Body).Decode(&minted)
+
+	// List shows it.
+	w = httptest.NewRecorder()
+	s.handleAPITokens(w, newAuthedRequest(http.MethodGet, APIVersionPrefix+"/tokens", nil, "alice"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("list failed: %d", w.Code)
+	}
+	var list []TokenListItem
+	if err := json.NewDecoder(w.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != minted.ID {
+		t.Errorf("list mismatch: %+v", list)
+	}
+
+	// Revoke.
+	w = httptest.NewRecorder()
+	s.handleAPITokenByID(w,
+		newAuthedRequest(http.MethodDelete, APIVersionPrefix+"/tokens/"+minted.ID, nil, "alice"))
+	if w.Code != http.StatusNoContent {
+		t.Errorf("revoke status = %d, want 204; body=%s", w.Code, w.Body.String())
+	}
+
+	// Revoke again is 404.
+	w = httptest.NewRecorder()
+	s.handleAPITokenByID(w,
+		newAuthedRequest(http.MethodDelete, APIVersionPrefix+"/tokens/"+minted.ID, nil, "alice"))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("second revoke status = %d, want 404", w.Code)
+	}
+}
+
+func TestRevokeForeignTokenFails(t *testing.T) {
+	t.Parallel()
+	s, mgr := apiTokenTestSetup(t)
+	mgr.StartTrial()
+
+	// Alice mints.
+	body, _ := json.Marshal(MintTokenRequest{Name: "alice-tok"})
+	w := httptest.NewRecorder()
+	s.handleAPITokens(w, newAuthedRequest(http.MethodPost, APIVersionPrefix+"/tokens", body, "alice"))
+	var minted MintTokenResponse
+	_ = json.NewDecoder(w.Body).Decode(&minted)
+
+	// Bob tries to revoke Alice's token.
+	w = httptest.NewRecorder()
+	s.handleAPITokenByID(w,
+		newAuthedRequest(http.MethodDelete, APIVersionPrefix+"/tokens/"+minted.ID, nil, "bob"))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("bob revoking alice's token: status = %d, want 404 (silent reject)", w.Code)
+	}
+}
+
+func TestAPITokenMiddlewareResolvesValidToken(t *testing.T) {
+	t.Parallel()
+	s, mgr := apiTokenTestSetup(t)
+	mgr.StartTrial()
+
+	// Mint a token directly via the repo so we have the plaintext.
+	id, secret, err := mintTokenMaterial()
+	if err != nil {
+		t.Fatalf("mintTokenMaterial: %v", err)
+	}
+	plaintext := APITokenPrefix + secret
+	rec := database.APITokenRecord{
+		ID: id, OwnerUsername: "carol", Name: "ci",
+		TokenHash: hashAPIToken(plaintext),
+		Prefix:    plaintext[:apiTokenDisplayPrefix],
+	}
+	if insErr := s.services.Auth.APITokens.Insert(context.Background(), rec); insErr != nil {
+		t.Fatalf("insert: %v", insErr)
+	}
+
+	var capturedUser string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedUser = r.Header.Get("X-Username")
+	})
+	mw := apiTokenMiddleware(s.services.Auth.APITokens, next)
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/anything", http.NoBody)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+
+	if capturedUser != "carol" {
+		t.Errorf("captured user = %q, want %q (status=%d)", capturedUser, "carol", w.Code)
+	}
+}
+
+func TestAPITokenMiddlewareRejectsBadToken(t *testing.T) {
+	t.Parallel()
+	s, _ := apiTokenTestSetup(t)
+
+	called := false
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true })
+	mw := apiTokenMiddleware(s.services.Auth.APITokens, next)
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/anything", http.NoBody)
+	req.Header.Set("Authorization", "Bearer "+APITokenPrefix+"deadbeef")
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+	if called {
+		t.Error("next handler should not run when token is invalid")
+	}
+}
+
+func TestAPITokenMiddlewareFallsThroughForJWT(t *testing.T) {
+	t.Parallel()
+	s, _ := apiTokenTestSetup(t)
+
+	called := false
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true })
+	mw := apiTokenMiddleware(s.services.Auth.APITokens, next)
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/anything", http.NoBody)
+	req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.fake.fake")
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("non-PAT bearer should fall through to next middleware")
+	}
+}
+
+func TestAPITokenMiddlewareSkipsNonAPI(t *testing.T) {
+	t.Parallel()
+	s, _ := apiTokenTestSetup(t)
+
+	called := false
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true })
+	mw := apiTokenMiddleware(s.services.Auth.APITokens, next)
+
+	req := httptest.NewRequest(http.MethodGet, "/static/app.js", http.NoBody)
+	req.Header.Set("Authorization", "Bearer "+APITokenPrefix+"anything")
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("non-API path should bypass token middleware")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/krisarmstrong/seed/internal/config"
 	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/dhcp"
+	"github.com/krisarmstrong/seed/internal/license"
 	"github.com/krisarmstrong/seed/internal/logging"
 	"github.com/krisarmstrong/seed/internal/mibdb"
 	"github.com/krisarmstrong/seed/internal/netif"
@@ -191,6 +192,8 @@ func NewServer(
 	// Initialize database services
 	services.Database.DB = db
 
+	initLicenseAndAPITokens(services, db)
+
 	s := &Server{
 		config:        cfg,
 		configPath:    configPath,
@@ -235,6 +238,21 @@ func NewServer(
 	s.setupRoutes()
 
 	return s
+}
+
+// initLicenseAndAPITokens wires the Phase D-2 license manager + API
+// token repository into the service container. The license manager is
+// best-effort: failure to load isn't fatal, the mint endpoint just
+// behaves as if no paid license is present (rejects with 402).
+func initLicenseAndAPITokens(services *ServiceContainer, db *database.DB) {
+	services.Auth.APITokens = database.NewAPITokenRepository(db)
+	lm, lmErr := license.NewManager()
+	if lmErr != nil {
+		logging.GetLogger().Warn("license manager init failed; minting will be disabled",
+			"error", lmErr)
+		return
+	}
+	services.Auth.License = lm
 }
 
 // Service accessors - provide backwards-compatible access to services (#888)

--- a/internal/api/server_lifecycle.go
+++ b/internal/api/server_lifecycle.go
@@ -41,6 +41,10 @@ func (s *Server) Start() error {
 	// Body limit middleware enforces request body size limits
 	// i18n middleware extracts Accept-Language and attaches localizer to context
 	// CSRF middleware validates tokens on state-changing requests (POST, PUT, DELETE)
+	// Phase D-2: apiTokenMiddleware sits in front of the JWT middleware.
+	// If the request carries `Authorization: Bearer sd_pat_…` it resolves
+	// the personal-access token, sets X-Username, and forwards. Otherwise
+	// it falls through and the JWT middleware handles the request normally.
 	handler := recoverMiddleware(
 		logging.RequestIDMiddleware(
 			logging.LoggingMiddleware(
@@ -48,8 +52,9 @@ func (s *Server) Start() error {
 					bodyLimitMiddleware(
 						corsMiddleware(
 							i18n.Middleware()(
-								s.authManager().Middleware(
-									s.csrfManager().CSRFMiddleware(s.mux)))))))))
+								apiTokenMiddleware(s.services.Auth.APITokens,
+									s.authManager().Middleware(
+										s.csrfManager().CSRFMiddleware(s.mux))))))))))
 
 	s.httpServer = &http.Server{
 		Addr:         addr,

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -14,6 +14,7 @@ import (
 func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("/__version", s.handleBuildVersion)
 	s.setupCoreRoutes()
+	s.setupAPITokenRoutes()
 	s.registerUpdateRoutes()
 	s.setupSAPRoutes()
 	s.setupShellRoutes()
@@ -21,6 +22,13 @@ func (s *Server) setupRoutes() {
 	s.setupCanopyRoutes()
 	s.setupHarvestRoutes()
 	s.setupSSEAndStatic()
+}
+
+// setupAPITokenRoutes registers the Phase D-2 personal-access-token
+// endpoints.
+func (s *Server) setupAPITokenRoutes() {
+	s.mux.HandleFunc(APIVersionPrefix+"/tokens", s.handleAPITokens)
+	s.mux.HandleFunc(APIVersionPrefix+"/tokens/", s.handleAPITokenByID)
 }
 
 // setupCoreRoutes registers auth, settings, config, and setup routes.

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -8,6 +8,7 @@ import (
 	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/dhcp"
 	"github.com/krisarmstrong/seed/internal/health"
+	"github.com/krisarmstrong/seed/internal/license"
 	"github.com/krisarmstrong/seed/internal/logging"
 	"github.com/krisarmstrong/seed/internal/mibdb"
 	"github.com/krisarmstrong/seed/internal/netif"
@@ -72,6 +73,12 @@ type AuthServices struct {
 	// WebAuthn is the optional WebAuthn (passkeys) manager, populated
 	// in server_init.go. Wave 3 (#85).
 	WebAuthn *auth.WebAuthnManager
+	// License is the offline license manager. Populated lazily in
+	// server_init.go (Phase D-2); may be nil in tests that don't
+	// exercise license-gated endpoints.
+	License *license.Manager
+	// APITokens persists personal-access tokens (Phase D-2).
+	APITokens *database.APITokenRepository
 }
 
 // RateLimitServices groups rate limiting services.

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -849,6 +849,29 @@ func getMigrationDefs() []migrationDef {
 				ON webauthn_credentials(credential_id);
 		`,
 		},
+		{
+			// Phase D-2 (LICENSE_STRATEGY.md): API personal-access tokens
+			// for programmatic access. Pro-tier capability; minting is
+			// gated server-side at the handler. Token plaintext is shown
+			// once at creation; only its SHA-256 hash is stored.
+			Description: "Add api_tokens table for personal-access tokens",
+			Up: `
+			CREATE TABLE IF NOT EXISTS api_tokens (
+				id              TEXT PRIMARY KEY,
+				owner_username  TEXT NOT NULL,
+				name            TEXT NOT NULL,
+				token_hash      TEXT NOT NULL UNIQUE,
+				prefix          TEXT NOT NULL,
+				created_at      TEXT NOT NULL,
+				last_used_at    TEXT,
+				revoked_at      TEXT
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_api_tokens_owner    ON api_tokens(owner_username);
+			CREATE INDEX IF NOT EXISTS idx_api_tokens_hash     ON api_tokens(token_hash);
+			CREATE INDEX IF NOT EXISTS idx_api_tokens_active   ON api_tokens(revoked_at);
+		`,
+		},
 	}
 }
 

--- a/internal/database/repository_api_tokens.go
+++ b/internal/database/repository_api_tokens.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// APITokenRecord is the persisted form of a personal-access token.
+// The plaintext token is never stored — only the SHA-256 hex digest
+// in TokenHash. Prefix is the first 12 chars of the plaintext, kept
+// so the UI can identify a token without revealing it.
+type APITokenRecord struct {
+	ID            string
+	OwnerUsername string
+	Name          string
+	TokenHash     string
+	Prefix        string
+	CreatedAt     time.Time
+	LastUsedAt    time.Time
+	RevokedAt     time.Time
+}
+
+// IsActive reports whether the token is currently usable (not revoked).
+func (r APITokenRecord) IsActive() bool {
+	return r.RevokedAt.IsZero()
+}
+
+// APITokenRepository persists api_tokens rows. Methods are safe to call
+// concurrently because they delegate to *database/sql which handles
+// connection pooling.
+type APITokenRepository struct {
+	db *DB
+}
+
+// NewAPITokenRepository constructs a repository bound to the given DB.
+func NewAPITokenRepository(db *DB) *APITokenRepository {
+	return &APITokenRepository{db: db}
+}
+
+// Insert persists a newly minted token record.
+func (r *APITokenRepository) Insert(ctx context.Context, t APITokenRecord) error {
+	_, err := r.db.conn.ExecContext(ctx, `
+		INSERT INTO api_tokens (id, owner_username, name, token_hash, prefix, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, t.ID, t.OwnerUsername, t.Name, t.TokenHash, t.Prefix, t.CreatedAt.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("insert api token: %w", err)
+	}
+	return nil
+}
+
+// FindActiveByHash returns the active (non-revoked) token row matching
+// the given hash, or [sql.ErrNoRows] if no match.
+func (r *APITokenRepository) FindActiveByHash(ctx context.Context, hash string) (APITokenRecord, error) {
+	row := r.db.conn.QueryRowContext(ctx, `
+		SELECT id, owner_username, name, token_hash, prefix, created_at,
+		       COALESCE(last_used_at, ''), COALESCE(revoked_at, '')
+		FROM api_tokens
+		WHERE token_hash = ? AND revoked_at IS NULL
+	`, hash)
+	return scanAPIToken(row)
+}
+
+// ListByOwner returns all tokens owned by the given user, ordered by
+// creation time descending. Revoked tokens are included so the UI can
+// show "revoked" entries that haven't been deleted; callers filter as
+// needed.
+func (r *APITokenRepository) ListByOwner(ctx context.Context, owner string) ([]APITokenRecord, error) {
+	rows, err := r.db.conn.QueryContext(ctx, `
+		SELECT id, owner_username, name, token_hash, prefix, created_at,
+		       COALESCE(last_used_at, ''), COALESCE(revoked_at, '')
+		FROM api_tokens
+		WHERE owner_username = ?
+		ORDER BY created_at DESC
+	`, owner)
+	if err != nil {
+		return nil, fmt.Errorf("list api tokens: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []APITokenRecord
+	for rows.Next() {
+		rec, scanErr := scanAPIToken(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, rec)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("iterate api tokens: %w", rowsErr)
+	}
+	return out, nil
+}
+
+// TouchLastUsed marks the token's last_used_at to now. Failures are
+// non-fatal for the caller's auth check but are returned so callers
+// that care can log them.
+func (r *APITokenRepository) TouchLastUsed(ctx context.Context, id string) error {
+	_, err := r.db.conn.ExecContext(ctx, `
+		UPDATE api_tokens SET last_used_at = ? WHERE id = ?
+	`, time.Now().UTC().Format(time.RFC3339Nano), id)
+	if err != nil {
+		return fmt.Errorf("touch api token: %w", err)
+	}
+	return nil
+}
+
+// Revoke marks the token as revoked. Returns [sql.ErrNoRows] if no token
+// with that ID exists for the given owner.
+func (r *APITokenRepository) Revoke(ctx context.Context, id, owner string) error {
+	res, err := r.db.conn.ExecContext(ctx, `
+		UPDATE api_tokens
+		SET revoked_at = ?
+		WHERE id = ? AND owner_username = ? AND revoked_at IS NULL
+	`, time.Now().UTC().Format(time.RFC3339Nano), id, owner)
+	if err != nil {
+		return fmt.Errorf("revoke api token: %w", err)
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// rowScanner abstracts *[sql.Row] and *[sql.Rows] for scanAPIToken's reuse.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAPIToken(r rowScanner) (APITokenRecord, error) {
+	var rec APITokenRecord
+	var createdStr, lastUsedStr, revokedStr string
+
+	scanErr := r.Scan(
+		&rec.ID, &rec.OwnerUsername, &rec.Name, &rec.TokenHash, &rec.Prefix,
+		&createdStr, &lastUsedStr, &revokedStr,
+	)
+	if scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return rec, sql.ErrNoRows
+		}
+		return rec, fmt.Errorf("scan api token: %w", scanErr)
+	}
+
+	rec.CreatedAt = parseTime(createdStr)
+	rec.LastUsedAt = parseTime(lastUsedStr)
+	rec.RevokedAt = parseTime(revokedStr)
+	return rec, nil
+}
+
+// parseTime is a forgiving parser — returns zero time on empty/invalid
+// inputs because legacy rows may use slightly different formats.
+func parseTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
+	}
+	return time.Time{}
+}

--- a/internal/database/repository_api_tokens_test.go
+++ b/internal/database/repository_api_tokens_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package database_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+func setupAPITokenTest(t *testing.T) (*database.APITokenRepository, context.Context) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp(t.TempDir(), "seed-test-*.db")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	tmpPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() { _ = os.Remove(tmpPath) })
+
+	db, openErr := database.Open(tmpPath)
+	if openErr != nil {
+		t.Fatalf("open db: %v", openErr)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	return database.NewAPITokenRepository(db), context.Background()
+}
+
+func TestAPITokenInsertAndLookup(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupAPITokenTest(t)
+
+	rec := database.APITokenRecord{
+		ID:            "tokenid01",
+		OwnerUsername: "alice",
+		Name:          "ci-bot",
+		TokenHash:     "deadbeef",
+		Prefix:        "sd_pat_abcd",
+		CreatedAt:     time.Now().UTC(),
+	}
+	if err := repo.Insert(ctx, rec); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	got, err := repo.FindActiveByHash(ctx, "deadbeef")
+	if err != nil {
+		t.Fatalf("FindActiveByHash: %v", err)
+	}
+	if got.OwnerUsername != "alice" || got.Name != "ci-bot" {
+		t.Errorf("unexpected record: %+v", got)
+	}
+	if !got.IsActive() {
+		t.Error("expected IsActive == true on fresh token")
+	}
+}
+
+func TestAPITokenRevokeMakesInactive(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupAPITokenTest(t)
+
+	rec := database.APITokenRecord{
+		ID: "tokenid02", OwnerUsername: "bob", Name: "old",
+		TokenHash: "cafe", Prefix: "sd_pat_cafe", CreatedAt: time.Now().UTC(),
+	}
+	if err := repo.Insert(ctx, rec); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := repo.Revoke(ctx, rec.ID, "bob"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+
+	if _, err := repo.FindActiveByHash(ctx, "cafe"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows after revoke, got: %v", err)
+	}
+
+	// Second revoke of the same token is a no-op (already revoked).
+	if err := repo.Revoke(ctx, rec.ID, "bob"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows on double-revoke, got: %v", err)
+	}
+}
+
+func TestAPITokenRevokeRequiresOwner(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupAPITokenTest(t)
+
+	rec := database.APITokenRecord{
+		ID: "tokenid03", OwnerUsername: "alice", Name: "mine",
+		TokenHash: "beef", Prefix: "sd_pat_beef", CreatedAt: time.Now().UTC(),
+	}
+	if err := repo.Insert(ctx, rec); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// Bob cannot revoke Alice's token.
+	if err := repo.Revoke(ctx, rec.ID, "bob"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows for wrong owner, got: %v", err)
+	}
+	// Token is still active for Alice.
+	if _, err := repo.FindActiveByHash(ctx, "beef"); err != nil {
+		t.Errorf("token should still be active for owner: %v", err)
+	}
+}
+
+func TestAPITokenListByOwnerSorted(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupAPITokenTest(t)
+
+	now := time.Now().UTC()
+	tokens := []database.APITokenRecord{
+		{
+			ID: "t1", OwnerUsername: "alice", Name: "first",
+			TokenHash: "h1", Prefix: "sd_pat_aaa", CreatedAt: now.Add(-3 * time.Hour),
+		},
+		{
+			ID: "t2", OwnerUsername: "alice", Name: "second",
+			TokenHash: "h2", Prefix: "sd_pat_bbb", CreatedAt: now.Add(-1 * time.Hour),
+		},
+		{
+			ID: "t3", OwnerUsername: "bob", Name: "other",
+			TokenHash: "h3", Prefix: "sd_pat_ccc", CreatedAt: now,
+		},
+	}
+	for _, t0 := range tokens {
+		if err := repo.Insert(ctx, t0); err != nil {
+			t.Fatalf("Insert %s: %v", t0.ID, err)
+		}
+	}
+
+	rows, err := repo.ListByOwner(ctx, "alice")
+	if err != nil {
+		t.Fatalf("ListByOwner: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows for alice, got %d", len(rows))
+	}
+	// DESC by created_at ⇒ "second" first.
+	if rows[0].Name != "second" || rows[1].Name != "first" {
+		t.Errorf("unexpected order: [%s, %s]", rows[0].Name, rows[1].Name)
+	}
+}
+
+func TestAPITokenTouchLastUsedUpdatesTimestamp(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupAPITokenTest(t)
+
+	rec := database.APITokenRecord{
+		ID: "tokenid04", OwnerUsername: "carol", Name: "k",
+		TokenHash: "abcd", Prefix: "sd_pat_xxx", CreatedAt: time.Now().UTC(),
+	}
+	if err := repo.Insert(ctx, rec); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	before, _ := repo.FindActiveByHash(ctx, "abcd")
+	if !before.LastUsedAt.IsZero() {
+		t.Error("expected LastUsedAt to be zero before TouchLastUsed")
+	}
+	if err := repo.TouchLastUsed(ctx, rec.ID); err != nil {
+		t.Fatalf("TouchLastUsed: %v", err)
+	}
+	after, _ := repo.FindActiveByHash(ctx, "abcd")
+	if after.LastUsedAt.IsZero() {
+		t.Error("expected LastUsedAt to be set after TouchLastUsed")
+	}
+}


### PR DESCRIPTION
## Summary

Phase D-2 first slice: API personal-access tokens — the customer-facing **\"REST API access\"** Pro capability per \`LICENSE_STRATEGY.md\` §2. Free and Starter users still drive the web UI (which talks to the API via the browser session); they just cannot mint long-lived tokens for external scripts, monitoring, or CI.

## What ships

### Backend

- **Migration** \`api_tokens\` (id, owner_username, name, token_hash, prefix, created_at, last_used_at, revoked_at).
- **\`internal/database/repository_api_tokens.go\`** — Insert / FindActiveByHash / ListByOwner / TouchLastUsed / Revoke. Owner-scoped revoke (Bob can't revoke Alice's token).
- **\`internal/api/handlers_api_tokens.go\`** —
  - \`POST /api/v1/tokens\` — mint; **402 Payment Required** if tier < Pro and not in trial
  - \`GET /api/v1/tokens\` — list owner's tokens (sanitized, no hash, no plaintext)
  - \`DELETE /api/v1/tokens/<id>\` — revoke, owner-scoped (foreign IDs return 404)
- **\`apiTokenMiddleware\`** sits in front of the existing JWT middleware. Bearers prefixed \`sd_pat_\` are resolved against the DB; anything else falls through to JWT auth — backward-compatible.
- **\`internal/api/services.go\`** — \`License\` and \`APITokens\` added to \`AuthServices\`. Wired in \`server.go\` via \`initLicenseAndAPITokens()\`.

### Token format

\`sd_pat_<64 hex chars>\` — 32 bytes (~256 bits) of entropy, distinguishable from JWTs by prefix. Plaintext shown ONCE at mint; only SHA-256 hex digest stored.

### Tests

- **Repository:** insert, lookup, owner-scoped revoke (Bob can't revoke Alice's; double-revoke = ErrNoRows), list sort DESC by creation, touch-last-used.
- **Handlers:** mint Pro-gated (no-license=402, trial=201), name validation (empty/whitespace=400, >64 chars=400), auth required, list+revoke round-trip, foreign-token revoke = 404.
- **Middleware:** valid PAT authenticates and sets \`X-Username\`, invalid PAT = 401, JWT bearer falls through, non-API path bypasses.

## Explicitly out of scope (filed as follow-ups)

- **UI panel for token management** (D-2.4) — backend is usable via \`curl\` today; UI is a separate small PR.
- **netif test slowness on macOS** — pre-existing; \`networksetup -getmedia\` takes ~5s per interface and several tests each pay the cost. Unrelated to this change; fix in a separate PR (cache the DetectAll result per-process).
- **libpcap duplicate-lib warning** — two gopacket forks (\`github.com/google/gopacket@v1.1.19\` via \`gosnmp\`, \`github.com/gopacket/gopacket@v1.6.0\` direct) both declare \`-lpcap\`. Cosmetic; fixable with a \`replace\` directive in go.mod. Separate PR.

## Test plan

- [x] \`go build ./...\` — clean
- [x] Targeted tests: \`go test ./internal/database/ ./internal/api/ -run "APIToken|Mint|List|Revoke"\` — all pass
- [x] \`golangci-lint run\` on affected packages — 0 issues
- [x] Phase D-1 license framework already merged (#1095); this builds on top
- [ ] CI green on this PR

## Follow-ups (already tracked)

- D-2.4: Settings → API panel UI with mint UX (disabled with tooltip for Free/Starter)
- D-2.6+: per-module tier gates (Canopy / Harvest / Roots / Sap / Shell)
- Phase E: NIAC license port (mirrors D-1)