### PR TITLE
feat(license): Gate /harvest/export + ReportsPage on export_csv_json (Starter+) (PR-B2)

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -253,8 +253,16 @@ func (s *Server) setupCanopyRoutes() {
 }
 
 // setupHarvestRoutes registers Harvest module routes (reporting).
+// /harvest/export is gated behind the `export_csv_json` feature
+// (Starter or higher) per LICENSE_STRATEGY §2. Log endpoints stay
+// ungated because operational visibility is a basic capability for
+// every tier; only data extraction (the customer-facing reporting
+// surface) is paid.
 func (s *Server) setupHarvestRoutes() {
-	s.mux.HandleFunc(APIVersionPrefix+"/harvest/export", s.handleExport)
+	s.mux.HandleFunc(
+		APIVersionPrefix+"/harvest/export",
+		s.requireFeature("export_csv_json", s.handleExport),
+	)
 	s.mux.HandleFunc(APIVersionPrefix+"/harvest/logs", s.handleLogs)
 	s.mux.HandleFunc(APIVersionPrefix+"/harvest/logs/client", s.handleClientLogs)
 	s.mux.HandleFunc(APIVersionPrefix+"/harvest/logs/query", s.handleLogsQuery)

--- a/ui/src/pages/ReportsPage.tsx
+++ b/ui/src/pages/ReportsPage.tsx
@@ -1,22 +1,47 @@
 import { BarChart3 } from 'lucide-react';
 import { SLADashboardCard } from '../components/cards/SlaDashboardCard';
+import { RequireFeature } from '../components/ui/RequireFeature';
 import { layout } from '../styles/theme';
 import { Breadcrumbs } from '../ui/Breadcrumbs';
 import { PageHeader } from '../ui/PageHeader';
 
 export function ReportsPage() {
   return (
-    <section className="space-y-6">
-      <Breadcrumbs />
-      <PageHeader
-        icon={BarChart3}
-        title="Reports"
-        description="Aggregated SLA dashboard, compliance tracking, and historical reporting."
-        iconColorClass="text-module-harvest"
-      />
-      <div className={layout.grid.cards}>
-        <SLADashboardCard />
-      </div>
-    </section>
+    <RequireFeature
+      feature="export_csv_json"
+      fallback={
+        <section className="space-y-6">
+          <Breadcrumbs />
+          <PageHeader
+            icon={BarChart3}
+            title="Reports"
+            description="Aggregated SLA dashboard, compliance tracking, and historical reporting."
+            iconColorClass="text-module-harvest"
+          />
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 text-sm text-amber-200">
+            Reports require the Starter tier or higher. Start a 14-day Pro trial with
+            <code className="mx-1 px-1 rounded bg-surface-raised">seed license trial</code>
+            or activate a Starter / Pro key with
+            <code className="ml-1 px-1 rounded bg-surface-raised">
+              seed license activate -k &lt;KEY&gt;
+            </code>
+            .
+          </div>
+        </section>
+      }
+    >
+      <section className="space-y-6">
+        <Breadcrumbs />
+        <PageHeader
+          icon={BarChart3}
+          title="Reports"
+          description="Aggregated SLA dashboard, compliance tracking, and historical reporting."
+          iconColorClass="text-module-harvest"
+        />
+        <div className={layout.grid.cards}>
+          <SLADashboardCard />
+        </div>
+      </section>
+    </RequireFeature>
   );
 }


### PR DESCRIPTION
Second Tier-2 gate using the PR #1153 framework.

Backend: `/api/v1/harvest/export` wrapped with `requireFeature("export_csv_json", ...)`. Log endpoints stay ungated (operational visibility = basic for every tier).

Frontend: ReportsPage wrapped with `<RequireFeature>`; Free users see an amber upgrade notice instead of empty cards.

scheduled_reports + audit_pdf features (Pro-only) have no routes yet — those land when the scheduler/PDF generator are actually implemented.