### PR TITLE
feat(i18n): add errors.license.* keys for tier-gating UI

### DIFF
--- a/internal/i18n/locales/en/errors.json
+++ b/internal/i18n/locales/en/errors.json
@@ -32,6 +32,14 @@
     "dhcpConfigFailed": "Failed to configure DHCP",
     "invalidMode": "Mode must be 'dhcp' or 'static'"
   },
+  "license": {
+    "tierTooLow": "This feature requires the {{tier}} tier",
+    "upgradeHint": "Start a 14-day {{tier}} trial with `seed license trial`, or activate a {{tier}} key with `seed license activate -k <KEY>`.",
+    "tierGateTooltip": "Requires the {{tier}} tier",
+    "featureUnavailable": "{{feature}} is not available on your current tier",
+    "currentTier": "Current tier: {{tier}}",
+    "loading": "Checking license…"
+  },
   "validation": {
     "failed": "Validation failed",
     "required": "{{field}} is required",

--- a/internal/i18n/locales/es/errors.json
+++ b/internal/i18n/locales/es/errors.json
@@ -32,6 +32,14 @@
     "dhcpConfigFailed": "Error al configurar DHCP",
     "invalidMode": "El modo debe ser 'dhcp' o 'static'"
   },
+  "license": {
+    "tierTooLow": "Esta función requiere el nivel {{tier}}",
+    "upgradeHint": "Inicia una prueba gratuita de {{tier}} de 14 días con `seed license trial`, o activa una clave {{tier}} con `seed license activate -k <CLAVE>`.",
+    "tierGateTooltip": "Requiere el nivel {{tier}}",
+    "featureUnavailable": "{{feature}} no está disponible en tu nivel actual",
+    "currentTier": "Nivel actual: {{tier}}",
+    "loading": "Verificando licencia…"
+  },
   "validation": {
     "failed": "Validación fallida",
     "required": "{{field}} es requerido",

--- a/ui/src/components/ui/TierGate.tsx
+++ b/ui/src/components/ui/TierGate.tsx
@@ -24,6 +24,7 @@
  */
 
 import type { ReactElement, ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLicense } from '../../contexts/LicenseContext';
 
 interface TierGateProps {
@@ -31,7 +32,7 @@ interface TierGateProps {
   children: ReactNode;
   /** Tier name shown in the hint (e.g. "Pro", "Starter"). */
   requiredTier?: string;
-  /** Custom message; default is "Requires the {tier} tier." */
+  /** Custom message; default is the localised "Requires the {tier} tier." */
   message?: string;
 }
 
@@ -42,6 +43,7 @@ export function TierGate({
   message,
 }: TierGateProps): ReactElement {
   const { hasFeature, loading } = useLicense();
+  const { t } = useTranslation('errors');
 
   // Always render children while the license is loading so layouts
   // don't shift; gate visually only after we know they lack the feature.
@@ -49,7 +51,7 @@ export function TierGate({
     return <>{children}</>;
   }
 
-  const hint = message ?? `Requires the ${requiredTier} tier.`;
+  const hint = message ?? t('license.tierGateTooltip', { tier: requiredTier });
 
   // CSS-only hover (via `group` + `group-hover:`) keeps the tooltip
   // tied to the wrapper without JS event handlers — that lets the


### PR DESCRIPTION
## Summary

Adds localised copy for the upgrade hints surfaced by the gating framework. Wires \`TierGate\` to use \`t('errors:license.tierGateTooltip', { tier })\` instead of a hard-coded English string so the Spanish locale (and any future ones) can keep parity as gates roll out.

## Changes

- \`internal/i18n/locales/{en,es}/errors.json\`: new \`errors.license.*\` group:
  - \`tierTooLow\`, \`upgradeHint\`, \`tierGateTooltip\`, \`featureUnavailable\`, \`currentTier\`, \`loading\`
- \`ui/src/components/ui/TierGate.tsx\`: tooltip default now comes from i18n. Caller-supplied \`message\` still overrides.

## Out of scope

The server-side \`FeatureGateResponse.upgradeMessage\` is still English-only — switching it to localised strings needs server-side i18n plumbing and is tracked as a follow-up.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [ ] CI green