### PR TITLE
ci(e2e): finish multi-browser rollout for full e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,7 +844,8 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: ui
-        run: npx playwright install --with-deps chromium
+        # Per E2E_CONVENTIONS: chromium (Chrome+Edge) and webkit (Safari).
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Start backend server
         env:
@@ -876,7 +877,9 @@ jobs:
           PLAYWRIGHT_IGNORE_HTTPS_ERRORS: "true"
         # Smoke tier runs in the e2e-smoke job; full e2e skips it to
         # avoid duplicate runtime. See seed#1053.
-        run: npx playwright test --project=chromium --reporter=html --grep-invert "@smoke"
+        # Both chromium and webkit run per E2E_CONVENTIONS — the projects
+        # array in playwright.config.ts is now exactly [chromium, webkit].
+        run: npx playwright test --reporter=html --grep-invert "@smoke"
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary
PR #1148 only updated the e2e-smoke job. The full e2e job still installed chromium-only and ran `--project=chromium`. WebKit coverage existed only at the smoke tier; the full suite remained single-browser.

## Changes
- Install: `chromium webkit` (was chromium only)
- Dropped `--project=chromium` so the run picks up both projects from `playwright.config.ts`, which is exactly `[chromium, webkit]` since #1148.

## Verification
`~/Developer/.e2e-remediation-2026q2/verify.sh seed` CI Reality Check will flip from `invoked=[project=chromium]` to `invoked=[(all projects from config)]`.

Completes Phase 2.4 for Seed.