### PR TITLE
test: add JSDoM polyfills (matchMedia, ResizeObserver, IntersectionObserver)

### DIFF
--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -85,6 +85,44 @@ vi.mock(
 );
 
 // ============================================================
+// JSDoM polyfills — common browser APIs not implemented by JSDoM
+// Universal baseline shared across seed/stem/niac test setups.
+// ============================================================
+
+// matchMedia: dark-mode detection, responsive hooks, prefers-reduced-motion
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // legacy API still used by some libs
+    removeListener: vi.fn(), // legacy
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }),
+});
+
+// ResizeObserver: used by xyflow, codemirror, recharts, headlessui
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+})) as unknown as typeof ResizeObserver;
+
+// IntersectionObserver: used by lazy loading, infinite scroll
+global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+  takeRecords: vi.fn(() => []),
+  root: null,
+  rootMargin: '',
+  thresholds: [],
+})) as unknown as typeof IntersectionObserver;
+
+// ============================================================
 // Mock localStorage
 // ============================================================
 export interface MockLocalStorage {


### PR DESCRIPTION
## Summary
Adds universal JSDoM polyfills (`matchMedia`, `ResizeObserver`, `IntersectionObserver`) so the 3 repos share a common test-setup baseline.

## Why
JSDoM does not implement these browser APIs. React components that use dark-mode detection (`matchMedia`), virtualized lists (`ResizeObserver`), or lazy loading (`IntersectionObserver`) throw `... is not defined` when tested. Adding polyfills proactively prevents flake when new components are added.

## Audit baseline
- seed: 345 lines (no polyfills)
- stem: 192 lines (no polyfills)
- niac: 33 lines (only had `matchMedia`)

This PR brings the polyfill baseline to parity. Repo-specific mocks (i18n, localStorage, fetch, business factories) stay as-is.

## No-op when unused
Polyfills only matter when a test exercises a component that calls them. Safe additive declarations.

## Verification
- [x] All existing tests pass (seed 92, stem 102, niac 60)
- [ ] CI green