### PR TITLE
feat(license): Gate path_analysis (Roots) behind Pro tier (PR-B5)

### DIFF
--- a/internal/api/handlers_path_gate_internal_test.go
+++ b/internal/api/handlers_path_gate_internal_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/license"
+)
+
+// TestRootsPathRequiresPro asserts the path-analysis route returns
+// 402 Payment Required for unlicensed (Free) callers and routes
+// through to the handler for Pro-trial callers. Subsumes the manual
+// proof that PR-B5's requireFeature wiring works end-to-end.
+func TestRootsPathRequiresPro(t *testing.T) {
+	t.Parallel()
+	s, mgr := apiTokenTestSetup(t)
+	// setupRoutes is normally called by NewServer; the test helper
+	// skips it (the helper builds a Server directly). Invoke it here
+	// so the /roots/path mux entry exists.
+	s.setupRoutes()
+
+	// 1. No license → 402.
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/roots/path", http.NoBody)
+	req.Header.Set("X-Username", "alice")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("free tier: status = %d, want 402; body=%s", w.Code, w.Body.String())
+	}
+	var body FeatureGateResponse
+	if decErr := json.NewDecoder(w.Body).Decode(&body); decErr != nil {
+		t.Fatalf("decode 402 body: %v", decErr)
+	}
+	if body.RequiredFeature != "path_analysis" {
+		t.Errorf("requiredFeature = %q, want %q", body.RequiredFeature, "path_analysis")
+	}
+	if body.CurrentTier != license.TierFree.String() {
+		t.Errorf("currentTier = %q, want %q", body.CurrentTier, license.TierFree.String())
+	}
+
+	// 2. Start trial → Pro features → no longer 402. The handler may
+	//    400/500 because it expects query params we don't supply, but
+	//    crucially it must NOT 402. That's what we assert.
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+	req2 := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/roots/path", http.NoBody)
+	req2.Header.Set("X-Username", "alice")
+	w2 := httptest.NewRecorder()
+	s.mux.ServeHTTP(w2, req2)
+	if w2.Code == http.StatusPaymentRequired {
+		t.Errorf("trial license: status = 402 (should pass the gate); body=%s", w2.Body.String())
+	}
+}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -202,12 +202,21 @@ func (s *Server) setupShellRoutes() {
 }
 
 // setupRootsRoutes registers Roots module routes (path analysis).
+// Both endpoints are gated on the `path_analysis` feature (Pro tier);
+// Free / Starter receive 402 with an upgrade hint. The rate-limit
+// middleware still wraps traceroute so abuse remains capped even for
+// trial users.
 func (s *Server) setupRootsRoutes() {
 	s.mux.Handle(
 		APIVersionPrefix+"/roots/traceroute",
-		s.endpointRateLimiter().RateLimitMiddleware(http.HandlerFunc(s.handleTraceroute)),
+		s.endpointRateLimiter().RateLimitMiddleware(
+			s.requireFeature("path_analysis", s.handleTraceroute),
+		),
 	)
-	s.mux.HandleFunc(APIVersionPrefix+"/roots/path", s.handlePath)
+	s.mux.HandleFunc(
+		APIVersionPrefix+"/roots/path",
+		s.requireFeature("path_analysis", s.handlePath),
+	)
 }
 
 // setupCanopyRoutes registers Canopy module routes (Wi-Fi planning).

--- a/ui/src/pages/PathAnalysisPage.tsx
+++ b/ui/src/pages/PathAnalysisPage.tsx
@@ -1,6 +1,7 @@
 import { Route } from 'lucide-react';
 import { NetworkDiscoveryCard } from '../components/cards/NetworkDiscoveryCard';
 import { PathDiscoveryCard } from '../components/cards/PathDiscoveryCard';
+import { RequireFeature } from '../components/ui/RequireFeature';
 import { useAppContext } from '../contexts/AppContext';
 import { layout } from '../styles/theme';
 import { Breadcrumbs } from '../ui/Breadcrumbs';
@@ -18,30 +19,54 @@ export function PathAnalysisPage() {
   } = useAppContext();
 
   return (
-    <section className="space-y-6">
-      <Breadcrumbs />
-      <PageHeader
-        icon={Route}
-        title="Path Analysis"
-        description="L2/L3 path discovery, traceroute hops, and on-link device discovery."
-        iconColorClass="text-module-roots"
-      />
-      <div className={layout.grid.cards}>
-        {(!isWifi || cards.wifi) && (
-          <PathDiscoveryCard
-            gateway={cards.gateway?.gateway}
-            dnsServer={cards.dns?.servers?.[0] ?? cards.dns?.server}
-            onRegisterTraceHandler={registerTraceHopHandler}
+    <RequireFeature
+      feature="path_analysis"
+      fallback={
+        <section className="space-y-6">
+          <Breadcrumbs />
+          <PageHeader
+            icon={Route}
+            title="Path Analysis"
+            description="L2/L3 path discovery, traceroute hops, and on-link device discovery."
+            iconColorClass="text-module-roots"
           />
-        )}
-        {!isWifi && cardSettings.networkDiscovery.enabled && (
-          <NetworkDiscoveryCard
-            data={networkDiscovery}
-            loading={loading}
-            onScan={triggerDeviceScan}
-          />
-        )}
-      </div>
-    </section>
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 text-sm text-amber-200">
+            Path Analysis is a Pro-tier feature. Start a 14-day Pro trial with
+            <code className="mx-1 px-1 rounded bg-surface-raised">seed license trial</code>
+            or activate a Pro key with
+            <code className="ml-1 px-1 rounded bg-surface-raised">
+              seed license activate -k &lt;KEY&gt;
+            </code>
+            .
+          </div>
+        </section>
+      }
+    >
+      <section className="space-y-6">
+        <Breadcrumbs />
+        <PageHeader
+          icon={Route}
+          title="Path Analysis"
+          description="L2/L3 path discovery, traceroute hops, and on-link device discovery."
+          iconColorClass="text-module-roots"
+        />
+        <div className={layout.grid.cards}>
+          {(!isWifi || cards.wifi) && (
+            <PathDiscoveryCard
+              gateway={cards.gateway?.gateway}
+              dnsServer={cards.dns?.servers?.[0] ?? cards.dns?.server}
+              onRegisterTraceHandler={registerTraceHopHandler}
+            />
+          )}
+          {!isWifi && cardSettings.networkDiscovery.enabled && (
+            <NetworkDiscoveryCard
+              data={networkDiscovery}
+              loading={loading}
+              onScan={triggerDeviceScan}
+            />
+          )}
+        </div>
+      </section>
+    </RequireFeature>
   );
 }


### PR DESCRIPTION
First per-feature gate on the framework from PR #1153. Gates `/api/v1/roots/path` + `/api/v1/roots/traceroute` with `requireFeature("path_analysis", ...)` and wraps `PathAnalysisPage` with `<RequireFeature>`. Free/Starter receive 402 with upgrade hint; UI page shows an amber notice instead of empty cards. New TestRootsPathRequiresPro asserts both paths.