### PR TITLE
fix(e2e): replace remaining /login/ heading regex in auth.spec.ts

### DIFF
--- a/ui/e2e/auth.spec.ts
+++ b/ui/e2e/auth.spec.ts
@@ -30,7 +30,7 @@ test.describe('Authentication', () => {
     await page.goto('/');
 
     // Check for login form elements
-    await expect(page.getByRole('heading', { name: /login/i })).toBeVisible();
+    await expect(page.getByTestId('login-title')).toBeVisible();
     await expect(page.getByLabel(/username/i)).toBeVisible();
     await expect(page.getByLabel(/password/i)).toBeVisible();
     await expect(page.getByRole('button', { name: /sign in|login/i })).toBeVisible();


### PR DESCRIPTION
## Summary

Tail of the bulk e2e selector fix (#1162) — that PR's sed pattern targeted \`/link.../\` regexes but missed **one** \`/login/\` heading regex in \`auth.spec.ts:33\` (the \"display login form when not authenticated\" test).

The login H1 is \`t('app.title')\` = \"The Seed\", not \"Login\", so the regex never matches. Each retry waits the full 30s timeout, which contributes to the CI E2E job for #1162 running ~25 min instead of the usual 10-12.

## Test plan

- [x] \`grep -rn \"getByRole('heading', { name: /login\" e2e/\` — zero matches after change
- [x] Pre-commit hook — pass