### PR TITLE
fix(e2e): use #profile-modal-title id for modal assertion

### DIFF
--- a/ui/e2e/coverage-gaps.spec.ts
+++ b/ui/e2e/coverage-gaps.spec.ts
@@ -14,7 +14,10 @@ test.describe('Coverage gaps', () => {
     await page.getByLabel(/select profile/i).click();
     await page.getByRole('button', { name: /manage profiles/i }).click();
 
-    await expect(page.getByRole('heading', { name: /profile management/i })).toBeVisible();
+    // ProfileManagement.tsx already gives the H2 id="profile-modal-title"
+    // (aria-labelledby target on the dialog); using it avoids i18n drift
+    // on the /profile management/i regex.
+    await expect(page.locator('#profile-modal-title')).toBeVisible();
 
     await page.getByRole('button', { name: /close/i }).click();
   });


### PR DESCRIPTION
Gap #2 from the post-#1170 analysis. The /profile management/i regex in coverage-gaps.spec.ts was the last brittle text-regex on a modal heading. Switch to the existing #profile-modal-title id (already on the H2 as the aria-labelledby target) to make the locator locale-independent.