### PR TITLE
fix(netif): Parallelize per-interface scoring in detector.DetectAll

### DIFF
--- a/internal/netif/detection/detection.go
+++ b/internal/netif/detection/detection.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/krisarmstrong/seed/internal/logging"
 )
@@ -84,24 +85,38 @@ func NewDetector() *Detector {
 
 // DetectAll discovers and scores all network interfaces.
 // Returns interfaces sorted by score (highest first).
+//
+// Per-interface scoring shells out to platform tools (e.g.
+// `networksetup -getmedia` on macOS, `ethtool` on Linux) and each
+// call carries a multi-second timeout. We score every interface
+// concurrently so the worst-case wall clock is one interface's
+// timeout, not N×timeout — without this, hosts with many virtual
+// interfaces (utun*, awdl*, bridge*) made test runs unboundedly slow.
 func (d *Detector) DetectAll() ([]InterfaceScore, error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil, err
 	}
 
-	scores := make([]InterfaceScore, 0, len(ifaces))
+	candidates := make([]net.Interface, 0, len(ifaces))
 	for _, iface := range ifaces {
-		// Skip loopback
 		if iface.Flags&net.FlagLoopback != 0 {
 			continue
 		}
-
-		score := d.ScoreInterface(iface)
-		scores = append(scores, score)
+		candidates = append(candidates, iface)
 	}
 
-	// Sort by score descending
+	scores := make([]InterfaceScore, len(candidates))
+	var wg sync.WaitGroup
+	for i := range candidates {
+		wg.Add(1)
+		go func(idx int, iface net.Interface) {
+			defer wg.Done()
+			scores[idx] = d.ScoreInterface(iface)
+		}(i, candidates[i])
+	}
+	wg.Wait()
+
 	sort.Slice(scores, func(i, j int) bool {
 		return scores[i].Score > scores[j].Score
 	})


### PR DESCRIPTION
## Summary

\`DetectAll()\` shells out to platform tools (\`networksetup -getmedia\` on macOS, \`ethtool\` on Linux) once per interface to read link speed, each call carrying a 5-second timeout. The previous implementation scored interfaces serially, so a host with many virtual interfaces (\`utun*\`, \`awdl*\`, \`bridge*\`) made wall-clock cost \`O(N × timeout)\`.

On macOS this pushed the \`internal/netif\` test suite past its 60s budget — \`TestRefreshInterfaces\` hung, and even tests that ran (\`TestNewManager\` 8.6s, \`TestLinkStatusWithRunningInterface\` 4.4s) burned the budget on the same slow calls. Surfaced during Phase D-2 verification but is a pre-existing bug.

## Fix

Run \`ScoreInterface\` concurrently in a fixed-size goroutine fan-out (one per interface; \`net.Interface\` count is bounded by the OS in practice). Sort the result after collection so the public ordering contract is unchanged. **No behavior change other than wall-clock.**

## Before / after on macOS

| Test | Before | After |
|---|---|---|
| \`TestNewManager\` | 8.6s | **1.9s** |
| \`TestLinkStatusWithRunningInterface\` | 4.4s | **1.1s** |
| \`TestRefreshInterfaces\` | 60s+ (timeout) | **1.9s** |
| Full \`internal/netif\` suite (-short) | timeout | **25s** |

## Test plan

- [x] \`go test -short ./internal/netif/...\` — all pass in 25s
- [x] \`go test -race -short ./internal/netif/...\` — clean (no races)
- [x] \`golangci-lint run ./internal/netif/...\` — 0 issues
- [ ] CI green