### PR TITLE
refactor(e2e): rename mockAuthenticated -> skipSetupWizard

### DIFF
--- a/ui/e2e/coverage-gaps.spec.ts
+++ b/ui/e2e/coverage-gaps.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 test.describe('Coverage gaps', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/dashboard.spec.ts
+++ b/ui/e2e/dashboard.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Dashboard E2E Tests
@@ -17,7 +17,7 @@ import { mockAuthenticated } from './helpers/auth';
 // is stabilised (#1053 follow-up).
 test.describe('Dashboard', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/error-scenarios.spec.ts
+++ b/ui/e2e/error-scenarios.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, test } from '@playwright/test';
-import { mockAuthenticated, TEST_CREDENTIALS } from './helpers/auth';
+import { skipSetupWizard, TEST_CREDENTIALS } from './helpers/auth';
 
 /**
  * Comprehensive Error Scenario E2E Tests
@@ -38,7 +38,7 @@ import { mockAuthenticated, TEST_CREDENTIALS } from './helpers/auth';
  * Helper: Login to the application
  */
 async function login(page: Page): Promise<void> {
-  await mockAuthenticated(page);
+  await skipSetupWizard(page);
   await page.goto('/');
   await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
     timeout: 10000,

--- a/ui/e2e/fab.spec.ts
+++ b/ui/e2e/fab.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * FAB (Floating Action Button) E2E Tests
@@ -15,7 +15,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('FAB - Run All Tests Flow', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/gateway.spec.ts
+++ b/ui/e2e/gateway.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Gateway E2E Tests
@@ -15,7 +15,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Gateway', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
@@ -122,7 +122,7 @@ test.describe('Gateway', () => {
 
 test.describe('Gateway Help', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -18,7 +18,7 @@ import type { Page } from '@playwright/test';
  * `test.use({ storageState: { cookies: [], origins: [] } })` and use
  * loginViaUI() / their own flows.
  *
- * mockAuthenticated() still exists for specs that need to short-
+ * skipSetupWizard() still exists for specs that need to short-
  * circuit the first-run setup wizard without driving the form — the
  * storageState already covers auth, so this helper now only mocks
  * /api/setup/status. Kept as a single call site so future setup-
@@ -49,7 +49,7 @@ export const AUTH_STORAGE_STATE = 'playwright/.auth/user.json';
  *
  * Must be called before page.goto so the route handler is registered.
  */
-export async function mockAuthenticated(page: Page): Promise<void> {
+export async function skipSetupWizard(page: Page): Promise<void> {
   // Match both legacy /api/setup/status and v1-prefixed /api/v1/setup/status.
   // UI calls the v1 form; the legacy form is kept for resilience until any
   // remaining legacy callers are excised.

--- a/ui/e2e/link-page.spec.ts
+++ b/ui/e2e/link-page.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Link Page (/link) E2E
@@ -14,7 +14,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Link Page', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/link');
     await expect(page.getByRole('heading', { name: /^link$/i, level: 1 })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/logs-page.spec.ts
+++ b/ui/e2e/logs-page.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Logs Page (/logs) E2E
@@ -11,7 +11,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Logs Page', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/logs');
     await expect(page.getByRole('heading', { name: /^logs$/i, level: 1 })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/network-page.spec.ts
+++ b/ui/e2e/network-page.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Network Page (/network) E2E
@@ -14,7 +14,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Network Page', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/network');
     await expect(page.getByRole('heading', { name: /^network$/i, level: 1 })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/path-analysis-page.spec.ts
+++ b/ui/e2e/path-analysis-page.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Path Analysis Page (/path) E2E
@@ -12,7 +12,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Path Analysis Page', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/path');
     await expect(page.getByRole('heading', { name: /path analysis/i, level: 1 })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/performance-page.spec.ts
+++ b/ui/e2e/performance-page.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Performance Page (/performance) E2E
@@ -12,7 +12,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Performance Page', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/performance');
     await expect(page.getByRole('heading', { name: /^performance$/i, level: 1 })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/reports-page.spec.ts
+++ b/ui/e2e/reports-page.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Reports Page (/reports) E2E
@@ -10,7 +10,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Reports Page', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/reports');
     await expect(page.getByRole('heading', { name: /^reports$/i, level: 1 })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/responsive.spec.ts
+++ b/ui/e2e/responsive.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Responsive Layout E2E Tests
@@ -32,7 +32,7 @@ test.describe('Responsive Layout Tests', () => {
       // Set mobile viewport
       await page.setViewportSize({ width: 375, height: 667 });
 
-      await mockAuthenticated(page);
+      await skipSetupWizard(page);
       await page.goto('/');
       await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
@@ -239,7 +239,7 @@ test.describe('Responsive Layout Tests', () => {
       // Set tablet viewport
       await page.setViewportSize({ width: 768, height: 1024 });
 
-      await mockAuthenticated(page);
+      await skipSetupWizard(page);
       await page.goto('/');
       await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
@@ -368,7 +368,7 @@ test.describe('Responsive Layout Tests', () => {
       // Set desktop viewport
       await page.setViewportSize({ width: 1920, height: 1080 });
 
-      await mockAuthenticated(page);
+      await skipSetupWizard(page);
       await page.goto('/');
       await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
@@ -538,7 +538,7 @@ test.describe('Responsive Layout Tests', () => {
     test('should maintain authentication across all viewports', async ({ page }) => {
       // Test on mobile
       await page.setViewportSize({ width: 375, height: 667 });
-      await mockAuthenticated(page);
+      await skipSetupWizard(page);
       await page.goto('/');
       await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
@@ -558,7 +558,7 @@ test.describe('Responsive Layout Tests', () => {
     test('should maintain theme preference across viewports', async ({ page }) => {
       // Login on desktop
       await page.setViewportSize({ width: 1920, height: 1080 });
-      await mockAuthenticated(page);
+      await skipSetupWizard(page);
       await page.goto('/');
       await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
@@ -612,7 +612,7 @@ test.describe('Responsive Layout Tests', () => {
     test('should display same card data across all viewports', async ({ page }) => {
       // Login on desktop
       await page.setViewportSize({ width: 1920, height: 1080 });
-      await mockAuthenticated(page);
+      await skipSetupWizard(page);
       await page.goto('/');
       await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,
@@ -638,7 +638,7 @@ test.describe('Responsive Layout Tests', () => {
     test('should provide working settings across all viewports', async ({ page }) => {
       // Login
       await page.setViewportSize({ width: 1920, height: 1080 });
-      await mockAuthenticated(page);
+      await skipSetupWizard(page);
       await page.goto('/');
       await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
         timeout: 10000,

--- a/ui/e2e/security-page.spec.ts
+++ b/ui/e2e/security-page.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Security Page (/security) E2E
@@ -11,7 +11,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Security Page', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/security');
     await expect(page.getByRole('heading', { name: /^security$/i, level: 1 })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/settings.spec.ts
+++ b/ui/e2e/settings.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Settings E2E Tests
@@ -19,7 +19,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Settings', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
@@ -163,7 +163,7 @@ test.describe('Settings', () => {
  */
 test.describe('Settings CRUD Operations', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/snmp-settings.spec.ts
+++ b/ui/e2e/snmp-settings.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * SNMP Settings E2E Tests
@@ -15,7 +15,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('SNMP Settings', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
@@ -235,7 +235,7 @@ test.describe('SNMP Settings', () => {
 
 test.describe('SNMP Authentication', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,
@@ -321,7 +321,7 @@ test.describe('SNMP Authentication', () => {
 
 test.describe('SNMP Test Connection', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /link/i })).toBeVisible({
       timeout: 10000,

--- a/ui/e2e/theme-and-help.spec.ts
+++ b/ui/e2e/theme-and-help.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Theme Toggle and Help Modal E2E Tests
@@ -26,7 +26,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/');
     // Pin to level: 1 + exact-match "Link" so the H3 "Link Status" card
     // chrome doesn't trip strict mode (same fix as auth.spec / dashboard.spec).

--- a/ui/e2e/wifi-page.spec.ts
+++ b/ui/e2e/wifi-page.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockAuthenticated } from './helpers/auth';
+import { skipSetupWizard } from './helpers/auth';
 
 /**
  * Wi-Fi Page (/wifi) E2E
@@ -17,7 +17,7 @@ import { mockAuthenticated } from './helpers/auth';
 
 test.describe('Wi-Fi Page', () => {
   test.beforeEach(async ({ page }) => {
-    await mockAuthenticated(page);
+    await skipSetupWizard(page);
     await page.goto('/wifi');
     await expect(page.getByRole('heading', { name: /wi-fi/i, level: 1 })).toBeVisible({
       timeout: 10000,


### PR DESCRIPTION
## Summary

The Seed helper was named `mockAuthenticated` but it doesn't mock auth — auth comes from the global-setup `storageState`. The helper only stubs the `/api/v1/setup/status` probe so the first-run wizard doesn't appear. Stem and NIAC already use the accurate name `skipSetupWizard` (per `msn-docs-internal/05-Engineering/E2E_CONVENTIONS.md` and the Wave 5 cross-repo helper rename — see stem #243). Seed was the last holdout.

Mechanical rename across 18 files: `helpers/auth.ts` (definition) plus 17 specs that imported and called it (46 call sites total). **Behavior is unchanged.**

This completes Phase 2 task 2.2 for Seed. The signature now matches across all three repos, which unblocks the shared-helpers extraction in Phase 2.1.

## Test plan
- [ ] All E2E tests pass with no behavior change.
- [ ] `grep -rn mockAuthenticated ui/e2e/` returns no matches.