### PR TITLE
fix(e2e): sync FAB tests on data-running attribute, not animate-spin (closes #1168)

### DIFF
--- a/ui/e2e/fab.spec.ts
+++ b/ui/e2e/fab.spec.ts
@@ -24,9 +24,7 @@ test.describe('FAB - Run All Tests Flow', () => {
 
   test('should display FAB button when authenticated', async ({ page }) => {
     // FAB should be visible in bottom-right corner
-    const fab = page
-      .locator('button[title="Run All Tests"]')
-      .or(page.locator('button[aria-label="Run All Tests"]'));
+    const fab = page.getByTestId('fab-run-all-tests');
     await expect(fab).toBeVisible();
 
     // Check FAB positioning (fixed bottom-right)
@@ -39,16 +37,15 @@ test.describe('FAB - Run All Tests Flow', () => {
   });
 
   test('should show loading spinner when FAB is clicked', async ({ page }) => {
-    const fab = page
-      .locator('button[title="Run All Tests"]')
-      .or(page.locator('button[aria-label="Run All Tests"]'));
+    const fab = page.getByTestId('fab-run-all-tests');
 
     // Click FAB
     await fab.click();
 
     // Should show spinner (animated SVG with opacity classes)
-    const spinner = fab.locator('svg.animate-spin');
-    await expect(spinner).toBeVisible({ timeout: 2000 });
+    // Synchronously check the data-running attribute instead of
+    // racing the animate-spin CSS class — see seed#1168.
+    await expect(fab).toHaveAttribute('data-running', 'true');
 
     // FAB should be disabled during test execution
     await expect(fab).toBeDisabled();
@@ -67,9 +64,7 @@ test.describe('FAB - Run All Tests Flow', () => {
       }
     });
 
-    const fab = page
-      .locator('button[title="Run All Tests"]')
-      .or(page.locator('button[aria-label="Run All Tests"]'));
+    const fab = page.getByTestId('fab-run-all-tests');
 
     // Click FAB to trigger all tests
     await fab.click();
@@ -99,57 +94,43 @@ test.describe('FAB - Run All Tests Flow', () => {
       }
     });
 
-    const fab = page
-      .locator('button[title="Run All Tests"]')
-      .or(page.locator('button[aria-label="Run All Tests"]'));
+    const fab = page.getByTestId('fab-run-all-tests');
 
     // Click FAB
     await fab.click();
 
     // Wait for tests to complete (spinner disappears)
-    await expect(fab.locator('svg.animate-spin')).toBeVisible({
-      timeout: 5000,
-    });
-    await expect(fab.locator('svg.animate-spin')).toBeHidden({
-      timeout: 65000,
-    }); // 60s timeout + buffer
+    await expect(fab).toHaveAttribute('data-running', 'true');
+    await expect(fab).toHaveAttribute('data-running', 'false', { timeout: 65000 }); // 60s timeout + buffer
 
     // Verify card data was updated
     expect(cardUpdated).toBeTruthy();
   });
 
   test('should complete and stop spinner after tests finish', async ({ page }) => {
-    const fab = page
-      .locator('button[title="Run All Tests"]')
-      .or(page.locator('button[aria-label="Run All Tests"]'));
+    const fab = page.getByTestId('fab-run-all-tests');
 
     // Click FAB
     await fab.click();
 
     // Spinner should appear
-    const spinner = fab.locator('svg.animate-spin');
-    await expect(spinner).toBeVisible({ timeout: 2000 });
+    // Synchronously check the data-running attribute instead of
+    // racing the animate-spin CSS class — see seed#1168.
+    await expect(fab).toHaveAttribute('data-running', 'true');
 
-    // Wait for completion - spinner should disappear
-    // Max timeout is 60s in FAB implementation
-    await expect(spinner).toBeHidden({ timeout: 65000 });
+    // Wait for completion — FAB returns to idle within 60s.
+    await expect(fab).toHaveAttribute('data-running', 'false', { timeout: 65000 });
 
     // FAB should be enabled again
     await expect(fab).toBeEnabled();
 
-    // Play icon should be back (spinner should be gone)
+    // Play icon should be back (FAB returned to idle).
     const playIcon = fab.locator('svg');
     await expect(playIcon).toBeVisible();
-
-    // Verify it's not a spinner anymore
-    const hasSpinClass = await playIcon.evaluate((el) => el.classList.contains('animate-spin'));
-    expect(hasSpinClass).toBe(false);
   });
 
   test('should not trigger tests if FAB is clicked while already running', async ({ page }) => {
-    const fab = page
-      .locator('button[title="Run All Tests"]')
-      .or(page.locator('button[aria-label="Run All Tests"]'));
+    const fab = page.getByTestId('fab-run-all-tests');
 
     // Click FAB first time
     await fab.click();
@@ -209,9 +190,7 @@ test.describe('FAB - Run All Tests Flow', () => {
       }
     });
 
-    const fab = page
-      .locator('button[title="Run All Tests"]')
-      .or(page.locator('button[aria-label="Run All Tests"]'));
+    const fab = page.getByTestId('fab-run-all-tests');
 
     // Click FAB
     await fab.click();
@@ -233,31 +212,23 @@ test.describe('FAB - Run All Tests Flow', () => {
       });
     });
 
-    const fab = page
-      .locator('button[title="Run All Tests"]')
-      .or(page.locator('button[aria-label="Run All Tests"]'));
+    const fab = page.getByTestId('fab-run-all-tests');
 
     // Click FAB
     await fab.click();
 
     // Spinner should still appear
-    await expect(fab.locator('svg.animate-spin')).toBeVisible({
-      timeout: 2000,
-    });
+    await expect(fab).toHaveAttribute('data-running', 'true');
 
     // Even with failures, tests should complete and spinner should stop
-    await expect(fab.locator('svg.animate-spin')).toBeHidden({
-      timeout: 65000,
-    });
+    await expect(fab).toHaveAttribute('data-running', 'false', { timeout: 65000 });
 
     // FAB should be enabled again
     await expect(fab).toBeEnabled();
   });
 
   test('should maintain FAB visibility on page scroll', async ({ page }) => {
-    const fab = page
-      .locator('button[title="Run All Tests"]')
-      .or(page.locator('button[aria-label="Run All Tests"]'));
+    const fab = page.getByTestId('fab-run-all-tests');
 
     // Verify FAB is visible initially
     await expect(fab).toBeVisible();
@@ -276,9 +247,7 @@ test.describe('FAB - Run All Tests Flow', () => {
   });
 
   test('should be keyboard accessible', async ({ page }) => {
-    const fab = page
-      .locator('button[title="Run All Tests"]')
-      .or(page.locator('button[aria-label="Run All Tests"]'));
+    const fab = page.getByTestId('fab-run-all-tests');
 
     // Tab to FAB (may need multiple tabs depending on page structure)
     // Focus the FAB using keyboard
@@ -304,9 +273,7 @@ test.describe('FAB - Run All Tests Flow', () => {
   });
 
   test('should show proper aria labels for accessibility', async ({ page }) => {
-    const fab = page
-      .locator('button[title="Run All Tests"]')
-      .or(page.locator('button[aria-label="Run All Tests"]'));
+    const fab = page.getByTestId('fab-run-all-tests');
 
     // Verify accessibility attributes
     const ariaLabel = await fab.getAttribute('aria-label');

--- a/ui/src/components/ui/fab.tsx
+++ b/ui/src/components/ui/fab.tsx
@@ -93,6 +93,12 @@ export function Fab({ className = '' }: FabProps): React.JSX.Element {
       )}
       title="Run All Tests"
       aria-label="Run All Tests"
+      // aria-busy + data-testid let E2E specs synchronise on the
+      // "running" → "idle" transition without racing the animate-spin
+      // class on the SVG. See seed#1168 / E2E_CONVENTIONS.
+      aria-busy={isRunning}
+      data-testid="fab-run-all-tests"
+      data-running={isRunning ? 'true' : 'false'}
     >
       {isRunning ? (
         <svg


### PR DESCRIPTION
Closes #1168 (Category D of #1170 triage). Last of the 5 sub-issues.

Five `fab.spec.ts` tests intermittently failed in CI because they asserted on the transient `svg.animate-spin` CSS class. If the backend completed faster than Playwright could attach the locator (the common case in CI), the spinner was gone before the visibility check ran — failing with "element(s) not found" despite the operation succeeding.

## Source-side (`src/components/ui/fab.tsx`)

- `data-testid="fab-run-all-tests"` on the button
- `aria-busy={isRunning}` (real a11y benefit too)
- `data-running="true"|"false"` — synchronously updates with React state, no animation timing involved

## Test-side (`e2e/fab.spec.ts`)

- Replace 11 `page.locator('button[title=...]').or(page.locator('button[aria-label=...]'))` chains with `page.getByTestId('fab-run-all-tests')`.
- Replace 7 `fab.locator('svg.animate-spin')` visibility/hidden assertions with `expect(fab).toHaveAttribute('data-running', '...')`. Attribute checks are deterministic — no race with the CSS class on the SVG.
- Drop the redundant `el.classList.contains('animate-spin')` evaluate() call; the toHaveAttribute on the parent FAB is enough.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] Pre-commit hook pass
- [ ] All 5 listed FAB tests green in CI (after #1172 lands the auth fix)
- [ ] No flakiness across 5 consecutive CI runs (the actual acceptance criterion in #1168)