### PR TITLE
fix(i18n): update document.lang on locale change for a11y

### DIFF
--- a/ui/src/i18n/index.ts
+++ b/ui/src/i18n/index.ts
@@ -129,4 +129,16 @@ i18n
     debug: import.meta.env.DEV,
   });
 
+// Keep the document's lang attribute in sync with the active locale.
+// Required for screen readers, search engines, browser spell-check, and
+// CSS :lang() selectors. Without this, `<html lang="en">` from index.html
+// stays English even after the user switches to Spanish — WCAG 3.1.1/3.1.2
+// violation. Per msn-docs-internal/05-Engineering/I18N_CONVENTIONS.md.
+if (typeof document !== 'undefined') {
+  document.documentElement.lang = i18n.language;
+  i18n.on('languageChanged', (lng) => {
+    document.documentElement.lang = lng;
+  });
+}
+
 export default i18n;


### PR DESCRIPTION
## Summary
The `<html lang="en">` attribute in `index.html` was hardcoded and never updated when a user switched to Spanish. Screen-reader announcements kept English voice for Spanish users; browser spell-check kept suggesting English corrections; search-engine indexing was wrong; CSS `:lang()` selectors didn't trigger. **WCAG 3.1.1 + 3.1.2 violation.**

## Fix
Attach a listener to `i18n.on('languageChanged', ...)` and set the initial value at module load. Both branches gated on `typeof document !== 'undefined'` (SSR-safe).

Per `msn-docs-internal/05-Engineering/I18N_CONVENTIONS.md` 'Required patterns' section.

## Test plan
- [ ] Load app in default locale → `document.documentElement.lang === 'en'`
- [ ] Switch to Spanish in Settings → `document.documentElement.lang === 'es'` and VoiceOver/JAWS announces in Spanish
- [ ] Reload → locale persists, lang attribute persists

## Context
Phase 1B for Seed. Stem follows. NIAC needs Phase 2 framework install before this can land there.