### PR TITLE
fix(ci): inject UIBuildHash ldflag (Universal Build Contract)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,8 +689,20 @@ jobs:
         env:
           CGO_ENABLED: 1
         run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          # UI build hash matches Makefile recipe; mandatory per CLAUDE.md
+          # Universal Build Contract — /__version must return non-empty
+          # uiBuildHash to prove the UI was embedded.
+          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
+          echo "UI_BUILD_HASH=${UI_BUILD_HASH}"
           go build -trimpath -buildvcs=false \
-            -ldflags="-s -w" \
+            -ldflags="-s -w \
+              -X github.com/krisarmstrong/seed/internal/version.Version=${VERSION} \
+              -X github.com/krisarmstrong/seed/internal/version.Commit=${COMMIT} \
+              -X github.com/krisarmstrong/seed/internal/version.BuildTime=${BUILD_TIME} \
+              -X github.com/krisarmstrong/seed/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
             -o seed-linux-amd64 ./cmd/seed
 
       - name: Install arm64 cross-build dependencies
@@ -728,8 +740,18 @@ jobs:
           CC: aarch64-linux-gnu-gcc
           PKG_CONFIG_PATH: /usr/lib/aarch64-linux-gnu/pkgconfig
         run: |
+          # Reuses UI_BUILD_HASH semantics from the amd64 step but computes
+          # afresh (each step gets its own shell — env doesn't persist).
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
           go build -trimpath -buildvcs=false \
-            -ldflags="-s -w" \
+            -ldflags="-s -w \
+              -X github.com/krisarmstrong/seed/internal/version.Version=${VERSION} \
+              -X github.com/krisarmstrong/seed/internal/version.Commit=${COMMIT} \
+              -X github.com/krisarmstrong/seed/internal/version.BuildTime=${BUILD_TIME} \
+              -X github.com/krisarmstrong/seed/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
             -o seed-linux-arm64 ./cmd/seed
 
       - name: Verify binaries


### PR DESCRIPTION
## Summary
CLAUDE.md mandate (Universal Build Contract): "Every build embeds version, commit, buildTime, uiBuildHash." The Makefiles correctly compute and inject all four via `-X` ldflags. CI was using raw `go build` without those ldflags — binaries built by CI returned `"unknown"` for `uiBuildHash` on `/__version`, silently violating the contract.

## What changed
For every `go build` in `.github/workflows/ci.yml`:
1. Compute `VERSION` (git describe), `COMMIT` (git rev-parse), `BUILD_TIME` (UTC ISO-8601)
2. Compute `UI_BUILD_HASH` using the same `find ... -exec md5sum | sort | md5sum` pipeline the Makefile uses
3. Pass all four as `-X .../internal/version.{Version,Commit,BuildTime,UIBuildHash}=...` ldflags

CI-built artifacts now satisfy the same `/__version` contract as Makefile-built ones.

## Verification
- [x] yaml syntax valid
- [ ] CI green (binary built, `UI_BUILD_HASH=...` echoed before each `go build`)
- [ ] Sibling PRs land in stem/niac with the same change

## Closes follow-up issue

Closes #1113