### PR TITLE
fix(e2e): replace brittle text regexes with stable id selectors (closes #1166)

### DIFF
--- a/ui/e2e/coverage-gaps.spec.ts
+++ b/ui/e2e/coverage-gaps.spec.ts
@@ -20,9 +20,9 @@ test.describe('Coverage gaps', () => {
   });
 
   test('opens log viewer modal', async ({ page }) => {
-    const logsCardTitle = page
-      .locator('h3:has-text("System Logs"), h4:has-text("System Logs")')
-      .first();
+    // Card.tsx generates id="card-title-<slug>" — see comment in
+    // dashboard.spec.ts. "System Logs" → "system-logs".
+    const logsCardTitle = page.locator('#card-title-system-logs');
     await expect(logsCardTitle).toBeVisible();
 
     const logsCard = logsCardTitle.locator('..').first();

--- a/ui/e2e/dashboard.spec.ts
+++ b/ui/e2e/dashboard.spec.ts
@@ -32,13 +32,14 @@ test.describe('Dashboard', () => {
   });
 
   test('should display Gateway card', async ({ page }) => {
-    const gatewayCard = page.locator('h3:has-text("Gateway"), h4:has-text("Gateway")').first();
-    await expect(gatewayCard).toBeVisible();
+    // Card.tsx generates id="card-title-<slug>" on every card's H3 —
+    // stable across i18n drift since slug derives from the title prop
+    // at component-mount time (still English in the dev backend).
+    await expect(page.locator('#card-title-gateway')).toBeVisible();
   });
 
   test('should display DNS card', async ({ page }) => {
-    const dnsCard = page.locator('h3:has-text("DNS"), h4:has-text("DNS")').first();
-    await expect(dnsCard).toBeVisible();
+    await expect(page.locator('#card-title-dns')).toBeVisible();
   });
 
   test('should open settings drawer', async ({ page }) => {
@@ -47,7 +48,7 @@ test.describe('Dashboard', () => {
     await settingsButton.click();
 
     // Settings drawer should be visible
-    await expect(page.getByText(/thresholds|appearance|discovery/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('settings-drawer')).toBeVisible({ timeout: 5000 });
   });
 
   test('should toggle theme in settings', async ({ page }) => {

--- a/ui/e2e/gateway.spec.ts
+++ b/ui/e2e/gateway.spec.ts
@@ -23,11 +23,11 @@ test.describe('Gateway', () => {
   });
 
   test('should display Gateway card', async ({ page }) => {
-    const gatewayCard = page
-      .getByRole('heading', { name: /gateway/i })
-      .or(page.locator('[data-testid="gateway-card"]'));
-
-    await expect(gatewayCard).toBeVisible({ timeout: 5000 });
+    // Card.tsx generates id="card-title-<slug>" — see comment in
+    // dashboard.spec.ts. The `.or()` chain previously hit a strict-
+    // mode violation because the page H1 "Link" + the card H3
+    // "Link Status" both matched a heading regex.
+    await expect(page.locator('#card-title-gateway')).toBeVisible({ timeout: 5000 });
   });
 
   test('should show gateway IP address', async ({ page }) => {

--- a/ui/src/components/settings/SettingsDrawer.tsx
+++ b/ui/src/components/settings/SettingsDrawer.tsx
@@ -525,6 +525,7 @@ export const SettingsDrawer: React.MemoExoticComponent<
         role="dialog"
         aria-modal="true"
         aria-labelledby="settings-drawer-title"
+        data-testid="settings-drawer"
         onClick={(e: React.MouseEvent): void => e.stopPropagation()}
         onKeyDown={(e: React.KeyboardEvent): void => e.stopPropagation()}
         className="fixed right-0 top-0 h-full w-full sm:w-96 lg:w-lg bg-surface-raised border-l border-surface-border z-50 overflow-y-auto shadow-xl"


### PR DESCRIPTION
Closes #1166 (Category B of #1170). Companion to #1167 (per-page H1 testid) and #1172 (global-setup auth fix).

## Changes

| Spec | Before | After |
|---|---|---|
| `dashboard.spec.ts` should open settings drawer | `getByText(/thresholds\|appearance\|discovery/i)` — strict-mode violation, matched 4 elements | `getByTestId('settings-drawer')` |
| `dashboard.spec.ts` Gateway card | `h3:has-text("Gateway"), h4:has-text("Gateway")` | `#card-title-gateway` |
| `dashboard.spec.ts` DNS card | same | `#card-title-dns` |
| `coverage-gaps.spec.ts` log viewer modal | same | `#card-title-system-logs` |
| `gateway.spec.ts` Gateway card | `getByRole('heading').or(testid).first()` | `#card-title-gateway` |

## Source-side

Add `data-testid="settings-drawer"` on the dialog root in `src/components/settings/SettingsDrawer.tsx` so tests have a stable handle that doesn't depend on drawer copy.

The `#card-title-<slug>` pattern uses the id already generated inside `Card.tsx` from the title prop (e.g., "Gateway" → `card-title-gateway`). No new testids needed on the cards.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] Pre-commit hook pass
- [ ] CI green for the affected tests after #1172 lands the auth fix