### PR TITLE
fix(e2e): add header-logout testid + retire SVG class fallback in auth-complete

### DIFF
--- a/ui/e2e/auth-complete.spec.ts
+++ b/ui/e2e/auth-complete.spec.ts
@@ -113,9 +113,7 @@ test.describe('Complete Authentication Lifecycle', () => {
 
     test('should logout successfully on desktop', async ({ page }) => {
       // Find and click logout button
-      const logoutButton = page
-        .getByRole('button', { name: /logout|sign out/i })
-        .or(page.locator('button:has(svg[class*="logout"], svg[class*="sign-out"])'));
+      const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
 
@@ -141,9 +139,7 @@ test.describe('Complete Authentication Lifecycle', () => {
       });
 
       // Click logout
-      const logoutButton = page
-        .getByRole('button', { name: /logout|sign out/i })
-        .or(page.locator('button:has(svg[class*="logout"], svg[class*="sign-out"])'));
+      const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
 
@@ -167,9 +163,7 @@ test.describe('Complete Authentication Lifecycle', () => {
       });
 
       // Logout
-      const logoutButton = page
-        .getByRole('button', { name: /logout|sign out/i })
-        .or(page.locator('button:has(svg[class*="logout"], svg[class*="sign-out"])'));
+      const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
       await expect(page.getByTestId('login-title')).toBeVisible({
@@ -190,9 +184,7 @@ test.describe('Complete Authentication Lifecycle', () => {
 
     test('should prevent access to protected routes after logout', async ({ page }) => {
       // Logout
-      const logoutButton = page
-        .getByRole('button', { name: /logout|sign out/i })
-        .or(page.locator('button:has(svg[class*="logout"], svg[class*="sign-out"])'));
+      const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
       await expect(page.getByTestId('login-title')).toBeVisible({
@@ -209,9 +201,7 @@ test.describe('Complete Authentication Lifecycle', () => {
 
     test('should display empty login form after logout', async ({ page }) => {
       // Logout
-      const logoutButton = page
-        .getByRole('button', { name: /logout|sign out/i })
-        .or(page.locator('button:has(svg[class*="logout"], svg[class*="sign-out"])'));
+      const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
       await expect(page.getByTestId('login-title')).toBeVisible({
@@ -276,9 +266,7 @@ test.describe('Complete Authentication Lifecycle', () => {
       });
 
       // Logout to simulate session expiry
-      const logoutButton = page
-        .getByRole('button', { name: /logout|sign out/i })
-        .or(page.locator('button:has(svg[class*="logout"], svg[class*="sign-out"])'));
+      const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
       await expect(page.getByTestId('login-title')).toBeVisible({
@@ -380,9 +368,7 @@ test.describe('Complete Authentication Lifecycle', () => {
       }
 
       // Find logout button
-      const logoutButton = page
-        .getByRole('button', { name: /logout|sign out/i })
-        .or(page.locator('button:has(svg[class*="logout"], svg[class*="sign-out"])'));
+      const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
 

--- a/ui/src/components/app/HeaderBar.tsx
+++ b/ui/src/components/app/HeaderBar.tsx
@@ -654,6 +654,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = memo(function headerBar({
             type="button"
             className={iconButtonClass}
             onClick={logout}
+            data-testid="header-logout"
             aria-label={t('buttons.logout')}
             title={t(
               'tooltips.header.logout',


### PR DESCRIPTION
Gap #3 + #7 from triage analysis. Cleans up the last brittle selector pattern in the app-shell area.

- HeaderBar logout button gets `data-testid="header-logout"` (mirrors the existing header-open-settings / header-open-help testids from #1115).
- auth-complete.spec.ts replaces 7 instances of the brittle `.getByRole('button', {name: /logout|sign out/i}).or(locator('button:has(svg[class*="logout"])...'))` chain with `getByTestId('header-logout')`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [ ] CI green (also depends on #1176 landing first to fix the storage-state poisoning)