### PR TITLE
test(e2e): Fix .or() chain to apply .first() across the union

### DIFF
--- a/ui/e2e/dashboard.spec.ts
+++ b/ui/e2e/dashboard.spec.ts
@@ -45,7 +45,8 @@ test.describe('Dashboard', () => {
     // Click settings button
     const settingsButton = page
       .getByRole('button', { name: /settings/i })
-      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+      .first();
     await settingsButton.click();
 
     // Settings drawer should be visible
@@ -56,7 +57,8 @@ test.describe('Dashboard', () => {
     // Open settings
     const settingsButton = page
       .getByRole('button', { name: /settings/i })
-      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+      .first();
     await settingsButton.click();
 
     // Find and click theme toggle
@@ -68,7 +70,8 @@ test.describe('Dashboard', () => {
     // Click help button
     const helpButton = page
       .getByRole('button', { name: /help/i })
-      .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+      .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+      .first();
     await helpButton.click();
 
     // Help modal should be visible

--- a/ui/e2e/error-scenarios.spec.ts
+++ b/ui/e2e/error-scenarios.spec.ts
@@ -454,7 +454,8 @@ test.describe('API Error Scenarios', () => {
       // Try to open settings
       const settingsButton = page
         .getByRole('button', { name: /settings/i })
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       if (await settingsButton.isVisible({ timeout: 3000 })) {
         await settingsButton.click();
@@ -512,7 +513,8 @@ test.describe('Validation Error Scenarios', () => {
       // Open settings
       const settingsButton = page
         .getByRole('button', { name: /settings/i })
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       if (await settingsButton.isVisible({ timeout: 3000 })) {
         await settingsButton.click();

--- a/ui/e2e/fab.spec.ts
+++ b/ui/e2e/fab.spec.ts
@@ -182,7 +182,8 @@ test.describe('FAB - Run All Tests Flow', () => {
     // Open settings drawer
     const settingsButton = page
       .getByRole('button', { name: /settings/i })
-      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+      .first();
     await settingsButton.click();
 
     // Wait for settings drawer

--- a/ui/e2e/responsive.spec.ts
+++ b/ui/e2e/responsive.spec.ts
@@ -115,7 +115,8 @@ test.describe('Responsive Layout Tests', () => {
       // Open settings
       const settingsButton = page
         .getByRole('button', { name: /settings/i })
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -201,7 +202,8 @@ test.describe('Responsive Layout Tests', () => {
       // Find help button
       const helpButton = page
         .getByRole('button', { name: /help/i })
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -230,14 +232,16 @@ test.describe('Responsive Layout Tests', () => {
       // Settings should be accessible
       const settingsButton = page
         .getByRole('button', { name: /settings/i })
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await expect(settingsButton).toBeVisible();
 
       // Help should be accessible
       const helpButton = page
         .getByRole('button', { name: /help/i })
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       const hasHelp = await helpButton.isVisible().catch(() => false);
       expect(hasHelp).toBeDefined();
@@ -309,7 +313,8 @@ test.describe('Responsive Layout Tests', () => {
       // Open settings
       const settingsButton = page
         .getByRole('button', { name: /settings/i })
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -472,7 +477,8 @@ test.describe('Responsive Layout Tests', () => {
       // Open settings
       const settingsButton = page
         .getByRole('button', { name: /settings/i })
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -533,7 +539,8 @@ test.describe('Responsive Layout Tests', () => {
       // Open help modal
       const helpButton = page
         .getByRole('button', { name: /help/i })
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -593,7 +600,8 @@ test.describe('Responsive Layout Tests', () => {
       // Set dark theme
       const settingsButton = page
         .getByRole('button', { name: /settings/i })
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -690,7 +698,8 @@ test.describe('Responsive Layout Tests', () => {
         // Open settings
         const settingsButton = page
           .getByRole('button', { name: /settings/i })
-          .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+          .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+          .first();
 
         await settingsButton.click();
         await page.waitForTimeout(150);

--- a/ui/e2e/settings.spec.ts
+++ b/ui/e2e/settings.spec.ts
@@ -28,7 +28,8 @@ test.describe('Settings', () => {
     // Open settings drawer
     const settingsButton = page
       .getByRole('button', { name: /settings/i })
-      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+      .first();
     await settingsButton.click();
 
     // Wait for drawer to open
@@ -175,7 +176,8 @@ test.describe('Settings CRUD Operations', () => {
     // Open settings drawer
     const settingsButton = page
       .getByRole('button', { name: /settings/i })
-      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+      .first();
     await settingsButton.click();
 
     // Wait for drawer to open
@@ -403,7 +405,8 @@ test.describe('Settings CRUD Operations', () => {
       // Open settings again
       const settingsButton = page
         .getByRole('button', { name: /settings/i })
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
       await settingsButton.click();
       await page.waitForTimeout(250);
 
@@ -577,7 +580,8 @@ test.describe('Settings CRUD Operations', () => {
     // Reopen drawer
     const settingsButton = page
       .getByRole('button', { name: /settings/i })
-      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+      .first();
     await settingsButton.click();
     await page.waitForTimeout(250);
 

--- a/ui/e2e/snmp-settings.spec.ts
+++ b/ui/e2e/snmp-settings.spec.ts
@@ -24,7 +24,8 @@ test.describe('SNMP Settings', () => {
     // Open settings drawer
     const settingsButton = page
       .getByRole('button', { name: /settings/i })
-      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+      .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+      .first();
     await settingsButton.click();
 
     // Wait for settings drawer

--- a/ui/e2e/theme-and-help.spec.ts
+++ b/ui/e2e/theme-and-help.spec.ts
@@ -41,7 +41,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const settingsButton = page
         .getByRole('button', { name: 'Open settings' })
         .first()
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -77,7 +78,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const settingsButton = page
         .getByRole('button', { name: 'Open settings' })
         .first()
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -115,7 +117,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const settingsButton = page
         .getByRole('button', { name: 'Open settings' })
         .first()
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -144,7 +147,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const settingsButton = page
         .getByRole('button', { name: 'Open settings' })
         .first()
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -188,7 +192,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const settingsButton = page
         .getByRole('button', { name: 'Open settings' })
         .first()
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -233,7 +238,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const settingsButton = page
         .getByRole('button', { name: 'Open settings' })
         .first()
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -285,7 +291,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
 
@@ -303,7 +310,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -324,7 +332,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -347,7 +356,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -369,7 +379,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -396,7 +407,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -415,7 +427,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -442,7 +455,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -471,7 +485,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -492,7 +507,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -529,7 +545,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -545,7 +562,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const settingsButton = page
         .getByRole('button', { name: 'Open settings' })
         .first()
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -587,7 +605,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);
@@ -596,7 +615,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const settingsButton = page
         .getByRole('button', { name: 'Open settings' })
         .first()
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       const settingsVisible = await settingsButton.isVisible().catch(() => false);
 
@@ -632,7 +652,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const settingsButton = page
         .getByRole('button', { name: 'Open settings' })
         .first()
-        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+        .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+        .first();
 
       await settingsButton.click();
       await page.waitForTimeout(150);
@@ -657,7 +678,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page
         .getByRole('button', { name: 'Open help' })
         .first()
-        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'));
+        .or(page.locator('button:has(svg[class*="help"], svg[class*="question"])'))
+        .first();
 
       await helpButton.click();
       await page.waitForTimeout(150);


### PR DESCRIPTION
## Summary

Fixes the pre-existing E2E Smoke / E2E Browser failure that's been red on every UI-touching PR for weeks. Surfaced as a blocker on PR #1098.

## Root cause

The selector pattern across e2e specs is:

\`\`\`ts
page.getByRole('button', { name: /settings/i })
    .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
\`\`\`

\`.or()\` produces a **union** locator. The app shell intentionally renders an "Open settings" button in **both** the HeaderBar and the Sidebar (similarly for "help") — both are valid affordances for the same action and both should remain. The union sees both, strict mode trips, click fails.

## Fix

Apply \`.first()\` to the union (not to the first branch alone):

\`\`\`diff
 page.getByRole('button', { name: /settings/i })
-    .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'));
+    .or(page.locator('button:has(svg[class*="settings"], svg[class*="cog"])'))
+    .first();
\`\`\`

The selector authors clearly intended "click the first matching settings button, wherever it is" — \`.first()\` makes that explicit.

## Scope

- 7 spec files touched (\`dashboard\`, \`error-scenarios\`, \`fab\`, \`responsive\`, \`settings\`, \`snmp-settings\`, \`theme-and-help\`)
- 21 settings selectors + 11 help selectors fixed
- **No app-shell change.** Both buttons stay. No accessibility regression.

## Test plan

- [x] Biome format pass on each modified file (one-by-one due to a known Biome stack-overflow when batched)
- [x] \`tsc --noEmit\` — clean
- [ ] CI E2E Smoke green for the first time in weeks