### PR TITLE
chore(ci): replace golangci-lint install+run with wrapper action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,11 +119,11 @@ jobs:
           npm ci
           npm run build
 
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1
-
       - name: Run golangci-lint
-        run: golangci-lint run --timeout=5m --new-from-rev=HEAD~1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        with:
+          version: v2.12.1
+          args: --timeout=5m --new-from-rev=HEAD~1
 
       - name: Run go vet
         run: go vet ./...


### PR DESCRIPTION
## Summary
Swap the two-step `go install ...@v2.12.1` + `golangci-lint run` sequence for `golangci/golangci-lint-action@v9.2.1` (already used by niac).

## Why
- The wrapper handles its own binary download — no `go install` toolchain spin-up
- Caches `~/.cache/golangci-lint` and the module cache between runs
- One block of config vs two
- Matches niac's pattern → cross-repo harmonization

## Preserved
- `version: v2.12.1` (CLAUDE.md mandate, no `@latest`)
- `args: --timeout=5m --new-from-rev=HEAD~1`
- `fetch-depth: 0` already set in the checkout step, required for `--new-from-rev`

## Stacking
- Base: `chore/ci-versions-harmonize` (depends on #1110)

## Verification
- [x] YAML valid
- [x] 0 remaining `go install golangci-lint` references
- [ ] CI green