### PR TITLE
chore(docker): expose HTTP redirector port (canonical 8042)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,12 @@ RUN setcap 'cap_net_raw,cap_net_admin=+ep' /usr/bin/seed
 
 USER seed
 WORKDIR /var/lib/seed
-EXPOSE 8443
+# Per CLAUDE.md Default Ports table:
+#   8443 = TLS canonical (post-Wave-1)
+#   8042 = HTTP->HTTPS 308 redirector (fallback port; the privileged
+#          port 80 isn't usable inside the container because we run
+#          as the unprivileged `seed` user).
+EXPOSE 8443 8042
 
 # OCI labels for traceability.
 ARG VERSION=dev


### PR DESCRIPTION
## Summary
Container EXPOSE was only declaring `8443`. Per CLAUDE.md Default Ports table seed also runs an HTTP->HTTPS 308 redirector on `8042` (the unprivileged fallback; port 80 isn't usable inside the container as the unprivileged `seed` user). Adding 8042 to EXPOSE so it's discoverable.

## Audit context
Cross-repo Dockerfile harmonization. stem already exposes `8444 8043` (TLS + redirector). niac gets `8445 8044` in [niac sibling PR].

## Verification
- Static change to EXPOSE only — no runtime behavior change.