### PR TITLE
fix(ui): Add data-testid card + update e2e selector (kill last pre-existing E2E flake)

### DIFF
--- a/ui/e2e/theme-and-help.spec.ts
+++ b/ui/e2e/theme-and-help.spec.ts
@@ -180,10 +180,7 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       await themeToggle.click();
 
       // Close settings
-      const closeButton = page
-        .getByRole('button', { name: /close/i })
-        .or(page.locator('button:has(svg[class*="x"], svg[class*="close"])'))
-        .first();
+      const closeButton = page.getByTestId('settings-drawer-close');
 
       await closeButton.click();
 
@@ -212,10 +209,7 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const isDark = htmlClasses?.includes('dark') ?? false;
 
       // Close and reopen settings
-      const closeButton = page
-        .getByRole('button', { name: /close/i })
-        .or(page.locator('button:has(svg[class*="x"], svg[class*="close"])'))
-        .first();
+      const closeButton = page.getByTestId('settings-drawer-close');
 
       await closeButton.click();
 
@@ -283,10 +277,7 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       await helpButton.click();
 
       // Find and click close button
-      const closeButton = page
-        .getByRole('button', { name: /close/i })
-        .or(page.locator('button:has(svg[class*="x"], svg[class*="close"])'))
-        .first();
+      const closeButton = page.getByTestId('settings-drawer-close');
 
       await closeButton.click();
 
@@ -468,10 +459,7 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
 
       await themeToggle.click();
 
-      const closeSettings = page
-        .getByRole('button', { name: /close/i })
-        .or(page.locator('button:has(svg[class*="x"], svg[class*="close"])'))
-        .first();
+      const closeSettings = page.getByTestId('settings-drawer-close');
 
       await closeSettings.click();
 
@@ -543,10 +531,7 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
 
       await themeToggle.click();
 
-      const closeSettings = page
-        .getByRole('button', { name: /close/i })
-        .or(page.locator('button:has(svg[class*="x"], svg[class*="close"])'))
-        .first();
+      const closeSettings = page.getByTestId('settings-drawer-close');
 
       await closeSettings.click();
 

--- a/ui/e2e/theme-and-help.spec.ts
+++ b/ui/e2e/theme-and-help.spec.ts
@@ -162,7 +162,7 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
 
     test('should render all cards correctly in both themes', async ({ page }) => {
       // Get initial card count
-      const initialCards = await page.locator('[class*="card"]').count();
+      const initialCards = await page.getByTestId('card').count();
       expect(initialCards).toBeGreaterThan(0);
 
       // Open settings
@@ -188,7 +188,7 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       await closeButton.click();
 
       // Verify all cards still visible
-      const cardsAfterToggle = await page.locator('[class*="card"]').count();
+      const cardsAfterToggle = await page.getByTestId('card').count();
       expect(cardsAfterToggle).toBeGreaterThanOrEqual(initialCards - 1); // Allow for minor variance
 
       // Toggle back
@@ -197,7 +197,7 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       await closeButton.click();
 
       // Verify cards still visible in original theme
-      const cardsAfterSecondToggle = await page.locator('[class*="card"]').count();
+      const cardsAfterSecondToggle = await page.getByTestId('card').count();
       expect(cardsAfterSecondToggle).toBeGreaterThanOrEqual(initialCards - 1);
     });
 

--- a/ui/src/components/settings/SettingsDrawer.tsx
+++ b/ui/src/components/settings/SettingsDrawer.tsx
@@ -546,6 +546,7 @@ export const SettingsDrawer: React.MemoExoticComponent<
             type="button"
             ref={closeButtonRef}
             onClick={onClose}
+            data-testid="settings-drawer-close"
             className={cn(
               button.size.md,
               radius.md,

--- a/ui/src/components/ui/card.tsx
+++ b/ui/src/components/ui/card.tsx
@@ -122,6 +122,7 @@ export function Card({
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: Interactive role is conditionally applied based on onClick presence
     <div
+      data-testid="card"
       className={cn(
         card.base,
         card.variant.default,


### PR DESCRIPTION
Killed task #117 — the e2e selector `[class*="card"]` matched zero elements because Card's className doesn't contain the substring "card". Three sites updated to use `getByTestId('card')`; Card root gets a stable testid.

Should be the last admin-merge-required E2E block. After this, future UI PRs should pass E2E cleanly without admin override.

Test plan:
- [x] biome check — clean
- [x] tsc --noEmit — clean
- [ ] CI green (including E2E for the first time normally)