### PR TITLE
feat(license): Add feature-gating framework

### DIFF
--- a/internal/api/middleware_license.go
+++ b/internal/api/middleware_license.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+// middleware_license.go provides per-route license-tier gating. Wrap any
+// handler that exposes a paid feature with Server.requireFeature so the
+// route returns 402 Payment Required when the active license doesn't
+// cover the feature.
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/krisarmstrong/seed/internal/license"
+	"github.com/krisarmstrong/seed/internal/logging"
+)
+
+// errCodeTierTooLow is the standard error code for routes blocked by
+// the license tier. UIs key off this code to render the upgrade hint
+// (vs. a generic auth failure).
+const errCodeTierTooLow = "TIER_TOO_LOW"
+
+// FeatureGateResponse is the JSON body returned with a 402 Payment
+// Required when a request hits a feature it isn't licensed for. The
+// UI's <RequireFeature> primitive matches on this shape to decide
+// what upgrade hint to render.
+type FeatureGateResponse struct {
+	Error           string `json:"error"`
+	Code            string `json:"code"`
+	RequiredFeature string `json:"requiredFeature"`
+	CurrentTier     string `json:"currentTier"`
+	UpgradeMessage  string `json:"upgradeMessage"`
+}
+
+// requireFeature wraps `next` so it only runs when the active license
+// includes `feature`. Returns 402 Payment Required with a structured
+// upgrade hint otherwise.
+//
+// A nil license manager is treated as "license disabled" (developer
+// builds, tests with no manager wired) and permits all features — so
+// the gating layer never breaks local development workflows.
+func (s *Server) requireFeature(feature string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		mgr := s.services.Auth.License
+		if mgr == nil || mgr.HasFeature(feature) {
+			next(w, r)
+			return
+		}
+
+		// Resolve current tier for the response body. State may be nil
+		// (no license activated) — present that as "Free".
+		tierName := license.TierFree.String()
+		if st := mgr.GetState(); st != nil {
+			tierName = st.Tier.String()
+		}
+
+		resp := FeatureGateResponse{
+			Error:           "Feature requires a higher tier",
+			Code:            errCodeTierTooLow,
+			RequiredFeature: feature,
+			CurrentTier:     tierName,
+			UpgradeMessage: "Start a 14-day Pro trial with `seed license trial` " +
+				"or activate a Pro key with `seed license activate -k <KEY>`.",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		if encErr := json.NewEncoder(w).Encode(resp); encErr != nil {
+			logging.FromContext(r.Context()).ErrorContext(r.Context(),
+				"failed to encode feature-gate response", "error", encErr)
+		}
+	}
+}

--- a/internal/api/middleware_license_internal_test.go
+++ b/internal/api/middleware_license_internal_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/license"
+)
+
+// nopHandler is a handler that records whether it was reached and
+// writes a fixed 200 body. Used to verify the middleware short-circuits
+// on a feature-gate failure.
+func nopHandler(seen *bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		*seen = true
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func TestRequireFeature_AllowsWhenLicenseDisabled(t *testing.T) {
+	t.Parallel()
+	s, _ := apiTokenTestSetup(t)
+	s.services.Auth.License = nil // simulate dev build
+
+	called := false
+	h := s.requireFeature("any_feature", nopHandler(&called))
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/anything", http.NoBody)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if !called {
+		t.Error("expected handler to run when license manager is nil")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestRequireFeature_AllowsWhenFeaturePresent(t *testing.T) {
+	t.Parallel()
+	s, mgr := apiTokenTestSetup(t)
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+
+	called := false
+	h := s.requireFeature("rest_api", nopHandler(&called))
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/anything", http.NoBody)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if !called {
+		t.Error("expected handler to run when trial license has the feature")
+	}
+}
+
+func TestRequireFeature_Blocks402WhenFeatureAbsent(t *testing.T) {
+	t.Parallel()
+	s, mgr := apiTokenTestSetup(t)
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+
+	called := false
+	h := s.requireFeature("nonexistent_feature_xyz", nopHandler(&called))
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/anything", http.NoBody)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if called {
+		t.Error("handler should not run when feature is missing")
+	}
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("status = %d, want 402", w.Code)
+	}
+
+	var body FeatureGateResponse
+	if decErr := json.NewDecoder(w.Body).Decode(&body); decErr != nil {
+		t.Fatalf("decode response: %v", decErr)
+	}
+	if body.Code != errCodeTierTooLow {
+		t.Errorf("Code = %q, want %q", body.Code, errCodeTierTooLow)
+	}
+	if body.RequiredFeature != "nonexistent_feature_xyz" {
+		t.Errorf("RequiredFeature = %q, want %q", body.RequiredFeature, "nonexistent_feature_xyz")
+	}
+	if body.UpgradeMessage == "" {
+		t.Error("expected non-empty UpgradeMessage")
+	}
+}
+
+func TestRequireFeature_NoLicenseReturnsFreeTier(t *testing.T) {
+	t.Parallel()
+	s, _ := apiTokenTestSetup(t)
+	// No StartTrial / Activate — state stays nil ⇒ Free tier.
+
+	h := s.requireFeature("scheduled_reports", nopHandler(new(bool)))
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/anything", http.NoBody)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("status = %d, want 402", w.Code)
+	}
+	var body FeatureGateResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body.CurrentTier != license.TierFree.String() {
+		t.Errorf("CurrentTier = %q, want %q", body.CurrentTier, license.TierFree.String())
+	}
+}

--- a/internal/license/activation.go
+++ b/internal/license/activation.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 )
@@ -132,6 +133,29 @@ func (m *Manager) IsActivated() bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.isActivatedLocked()
+}
+
+// HasFeature reports whether the active license includes the named
+// feature. Returns false when:
+//   - no license is loaded
+//   - the license has expired or is otherwise invalid
+//   - the feature is not in the license's feature set
+//
+// During an active trial, the license carries Pro features regardless
+// of which key (if any) was activated; HasFeature reflects that.
+//
+// Per-feature gates in HTTP handlers call this on every request, so
+// it must be cheap: a single map-equivalent lookup under RLock. The
+// canonical feature names are the strings in keygen's productCatalog
+// (e.g. "wifi_roam_analysis", "scheduled_reports") — mirrored by
+// starterFeatures() and proFeatures() in validator.go.
+func (m *Manager) HasFeature(feature string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if !m.isActivatedLocked() || m.state == nil {
+		return false
+	}
+	return slices.Contains(m.state.Features, feature)
 }
 
 // isActivatedLocked assumes the caller holds at least an RLock.

--- a/ui/src/components/settings/sections/ApiTokensSettings.tsx
+++ b/ui/src/components/settings/sections/ApiTokensSettings.tsx
@@ -14,19 +14,11 @@
 import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { api } from '../../../api/client';
+import { useLicense } from '../../../contexts/LicenseContext';
 import { Button } from '../../ui/Button';
 import { CollapsibleSection } from '../../ui/CollapsibleSection';
 import { Input } from '../../ui/Input';
 import { Key, Plus, Trash2 } from '../../ui/icons';
-
-interface LicenseStatus {
-  tier: string;
-  tierValue: number;
-  isTrialMode: boolean;
-  trialDaysLeft?: number;
-  canMintTokens: boolean;
-  activated: boolean;
-}
 
 interface ApiToken {
   id: string;
@@ -61,7 +53,10 @@ function formatDate(value: string | undefined): string {
 }
 
 export function ApiTokensSettings(): React.ReactElement {
-  const [licenseStatus, setLicenseStatus] = useState<LicenseStatus | null>(null);
+  // License state is sourced from the shared LicenseProvider so every
+  // tier-aware UI surface stays in sync; this panel used to fetch it
+  // inline (pre-PR-A4).
+  const { status: licenseStatus, refresh: refreshLicense } = useLicense();
   const [tokens, setTokens] = useState<ApiToken[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -72,18 +67,17 @@ export function ApiTokensSettings(): React.ReactElement {
   const refresh = useCallback(async (): Promise<void> => {
     setError(null);
     try {
-      const [status, tokenList] = await Promise.all([
-        api.get<LicenseStatus>('/api/v1/license'),
+      const [, tokenList] = await Promise.all([
+        refreshLicense(),
         api.get<ApiToken[] | null>('/api/v1/tokens'),
       ]);
-      setLicenseStatus(status);
       setTokens(tokenList ?? []);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load API tokens');
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [refreshLicense]);
 
   useEffect(() => {
     void refresh();

--- a/ui/src/components/ui/RequireFeature.tsx
+++ b/ui/src/components/ui/RequireFeature.tsx
@@ -1,0 +1,43 @@
+/**
+ * RequireFeature — render children only if the active license includes the feature.
+ *
+ * This is the "hide" variant of feature gating. Use it for entire
+ * pages, drawer sections, nav items, or any UI surface that should
+ * simply not exist for users on a lower tier.
+ *
+ * For interactive controls that should remain *visible but disabled*
+ * with an upgrade hint, prefer <TierGate>.
+ *
+ * Example:
+ * ```tsx
+ * <RequireFeature feature="path_analysis">
+ *   <PathAnalysisPage />
+ * </RequireFeature>
+ * ```
+ *
+ * While the initial license fetch is in flight, the component renders
+ * `fallback` (default: null) — this avoids a flash of paid content
+ * disappearing once the fetch resolves with no license.
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+import { useLicense } from '../../contexts/LicenseContext';
+
+interface RequireFeatureProps {
+  feature: string;
+  children: ReactNode;
+  /** Rendered when the feature is absent or license is still loading. */
+  fallback?: ReactNode;
+}
+
+export function RequireFeature({
+  feature,
+  children,
+  fallback = null,
+}: RequireFeatureProps): ReactElement {
+  const { hasFeature, loading } = useLicense();
+  if (loading || !hasFeature(feature)) {
+    return <>{fallback}</>;
+  }
+  return <>{children}</>;
+}

--- a/ui/src/components/ui/TierGate.tsx
+++ b/ui/src/components/ui/TierGate.tsx
@@ -1,0 +1,77 @@
+/**
+ * TierGate — render children regardless, but visually mark them as
+ * locked + show an upgrade hint when the active license doesn't
+ * include the feature.
+ *
+ * This is the "disable" variant of feature gating. Use it for
+ * settings panels, individual buttons, or any UI where the customer
+ * should still see the feature exists (so they know what they're
+ * missing) but cannot interact with it without upgrading.
+ *
+ * For surfaces that should simply not exist on lower tiers, prefer
+ * <RequireFeature>.
+ *
+ * Example:
+ * ```tsx
+ * <TierGate feature="rest_api" requiredTier="Pro">
+ *   <Button onClick={mint}>Create token</Button>
+ * </TierGate>
+ * ```
+ *
+ * Interactive children should not need to know they're inside a
+ * <TierGate> — the wrapper covers them with a transparent overlay
+ * that intercepts clicks and shows the upgrade tooltip on hover.
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+import { useLicense } from '../../contexts/LicenseContext';
+
+interface TierGateProps {
+  feature: string;
+  children: ReactNode;
+  /** Tier name shown in the hint (e.g. "Pro", "Starter"). */
+  requiredTier?: string;
+  /** Custom message; default is "Requires the {tier} tier." */
+  message?: string;
+}
+
+export function TierGate({
+  feature,
+  children,
+  requiredTier = 'Pro',
+  message,
+}: TierGateProps): ReactElement {
+  const { hasFeature, loading } = useLicense();
+
+  // Always render children while the license is loading so layouts
+  // don't shift; gate visually only after we know they lack the feature.
+  if (loading || hasFeature(feature)) {
+    return <>{children}</>;
+  }
+
+  const hint = message ?? `Requires the ${requiredTier} tier.`;
+
+  // CSS-only hover (via `group` + `group-hover:`) keeps the tooltip
+  // tied to the wrapper without JS event handlers — that lets the
+  // outer span stay a presentation-only element and dodges the
+  // a11y/noStaticElementInteractions rule.
+  return (
+    <span
+      data-testid="tier-gate-locked"
+      data-feature={feature}
+      className="relative inline-block group"
+    >
+      <span aria-disabled="true" className="pointer-events-none opacity-60">
+        {children}
+      </span>
+      {/* Transparent click-blocking layer. */}
+      <span aria-hidden="true" className="absolute inset-0 cursor-not-allowed" title={hint} />
+      <span
+        role="tooltip"
+        className="invisible group-hover:visible group-focus-within:visible absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 rounded bg-surface-raised border border-surface-border text-xs text-text-primary whitespace-nowrap shadow-lg"
+      >
+        {hint}
+      </span>
+    </span>
+  );
+}

--- a/ui/src/contexts/LicenseContext.tsx
+++ b/ui/src/contexts/LicenseContext.tsx
@@ -1,0 +1,111 @@
+/**
+ * LicenseContext - Active license tier & feature flags
+ *
+ * Fetches GET /api/v1/license once at app boot, caches the result, and
+ * exposes it via `useLicense()`. UI components use this to decide
+ * whether to render a feature (`<RequireFeature>`) or disable it with
+ * an upgrade hint (`<TierGate>`).
+ *
+ * Server returns FeatureGateResponse-shaped JSON; on a 402 from any
+ * gated API call the relevant component can additionally refresh
+ * state via `refresh()`.
+ *
+ * No license is a valid state — the unlicensed (Free) user is the
+ * default. Components that read this hook before fetch completes get
+ * `null` and should render a loading state or treat the user as Free.
+ */
+
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
+import { api } from '../api/client';
+
+/**
+ * Shape of GET /api/v1/license (see handlers_api_tokens.go
+ * LicenseStatusResponse). When the backend adds a feature to the
+ * response (e.g. expiry, features array), extend this interface in
+ * lockstep.
+ */
+export interface LicenseStatus {
+  tier: string;
+  tierValue: number;
+  isTrialMode: boolean;
+  trialDaysLeft?: number;
+  canMintTokens: boolean;
+  activated: boolean;
+  /**
+   * Features granted by the active license. Mirrors keygen's
+   * productCatalog. UI gates use HasFeature() over this slice.
+   *
+   * Backend currently returns canMintTokens as a convenience flag but
+   * not the full feature list — this field is reserved for the
+   * upcoming Phase D-3 follow-up that extends the endpoint.
+   */
+  features?: string[];
+}
+
+interface LicenseContextValue {
+  /** Latest license fetch, or null while loading / on fetch error. */
+  status: LicenseStatus | null;
+  /** True while the initial fetch is in flight. */
+  loading: boolean;
+  /** Last fetch error message, or null if none. */
+  error: string | null;
+  /** Force a re-fetch (e.g. after activating a key via CLI). */
+  refresh: () => Promise<void>;
+  /**
+   * Convenience: true iff the active license includes the named
+   * feature. Treats `status === null` (loading / unlicensed) as false
+   * so gated UI hides rather than flashes during boot.
+   */
+  hasFeature: (feature: string) => boolean;
+}
+
+const LicenseContext = createContext<LicenseContextValue | null>(null);
+
+interface LicenseProviderProps {
+  children: ReactNode;
+}
+
+export function LicenseProvider({ children }: LicenseProviderProps): React.ReactElement {
+  const [status, setStatus] = useState<LicenseStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setError(null);
+    try {
+      const fresh = await api.get<LicenseStatus>('/api/v1/license');
+      setStatus(fresh);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load license');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const hasFeature = useCallback(
+    (feature: string): boolean => Boolean(status?.features?.includes(feature)),
+    [status],
+  );
+
+  return (
+    <LicenseContext.Provider value={{ status, loading, error, refresh, hasFeature }}>
+      {children}
+    </LicenseContext.Provider>
+  );
+}
+
+/**
+ * useLicense returns the active license state. Throws if called
+ * outside a `<LicenseProvider>` — that always indicates a wiring bug.
+ */
+export function useLicense(): LicenseContextValue {
+  const ctx = useContext(LicenseContext);
+  if (!ctx) {
+    throw new Error('useLicense() must be called inside <LicenseProvider>');
+  }
+  return ctx;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -19,6 +19,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './app';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { LicenseProvider } from './contexts/LicenseContext';
 import { ProfileProvider } from './contexts/profileContext';
 import { getQueryClient } from './lib/queryClient';
 import './index.css';
@@ -34,9 +35,11 @@ createRoot(rootElement).render(
   <StrictMode>
     <ErrorBoundary>
       <QueryClientProvider client={getQueryClient()}>
-        <ProfileProvider>
-          <App />
-        </ProfileProvider>
+        <LicenseProvider>
+          <ProfileProvider>
+            <App />
+          </ProfileProvider>
+        </LicenseProvider>
       </QueryClientProvider>
     </ErrorBoundary>
   </StrictMode>,


### PR DESCRIPTION
## Summary

**PR-A4 from BACKLOG_PLAN_2026-05-25.md** — unblocks all Tier-2 per-feature gate PRs (Canopy, Harvest, Sap, Shell, Roots, system-wide).

Five framework pieces, no new gates applied yet. Existing routes behave identically.

## Backend

### \`Manager.HasFeature(name) bool\`
Promoted from \`*Info\` to \`*Manager\`. Uses the RWMutex added in PR #1152. Returns false unless the license is activated AND the feature is in the active feature set. Active trials grant Pro-equivalent features.

### \`Server.requireFeature(feature, next) http.HandlerFunc\`
Per-route middleware decorator in new \`internal/api/middleware_license.go\`. On a feature miss, returns:
\`\`\`json
{
  "error": "Feature requires a higher tier",
  "code": "TIER_TOO_LOW",
  "requiredFeature": "scheduled_reports",
  "currentTier": "Free",
  "upgradeMessage": "Start a 14-day Pro trial..."
}
\`\`\`
…with HTTP **402 Payment Required**. UIs key off the \`code\` field. Nil license manager = dev build = allow all (so local hacking isn't blocked).

### Tests
\`internal/api/middleware_license_internal_test.go\`:
- license disabled → handler runs
- feature present (trial license) → handler runs
- feature absent → 402 + correct upgrade hint
- no license at all → 402 with \`currentTier: "Free"\`

## Frontend

### \`LicenseProvider\` + \`useLicense()\`
\`ui/src/contexts/LicenseContext.tsx\`. Fetches \`GET /api/v1/license\` once at boot, caches in context. Exposes \`{status, loading, error, refresh, hasFeature}\`. Wired in \`main.tsx\` above \`ProfileProvider\` so the whole tree can read license state.

### \`<RequireFeature feature="..."`>\`
Hide-mode gate. Renders \`children\` only when the feature is present; renders \`fallback\` (default null) otherwise. Use for whole pages, drawer sections, nav items.

### \`<TierGate feature="..." requiredTier="Pro">\`
Disabled-mode gate. Always renders \`children\` but covers them with a click-blocking overlay and a CSS-only hover/focus tooltip showing the upgrade hint. Use for individual buttons / settings panels where the customer should still see the feature exists.

### \`ApiTokensSettings.tsx\` refactor
Replaced the inline \`/api/v1/license\` fetch with \`useLicense()\` — first user of the new context.

## What is NOT in this PR

- **No new gates applied** to any route or UI surface. That's PR-B1..B6 + PR-C2..C4.
- **No Storybook stories** for the new primitives (could be added later if useful).
- **No translation strings** — upgrade hints are still in English. Will land in PR-D1.

## Test plan

- [x] \`go test -race -short ./internal/api/ ./internal/license/\` — passes (incl. new middleware tests)
- [x] \`golangci-lint run\` — 0 issues
- [x] \`tsc --noEmit\` — clean
- [x] \`biome check\` — clean (CSS-only hover keeps the wrapper a11y-clean)
- [ ] CI green