### PR TITLE
feat(license): refresh feature catalog per 2026-05-26 review

### DIFF
--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -109,7 +109,16 @@ func TestFormatKey(t *testing.T) {
 // fix the cipher, or regenerate keygen + update all three products in
 // lockstep.
 //
-// Anchored to keygen v2.0.0 (2026-05-21).
+// Anchored to keygen v2.1.0 (2026-05-26). Features updated:
+//   - multi_interface moved Starter→Pro (definition tightened to
+//     "more than 1 ethernet + 1 wifi configured concurrently").
+//   - multi_user added to Pro (replaces the previously-muddy role
+//     multi_interface used to play as the ops-team differentiator).
+//   - multi_site renamed → multi_client (same feature, clearer
+//     name; old name confused with geographic locations).
+//
+// Keys themselves are unchanged — they encode only
+// (product, serial, tier), not the feature list.
 func TestKeygenContract(t *testing.T) {
 	t.Parallel()
 	vectors := []keygenVector{
@@ -121,7 +130,6 @@ func TestKeygenContract(t *testing.T) {
 			serial:  "SEEDSTR",
 			features: []string{
 				"monitoring_scheduled",
-				"multi_interface",
 				"wifi_visibility_basic",
 				"compliance_basic",
 				"export_csv_json",
@@ -134,12 +142,13 @@ func TestKeygenContract(t *testing.T) {
 			product: "4002",
 			serial:  "SEEDPRO",
 			features: []string{
-				"monitoring_scheduled", "multi_interface", "wifi_visibility_basic",
+				"monitoring_scheduled", "wifi_visibility_basic",
 				"compliance_basic", "export_csv_json",
 				"wifi_roam_analysis", "wifi_association_forensics",
 				"airmapper_baseline_diff", "anomaly_detection", "path_analysis",
 				"live_telemetry", "compliance_advanced", "scheduled_reports",
-				"audit_pdf", "multi_site", "white_label", "rest_api",
+				"audit_pdf", "multi_interface", "multi_user", "multi_client",
+				"white_label", "rest_api",
 			},
 		},
 	}

--- a/internal/license/validator.go
+++ b/internal/license/validator.go
@@ -247,10 +247,13 @@ func (li *Info) CanRunPro() bool {
 
 // starterFeatures returns the feature list granted to Seed Starter
 // (product code 4001). Mirrors keygen's productCatalog.
+//
+// 2026-05-26: multi_interface moved to Pro-only — definition
+// tightened to mean "more than 1 ethernet + 1 wifi configured
+// concurrently." Starter stays at the 1+1 baseline like Free.
 func starterFeatures() []string {
 	return []string{
 		"monitoring_scheduled",
-		"multi_interface",
 		"wifi_visibility_basic",
 		"compliance_basic",
 		"export_csv_json",
@@ -260,6 +263,19 @@ func starterFeatures() []string {
 // proFeatures returns the feature list granted to Seed Pro (product
 // code 4002). Includes every Starter feature plus the Pro additions.
 // Mirrors keygen's productCatalog.
+//
+// 2026-05-26 catalog changes:
+//   - multi_interface moved here from Starter (now Pro-only).
+//     Free/Starter cap at 1 ethernet + 1 wifi; Pro unlimited.
+//     Profile-schema spec in seed#1192.
+//   - multi_user added — backend (UserStore, per-user token
+//     version) already in place; CRUD + UI tracked in seed#1191.
+//     "Ops team vs solo" differentiator.
+//   - multi_client renamed from multi_site. Same feature (the MSP
+//     Profile system, seed#754 — one Seed instance, N client-
+//     specific profiles) under a clearer name. The old name
+//     sounded like geographically distributed locations, which
+//     isn't what this is.
 func proFeatures() []string {
 	pro := []string{
 		"wifi_roam_analysis",
@@ -271,7 +287,9 @@ func proFeatures() []string {
 		"compliance_advanced",
 		"scheduled_reports",
 		"audit_pdf",
-		"multi_site",
+		"multi_interface",
+		"multi_user",
+		"multi_client",
 		"white_label",
 		"rest_api",
 	}


### PR DESCRIPTION
Aligns seed validator + contract test with keygen v2.1.0 catalog. Companion to msn-internal-tools PR #1 (catalog) and msn-docs-internal PR #12 (matrix).

- multi_interface moved Starter → Pro
- multi_user added to Pro (backend ready via UserStore; UI in seed#1191)
- multi_site renamed → multi_client (same MSP Profile feature, clearer name)

Tests: `go test -race ./internal/license/` clean.