### PR TITLE
chore(e2e): delete 17 no-value tests + 1 fixme per per-test eval

### DIFF
--- a/ui/e2e/fab.spec.ts
+++ b/ui/e2e/fab.spec.ts
@@ -129,79 +129,19 @@ test.describe('FAB - Run All Tests Flow', () => {
     await expect(playIcon).toBeVisible();
   });
 
-  test('should not trigger tests if FAB is clicked while already running', async ({ page }) => {
-    const fab = page.getByTestId('fab-run-all-tests');
-
-    // Click FAB first time
-    await fab.click();
-    await expect(fab).toBeDisabled();
-
-    // Try clicking again while disabled
-    const _clickCount = await page.evaluate(() => {
-      let count = 0;
-      window.addEventListener('runAllTests', () => count++);
-      return count;
-    });
-
-    // Try to click disabled FAB
-    await fab.click({ force: true }).catch(() => {
-      // Expected to fail or do nothing
-    });
-
-    // Should still only have one test run
-    const finalCount = await page.evaluate(
-      () => (window as unknown as { runAllTestsCount?: number }).runAllTestsCount || 0,
-    );
-
-    // Event should not have fired multiple times
-    expect(finalCount).toBeLessThanOrEqual(1);
-  });
-
-  test('should respect FAB options from settings', async ({ page }) => {
-    // Open settings drawer
-    const settingsButton = page.getByTestId('header-open-settings');
-    await settingsButton.click();
-
-    // Wait for settings drawer
-    await expect(page.getByTestId('settings-drawer')).toBeVisible({ timeout: 5000 });
-
-    // Look for FAB-related settings (if they exist in UI)
-    // This will help verify FAB options are configurable
-    const fabSettings = page.locator('text=/FAB|Run All Tests|Test Options/i').first();
-    const hasFabSettings = await fabSettings.isVisible();
-
-    if (hasFabSettings) {
-      // If FAB settings exist, verify they can be changed
-      await expect(fabSettings).toBeVisible();
-    }
-
-    // Close settings
-    const closeButton = page.getByRole('button', { name: /close/i }).first();
-    await closeButton.click();
-  });
-
-  test('should trigger network discovery scan when FAB is clicked', async ({ page }) => {
-    // Track if network discovery scan endpoint is called
-    let scanTriggered = false;
-
-    page.on('request', (request) => {
-      if (request.url().includes('/api/devices/scan') && request.method() === 'POST') {
-        scanTriggered = true;
-      }
-    });
-
-    const fab = page.getByTestId('fab-run-all-tests');
-
-    // Click FAB
-    await fab.click();
-
-    // Wait a bit for scan to be triggered
-
-    // Verify scan was triggered (if network discovery is enabled in FAB options)
-    // Note: This depends on default FAB options configuration
-    // The test verifies the mechanism works, actual behavior depends on settings
-    expect(scanTriggered).toBeDefined();
-  });
+  // Deleted: "should not trigger tests if FAB is clicked while already
+  //   running" — tested window.runAllTestsCount which is never set;
+  //   finalCount was always 0 and `expect(0).toBeLessThanOrEqual(1)`
+  //   is tautologically true. The disabled-state on click is already
+  //   covered by `toBeDisabled()` in the spinner test above.
+  // Deleted: "should respect FAB options from settings" — body wrapped
+  //   in `if (hasFabSettings)`; silently passes when the panel doesn't
+  //   exist (which is always, currently). Tested nothing.
+  // Deleted: "should trigger network discovery scan when FAB is
+  //   clicked" — final assertion `expect(scanTriggered).toBeDefined()`
+  //   on a `let scanTriggered = false` is tautological.
+  // See msn-docs-internal/05-Engineering/SEED_E2E_PER_TEST_EVAL_2026-05-26.md
+  // for the full evaluation.
 
   test('should handle test failures gracefully', async ({ page }) => {
     // Intercept an API call and make it fail

--- a/ui/e2e/snmp-settings.spec.ts
+++ b/ui/e2e/snmp-settings.spec.ts
@@ -4,13 +4,24 @@ import { skipSetupWizard } from './helpers/auth';
 /**
  * SNMP Settings E2E Tests
  *
- * Tests for SNMP configuration functionality:
- * - SNMP version selection (v1, v2c, v3)
- * - Community string configuration
- * - SNMPv3 credentials (username, auth, privacy)
- * - Target device configuration
- * - Settings persistence
- * - Validation and error handling
+ * Two intentionally narrow tests after the 2026-05-26 prune:
+ *  - Section exists in the settings drawer.
+ *  - Password fields are masked (input[type="password"]).
+ *
+ * The previous shape of this file had 14 additional tests, every
+ * single one wrapped in `if (hasInput) { ... }` / `if (hasSelector)
+ * { try { ... } catch { expect(true).toBeTruthy() } }` / final
+ * assertion `expect(hasButton).toBeDefined()`. All silent-passes
+ * or tautological. They tested nothing — when the SNMP form
+ * inputs weren't found (the actual current state of the UI) the
+ * tests passed without exercising any code path. Per Daisy's rule
+ * "tests must have real value, not just exist", they're gone.
+ *
+ * When SNMP configuration UI lands properly, add focused tests
+ * here that use mocks (page.route on /api/v1/snmp/...) and assert
+ * on deterministic round-trip behaviour, with stable testids on
+ * the form inputs. See msn-docs-internal/05-Engineering/
+ * SEED_E2E_PER_TEST_EVAL_2026-05-26.md for the full audit.
  */
 
 test.describe('SNMP Settings', () => {
@@ -21,372 +32,34 @@ test.describe('SNMP Settings', () => {
       timeout: 10000,
     });
 
-    // Open settings drawer
     const settingsButton = page.getByTestId('header-open-settings');
     await settingsButton.click();
 
-    // Wait for settings drawer (use the stable testid added in #1174;
-    // the /settings/i text matched too many elements).
     await expect(page.getByTestId('settings-drawer')).toBeVisible({ timeout: 5000 });
   });
 
   test('should display SNMP settings section', async ({ page }) => {
-    // Look for SNMP section in settings
+    // Section heading inside the drawer. Currently looked up by
+    // /snmp/i text — fine for the section heading which is short
+    // and unique inside the drawer. If a sibling element ever
+    // adds the substring "SNMP" elsewhere in the drawer, add a
+    // data-testid="settings-section-snmp" on SnmpSettings.tsx and
+    // switch to that.
     const snmpSection = page.getByText(/snmp/i).first();
     await expect(snmpSection).toBeVisible();
   });
 
-  test('should have SNMP version selector', async ({ page }) => {
-    // Look for version selector
-    const versionSelector = page
-      .locator('select[name*="snmp" i]')
-      .or(page.locator('select:near(:text("SNMP"))'))
-      .or(page.getByRole('combobox', { name: /version/i }))
-      .first();
-
-    const hasSelector = await versionSelector.isVisible();
-
-    if (hasSelector) {
-      // Check for version options
-      const options = await versionSelector.locator('option').allTextContents();
-      expect(options.length).toBeGreaterThan(0);
-    }
-  });
-
-  test('should allow configuring community string for SNMPv2c', async ({ page }) => {
-    // Look for community string input
-    const communityInput = page
-      .locator('input[name*="community" i]')
-      .or(page.locator('input[placeholder*="community" i]'))
-      .or(page.locator('input:near(:text("Community"))'))
-      .first();
-
-    const hasInput = await communityInput.isVisible();
-
-    if (hasInput) {
-      const originalValue = await communityInput.inputValue();
-
-      // Enter test community string
-      await communityInput.fill('test-community');
-
-      // Verify value was set
-      const newValue = await communityInput.inputValue();
-      expect(newValue).toBe('test-community');
-
-      // Restore original
-      await communityInput.fill(originalValue || 'public');
-    }
-  });
-
-  test('should show SNMPv3 credentials when v3 selected', async ({ page }) => {
-    // Find version selector
-    const versionSelector = page
-      .locator('select[name*="snmp" i]')
-      .or(page.locator('select:near(:text("SNMP"))'))
-      .first();
-
-    const hasSelector = await versionSelector.isVisible();
-
-    if (hasSelector) {
-      // Select v3
-      await versionSelector.selectOption({ label: /v3/i });
-
-      // Look for v3-specific fields
-      const usernameField = page.locator(
-        'input[name*="username" i], input[placeholder*="username" i]',
-      );
-      const authField = page.locator('input[name*="auth" i], select[name*="auth" i]');
-      const privField = page.locator('input[name*="priv" i], select[name*="priv" i]');
-
-      const hasUsername = await usernameField.isVisible();
-      const hasAuth = await authField.isVisible();
-      const hasPriv = await privField.isVisible();
-
-      // At least some v3 fields should appear
-      expect(hasUsername || hasAuth || hasPriv).toBeTruthy();
-    }
-  });
-
-  test('should allow configuring SNMP target address', async ({ page }) => {
-    // Look for target/host input
-    const targetInput = page
-      .locator('input[name*="target" i]')
-      .or(page.locator('input[name*="host" i]'))
-      .or(page.locator('input[placeholder*="ip" i]'))
-      .first();
-
-    const hasInput = await targetInput.isVisible();
-
-    if (hasInput) {
-      // Enter test target
-      await targetInput.fill('192.168.1.1');
-
-      const value = await targetInput.inputValue();
-      expect(value).toBe('192.168.1.1');
-    }
-  });
-
-  test('should validate SNMP port number', async ({ page }) => {
-    // Look for port input
-    const portInput = page
-      .locator('input[name*="port" i]')
-      .or(page.locator('input[type="number"]:near(:text("Port"))'))
-      .first();
-
-    const hasInput = await portInput.isVisible();
-
-    if (hasInput) {
-      const originalValue = await portInput.inputValue();
-
-      // Try invalid port
-      await portInput.fill('999999');
-
-      // Should either show error or clamp to valid range
-      const value = await portInput.inputValue();
-      const portNum = Number.parseInt(value, 10);
-
-      // Valid port range is 1-65535
-      expect(portNum).toBeLessThanOrEqual(65535);
-
-      // Restore original
-      await portInput.fill(originalValue || '161');
-    }
-  });
-
-  test('should persist SNMP settings', async ({ page }) => {
-    // Find community input
-    const communityInput = page
-      .locator('input[name*="community" i]')
-      .or(page.locator('input[placeholder*="community" i]'))
-      .first();
-
-    const hasInput = await communityInput.isVisible();
-
-    if (hasInput) {
-      // Set unique value
-      const testValue = `persist-test-${Date.now()}`;
-      await communityInput.fill(testValue);
-
-      // Close settings
-      const closeButton = page.getByRole('button', { name: /close/i }).first();
-      await closeButton.click();
-
-      // Reopen settings
-      const settingsButton = page.getByRole('button', { name: /settings/i });
-      await settingsButton.click();
-
-      // Check if value persisted
-      const reopenedInput = page
-        .locator('input[name*="community" i]')
-        .or(page.locator('input[placeholder*="community" i]'))
-        .first();
-
-      const persistedValue = await reopenedInput.inputValue();
-
-      // Value should persist
-      expect(persistedValue).toBe(testValue);
-    }
-  });
-
-  test('should show SNMP toggle to enable/disable', async ({ page }) => {
-    // Look for enable/disable toggle
-    const enableToggle = page
-      .locator('input[type="checkbox"]:near(:text("SNMP"))')
-      .or(page.locator('label:has-text("SNMP") input[type="checkbox"]'))
-      .first();
-
-    const hasToggle = await enableToggle.isVisible();
-
-    if (hasToggle) {
-      const _wasChecked = await enableToggle.isChecked();
-
-      // Toggle and verify changes
-      await enableToggle.click();
-
-      // Restore
-      await enableToggle.click();
-    }
-  });
-
-  test('should hide/show SNMP fields based on enable toggle', async ({ page }) => {
-    // Find enable toggle
-    const enableToggle = page.locator('input[type="checkbox"]:near(:text("SNMP"))').first();
-
-    const hasToggle = await enableToggle.isVisible();
-
-    if (hasToggle) {
-      // If SNMP is enabled, fields should be visible
-      const _wasChecked = await enableToggle.isChecked();
-
-      // Look for SNMP config fields
-      const configFields = page.locator(
-        'input[name*="community" i], input[name*="target" i], select[name*="version" i]',
-      );
-
-      const fieldCount = await configFields.count();
-
-      // Fields visibility may depend on toggle state
-      expect(typeof fieldCount).toBe('number');
-    }
-  });
-});
-
-test.describe('SNMP Authentication', () => {
-  test.beforeEach(async ({ page }) => {
-    await skipSetupWizard(page);
-    await page.goto('/');
-    await expect(page.getByTestId('page-header-title')).toBeVisible({
-      timeout: 10000,
-    });
-
-    const settingsButton = page.getByRole('button', { name: /settings/i });
-    await settingsButton.click();
-  });
-
-  test('should have authentication protocol selector for SNMPv3', async ({ page }) => {
-    // Select v3 first
-    const versionSelector = page.locator('select:near(:text("SNMP"))').first();
-    const hasSelector = await versionSelector.isVisible();
-
-    if (hasSelector) {
-      // Try to select v3
-      try {
-        await versionSelector.selectOption({ label: /v3/i });
-
-        // Look for auth protocol selector
-        const authProtocol = page
-          .locator('select[name*="auth" i]')
-          .or(page.getByRole('combobox', { name: /auth/i }))
-          .first();
-
-        const hasAuthProtocol = await authProtocol.isVisible();
-
-        // Should have auth protocol options (MD5, SHA, etc.)
-        if (hasAuthProtocol) {
-          const options = await authProtocol.locator('option').allTextContents();
-          expect(options.length).toBeGreaterThan(0);
-        }
-      } catch {
-        // v3 option may not exist
-        expect(true).toBeTruthy();
-      }
-    }
-  });
-
-  test('should have privacy protocol selector for SNMPv3', async ({ page }) => {
-    // Select v3 first
-    const versionSelector = page.locator('select:near(:text("SNMP"))').first();
-    const hasSelector = await versionSelector.isVisible();
-
-    if (hasSelector) {
-      try {
-        await versionSelector.selectOption({ label: /v3/i });
-
-        // Look for privacy protocol selector
-        const privProtocol = page
-          .locator('select[name*="priv" i]')
-          .or(page.getByRole('combobox', { name: /priv/i }))
-          .first();
-
-        const hasPrivProtocol = await privProtocol.isVisible();
-
-        // Should have privacy protocol options (DES, AES, etc.)
-        if (hasPrivProtocol) {
-          const options = await privProtocol.locator('option').allTextContents();
-          expect(options.length).toBeGreaterThan(0);
-        }
-      } catch {
-        // v3 option may not exist
-        expect(true).toBeTruthy();
-      }
-    }
-  });
-
   test('should mask password/passphrase fields', async ({ page }) => {
-    // Look for password inputs
+    // Walk every password input rendered in the drawer and assert
+    // type is 'password'. A regression to type="text" would leak
+    // credentials in screen captures and clipboard.
     const passwordInputs = page.locator('input[type="password"]');
-
     const count = await passwordInputs.count();
 
-    // Password fields should be masked
     for (let i = 0; i < count; i++) {
       const input = passwordInputs.nth(i);
       const type = await input.getAttribute('type');
       expect(type).toBe('password');
-    }
-  });
-});
-
-test.describe('SNMP Test Connection', () => {
-  test.beforeEach(async ({ page }) => {
-    await skipSetupWizard(page);
-    await page.goto('/');
-    await expect(page.getByTestId('page-header-title')).toBeVisible({
-      timeout: 10000,
-    });
-
-    const settingsButton = page.getByRole('button', { name: /settings/i });
-    await settingsButton.click();
-  });
-
-  test('should have test connection button', async ({ page }) => {
-    // Look for test connection button in SNMP section
-    const testButton = page
-      .locator('button:has-text("Test")')
-      .or(page.locator('button:has-text("Connect")'))
-      .or(page.locator('button:has-text("Verify")'))
-      .first();
-
-    const hasButton = await testButton.isVisible();
-    expect(hasButton).toBeDefined();
-  });
-
-  test('should show connection status after test', async ({ page }) => {
-    // Find and click test button
-    const testButton = page
-      .locator('button:has-text("Test")')
-      .or(page.locator('button:has-text("Connect")'))
-      .first();
-
-    const hasButton = await testButton.isVisible();
-
-    if (hasButton) {
-      await testButton.click();
-
-      // Look for status message
-      const statusMessage = page.getByText(/success|failed|error|connected|timeout/i).first();
-
-      const hasStatus = await statusMessage.isVisible();
-      expect(hasStatus).toBeDefined();
-    }
-  });
-
-  test('should handle connection timeout gracefully', async ({ page }) => {
-    // Set unreachable target
-    const targetInput = page
-      .locator('input[name*="target" i]')
-      .or(page.locator('input[placeholder*="ip" i]'))
-      .first();
-
-    const hasInput = await targetInput.isVisible();
-
-    if (hasInput) {
-      await targetInput.fill('10.255.255.1');
-
-      // Try to test connection
-      const testButton = page.locator('button:has-text("Test")').first();
-      const hasButton = await testButton.isVisible();
-
-      if (hasButton) {
-        await testButton.click();
-
-        // Should show timeout/error message (not crash)
-        const errorMessage = page.getByText(/timeout|error|failed|unreachable/i);
-        const _hasError = await errorMessage.isVisible();
-
-        // App should handle gracefully
-        expect(true).toBeTruthy();
-      }
     }
   });
 });

--- a/ui/e2e/theme-and-help.spec.ts
+++ b/ui/e2e/theme-and-help.spec.ts
@@ -222,20 +222,18 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       expect(stillDark).toBe(isDark);
     });
 
-    test('should respect system theme preference if implemented', async ({ page }) => {
-      // This test is skipped as system theme preference may not be implemented
-      // To implement: check if theme matches system preference on first load
-
-      // Get system theme preference
+    // System-theme-sync (prefers-color-scheme) is not implemented in
+    // seed; this test would always fail until the feature exists.
+    // Marked fixme so it surfaces in reports as expected-broken
+    // (loud-failure pattern, no silent skip) without blocking CI.
+    // Drop the fixme when the feature lands. Per 2026-05-26 audit
+    // in msn-docs-internal/05-Engineering/SEED_E2E_PER_TEST_EVAL_*.
+    test.fixme('should respect system theme preference if implemented', async ({ page }) => {
       const systemPrefersDark = await page.evaluate(
         () => window.matchMedia('(prefers-color-scheme: dark)').matches,
       );
-
-      // Check if app theme matches system theme
       const htmlClasses = await page.locator('html').getAttribute('class');
       const appIsDark = htmlClasses?.includes('dark') ?? false;
-
-      // If system theme sync is implemented, these should match
       expect(appIsDark).toBe(systemPrefersDark);
     });
   });


### PR DESCRIPTION
Per the directive **"tests must have real value, not just exist"**, removes tests that demonstrably cannot fail meaningfully.

Full per-test rationale in [SEED_E2E_PER_TEST_EVAL_2026-05-26.md](https://github.com/krisarmstrong/msn-docs-internal/pull/9).

## Patterns removed

1. `if (visible) { real assertion }` silent-pass — when the UI element isn't found the test passes without exercising any assertion.
2. `expect(<bool>).toBeDefined()` — assertion on a boolean from `isVisible()` is always true regardless of visibility.
3. `try { real check } catch { expect(true).toBeTruthy() }` — catch branch makes the test always pass.
4. Tests checking globals that nothing sets (e.g. `window.runAllTestsCount` in fab.spec.ts).

## Files

| File | Δ tests | Note |
|---|---|---|
| `e2e/fab.spec.ts` | -3 | Removed: "should not trigger tests if FAB is clicked while already running", "should respect FAB options from settings", "should trigger network discovery scan when FAB is clicked" |
| `e2e/snmp-settings.spec.ts` | -14 (rewrite) | Kept the 2 with real assertions (section-exists + password-masking). All other 14 used `if (hasInput)` swallows + tautological `.toBeDefined()`. |
| `e2e/theme-and-help.spec.ts` | -1 active, +1 fixme | `should respect system theme preference if implemented` — flipped to `test.fixme` since prefers-color-scheme sync isn't implemented in seed. Loud-failure pattern (no silent skip). Drop the fixme when the feature lands. |

## Expected impact

Takes the failing-test list from 64 events to roughly 14 (the FIX category from the eval doc), unblocking CI from admin-merge dependence.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] Pre-commit hook pass
- [ ] CI green or near-green (validates the prediction)