### PR TITLE
chore(deps): bump i18next 26.2.0 -> 26.3.0 per always-latest

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,7 +13,7 @@
         "@tailwindcss/postcss": "4.3.0",
         "@tanstack/react-query": "5.100.14",
         "cmdk": "^1.1.1",
-        "i18next": "26.2.0",
+        "i18next": "26.3.0",
         "i18next-browser-languagedetector": "8.2.1",
         "immer": "11.1.8",
         "jszip": "3.10.1",
@@ -5174,9 +5174,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
-      "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.0.tgz",
+      "integrity": "sha512-gHSgGpUXVmuqE2El1W61DmxeyeTlFfZgdJRWMo9jScAn5pu7TuTuiccb1zh3E2J9hEBVGJ23+96x0ieBhfuIHA==",
       "funding": [
         {
           "type": "individual",

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,7 +30,7 @@
     "@tailwindcss/postcss": "4.3.0",
     "@tanstack/react-query": "5.100.14",
     "cmdk": "^1.1.1",
-    "i18next": "26.2.0",
+    "i18next": "26.3.0",
     "i18next-browser-languagedetector": "8.2.1",
     "immer": "11.1.8",
     "jszip": "3.10.1",


### PR DESCRIPTION
Per CLAUDE.md always-latest policy and I18N_CONVENTIONS.md locked versions. Lockstep with Stem. Pure maintenance bump (26.3.0 is non-breaking). Phase 1C.