### PR TITLE
fix(e2e): remove garbage JS in theme-and-help.spec.ts

### DIFF
--- a/ui/e2e/theme-and-help.spec.ts
+++ b/ui/e2e/theme-and-help.spec.ts
@@ -515,8 +515,6 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       // Get initial theme
       const initialClasses = await page.locator('html').getAttribute('class');
       const initialTheme = initialClasses?.includes('dark') ? 'dark' : 'light';
-      theme - toggle;
-      (');');
 
       // Open settings and toggle theme
       const settingsButton = page.getByTestId('header-open-settings');
@@ -543,8 +541,6 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       // Verify theme changed
       const newClasses = await page.locator('html').getAttribute('class');
       const newTheme = newClasses?.includes('dark') ? 'dark' : 'light';
-      theme - toggle;
-      (');');
 
       expect(newTheme).not.toBe(initialTheme);
 


### PR DESCRIPTION
Closes #1169. Category F of #1170 — the trivial free win.

PR #1151's codemod accidentally inserted two stray lines at line 518 and 546:

```
theme - toggle;
(');');
```

`theme` and `toggle` are undefined → `ReferenceError`. The `(');');` is not even valid JS but parses as a no-op expression sequence, which is why the file still compiles (but throws at runtime).

The actual theme toggle happens later in the test at line 532 via `themeToggle.click()`. The two stray lines were never doing anything intentional — pure codemod corruption.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Pre-commit hook pass
- [ ] CI green on the @smoke run for this spec