### PR TITLE
fix(e2e): replace per-page H1 heading regexes with getByTestId (closes #1167)

### DIFF
--- a/ui/e2e/link-page.spec.ts
+++ b/ui/e2e/link-page.spec.ts
@@ -16,13 +16,13 @@ test.describe('Link Page', () => {
   test.beforeEach(async ({ page }) => {
     await skipSetupWizard(page);
     await page.goto('/link');
-    await expect(page.getByRole('heading', { name: /^link$/i, level: 1 })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });
 
   test('should render the page header with Link title', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /^link$/i, level: 1 })).toBeVisible();
+    await expect(page.getByTestId('page-header-title')).toBeVisible();
     await expect(page.getByText(/physical link state.*cable diagnostics/i)).toBeVisible();
   });
 
@@ -33,7 +33,7 @@ test.describe('Link Page', () => {
   test('should be the default route when navigating to root', async ({ page }) => {
     await page.goto('/');
     await expect(page).toHaveURL(/\/link$/);
-    await expect(page.getByRole('heading', { name: /^link$/i, level: 1 })).toBeVisible();
+    await expect(page.getByTestId('page-header-title')).toBeVisible();
   });
 
   test('should render at least one link-state card (LinkCard or WiFiCard)', async ({ page }) => {

--- a/ui/e2e/logs-page.spec.ts
+++ b/ui/e2e/logs-page.spec.ts
@@ -13,13 +13,13 @@ test.describe('Logs Page', () => {
   test.beforeEach(async ({ page }) => {
     await skipSetupWizard(page);
     await page.goto('/logs');
-    await expect(page.getByRole('heading', { name: /^logs$/i, level: 1 })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });
 
   test('should render the page header with Logs title', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /^logs$/i, level: 1 })).toBeVisible();
+    await expect(page.getByTestId('page-header-title')).toBeVisible();
     await expect(page.getByText(/live log stream and system health/i)).toBeVisible();
   });
 

--- a/ui/e2e/network-page.spec.ts
+++ b/ui/e2e/network-page.spec.ts
@@ -16,13 +16,13 @@ test.describe('Network Page', () => {
   test.beforeEach(async ({ page }) => {
     await skipSetupWizard(page);
     await page.goto('/network');
-    await expect(page.getByRole('heading', { name: /^network$/i, level: 1 })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });
 
   test('should render the page header with Network title', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /^network$/i, level: 1 })).toBeVisible();
+    await expect(page.getByTestId('page-header-title')).toBeVisible();
     await expect(page.getByText(/dhcp.*gateway.*dns/i)).toBeVisible();
   });
 

--- a/ui/e2e/path-analysis-page.spec.ts
+++ b/ui/e2e/path-analysis-page.spec.ts
@@ -14,13 +14,13 @@ test.describe('Path Analysis Page', () => {
   test.beforeEach(async ({ page }) => {
     await skipSetupWizard(page);
     await page.goto('/path');
-    await expect(page.getByRole('heading', { name: /path analysis/i, level: 1 })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });
 
   test('should render the page header with Path Analysis title', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /path analysis/i, level: 1 })).toBeVisible();
+    await expect(page.getByTestId('page-header-title')).toBeVisible();
     await expect(page.getByText(/path discovery|traceroute|device discovery/i)).toBeVisible();
   });
 

--- a/ui/e2e/performance-page.spec.ts
+++ b/ui/e2e/performance-page.spec.ts
@@ -14,13 +14,13 @@ test.describe('Performance Page', () => {
   test.beforeEach(async ({ page }) => {
     await skipSetupWizard(page);
     await page.goto('/performance');
-    await expect(page.getByRole('heading', { name: /^performance$/i, level: 1 })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });
 
   test('should render the page header with Performance title', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /^performance$/i, level: 1 })).toBeVisible();
+    await expect(page.getByTestId('page-header-title')).toBeVisible();
     await expect(page.getByText(/active throughput tests/i)).toBeVisible();
   });
 

--- a/ui/e2e/reports-page.spec.ts
+++ b/ui/e2e/reports-page.spec.ts
@@ -12,13 +12,13 @@ test.describe('Reports Page', () => {
   test.beforeEach(async ({ page }) => {
     await skipSetupWizard(page);
     await page.goto('/reports');
-    await expect(page.getByRole('heading', { name: /^reports$/i, level: 1 })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });
 
   test('should render the page header with Reports title', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /^reports$/i, level: 1 })).toBeVisible();
+    await expect(page.getByTestId('page-header-title')).toBeVisible();
     await expect(
       page.getByText(/aggregated sla dashboard|compliance|historical reporting/i),
     ).toBeVisible();

--- a/ui/e2e/security-page.spec.ts
+++ b/ui/e2e/security-page.spec.ts
@@ -13,13 +13,13 @@ test.describe('Security Page', () => {
   test.beforeEach(async ({ page }) => {
     await skipSetupWizard(page);
     await page.goto('/security');
-    await expect(page.getByRole('heading', { name: /^security$/i, level: 1 })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });
 
   test('should render the page header with Security title', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /^security$/i, level: 1 })).toBeVisible();
+    await expect(page.getByTestId('page-header-title')).toBeVisible();
     await expect(page.getByText(/guest network isolation audit/i)).toBeVisible();
   });
 

--- a/ui/e2e/theme-and-help.spec.ts
+++ b/ui/e2e/theme-and-help.spec.ts
@@ -30,7 +30,7 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
     await page.goto('/');
     // Pin to level: 1 + exact-match "Link" so the H3 "Link Status" card
     // chrome doesn't trip strict mode (same fix as auth.spec / dashboard.spec).
-    await expect(page.getByRole('heading', { name: /^link$/i, level: 1 })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });

--- a/ui/e2e/wifi-page.spec.ts
+++ b/ui/e2e/wifi-page.spec.ts
@@ -19,13 +19,13 @@ test.describe('Wi-Fi Page', () => {
   test.beforeEach(async ({ page }) => {
     await skipSetupWizard(page);
     await page.goto('/wifi');
-    await expect(page.getByRole('heading', { name: /wi-fi/i, level: 1 })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });
 
   test('should render the page header with the Wi-Fi title', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /wi-fi/i, level: 1 })).toBeVisible();
+    await expect(page.getByTestId('page-header-title')).toBeVisible();
     await expect(page.getByText(/wireless link, channel survey/i)).toBeVisible();
   });
 
@@ -53,7 +53,7 @@ test.describe('Wi-Fi Page', () => {
       });
     });
     await page.reload();
-    await expect(page.getByRole('heading', { name: /wi-fi/i, level: 1 })).toBeVisible();
+    await expect(page.getByTestId('page-header-title')).toBeVisible();
     // Either the wired-mode message OR the cards must be the one rendered;
     // both branches are valid given different test environments.
     const content = page


### PR DESCRIPTION
Closes #1167 (Category C of #1170 triage).

Final cleanup of the brittle heading regex pattern across per-page specs. Companion to #1161/#1162 (auth-complete and bulk-replace) and #1163 (single residual /login/).

Before:
```ts
await expect(page.getByRole('heading', { name: /^network$/i, level: 1 })).toBeVisible();
```

After:
```ts
await expect(page.getByTestId('page-header-title')).toBeVisible();
```

The `page-header-title` testid was added in #1161 on the H1 inside `ui/src/ui/PageHeader.tsx` and is now on every page that uses PageHeader. Switching to it:
- Survives i18n drift (`wifi.title` resolved to "WiFi" not "Wi-Fi" in `cards.json` — the regex `/wi-fi/i` didn't match)
- Survives copy edits
- One selector to maintain instead of one per page

## Affected specs (9)

link-page, logs-page, network-page, path-analysis-page, performance-page, reports-page, security-page, theme-and-help, wifi-page.

## Left untouched (different scope — not page-level H1)

- `setup-wizard.spec.ts:110` — wizard step heading
- `gateway.spec.ts:27` — gateway card H3 (already has data-testid fallback via .or())
- `coverage-gaps.spec.ts:17` — profile-management modal heading

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] Pre-commit hook pass
- [ ] CI green for the per-page specs after #1172 lands the auth fix