### PR TITLE
feat(ui): validate SSE frames with valibot in useSse

### DIFF
--- a/ui/src/hooks/useSse.ts
+++ b/ui/src/hooks/useSse.ts
@@ -29,6 +29,12 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { LogComponents, logger } from '../lib/logger';
+import {
+  parseSseCardUpdate,
+  parseSseMessage,
+  type SseCardUpdate as SseCardUpdateSchemaType,
+  type SseMessage as SseMessageSchemaType,
+} from '../schemas/sse';
 
 /** SSE connection status states */
 export type SseConnectionStatus =
@@ -37,18 +43,18 @@ export type SseConnectionStatus =
   | 'disconnected' // Not connected (intentional or after failure)
   | 'error'; // Connection error occurred
 
-/** Base message structure for SSE communication */
-export interface SseMessage {
-  type: string; // Message type identifier
-  payload: unknown; // Message data (type varies by message type)
-}
+/**
+ * Base message structure for SSE communication. Re-exports the type
+ * derived from the valibot schema in `@/schemas/sse` — adding fields
+ * means updating the schema and the type falls out automatically.
+ */
+export type SseMessage = SseMessageSchemaType;
 
-/** Card update message for real-time UI updates */
-export interface SseCardUpdate {
-  cardId: string; // ID of the card to update
-  data: unknown; // Updated card data
-  interface?: string; // Network interface name (e.g., "eth0", "wlan0")
-}
+/**
+ * Card update message for real-time UI updates. Re-exports the
+ * schema-derived type from `@/schemas/sse`.
+ */
+export type SseCardUpdate = SseCardUpdateSchemaType;
 
 /** Configuration options for useSse hook */
 interface UseSseOptions {
@@ -70,29 +76,10 @@ interface UseSseReturn {
   reconnect: () => void;
 }
 
-/**
- * Validates message structure before processing.
- * Defined outside component to be stable across renders.
- */
-function isValidMessage(message: unknown): message is SseMessage {
-  if (!message || typeof message !== 'object') {
-    return false;
-  }
-  const msg = message as Record<string, unknown>;
-  return typeof msg.type === 'string';
-}
-
-/**
- * Validates card update payload structure.
- * Defined outside component to be stable across renders.
- */
-function isValidCardUpdate(payload: unknown): payload is SseCardUpdate {
-  if (!payload || typeof payload !== 'object') {
-    return false;
-  }
-  const update = payload as Record<string, unknown>;
-  return typeof update.cardId === 'string';
-}
+// Frame-level validation lives in @/schemas/sse via valibot safeParse.
+// The hand-rolled isValidMessage / isValidCardUpdate guards that used
+// to live here drifted independently from the Go side; the schemas now
+// keep the runtime check and the static type in one place.
 
 /**
  * Custom hook for managing SSE connections with automatic reconnection.
@@ -133,34 +120,40 @@ export function useSse({
         return;
       }
 
+      let raw: unknown;
       try {
-        const message: unknown = JSON.parse(data);
-
-        if (!isValidMessage(message)) {
-          logger.warn(LogComponents.SSE, 'Invalid message structure', { data });
-          return;
-        }
-
-        // Handle card update messages specially with validation
-        if (message.type === 'card_update') {
-          if (!isValidCardUpdate(message.payload)) {
-            logger.warn(LogComponents.SSE, 'Invalid card_update payload', {
-              type: typeof message.payload,
-            });
-            return;
-          }
-
-          if (onCardUpdateRef.current) {
-            onCardUpdateRef.current(message.payload);
-          }
-        }
-
-        // Always invoke general message handler
-        if (onMessageRef.current) {
-          onMessageRef.current(message);
-        }
+        raw = JSON.parse(data);
       } catch (error) {
         logger.error(LogComponents.SSE, 'Failed to parse SSE message', error, { data });
+        return;
+      }
+
+      const message = parseSseMessage(raw);
+      if (!message) {
+        logger.warn(LogComponents.SSE, 'Invalid SSE envelope', { data });
+        return;
+      }
+
+      // Handle card update messages specially with per-type validation.
+      // The envelope's payload is `unknown` until we narrow it via the
+      // card-update schema; dropping invalid card_update frames is
+      // safer than dispatching them and crashing the subscriber.
+      if (message.type === 'card_update') {
+        const update = parseSseCardUpdate(message.payload);
+        if (!update) {
+          logger.warn(LogComponents.SSE, 'Invalid card_update payload', {
+            payloadType: typeof message.payload,
+          });
+          return;
+        }
+        if (onCardUpdateRef.current) {
+          onCardUpdateRef.current(update);
+        }
+      }
+
+      // Always invoke general message handler with the validated envelope.
+      if (onMessageRef.current) {
+        onMessageRef.current(message);
       }
     },
     // Validation functions are pure and stable - no dependencies needed

--- a/ui/src/schemas/sse.test.ts
+++ b/ui/src/schemas/sse.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { parseSseCardUpdate, parseSseMessage } from './sse';
+
+describe('parseSseMessage', () => {
+  it('accepts a minimal envelope with type only', () => {
+    const msg = parseSseMessage({ type: 'ping', payload: null });
+    expect(msg).not.toBeNull();
+    expect(msg?.type).toBe('ping');
+  });
+
+  it('accepts an envelope with arbitrary payload', () => {
+    const msg = parseSseMessage({
+      type: 'card_update',
+      payload: { cardId: 'wlan0', data: { rssi: -65 } },
+    });
+    expect(msg).not.toBeNull();
+    expect(msg?.type).toBe('card_update');
+  });
+
+  it('rejects missing type', () => {
+    expect(parseSseMessage({ payload: 'oops' })).toBeNull();
+  });
+
+  it('rejects non-string type', () => {
+    expect(parseSseMessage({ type: 42, payload: null })).toBeNull();
+  });
+
+  it('rejects non-objects', () => {
+    expect(parseSseMessage(null)).toBeNull();
+    expect(parseSseMessage('not an envelope')).toBeNull();
+    expect(parseSseMessage(42)).toBeNull();
+  });
+});
+
+describe('parseSseCardUpdate', () => {
+  it('accepts a minimal card update', () => {
+    const update = parseSseCardUpdate({ cardId: 'wlan0', data: null });
+    expect(update).not.toBeNull();
+    expect(update?.cardId).toBe('wlan0');
+  });
+
+  it('accepts an update with optional interface', () => {
+    const update = parseSseCardUpdate({
+      cardId: 'wlan0',
+      data: { rssi: -65 },
+      interface: 'wlan0',
+    });
+    expect(update?.interface).toBe('wlan0');
+  });
+
+  it('rejects missing cardId', () => {
+    expect(parseSseCardUpdate({ data: 'whatever' })).toBeNull();
+  });
+
+  it('rejects non-string cardId', () => {
+    expect(parseSseCardUpdate({ cardId: 42, data: null })).toBeNull();
+  });
+
+  it('rejects non-objects', () => {
+    expect(parseSseCardUpdate(null)).toBeNull();
+    expect(parseSseCardUpdate('wlan0')).toBeNull();
+  });
+
+  it('rejects non-string interface when present', () => {
+    expect(parseSseCardUpdate({ cardId: 'wlan0', data: null, interface: 42 })).toBeNull();
+  });
+});

--- a/ui/src/schemas/sse.ts
+++ b/ui/src/schemas/sse.ts
@@ -1,0 +1,62 @@
+/**
+ * Valibot schemas for the seed SSE channel.
+ *
+ * The SSE stream pushes JSON frames from the backend; each frame has a
+ * `type` discriminator and a per-type `payload`. Before this layer,
+ * `ui/src/hooks/useSse.ts` carried two inline guards (`isValidMessage`,
+ * `isValidCardUpdate`) that drifted independently from the Go side.
+ * Centralising the shapes here:
+ *
+ *   - keeps one source of truth (the schema) for both the runtime
+ *     check and the static type (via v.InferOutput),
+ *   - lets the hook drop invalid frames cleanly (safeParse → log →
+ *     skip) instead of crashing the page,
+ *   - prepares the ground for additional frame types (telemetry,
+ *     alerts, etc.) — each adds one schema and one branch.
+ */
+import * as v from 'valibot';
+
+/**
+ * SseMessage — the outer envelope. Every frame has a string `type` and
+ * an opaque `payload`. The hook narrows `payload` via per-type schemas
+ * (e.g., SseCardUpdateSchema) once it knows the `type`.
+ */
+export const SseMessageSchema = v.object({
+  type: v.string(),
+  payload: v.unknown(),
+});
+
+export type SseMessage = v.InferOutput<typeof SseMessageSchema>;
+
+/**
+ * SseCardUpdate — payload for `type: "card_update"` frames. The hook
+ * dispatches these to a separate callback so card components don't
+ * have to re-parse the envelope.
+ */
+export const SseCardUpdateSchema = v.object({
+  cardId: v.string(),
+  data: v.unknown(),
+  interface: v.optional(v.string()),
+});
+
+export type SseCardUpdate = v.InferOutput<typeof SseCardUpdateSchema>;
+
+/**
+ * parseSseMessage — runs the envelope schema on a raw `unknown` (the
+ * result of `JSON.parse(event.data)`). Returns the typed message on
+ * success or `null` so the consumer can drop + log without branching
+ * on a structured error.
+ */
+export function parseSseMessage(value: unknown): SseMessage | null {
+  const result = v.safeParse(SseMessageSchema, value);
+  return result.success ? result.output : null;
+}
+
+/**
+ * parseSseCardUpdate — runs the per-type schema on a card_update
+ * payload. Returns the parsed payload or null on shape mismatch.
+ */
+export function parseSseCardUpdate(value: unknown): SseCardUpdate | null {
+  const result = v.safeParse(SseCardUpdateSchema, value);
+  return result.success ? result.output : null;
+}


### PR DESCRIPTION
## Summary

Replaces hand-rolled type guards in `ui/src/hooks/useSse.ts` with valibot safeParse against explicit schemas. SSE frames cross a trust boundary (network → subscriber); invalid frames are now dropped + logged instead of risking a `as` cast that surfaces deep in subscriber code.

- Closes #1107
- Part of #1099 — Phase 4 of the boundary-validation hardening epic
- Mirrors the pattern in seed#1106 (PR #1133) and stem#272 (PR #295)
- `valibot` was added as a dep in #1106; no new dependency in this PR

## What changed

- `ui/src/schemas/sse.ts` — new. `SseMessageSchema` (envelope: required `type` string + opaque `payload`), `SseCardUpdateSchema` (per-type payload), with `parseSseMessage` / `parseSseCardUpdate` helpers returning typed value or `null`.
- `ui/src/hooks/useSse.ts` — drops the two inline guards. Re-exports `SseMessage` / `SseCardUpdate` as schema-derived types via `v.InferOutput`. Handler does envelope parse → optional per-type parse → dispatch; invalid frames at either layer are dropped + logged.
- `ui/src/schemas/sse.test.ts` — 11 cases.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test src/schemas/sse.test.ts` — 11/11 pass
- [x] `npm run lint` — clean

## Notes for reviewers

- The hook still has the same outward contract: `onMessage` receives a validated envelope, `onCardUpdate` receives a validated card update. Invalid frames are dropped before either callback runs, so subscribers can safely assume the shape.
- `parseSseMessage` / `parseSseCardUpdate` return `null` on shape mismatch (mirrors `parseModeUpdateResponse` in stem#272). The consumer makes the dispatch-vs-drop decision based on null-ness, which keeps the call sites tight.
- Per-type schemas will grow as more SSE frame types land. Adding a new type means: (a) add a schema in `sse.ts`, (b) add a branch in `useSse.ts` to call its parser. The envelope schema doesn't change.
