### PR TITLE
fix(e2e,test): repair v1-API URL drift and add EventSource polyfill

### DIFF
--- a/ui/e2e/auth-complete.spec.ts
+++ b/ui/e2e/auth-complete.spec.ts
@@ -131,7 +131,8 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Setup request interception
       const logoutRequests: { method: string; url: string }[] = [];
       page.on('request', (request) => {
-        if (request.url().includes('/api/auth/logout')) {
+        // Match both /api/auth/logout (legacy) and /api/v1/auth/logout (current).
+        if (/\/api(\/v1)?\/auth\/logout/.test(request.url())) {
           logoutRequests.push({
             method: request.method(),
             url: request.url(),
@@ -243,8 +244,8 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Mock expired session by intercepting API calls to return 401
       await page.route('**/api/**', (route) => {
         const url = route.request().url();
-        // Don't intercept login/logout endpoints
-        if (url.includes('/api/auth/login') || url.includes('/api/auth/logout')) {
+        // Don't intercept login/logout endpoints (match v1 + legacy).
+        if (/\/api(\/v1)?\/auth\/(login|logout)/.test(url)) {
           route.continue();
         } else {
           route.fulfill({
@@ -395,10 +396,10 @@ test.describe('Complete Authentication Lifecycle', () => {
 
   test.describe('Token Refresh', () => {
     test('should handle token refresh transparently', async ({ page }) => {
-      // Track refresh requests
+      // Track refresh requests (match v1 + legacy paths).
       const refreshRequests: { method: string; url: string }[] = [];
       page.on('request', (request) => {
-        if (request.url().includes('/api/auth/refresh')) {
+        if (/\/api(\/v1)?\/auth\/refresh/.test(request.url())) {
           refreshRequests.push({
             method: request.method(),
             url: request.url(),

--- a/ui/e2e/error-scenarios.spec.ts
+++ b/ui/e2e/error-scenarios.spec.ts
@@ -50,8 +50,11 @@ test.describe('API Error Scenarios', () => {
     test('should handle 500 error on login', async ({ page }) => {
       await page.goto('/');
 
-      // Mock login endpoint returning 500
-      await page.route('**/api/auth/login', async (route) => {
+      // Mock login endpoint returning 500. Match both /api/auth/login (legacy)
+      // and /api/v1/auth/login (current — UI calls this since the v1 prefix
+      // rollout). The previous glob `**/api/auth/login` would not intercept
+      // the v1 form, so the mock was silently inert.
+      await page.route(/\/api(\/v1)?\/auth\/login$/, async (route) => {
         await route.fulfill({
           status: 500,
           contentType: 'application/json',
@@ -193,9 +196,10 @@ test.describe('API Error Scenarios', () => {
     test('should handle API timeout gracefully', async ({ page }) => {
       await page.goto('/');
 
-      // Mock login endpoint that never responds (simulates timeout)
+      // Mock login endpoint that never responds (simulates timeout).
+      // RegExp matches both /api/auth/login and /api/v1/auth/login.
       let timeoutHandle: NodeJS.Timeout;
-      await page.route('**/api/auth/login', async (route) => {
+      await page.route(/\/api(\/v1)?\/auth\/login$/, async (route) => {
         // Delay indefinitely to trigger timeout
         await new Promise((resolve) => {
           timeoutHandle = setTimeout(resolve, 60000); // 1 minute
@@ -1105,8 +1109,9 @@ test.describe('Error Recovery Mechanisms', () => {
 
     let attemptCount = 0;
 
-    // First attempt fails, second succeeds
-    await page.route('**/api/auth/login', async (route) => {
+    // First attempt fails, second succeeds.
+    // RegExp matches both /api/auth/login and /api/v1/auth/login.
+    await page.route(/\/api(\/v1)?\/auth\/login$/, async (route) => {
       attemptCount++;
       if (attemptCount === 1) {
         await route.fulfill({

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -50,7 +50,10 @@ export const AUTH_STORAGE_STATE = 'playwright/.auth/user.json';
  * Must be called before page.goto so the route handler is registered.
  */
 export async function mockAuthenticated(page: Page): Promise<void> {
-  await page.route('**/api/setup/status', (route) => {
+  // Match both legacy /api/setup/status and v1-prefixed /api/v1/setup/status.
+  // UI calls the v1 form; the legacy form is kept for resilience until any
+  // remaining legacy callers are excised.
+  await page.route(/\/api(\/v1)?\/setup\/status$/, (route) => {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -68,7 +71,10 @@ export async function loginViaUI(
   page: Page,
   creds: { username: string; password: string } = TEST_CREDENTIALS,
 ): Promise<void> {
-  await page.route('**/api/setup/status', (route) => {
+  // Match both legacy /api/setup/status and v1-prefixed /api/v1/setup/status.
+  // UI calls the v1 form; the legacy form is kept for resilience until any
+  // remaining legacy callers are excised.
+  await page.route(/\/api(\/v1)?\/setup\/status$/, (route) => {
     route.fulfill({
       status: 200,
       contentType: 'application/json',

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -122,6 +122,29 @@ global.IntersectionObserver = vi.fn().mockImplementation(() => ({
   thresholds: [],
 })) as unknown as typeof IntersectionObserver;
 
+// EventSource: required by useSse (#1134) — mounted at the top level in app.tsx,
+// so EVERY component test that renders the root App tree hits this. JSDoM does
+// not implement EventSource. Without this polyfill, tests throw
+// "ReferenceError: EventSource is not defined". Tests that need to assert SSE
+// behavior should mock this further per-suite.
+const eventSourceMock = vi.fn().mockImplementation(() => ({
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  close: vi.fn(),
+  dispatchEvent: vi.fn(() => true),
+  url: '/api/v1/events',
+  readyState: 1, // OPEN
+  withCredentials: false,
+  onerror: null,
+  onmessage: null,
+  onopen: null,
+  CONNECTING: 0,
+  OPEN: 1,
+  CLOSED: 2,
+}));
+Object.assign(eventSourceMock, { CONNECTING: 0, OPEN: 1, CLOSED: 2 });
+global.EventSource = eventSourceMock as unknown as typeof EventSource;
+
 // ============================================================
 // Mock localStorage
 // ============================================================


### PR DESCRIPTION
## Summary

Six E2E mock and listener paths used legacy `/api/auth/...` and `/api/setup/...` but the UI calls the v1-prefixed forms (e.g. `/api/v1/auth/login`). The `**/api/auth/login` glob does NOT match `/api/v1/auth/login` (the `/v1/` segment breaks the contiguous match), so these mocks were silently inert. The same problem affected `request.url().includes('/api/auth/...')` checks.

Switched to `RegExp` matching that accepts both legacy and v1 forms so the tests work regardless of which form the UI calls.

Also added an `EventSource` polyfill to `src/test/setup.ts`. `useSse` is integrated at the top of `app.tsx` (#1134), so every component test rendering the App tree would throw `ReferenceError` without it.

### Files touched
- `ui/e2e/helpers/auth.ts` — `/api/setup/status` mock pattern
- `ui/e2e/error-scenarios.spec.ts` — 3× login mocks
- `ui/e2e/auth-complete.spec.ts` — 3× `url.includes` checks for login/logout/refresh
- `ui/src/test/setup.ts` — EventSource polyfill

### Deferred to Phase 1
Survey-related mocks (`**/api/survey/list` vs real `/api/v1/canopy/survey/list`) have the same drift but are inside `if (isVisible)` conditional skips — deferred to Phase 1 Stream A theater cleanup. They're silently no-ops today, not blocking infra.

## Test plan
- [ ] `npm run test:e2e -- auth-complete` passes against current backend (mocks now actually intercept v1 paths).
- [ ] `npm run test:e2e -- error-scenarios` passes — the 500/timeout/retry login tests should now actually exercise their fault-injection paths.
- [ ] Unit tests pass — components rendering `<App />` no longer throw on EventSource.

## Context
Part of Phase 0.5 E2E remediation. Audit predicted login-body strict-decode drift; investigation found the bigger issue is URL pattern staleness (mocks not being hit at all). See `~/Developer/.e2e-remediation-2026q2/broken-tests-2026-05-25.md` for the full breakage map. Conventions doc: `msn-docs-internal/05-Engineering/E2E_CONVENTIONS.md`.