### PR TITLE
feat(api): add decodeJSONStrict + HandlerContext.DecodeJSONOrFail

### DIFF
--- a/internal/api/decode.go
+++ b/internal/api/decode.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/krisarmstrong/seed/internal/logging"
+)
+
+// decodeJSONStrict reads and validates JSON from r.Body into dst. It applies
+// [http.MaxBytesReader] to cap memory, DisallowUnknownFields to reject typoed
+// keys, and rejects trailing data after the JSON object.
+//
+// On any decode failure it writes a structured error response (413 for
+// oversized bodies, 400 for everything else) and returns false; the caller
+// should return immediately. On success it returns true and dst is
+// populated.
+//
+// Use this for handler call sites that do not already hold a [HandlerContext];
+// for HandlerContext-based handlers, prefer [HandlerContext.DecodeJSONOrFail]
+// which is a thin wrapper.
+//
+// Pick maxSize from the constants in limits.go ([MaxBodySizeAuth],
+// [MaxBodySizeConfig], [MaxBodySizeJSON], …) — never pass a magic number.
+func decodeJSONStrict(w http.ResponseWriter, r *http.Request, dst any, maxSize int64) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxSize)
+
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(dst); err != nil {
+		logger := logging.FromContext(r.Context())
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			sendErrorResponseWithDetails(
+				w, logger,
+				http.StatusRequestEntityTooLarge,
+				ErrCodeValidation,
+				"Request body too large",
+				"",
+			)
+			return false
+		}
+		// Don't leak json parser internals to clients.
+		sendErrorResponseWithDetails(
+			w, logger,
+			http.StatusBadRequest,
+			ErrCodeValidation,
+			"Invalid JSON in request body",
+			"",
+		)
+		return false
+	}
+
+	// Reject "smuggled" data after the top-level JSON object — multiple
+	// concatenated payloads, trailing garbage, etc.
+	if decoder.More() {
+		sendErrorResponseWithDetails(
+			w, logging.FromContext(r.Context()),
+			http.StatusBadRequest,
+			ErrCodeValidation,
+			"Unexpected trailing data after JSON object",
+			"",
+		)
+		return false
+	}
+
+	return true
+}
+
+// DecodeJSONOrFail is the HandlerContext-flavoured wrapper around
+// decodeJSONStrict. Same contract: returns false (and has already written
+// a 400/413) if the body was unreadable or malformed; the caller should
+// return immediately.
+//
+// Prefer this over the existing (*HandlerContext).DecodeJSON when the
+// handler has no use for a typed error and just wants to bail.
+func (c *HandlerContext) DecodeJSONOrFail(dst any, maxSize int64) bool {
+	return decodeJSONStrict(c.W, c.R, dst, maxSize)
+}

--- a/internal/api/decode_test.go
+++ b/internal/api/decode_test.go
@@ -1,0 +1,148 @@
+package api_test
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/api"
+)
+
+type decodeFixture struct {
+	Name string `json:"name"`
+	Port int    `json:"port"`
+}
+
+func newDecodeRequest(body string) *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+}
+
+func TestDecodeJSONStrict_ValidJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`{"name":"alpha","port":8080}`)
+	var dst decodeFixture
+
+	if !api.ExportDecodeJSONStrict(w, r, &dst, api.MaxBodySizeJSON) {
+		t.Fatalf("expected success, got %d: %s", w.Code, w.Body.String())
+	}
+	if dst.Name != "alpha" || dst.Port != 8080 {
+		t.Errorf("unexpected decode: %+v", dst)
+	}
+}
+
+func TestDecodeJSONStrict_RejectsUnknownField(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`{"name":"alpha","port":8080,"extra":"oops"}`)
+	var dst decodeFixture
+
+	if api.ExportDecodeJSONStrict(w, r, &dst, api.MaxBodySizeJSON) {
+		t.Fatal("expected failure for unknown field")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid JSON") {
+		t.Errorf("response should mention invalid JSON: %s", w.Body.String())
+	}
+}
+
+func TestDecodeJSONStrict_RejectsMalformedJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`{"name":}`)
+	var dst decodeFixture
+
+	if api.ExportDecodeJSONStrict(w, r, &dst, api.MaxBodySizeJSON) {
+		t.Fatal("expected failure for malformed JSON")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDecodeJSONStrict_RejectsOversizedBody(t *testing.T) {
+	// Build a body slightly larger than the tiny cap we'll pass in.
+	big := strings.Repeat("x", 100)
+	body := `{"name":"` + big + `","port":1}`
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(body)
+	var dst decodeFixture
+
+	if api.ExportDecodeJSONStrict(w, r, &dst, 50) {
+		t.Fatal("expected failure for oversized body")
+	}
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "too large") {
+		t.Errorf("response should mention size: %s", w.Body.String())
+	}
+}
+
+func TestDecodeJSONStrict_RejectsTrailingData(t *testing.T) {
+	// Two concatenated JSON objects — decoder.More() should reject this.
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`{"name":"a","port":1}{"name":"b","port":2}`)
+	var dst decodeFixture
+
+	if api.ExportDecodeJSONStrict(w, r, &dst, api.MaxBodySizeJSON) {
+		t.Fatal("expected failure for trailing data")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "trailing") {
+		t.Errorf("response should mention trailing data: %s", w.Body.String())
+	}
+}
+
+func TestDecodeJSONStrict_RejectsEmptyBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(``)
+	var dst decodeFixture
+
+	if api.ExportDecodeJSONStrict(w, r, &dst, api.MaxBodySizeJSON) {
+		t.Fatal("expected failure for empty body")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDecodeJSONOrFail_WrapsThroughHandlerContext(t *testing.T) {
+	// Smoke test: the HandlerContext method should delegate to the same
+	// implementation. Mirror one of the failure paths to prove it.
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`{"name":"alpha","port":8080,"extra":1}`)
+	c := &api.HandlerContext{
+		W:      w,
+		R:      r,
+		Logger: slog.New(slog.DiscardHandler),
+	}
+	var dst decodeFixture
+
+	if c.DecodeJSONOrFail(&dst, api.MaxBodySizeJSON) {
+		t.Fatal("expected failure for unknown field via HandlerContext")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDecodeJSONStrict_ResponseIsValidJSON(t *testing.T) {
+	// Error responses themselves should be valid JSON the frontend can parse.
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`not json`)
+	var dst decodeFixture
+
+	_ = api.ExportDecodeJSONStrict(w, r, &dst, api.MaxBodySizeJSON)
+	var envelope map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("error response is not valid JSON: %v\n  body: %s", err, w.Body.String())
+	}
+	if envelope["code"] != api.ErrCodeValidation {
+		t.Errorf("expected code=%s, got %v", api.ErrCodeValidation, envelope["code"])
+	}
+}

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -352,6 +352,11 @@ func ExportSecurityHeadersMiddleware(next http.Handler) http.Handler {
 	return securityHeadersMiddleware(next)
 }
 
+// ExportDecodeJSONStrict exposes decodeJSONStrict for testing.
+func ExportDecodeJSONStrict(w http.ResponseWriter, r *http.Request, dst any, maxSize int64) bool {
+	return decodeJSONStrict(w, r, dst, maxSize)
+}
+
 // ExportRecoverMiddleware exposes recoverMiddleware for testing.
 func ExportRecoverMiddleware(next http.Handler) http.Handler {
 	return recoverMiddleware(next)


### PR DESCRIPTION
## Summary

Adds a free-function `decodeJSONStrict(w, r, dst, maxSize) bool` variant of seed's existing JSON-decode helper, plus a thin `(*HandlerContext).DecodeJSONOrFail` wrapper for HandlerContext-based handlers. Sets up the call-site ergonomics needed for the bulk conversion in #1101.

- Closes #1100
- Part of #1099 — Phase 1 of the boundary-validation hardening epic
- Unblocks #1101 (apply strict decode to all handlers)

## Background

The audit comment at https://github.com/krisarmstrong/seed/issues/1100#issuecomment-4531700182 confirmed seed already had `(*HandlerContext).DecodeJSON` doing the strict-decode work. That helper returns `error`, so callers must write their own 4xx response. Stem's `decodeJSONStrict` returns `bool` and writes the response itself — much tighter at call sites:

```go
// Before (per-handler boilerplate):
if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
    sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
        ErrCodeValidation, "Invalid JSON", "")
    return
}

// After:
if !decodeJSONStrict(w, r, &req, MaxBodySizeJSON) { return }
```

This PR adds the bool-returning variant without removing the existing method.

## What changed

- `internal/api/decode.go` — new helper. Wraps `http.MaxBytesReader`, `DisallowUnknownFields()`, and a `decoder.More()` trailing-data guard. Writes 413 for oversized bodies, 400 for everything else, using the existing `sendErrorResponseWithDetails` envelope so error responses match the rest of the API.
- `internal/api/export_test.go` — `ExportDecodeJSONStrict` export to keep tests in `package api_test` (matches the established pattern).
- `internal/api/decode_test.go` — 8 cases:
  - valid JSON happy path
  - unknown field rejected (400)
  - malformed JSON rejected (400)
  - oversized body rejected (413)
  - trailing data after JSON rejected (400)
  - empty body rejected (400)
  - `DecodeJSONOrFail` HandlerContext wrapper delegation
  - error response is itself valid JSON with `code=ErrCodeValidation`

## Test plan

- [x] `go test ./internal/api/ -run TestDecodeJSON` — 8/8 pass
- [x] `golangci-lint run ./internal/api/...` — clean
- [ ] `go test ./...` — full suite (will be confirmed by CI)
- [ ] CI checks green

## Notes for reviewers

- Picks body-size limit from `limits.go` constants — no magic numbers. The doc comment on `decodeJSONStrict` calls this out so callers in #1101 follow the same rule.
- Error envelope uses `ErrCodeValidation` for both 400 and 413 paths. That's intentional — clients should treat both as "request was rejected before any business logic ran." A separate code (e.g., `REQUEST_TOO_LARGE`) could be added later; not blocking #1101.
- `decoder.More()` check rejects concatenated JSON payloads after the top-level object. That's a hardening detail seed's existing `DecodeJSON` method already had; this helper preserves it.
- `slog.DiscardHandler` (Go 1.24+) used in the HandlerContext test to keep tests quiet.
