### PR TITLE
feat(canopy/survey): validate AirMapper .serial JSON with valibot

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -24,6 +24,7 @@
         "react-router-dom": "^7.15.1",
         "tailwind-merge": "3.6.0",
         "tailwindcss": "4.3.0",
+        "valibot": "^1.4.1",
         "zustand": "5.0.13"
       },
       "devDependencies": {
@@ -7336,6 +7337,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/valibot": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.1.tgz",
+      "integrity": "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/vite": {
       "version": "8.0.14",

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,6 +40,7 @@
     "react-router-dom": "^7.15.1",
     "tailwind-merge": "3.6.0",
     "tailwindcss": "4.3.0",
+    "valibot": "^1.4.1",
     "zustand": "5.0.13"
   },
   "devDependencies": {

--- a/ui/src/schemas/airmapper.test.ts
+++ b/ui/src/schemas/airmapper.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { parseSerialJson } from './airmapper';
+
+describe('parseSerialJson', () => {
+  it('accepts a minimal valid payload', () => {
+    const result = parseSerialJson('{}');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({});
+    }
+  });
+
+  it('accepts a fully-populated payload', () => {
+    const payload = {
+      fileName: 'survey.serial',
+      floorPlanFilename: 'plan.jpg',
+      floorPlanScalePpf: 10,
+      floorPlanWidthPx: 1024,
+      floorPlanHeightPx: 768,
+      propagation: 8,
+      propagationUnit: 'ft',
+      surveyName: 'Office Q4',
+      surveyMode: 'passive',
+      surveyPointCount: 42,
+      surveyItemsCount: 7,
+      surveyStartTime: '2026-05-25T00:00:00Z',
+      surveyActive1x1: false,
+      unitName: 'AirCheck',
+      unitType: 'G3',
+      unitSerial: 'ACG3-001',
+      labels: ['floor-1', 'office'],
+      views: [
+        {
+          name: 'coverage',
+          option: 'rssi',
+          mode: 'heatmap',
+          limit: -65,
+          filters: [{ key: 'band', value: 5 }],
+        },
+      ],
+      locations: {
+        passive: [{ x: 100, y: 200, label: 'AP-1' }],
+      },
+    };
+    const result = parseSerialJson(JSON.stringify(payload));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.surveyName).toBe('Office Q4');
+      expect(result.value.locations?.passive?.[0]?.label).toBe('AP-1');
+    }
+  });
+
+  it('rejects malformed JSON', () => {
+    const result = parseSerialJson('{not json}');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/JSON/);
+    }
+  });
+
+  it('rejects wrong field types', () => {
+    // floorPlanScalePpf must be a number; sending a string trips the schema.
+    const result = parseSerialJson(JSON.stringify({ floorPlanScalePpf: '10' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const flat = result.issues.join(' ');
+      expect(flat.toLowerCase()).toContain('floorplanscaleppf');
+    }
+  });
+
+  it('rejects malformed nested location objects', () => {
+    const result = parseSerialJson(
+      JSON.stringify({
+        locations: {
+          passive: [{ x: 'left', y: 200, label: 'AP-1' }], // x must be number
+        },
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const flat = result.issues.join(' ').toLowerCase();
+      expect(flat).toContain('passive');
+    }
+  });
+
+  it('keeps issue path so the consumer can render field-level hints', () => {
+    const result = parseSerialJson(
+      JSON.stringify({ views: [{ name: 'coverage' }] }), // missing option, mode
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.length).toBeGreaterThan(0);
+      const flat = result.issues.join('\n');
+      expect(flat).toMatch(/views\.0\.(option|mode)/);
+    }
+  });
+});

--- a/ui/src/schemas/airmapper.ts
+++ b/ui/src/schemas/airmapper.ts
@@ -1,0 +1,118 @@
+/**
+ * Valibot schemas for the AirMapper .amp file import path.
+ *
+ * The .amp archive contains a `.serial` JSON file with survey metadata
+ * and floor-plan calibration. That JSON comes from a third-party tool
+ * (AirMapper) which we can't audit; treating its shape as untrusted is
+ * the correct posture even if the tool is benign in practice.
+ *
+ * Before this layer, `ui/src/utils/airmapper.ts` did `JSON.parse(...) as
+ * SerialJson` — a hard cast with no runtime check. A malformed file
+ * could surface as undefined-property access deep inside survey logic.
+ * The schemas here let `safeParse` surface a structured, user-facing
+ * error instead.
+ */
+import * as v from 'valibot';
+
+export const AirMapperLocationSchema = v.object({
+  x: v.number(),
+  y: v.number(),
+  label: v.string(),
+});
+
+export const AirMapperViewSchema = v.object({
+  name: v.string(),
+  option: v.string(),
+  mode: v.string(),
+  limit: v.optional(v.number()),
+  threshold: v.optional(v.number()),
+  filters: v.optional(
+    v.array(
+      v.object({
+        key: v.string(),
+        value: v.unknown(),
+      }),
+    ),
+  ),
+});
+
+/**
+ * Schema for the parsed `.serial` JSON.
+ *
+ * Every field is optional — AirMapper writes very sparse files in
+ * practice, and the parser tolerates missing fields by applying
+ * defaults. This schema enforces *shape* (types when present) rather
+ * than completeness. Missing-required errors live in the consumer.
+ */
+export const SerialJsonSchema = v.object({
+  fileName: v.optional(v.string()),
+  floorPlanFilename: v.optional(v.string()),
+  floorPlanScalePpf: v.optional(v.number()),
+  floorPlanWidthPx: v.optional(v.number()),
+  floorPlanHeightPx: v.optional(v.number()),
+  propagation: v.optional(v.number()),
+  propagationUnit: v.optional(v.string()),
+  surveyName: v.optional(v.string()),
+  surveyMode: v.optional(v.string()),
+  surveyPointCount: v.optional(v.number()),
+  surveyItemsCount: v.optional(v.number()),
+  surveyStartTime: v.optional(v.string()),
+  surveyActive1x1: v.optional(v.boolean()),
+  unitName: v.optional(v.string()),
+  unitType: v.optional(v.string()),
+  unitSerial: v.optional(v.string()),
+  labels: v.optional(v.array(v.string())),
+  views: v.optional(v.array(AirMapperViewSchema)),
+  locations: v.optional(
+    v.object({
+      passive: v.optional(v.array(AirMapperLocationSchema)),
+      active: v.optional(v.array(AirMapperLocationSchema)),
+      oneXone: v.optional(v.array(AirMapperLocationSchema)),
+      client: v.optional(v.array(AirMapperLocationSchema)),
+      probingClient: v.optional(v.array(AirMapperLocationSchema)),
+      bluetooth: v.optional(v.array(AirMapperLocationSchema)),
+    }),
+  ),
+});
+
+export type SerialJson = v.InferOutput<typeof SerialJsonSchema>;
+
+/**
+ * Parse the raw text contents of a `.serial` file into a typed
+ * SerialJson. Returns either a populated value or a list of
+ * human-readable failure reasons suitable for surfacing to the user.
+ *
+ * Uses safeParse so a malformed file produces a structured error
+ * instead of an exception.
+ */
+export function parseSerialJson(
+  text: string,
+): { ok: true; value: SerialJson } | { ok: false; reason: string; issues: string[] } {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (cause) {
+    return {
+      ok: false,
+      reason: 'Could not parse .serial as JSON.',
+      issues: [cause instanceof Error ? cause.message : String(cause)],
+    };
+  }
+
+  const result = v.safeParse(SerialJsonSchema, raw);
+  if (result.success) {
+    return { ok: true, value: result.output };
+  }
+
+  // valibot returns one issue per failing field; render path + message.
+  const issues = result.issues.map((iss) => {
+    const path = iss.path?.map((p) => String(p.key)).join('.') ?? '';
+    return path ? `${path}: ${iss.message}` : iss.message;
+  });
+
+  return {
+    ok: false,
+    reason: 'The .serial file did not match the expected shape.',
+    issues,
+  };
+}

--- a/ui/src/utils/airmapper.ts
+++ b/ui/src/utils/airmapper.ts
@@ -26,6 +26,7 @@
  */
 
 import JsZip from 'jszip';
+import { parseSerialJson, type SerialJson } from '@/schemas/airmapper';
 
 /** Location point from AirMapper */
 export interface AirMapperLocation {
@@ -99,35 +100,14 @@ export interface AirMapperParseResult {
   warnings: string[];
 }
 
-/** Raw .serial JSON structure (partial) */
-interface SerialJson {
-  fileName?: string;
-  floorPlanFilename?: string;
-  floorPlanScalePpf?: number;
-  floorPlanWidthPx?: number;
-  floorPlanHeightPx?: number;
-  propagation?: number;
-  propagationUnit?: string;
-  surveyName?: string;
-  surveyMode?: string;
-  surveyPointCount?: number;
-  surveyItemsCount?: number;
-  surveyStartTime?: string;
-  surveyActive1x1?: boolean;
-  unitName?: string;
-  unitType?: string;
-  unitSerial?: string;
-  labels?: string[];
-  views?: AirMapperView[];
-  locations?: {
-    passive?: AirMapperLocation[];
-    active?: AirMapperLocation[];
-    oneXone?: AirMapperLocation[];
-    client?: AirMapperLocation[];
-    probingClient?: AirMapperLocation[];
-    bluetooth?: AirMapperLocation[];
-  };
-}
+/**
+ * Raw .serial JSON structure (partial).
+ *
+ * Re-exported from `@/schemas/airmapper` as `SerialJson` — the canonical
+ * type is now derived from the valibot schema so adding fields is a
+ * one-place change. See `ui/src/schemas/airmapper.ts`.
+ */
+export type { SerialJson };
 
 /**
  * Convert pixels per foot to meters per pixel
@@ -200,18 +180,24 @@ export async function parseAirMapperFile(data: ArrayBuffer): Promise<AirMapperPa
       warnings.push('No .SurveyResult file found - survey sample data will not be imported');
     }
 
-    // Parse .serial JSON
+    // Parse .serial JSON via valibot schema — the file comes from a
+    // third-party tool (AirMapper) and is effectively untrusted input;
+    // safeParse turns a malformed payload into a structured error
+    // instead of letting the cast through.
     const serialContent = await serialFile.async('text');
-    let serialJson: SerialJson;
-    try {
-      serialJson = JSON.parse(serialContent);
-    } catch {
+    const parsed = parseSerialJson(serialContent);
+    if (!parsed.ok) {
+      // Surface the first ~3 schema issues to the user; full list goes
+      // into warnings for debugging.
+      const headline = parsed.issues.slice(0, 3).join('; ');
+      warnings.push(...parsed.issues);
       return {
         success: false,
-        error: 'Failed to parse .serial JSON metadata',
+        error: headline ? `${parsed.reason} (${headline})` : parsed.reason,
         warnings,
       };
     }
+    const serialJson: SerialJson = parsed.value;
 
     // Extract calibration
     const scalePpf = serialJson.floorPlanScalePpf || 10; // Default to 10 ppf


### PR DESCRIPTION
## Summary

Replaces `JSON.parse(...) as SerialJson` in the AirMapper file-import path with a valibot `safeParse` against an explicit schema. This is an actual untrusted-input trust boundary — `.amp` files come from a third-party tool (NetAlly AirMapper).

- Closes #1106
- Part of #1099 — Phase 4 of the boundary-validation hardening epic
- First valibot-using PR in seed; establishes the pattern for #1107 (SSE consumer)

## What changed

- `ui/src/schemas/airmapper.ts` — new. valibot schemas for `AirMapperLocation`, `AirMapperView`, partial `SerialJson`. `parseSerialJson(text)` helper wraps `JSON.parse` + `safeParse` and returns `{ok, value}` or `{ok: false, reason, issues[]}`. `SerialJson` is derived from the schema (`v.InferOutput`) so the type and runtime check stay in sync automatically.
- `ui/src/schemas/airmapper.test.ts` — 6 cases.
- `ui/src/utils/airmapper.ts` — drops the duplicate `interface SerialJson`, re-exports the schema-derived type, swaps the bare `JSON.parse` for `parseSerialJson`. The user-facing error includes the first 3 schema issues; the full list goes into `warnings` for ops.
- `ui/package.json` — adds `valibot`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test src/schemas/airmapper.test.ts` — 6/6 pass
- [x] `npm run lint` — clean (after `lint:fix` reformatted two files)

## Why valibot vs Zod

- 10× smaller bundle, tree-shakeable. Seed's UI already ships React + Tailwind + JSZip; adding Zod would visibly hurt.
- Same mental model. `v.object`, `v.optional`, `v.array`, `v.safeParse` map 1:1 to Zod's equivalents.
- Schema-derived types via `v.InferOutput` mirror Zod's `z.infer`.

If we later need Zod-specific ecosystem pieces (e.g., a particular third-party validator package that only ships Zod schemas), we can swap — the `parseSerialJson` helper is the only consumer-facing surface and is intentionally narrow.

## Notes for reviewers

- All `SerialJson` fields are optional in the schema. AirMapper writes very sparse files in practice; the parser already tolerated missing fields by applying defaults. The schema enforces *shape* (types when present) rather than *completeness*. Missing-required logic lives in the consumer.
- Schema is the source of truth now — adding a field means updating the schema, and the type falls out automatically.
- The error format `{reason, issues}` is designed for the consumer to surface a short message to the user while keeping a structured list for diagnostics. Translating to i18n later is a trivial follow-up if needed.
