### PR TITLE
ci(e2e): adopt Chromium + WebKit per E2E_CONVENTIONS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,7 +941,8 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: ui
-        run: npx playwright install --with-deps chromium
+        # Per E2E_CONVENTIONS: chromium (Chrome+Edge) and webkit (Safari).
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Start backend server
         env:
@@ -968,7 +969,9 @@ jobs:
         working-directory: ui
         env:
           E2E_BASE_URL: https://localhost:8443
-        run: npx playwright test --project=chromium --reporter=html --grep "@smoke"
+        # Both chromium and webkit run; smoke tier on both browsers per PR
+        # per E2E_CONVENTIONS.
+        run: npx playwright test --reporter=html --grep "@smoke"
 
       - name: Upload Playwright smoke report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -56,36 +56,17 @@ export default defineConfig({
     storageState: AUTH_STORAGE_STATE,
   },
   projects: [
-    // Desktop browsers
+    // Per msn-docs-internal/05-Engineering/E2E_CONVENTIONS.md, only chromium
+    // (covers Chrome and Edge — same engine) and webkit (covers Safari) are
+    // supported. The previous firefox/edge/mobile-chrome/mobile-safari/tablet
+    // entries were configured but never invoked in CI, lying about coverage.
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
     {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-    {
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
-    },
-    {
-      name: 'edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    },
-    // Mobile viewports
-    {
-      name: 'mobile-chrome',
-      use: { ...devices['Pixel 5'] },
-    },
-    {
-      name: 'mobile-safari',
-      use: { ...devices['iPhone 12'] },
-    },
-    // Tablet viewport
-    {
-      name: 'tablet',
-      use: { ...devices['iPad (gen 7)'] },
     },
   ],
   // Run local dev server before tests if not in CI


### PR DESCRIPTION
## Summary

Aligns Seed with `msn-docs-internal/05-Engineering/E2E_CONVENTIONS.md` multi-browser policy. Chromium covers Chrome and Edge (same engine); WebKit covers Safari. The previous config had **7 projects** (chromium, firefox, webkit, edge, mobile-chrome, mobile-safari, tablet) but CI only installed chromium and only invoked `--project=chromium` for both the e2e (full) and e2e-smoke jobs. The config was lying about coverage.

### Changes
- `ui/playwright.config.ts`: shrunk projects array from 7 to `[chromium, webkit]`. Edge is implicit via chromium; the others had no CI invocation and no customer commitment.
- `.github/workflows/ci.yml` (both e2e and e2e-smoke jobs):
  - Install: `chromium webkit` (was `chromium`)
  - Drop `--project=chromium` so all configured projects run. With the config trimmed to `[chromium, webkit]`, this means both browsers run on every smoke gate and every full-suite gate.

## Verification
`~/Developer/.e2e-remediation-2026q2/verify.sh seed` CI Reality Check will now show `chromium+webkit` installed and invoked.

## Risk
If WebKit reveals real cross-browser bugs not in Chromium, those are real bugs to fix — not test problems. Triage per the conventions doc Risk Register.

## Test plan
- [ ] CI's e2e job goes green on both browsers.
- [ ] CI's e2e-smoke job goes green on both browsers.
- [ ] Smoke tier remains under the ~5 min target with the doubled browser count.