### PR TITLE
fix(ui): enable erasableSyntaxOnly + refactor logger.ts TS-only syntax

### DIFF
--- a/ui/src/lib/logger.ts
+++ b/ui/src/lib/logger.ts
@@ -28,33 +28,36 @@ export interface LogEntry {
   stack?: string;
 }
 
-// Standard component names matching backend constants
-export enum LogComponents {
-  AUTH = 'auth',
-  DISCOVERY = 'discovery',
-  DEVICES = 'devices',
-  NETWORK = 'network',
-  SURVEY = 'survey',
-  WEBSOCKET = 'websocket',
-  SSE = 'sse', // Server-Sent Events (replaces WebSocket)
-  SPEEDTEST = 'speedtest',
-  IPERF = 'iperf',
-  VULN = 'vulnerabilities',
-  CONFIG = 'config',
-  SYSTEM = 'system',
-  DNS = 'dns',
-  DHCP = 'dhcp',
-  GATEWAY = 'gateway',
-  VLAN = 'vlan',
-  WIFI = 'wifi',
-  CABLE = 'cable',
-  PUBLICIP = 'publicip',
-  EXPORT = 'export',
-  SETUP = 'setup',
-  PROFILES = 'profiles',
-  UI = 'ui',
-  APP = 'app',
-}
+// Standard component names matching backend constants.
+// Using a const-as-const object (not TS `enum`) so the module is
+// erasable-syntax-only compatible (tsconfig.json:erasableSyntaxOnly).
+export const LogComponents = {
+  AUTH: 'auth',
+  DISCOVERY: 'discovery',
+  DEVICES: 'devices',
+  NETWORK: 'network',
+  SURVEY: 'survey',
+  WEBSOCKET: 'websocket',
+  SSE: 'sse', // Server-Sent Events (replaces WebSocket)
+  SPEEDTEST: 'speedtest',
+  IPERF: 'iperf',
+  VULN: 'vulnerabilities',
+  CONFIG: 'config',
+  SYSTEM: 'system',
+  DNS: 'dns',
+  DHCP: 'dhcp',
+  GATEWAY: 'gateway',
+  VLAN: 'vlan',
+  WIFI: 'wifi',
+  CABLE: 'cable',
+  PUBLICIP: 'publicip',
+  EXPORT: 'export',
+  SETUP: 'setup',
+  PROFILES: 'profiles',
+  UI: 'ui',
+  APP: 'app',
+} as const;
+export type LogComponents = (typeof LogComponents)[keyof typeof LogComponents];
 
 export type LogComponent = `${LogComponents}`;
 
@@ -409,10 +412,15 @@ class Logger {
  * A logger bound to a specific component.
  */
 class ComponentLogger {
-  constructor(
-    private parent: Logger,
-    private component: string,
-  ) {}
+  // Explicit field declarations (no parameter properties) to satisfy
+  // tsconfig.json:erasableSyntaxOnly.
+  private readonly parent: Logger;
+  private readonly component: string;
+
+  constructor(parent: Logger, component: string) {
+    this.parent = parent;
+    this.component = component;
+  }
 
   debug(message: string, metadata?: Record<string, unknown>): void {
     this.parent.debug(this.component, message, metadata);

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "erasableSyntaxOnly": true,
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],


### PR DESCRIPTION
## Summary
Enables `erasableSyntaxOnly: true` in `ui/tsconfig.json`. niac already has it; this brings the third repo to parity.

## Why
`erasableSyntaxOnly` (TypeScript 5.8+) prevents TS-only syntax (enums, parameter properties, namespaces) that does not survive type-only transpilers — Vites rolldown bundler, esbuilds `--strip-only` mode, oxc, swc-typescript all prefer this guarantee. Modern bundlers move in this direction.

## Verification
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [ ] CI green

Closes #1122