### PR TITLE
chore: final config harmonization with niac

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,44 @@
+# Default to LF line endings everywhere; Git auto-converts on Windows checkouts.
+* text=auto eol=lf
+
+# Force LF on shell scripts and CI files even on Windows checkouts (would
+# otherwise refuse to execute on Linux runners).
+*.sh        text eol=lf
+*.bash      text eol=lf
+.husky/*    text eol=lf
+
+# CRLF for files that are run by Windows tooling.
+*.ps1       text eol=crlf
+*.bat       text eol=crlf
+*.cmd       text eol=crlf
+
+# Treat binary blobs as binary so Git doesn't munge or diff them.
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.ico       binary
+*.pdf       binary
+*.zip       binary
+*.tar.gz    binary
+*.tgz       binary
+*.deb       binary
+*.rpm       binary
+*.pkg       binary
+*.exe       binary
+*.dll       binary
+*.so        binary
+*.dylib     binary
+
+# Tell GitHub language stats what to count and what to skip. The `linguist-`
+# attributes tweak how the language bar on the repo page is computed.
+# Embedded UI build output, fixtures, and vendored data shouldn't dominate.
+internal/api/ui/**          linguist-generated=true
+ui/dist/**                  linguist-generated=true
+ui/coverage/**              linguist-generated=true
+ui/playwright-report/**     linguist-generated=true
+**/*_gen.go                 linguist-generated=true
+
+# pcap fixtures (binary)
+*.pcap      binary
+*.pcapng    binary

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,7 @@
 *.go @krisarmstrong
 
 # Frontend
-/web/ @krisarmstrong
+/ui/ @krisarmstrong
 
 # Infrastructure
 /.github/ @krisarmstrong

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
       - id: check-yaml
         args: [--allow-multiple-documents]
       - id: check-json
+      - id: check-toml
       - id: check-added-large-files
         args: [--maxkb=1000]
       - id: check-merge-conflict
@@ -96,6 +97,15 @@ repos:
         language: system
         files: ^ui/.*\.(ts|tsx|js|jsx)$
         pass_filenames: false
+
+  # ===========================================================================
+  # Shell Script Checks
+  # ===========================================================================
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        files: \.(sh|bash)$
 
   # ===========================================================================
   # Markdown Checks


### PR DESCRIPTION
## Summary
Small additions to bring seed in line with niac's config baseline.

### 1. `.gitattributes` (NEW)
Port niac's canonical file. Line ending normalization (LF default, CRLF for Windows tooling), binary attribution, linguist-generated for embedded UI / coverage / generated files (keeps the GitHub language bar honest). Niac-specific `examples/device_walks` + `examples/pcaps` paths stripped.

### 2. `.pre-commit-config.yaml`
Add two hooks niac already runs:
- `check-toml` — validates any .toml files
- `shellcheck` — catches shell-script bugs on commits that touch `.sh`. Same friction model as niac (only blocks when staged shell scripts have findings; existing untouched scripts are unaffected).

### 3. `.github/CODEOWNERS` typo
Fix `/web/` → `/ui/`. Same bug class as the `cd web` → `cd ui` PR template fix.

## Verification
- Local shellcheck on existing scripts identifies pre-existing warnings; these only block commits that touch the affected scripts. Mirrors niac's current state.