### PR TITLE
fix(ui): Add data-testid + aria-label to theme quick-toggle button

### DIFF
--- a/ui/src/components/settings/sections/AppearanceSettings.tsx
+++ b/ui/src/components/settings/sections/AppearanceSettings.tsx
@@ -166,6 +166,8 @@ export const AppearanceSettings: React.NamedExoticComponent<AppearanceSettingsPr
           <button
             type="button"
             onClick={(): void => setTheme(isDark ? 'light' : 'dark')}
+            data-testid="theme-toggle"
+            aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
             className={cn(
               'w-full',
               layout.flex.between,


### PR DESCRIPTION
## Summary

Fixes the pre-existing \`theme-and-help.spec.ts:39\` E2E timeout that's been failing on main since well before today's licensing work. Surfaced as the next blocker once PR #1108 cleared the strict-mode violations.

## Root cause

The theme quick-toggle button in \`AppearanceSettings\` had only visible text "Quick toggle" plus an emoji (🌙/☀️). Its accessible name was effectively \`Quick toggle 🌙\` — which doesn't match the e2e test's selector regex \`/dark|light|theme/i\`. The test's third fallback (\`[data-testid="theme-toggle"]\`) also wasn't present. The locator chain matched zero buttons → the click sat at the 30-second default timeout.

## Fix

Two attributes on the button (~2 lines):

\`\`\`tsx
data-testid="theme-toggle"
aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
\`\`\`

- The **testid** makes the test selector work intentionally rather than incidentally
- The **aria-label** describes the action with current state so screen readers get a clear directive regardless of the emoji-only visual content

## Test plan

- [x] \`biome check\` — clean
- [x] \`tsc --noEmit\` — clean
- [ ] CI green — first time in weeks for E2E Smoke