### PR TITLE
fix(license): Add sync.RWMutex to Manager for safe concurrent access

### DIFF
--- a/internal/license/activation.go
+++ b/internal/license/activation.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
@@ -66,7 +67,15 @@ type ActivationResult struct {
 }
 
 // Manager handles license activation and validation.
+//
+// Manager is safe for concurrent use. State mutations (Activate,
+// Deactivate, StartTrial, CheckIn) take a write lock; reads
+// (GetState, IsActivated, HasFeature, etc.) take a read lock.
+// Per-feature gates in the HTTP layer call read methods on every
+// request, so contention on the write path must stay rare — in
+// practice activation happens once at deploy time.
 type Manager struct {
+	mu          sync.RWMutex
 	state       *ActivationState
 	fingerprint *DeviceFingerprint
 	configDir   string
@@ -102,23 +111,36 @@ func NewManagerWithDir(configDir string) (*Manager, error) {
 	return m, nil
 }
 
-// GetState returns the current activation state.
+// GetState returns the current activation state. The returned pointer
+// must not be mutated by callers; treat it as read-only. (Tests
+// occasionally read fields off it, hence the pointer return rather
+// than a copy.)
 func (m *Manager) GetState() *ActivationState {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.state
 }
 
-// GetFingerprint returns the device fingerprint.
+// GetFingerprint returns the device fingerprint. The fingerprint is
+// immutable after construction, so no lock is needed.
 func (m *Manager) GetFingerprint() *DeviceFingerprint {
 	return m.fingerprint
 }
 
 // IsActivated returns true if a valid license is active.
 func (m *Manager) IsActivated() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.isActivatedLocked()
+}
+
+// isActivatedLocked assumes the caller holds at least an RLock.
+func (m *Manager) isActivatedLocked() bool {
 	if m.state == nil {
 		return false
 	}
 	if m.state.IsTrialMode {
-		return m.IsTrialValid()
+		return m.isTrialValidLocked()
 	}
 	if !m.state.ExpiresAt.IsZero() && time.Now().After(m.state.ExpiresAt) {
 		return false
@@ -131,6 +153,12 @@ func (m *Manager) IsActivated() bool {
 
 // IsTrialValid returns true if trial period is still active.
 func (m *Manager) IsTrialValid() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.isTrialValidLocked()
+}
+
+func (m *Manager) isTrialValidLocked() bool {
 	if m.state == nil || !m.state.IsTrialMode {
 		return false
 	}
@@ -143,6 +171,12 @@ func (m *Manager) IsTrialValid() bool {
 
 // TrialDaysRemaining returns days left in trial.
 func (m *Manager) TrialDaysRemaining() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.trialDaysRemainingLocked()
+}
+
+func (m *Manager) trialDaysRemainingLocked() int {
 	if m.state == nil || !m.state.IsTrialMode {
 		return 0
 	}
@@ -159,7 +193,10 @@ func (m *Manager) TrialDaysRemaining() int {
 
 // StartTrial begins the trial period.
 func (m *Manager) StartTrial() *ActivationResult {
-	if m.IsActivated() && !m.state.IsTrialMode {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.isActivatedLocked() && !m.state.IsTrialMode {
 		return &ActivationResult{
 			Success: true,
 			Message: "Already activated with full license",
@@ -168,7 +205,7 @@ func (m *Manager) StartTrial() *ActivationResult {
 	}
 
 	if m.state != nil && !m.state.TrialStartedAt.IsZero() {
-		remaining := m.TrialDaysRemaining()
+		remaining := m.trialDaysRemainingLocked()
 		if remaining <= 0 {
 			return &ActivationResult{
 				Success:     false,
@@ -223,6 +260,9 @@ func (m *Manager) Activate(licenseKey string) *ActivationResult {
 		}
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.state = &ActivationState{
 		LicenseKey:      info.Key,
 		DeviceHash:      m.fingerprint.Hash(),
@@ -252,6 +292,8 @@ func (m *Manager) Activate(licenseKey string) *ActivationResult {
 
 // Deactivate removes the current license.
 func (m *Manager) Deactivate() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	licensePath := filepath.Join(m.configDir, licenseFileName)
 	if removeErr := os.Remove(licensePath); removeErr != nil && !os.IsNotExist(removeErr) {
 		return fmt.Errorf("failed to remove license file: %w", removeErr)
@@ -262,6 +304,8 @@ func (m *Manager) Deactivate() error {
 
 // CheckIn updates the last-validated timestamp on a non-trial license.
 func (m *Manager) CheckIn() *ActivationResult {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.state == nil {
 		return &ActivationResult{
 			Success: false,
@@ -280,6 +324,8 @@ func (m *Manager) CheckIn() *ActivationResult {
 
 // NeedsCheckIn returns true if optional check-in is recommended.
 func (m *Manager) NeedsCheckIn() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if m.state == nil || m.state.IsTrialMode {
 		return false
 	}

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -241,3 +241,48 @@ func TestActivationLifecycle(t *testing.T) {
 		t.Error("expected !IsActivated after Deactivate")
 	}
 }
+
+// TestManagerConcurrentReadsAndWrites exercises the RWMutex so `go test
+// -race` fails loudly if the locking ever regresses. Per-feature gates
+// in the HTTP layer call read methods on every request; activation
+// can land via CLI or future portal pushes mid-flight.
+func TestManagerConcurrentReadsAndWrites(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	mgr, err := license.NewManagerWithDir(tmp)
+	if err != nil {
+		t.Fatalf("NewManagerWithDir: %v", err)
+	}
+
+	key, _ := license.GenerateLicenseKey("4002", "ABCDEFG", license.TierPro)
+
+	// Spin up a writer goroutine that toggles activation, plus several
+	// reader goroutines that hammer the read API.
+	done := make(chan struct{})
+	go func() {
+		for range 50 {
+			mgr.Activate(key)
+			_ = mgr.Deactivate()
+		}
+		close(done)
+	}()
+
+	for range 8 {
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = mgr.IsActivated()
+					_ = mgr.GetState()
+					_ = mgr.IsTrialValid()
+					_ = mgr.TrialDaysRemaining()
+					_ = mgr.NeedsCheckIn()
+				}
+			}
+		}()
+	}
+
+	<-done
+}


### PR DESCRIPTION
## Summary

`license.Manager.state` was read and mutated from multiple goroutines (per-request reads from HTTP handlers, write from CLI activate / future portal pushes) with **no synchronization**. Race detector hits would be a matter of time once per-feature gates land and call `IsActivated()` / `GetState()` on every request.

Surfaced during Pass 14 of the backlog analysis ([BACKLOG_PLAN_2026-05-25.md](https://github.com/krisarmstrong/msn-docs-internal/blob/main/10-Portal-License/BACKLOG_PLAN_2026-05-25.md) finding #7).

## Fix

Add `sync.RWMutex` to `Manager`. Public methods take:
- `RLock` for reads: `GetState`, `IsActivated`, `IsTrialValid`, `TrialDaysRemaining`, `NeedsCheckIn`
- `Lock` for writes: `Activate`, `Deactivate`, `StartTrial`, `CheckIn`

Internal locked variants (`isActivatedLocked`, `isTrialValidLocked`, `trialDaysRemainingLocked`) let writer methods reuse read logic without recursive locking.

New `TestManagerConcurrentReadsAndWrites` runs a writer goroutine toggling `Activate`/`Deactivate` alongside 8 reader goroutines hammering the read API; passes cleanly under `go test -race`.

## What does NOT change

- Public API shapes
- Behavior in single-threaded use
- Trial / activation / fingerprint semantics

## Test plan

- [x] `go test -race ./internal/license/...` — clean
- [x] `golangci-lint run` — 0 issues
- [ ] CI green