### PR TITLE
feat(license): Gate Canopy AirMapper import on airmapper_baseline_diff (PR-B1)

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -232,9 +232,15 @@ func (s *Server) setupCanopyRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floorplan", s.updateSurveyFloorPlan)
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/settings", s.updateSurveySettings)
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/imported-data", s.updateSurveyImportedData)
+	// AirMapper baseline-diff is a Pro feature (LICENSE_STRATEGY §2):
+	// imports an existing AirMapper survey JSON and diffs it against
+	// the current floor-plan baseline. The rate limiter still wraps
+	// the gated handler so trial / Pro users can't abuse the endpoint.
 	s.mux.Handle(
 		APIVersionPrefix+"/canopy/survey/import/airmapper",
-		s.endpointRateLimiter().RateLimitMiddleware(http.HandlerFunc(s.importAirMapper)),
+		s.endpointRateLimiter().RateLimitMiddleware(
+			s.requireFeature("airmapper_baseline_diff", s.importAirMapper),
+		),
 	)
 	s.mux.Handle(
 		APIVersionPrefix+"/canopy/survey/heatmap",


### PR DESCRIPTION
Third Tier-2 gate using the PR #1153 framework.

Only the AirMapper baseline-diff import route exists today for Canopy Pro features; wifi_roam_analysis + wifi_association_forensics will be gated when their routes are implemented.

Rate limit middleware still wraps the gated handler.