### PR TITLE
fix(docs): correct PR template 'cd web' -> 'cd ui'

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@
 <!-- Describe how you tested these changes -->
 
 - [ ] Unit tests pass (`go test ./...`)
-- [ ] Frontend builds (`cd web && npm run build`)
+- [ ] Frontend builds (`cd ui && npm run build`)
 - [ ] Manual testing on Ubuntu VM
 
 ## Related Issues


### PR DESCRIPTION
## Summary
Tiny CLAUDE.md compliance fix. The PR template Testing checklist said `cd web && npm run build` but the UI source lives in `ui/` per CLAUDE.md canonical project structure. One-line fix to `cd ui`.

## Related
Companion PRs in the sibling repos to keep templates in sync.