### PR TITLE
fix(e2e): replace remaining settings-drawer text regexes with testid (bulk)

### DIFF
--- a/ui/e2e/fab.spec.ts
+++ b/ui/e2e/fab.spec.ts
@@ -163,7 +163,7 @@ test.describe('FAB - Run All Tests Flow', () => {
     await settingsButton.click();
 
     // Wait for settings drawer
-    await expect(page.getByText(/thresholds|appearance|discovery/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('settings-drawer')).toBeVisible({ timeout: 5000 });
 
     // Look for FAB-related settings (if they exist in UI)
     // This will help verify FAB options are configurable

--- a/ui/e2e/responsive.spec.ts
+++ b/ui/e2e/responsive.spec.ts
@@ -115,7 +115,7 @@ test.describe('Responsive Layout Tests', () => {
       await settingsButton.click();
 
       // Settings drawer should be visible
-      await expect(page.getByText(/thresholds|appearance|discovery/i)).toBeVisible();
+      await expect(page.getByTestId('settings-drawer')).toBeVisible();
 
       // Check if drawer is full-screen or near full-screen
       const drawer = page.locator('[class*="drawer"], [role="dialog"]').first();
@@ -287,7 +287,7 @@ test.describe('Responsive Layout Tests', () => {
       await settingsButton.click();
 
       // Settings drawer should be visible
-      await expect(page.getByText(/thresholds|appearance|discovery/i)).toBeVisible();
+      await expect(page.getByTestId('settings-drawer')).toBeVisible();
 
       // Drawer should overlay content (not full-screen)
       const drawer = page.locator('[class*="drawer"], [role="dialog"]').first();
@@ -440,7 +440,7 @@ test.describe('Responsive Layout Tests', () => {
       await settingsButton.click();
 
       // Settings drawer should be visible
-      await expect(page.getByText(/thresholds|appearance|discovery/i)).toBeVisible();
+      await expect(page.getByTestId('settings-drawer')).toBeVisible();
 
       // Drawer should be positioned on right side
       const drawer = page.locator('[class*="drawer"], [role="dialog"]').first();
@@ -634,7 +634,7 @@ test.describe('Responsive Layout Tests', () => {
         await settingsButton.click();
 
         // Verify settings content visible
-        await expect(page.getByText(/thresholds|appearance|discovery/i)).toBeVisible({
+        await expect(page.getByTestId('settings-drawer')).toBeVisible({
           timeout: 5000,
         });
 

--- a/ui/e2e/settings.spec.ts
+++ b/ui/e2e/settings.spec.ts
@@ -30,7 +30,7 @@ test.describe('Settings', () => {
     await settingsButton.click();
 
     // Wait for drawer to open
-    await expect(page.getByText(/thresholds|appearance|discovery/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('settings-drawer')).toBeVisible({ timeout: 5000 });
   });
 
   test('should display Appearance settings section', async ({ page }) => {
@@ -171,7 +171,7 @@ test.describe('Settings CRUD Operations', () => {
     await settingsButton.click();
 
     // Wait for drawer to open
-    await expect(page.getByText(/thresholds|appearance|discovery/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('settings-drawer')).toBeVisible({ timeout: 5000 });
   });
 
   test('should update threshold values and persist', async ({ page }) => {

--- a/ui/e2e/snmp-settings.spec.ts
+++ b/ui/e2e/snmp-settings.spec.ts
@@ -25,8 +25,9 @@ test.describe('SNMP Settings', () => {
     const settingsButton = page.getByTestId('header-open-settings');
     await settingsButton.click();
 
-    // Wait for settings drawer
-    await expect(page.getByText(/settings/i)).toBeVisible({ timeout: 5000 });
+    // Wait for settings drawer (use the stable testid added in #1174;
+    // the /settings/i text matched too many elements).
+    await expect(page.getByTestId('settings-drawer')).toBeVisible({ timeout: 5000 });
   });
 
   test('should display SNMP settings section', async ({ page }) => {


### PR DESCRIPTION
Bulk follow-up to #1174 — that PR added `data-testid="settings-drawer"` to `SettingsDrawer.tsx` but only migrated ONE call site (dashboard.spec.ts). 

The post-#1176 CI revealed **56 retry events of `getByText(/thresholds|appearance|discovery/i)`** still failing strict-mode (matches the drawer's description paragraph + 3 tab buttons).

## Sites migrated (8 total)

- `e2e/fab.spec.ts` ×1
- `e2e/responsive.spec.ts` ×4 (one per viewport tier)
- `e2e/settings.spec.ts` ×2
- `e2e/snmp-settings.spec.ts` ×1 (was `/settings/i` — even broader; matched the drawer AND the header Open Settings button)

## Left alone

Tests that look for the specific tabs INSIDE the drawer (Appearance, Thresholds, Discovery, SNMP) — those genuinely need the per-tab text or per-tab testids.

## Test plan

- [x] tsc clean
- [x] biome check clean
- [ ] CI green — predicts a further reduction from 85 → ~30 failing