### PR TITLE
feat(ui): Add Settings → API Tokens panel with Pro-gated mint UX

### DIFF
--- a/internal/api/handlers_api_tokens.go
+++ b/internal/api/handlers_api_tokens.go
@@ -75,6 +75,64 @@ type TokenListItem struct {
 	RevokedAt  time.Time `json:"revokedAt,omitzero"`
 }
 
+// LicenseStatusResponse is returned by GET /api/v1/license. It tells
+// the UI which tier is active, whether features should be exposed,
+// and how much trial time (if any) remains.
+type LicenseStatusResponse struct {
+	Tier          string    `json:"tier"`      // "Free" | "Starter" | "Pro" | "Trial"
+	TierValue     int       `json:"tierValue"` // numeric (0=Free, 1=Starter, 2=Pro)
+	IsTrialMode   bool      `json:"isTrialMode"`
+	TrialDaysLeft int       `json:"trialDaysLeft,omitempty"`
+	CanMintTokens bool      `json:"canMintTokens"` // true iff Tier >= Pro or active trial
+	Activated     bool      `json:"activated"`
+	ExpiresAt     time.Time `json:"expiresAt,omitzero"`
+}
+
+// handleLicenseStatus exposes the local license state to the UI. The
+// unlicensed (Free) state is a valid result, not an error condition.
+func (s *Server) handleLicenseStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeAPITokenError(w, r, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed,
+			"Method not allowed")
+		return
+	}
+
+	resp := LicenseStatusResponse{
+		Tier:          license.TierFree.String(),
+		TierValue:     int(license.TierFree),
+		CanMintTokens: false,
+	}
+
+	mgr := s.services.Auth.License
+	if mgr == nil {
+		// License disabled (dev / test build) — allow minting so the
+		// feature stays usable. Matches licenseAllowsAPITokens().
+		resp.CanMintTokens = true
+		sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusOK, resp)
+		return
+	}
+
+	st := mgr.GetState()
+	if st == nil {
+		sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusOK, resp)
+		return
+	}
+
+	resp.Activated = true
+	resp.IsTrialMode = st.IsTrialMode
+	resp.ExpiresAt = st.ExpiresAt
+	resp.TierValue = int(st.Tier)
+	if st.IsTrialMode {
+		resp.Tier = "Trial"
+		resp.TrialDaysLeft = mgr.TrialDaysRemaining()
+		resp.CanMintTokens = true
+	} else {
+		resp.Tier = st.Tier.String()
+		resp.CanMintTokens = st.Tier >= license.TierPro
+	}
+	sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusOK, resp)
+}
+
 // handleAPITokens routes /api/v1/tokens (POST = mint, GET = list).
 func (s *Server) handleAPITokens(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -25,10 +25,12 @@ func (s *Server) setupRoutes() {
 }
 
 // setupAPITokenRoutes registers the Phase D-2 personal-access-token
-// endpoints.
+// endpoints and the read-only license status endpoint the UI uses to
+// know whether the mint button should be enabled.
 func (s *Server) setupAPITokenRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/tokens", s.handleAPITokens)
 	s.mux.HandleFunc(APIVersionPrefix+"/tokens/", s.handleAPITokenByID)
+	s.mux.HandleFunc(APIVersionPrefix+"/license", s.handleLicenseStatus)
 }
 
 // setupCoreRoutes registers auth, settings, config, and setup routes.

--- a/ui/src/components/settings/SettingsDrawer.tsx
+++ b/ui/src/components/settings/SettingsDrawer.tsx
@@ -50,6 +50,7 @@ import type {
 } from '../../types/settings';
 import { SettingsDrawerFooter } from './SettingsDrawerFooter';
 import { SettingsDrawerNetworkSection } from './SettingsDrawerNetworkSection';
+import { ApiTokensSettings } from './sections/ApiTokensSettings';
 import { AppearanceSettings } from './sections/AppearanceSettings';
 import { CableTestSettings } from './sections/CableTestSettings';
 import { ConfigBackupsSection } from './sections/ConfigBackupsSection';
@@ -689,6 +690,9 @@ export const SettingsDrawer: React.MemoExoticComponent<
               setDisplayOptions((prev) => ({ ...prev, unitSystem: unit }))
             }
           />
+
+          {/* API tokens (Phase D-2 LICENSE_STRATEGY) */}
+          <ApiTokensSettings />
 
           {/* Config Backups Section (implements #494) */}
           <ConfigBackupsSection />

--- a/ui/src/components/settings/sections/ApiTokensSettings.tsx
+++ b/ui/src/components/settings/sections/ApiTokensSettings.tsx
@@ -1,0 +1,265 @@
+/**
+ * ApiTokensSettings Component
+ *
+ * Settings panel for personal-access API tokens (Phase D-2 of
+ * LICENSE_STRATEGY). Free and Starter tiers can see the panel and
+ * their existing tokens but cannot mint new ones — the mint button
+ * is disabled with a tooltip explaining the Pro requirement.
+ *
+ * Token plaintext is shown ONLY at creation time (server-side: only
+ * SHA-256 hex is stored). The freshly minted token stays visible in
+ * the UI until the user dismisses it.
+ */
+
+import type React from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '../../../api/client';
+import { Button } from '../../ui/Button';
+import { CollapsibleSection } from '../../ui/CollapsibleSection';
+import { Input } from '../../ui/Input';
+import { Key, Plus, Trash2 } from '../../ui/icons';
+
+interface LicenseStatus {
+  tier: string;
+  tierValue: number;
+  isTrialMode: boolean;
+  trialDaysLeft?: number;
+  canMintTokens: boolean;
+  activated: boolean;
+}
+
+interface ApiToken {
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: string;
+  lastUsedAt?: string;
+  revokedAt?: string;
+}
+
+interface MintTokenResponse {
+  id: string;
+  name: string;
+  token: string;
+  prefix: string;
+  createdAt: string;
+}
+
+const ZERO_TIME_PREFIX = '0001-01-01';
+
+function isZeroTime(value: string | undefined): boolean {
+  return !value || value.startsWith(ZERO_TIME_PREFIX);
+}
+
+function formatDate(value: string | undefined): string {
+  if (isZeroTime(value)) return '—';
+  try {
+    return new Date(value as string).toLocaleDateString();
+  } catch {
+    return value as string;
+  }
+}
+
+export function ApiTokensSettings(): React.ReactElement {
+  const [licenseStatus, setLicenseStatus] = useState<LicenseStatus | null>(null);
+  const [tokens, setTokens] = useState<ApiToken[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [newTokenName, setNewTokenName] = useState('');
+  const [minting, setMinting] = useState(false);
+  const [mintedToken, setMintedToken] = useState<MintTokenResponse | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setError(null);
+    try {
+      const [status, tokenList] = await Promise.all([
+        api.get<LicenseStatus>('/api/v1/license'),
+        api.get<ApiToken[] | null>('/api/v1/tokens'),
+      ]);
+      setLicenseStatus(status);
+      setTokens(tokenList ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load API tokens');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleMint = useCallback(async (): Promise<void> => {
+    const trimmed = newTokenName.trim();
+    if (!trimmed) return;
+    setMinting(true);
+    setError(null);
+    try {
+      const created = await api.post<MintTokenResponse>('/api/v1/tokens', { name: trimmed });
+      setMintedToken(created);
+      setNewTokenName('');
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to mint token');
+    } finally {
+      setMinting(false);
+    }
+  }, [newTokenName, refresh]);
+
+  const handleRevoke = useCallback(
+    async (token: ApiToken): Promise<void> => {
+      const ok = window.confirm(
+        `Revoke token "${token.name}"? Any script using it will stop working immediately.`,
+      );
+      if (!ok) return;
+      setError(null);
+      try {
+        await api.delete(`/api/v1/tokens/${token.id}`);
+        await refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to revoke token');
+      }
+    },
+    [refresh],
+  );
+
+  const canMint = licenseStatus?.canMintTokens ?? false;
+  const tierLabel = licenseStatus?.tier ?? 'Free';
+
+  return (
+    <CollapsibleSection
+      title={
+        <div className="inline-flex items-center gap-2">
+          <Key className="w-4 h-4" />
+          <span>API Tokens</span>
+        </div>
+      }
+      defaultOpen={false}
+    >
+      <div className="stack-sm">
+        <p className="text-sm text-text-secondary">
+          Personal-access tokens for programmatic API calls (scripts, monitoring, CI). Available on
+          the <strong>Pro</strong> tier. The web UI works on every tier without a token.
+        </p>
+
+        {!canMint && (
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm text-amber-200">
+            Current tier: <strong>{tierLabel}</strong>. Minting API tokens requires Pro. Start a
+            14-day trial with <code>seed license trial</code>, or activate a Pro key with{' '}
+            <code>seed license activate -k &lt;KEY&gt;</code>.
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-lg border border-status-error/30 bg-status-error/5 p-3 text-sm text-status-error">
+            {error}
+          </div>
+        )}
+
+        {mintedToken && (
+          <div className="rounded-lg border border-status-success/40 bg-status-success/5 p-3 stack-xs">
+            <div className="text-sm font-medium text-status-success">
+              Token created — copy it now. It will not be shown again.
+            </div>
+            <code className="block break-all rounded bg-surface-raised px-2 py-1 text-xs">
+              {mintedToken.token}
+            </code>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                tone="green"
+                size="sm"
+                onClick={() => void navigator.clipboard?.writeText(mintedToken.token)}
+              >
+                Copy
+              </Button>
+              <Button variant="ghost" tone="gray" size="sm" onClick={() => setMintedToken(null)}>
+                I&apos;ve saved it
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-end gap-2">
+          <div className="flex-1">
+            <label className="block text-xs text-text-muted mb-1" htmlFor="api-token-name">
+              Token name
+            </label>
+            <Input
+              id="api-token-name"
+              value={newTokenName}
+              onChange={(e) => setNewTokenName(e.target.value)}
+              placeholder="e.g. monitoring-prod"
+              maxLength={64}
+              disabled={!canMint || minting}
+            />
+          </div>
+          <Button
+            variant="solid"
+            tone="violet"
+            size="md"
+            leftIcon={<Plus className="w-4 h-4" />}
+            disabled={!canMint || minting || newTokenName.trim().length === 0}
+            loading={minting}
+            title={canMint ? undefined : 'API token minting requires the Pro tier'}
+            onClick={() => void handleMint()}
+          >
+            Create token
+          </Button>
+        </div>
+
+        {loading ? (
+          <div className="text-sm text-text-muted">Loading…</div>
+        ) : tokens.length === 0 ? (
+          <div className="text-sm text-text-muted">No API tokens yet.</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-xs text-text-muted text-left">
+              <tr>
+                <th className="py-2 pr-2">Name</th>
+                <th className="py-2 pr-2">Prefix</th>
+                <th className="py-2 pr-2">Created</th>
+                <th className="py-2 pr-2">Last used</th>
+                <th className="py-2 pr-2">Status</th>
+                <th className="py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {tokens.map((t) => {
+                const revoked = !isZeroTime(t.revokedAt);
+                return (
+                  <tr key={t.id} className="border-t border-surface-border">
+                    <td className="py-2 pr-2">{t.name}</td>
+                    <td className="py-2 pr-2 font-mono text-xs">{t.prefix}…</td>
+                    <td className="py-2 pr-2">{formatDate(t.createdAt)}</td>
+                    <td className="py-2 pr-2">{formatDate(t.lastUsedAt)}</td>
+                    <td className="py-2 pr-2">
+                      {revoked ? (
+                        <span className="text-status-error">revoked</span>
+                      ) : (
+                        <span className="text-status-success">active</span>
+                      )}
+                    </td>
+                    <td className="py-2 text-right">
+                      {!revoked && (
+                        <Button
+                          variant="ghost"
+                          tone="red"
+                          size="xs"
+                          leftIcon={<Trash2 className="w-3 h-3" />}
+                          onClick={() => void handleRevoke(t)}
+                        >
+                          Revoke
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </CollapsibleSection>
+  );
+}


### PR DESCRIPTION
## Summary

Completes Phase D-2: the customer-visible UI for personal-access tokens. **Free** and **Starter** users see the panel and any existing tokens but the **mint button is disabled** with a tooltip + amber notice explaining the Pro requirement. **Pro** users (and anyone in the 14-day trial) can mint, copy, and revoke tokens.

## What's in this PR

### Backend (single new endpoint)

- **\`GET /api/v1/license\`** — returns the current tier, trial state, and a precomputed \`canMintTokens\` flag the UI uses to enable/disable the mint button. Always 200; the unlicensed (Free) state is a valid response, not an error.

\`\`\`json
{
  \"tier\": \"Pro\",
  \"tierValue\": 2,
  \"isTrialMode\": false,
  \"canMintTokens\": true,
  \"activated\": true,
  \"expiresAt\": \"2027-05-23T00:00:00Z\"
}
\`\`\`

### Frontend

- **\`ui/src/components/settings/sections/ApiTokensSettings.tsx\`** — new section component. Fetches both \`/api/v1/license\` and \`/api/v1/tokens\` on mount, exposes:
  - **Mint:** name input (max 64) + \"Create token\" button. Disabled with tooltip when tier < Pro and not in trial.
  - **Show-once:** freshly minted token shown inline in a green highlight box with copy-to-clipboard and \"I've saved it\" dismiss.
  - **List:** name / prefix (\`sd_pat_xxxxx…\`) / created / last-used / active|revoked.
  - **Revoke:** per-row trash button, \`window.confirm\` guard (single-shot action — not worth a full modal yet).
- **\`SettingsDrawer.tsx\`** — wires the new section between Appearance and Config Backups.

### Free/Starter UX

> ⚠ Current tier: **Free**. Minting API tokens requires Pro.
> Start a 14-day trial with \`seed license trial\`, or activate a Pro key with \`seed license activate -k <KEY>\`.

The mint button is visibly disabled with the same hint as a hover tooltip.

## Test plan

- [x] \`go test ./internal/api/ -run \"License|APIToken|Mint\"\` — pass
- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`npx biome check\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [ ] CI green

## Closes Phase D-2

Backend + middleware: PR #1096
Cipher correctness contract: stem PR #266
License framework + CLI: PR #1095
UI panel: **this PR**

## Follow-ups (separate phases)

- Phase D-3+: per-module tier gates (Canopy / Harvest / Roots / Sap / Shell)
- Phase E: NIAC license port (mirrors Phase D-1)