### PR TITLE
feat(i18n): add useLocale hook + migrate VulnerabilitySettings plural (Phase 7 backfill)

### DIFF
--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -162,5 +162,11 @@
       "howToFix": "How to fix:",
       "dismiss": "Dismiss warning"
     }
+  },
+  "plurals": {
+    "intervalMinutes": "{{count}} min",
+    "intervalHours": "{{count}} hr",
+    "intervalDays_one": "{{count}} day",
+    "intervalDays_other": "{{count}} days"
   }
 }

--- a/internal/i18n/locales/es/common.json
+++ b/internal/i18n/locales/es/common.json
@@ -162,5 +162,11 @@
       "howToFix": "Cómo solucionarlo:",
       "dismiss": "Descartar advertencia"
     }
+  },
+  "plurals": {
+    "intervalMinutes": "{{count}} min",
+    "intervalHours": "{{count}} h",
+    "intervalDays_one": "{{count}} día",
+    "intervalDays_other": "{{count}} días"
   }
 }

--- a/ui/src/components/settings/sections/VulnerabilitySettings.tsx
+++ b/ui/src/components/settings/sections/VulnerabilitySettings.tsx
@@ -51,6 +51,7 @@ interface VulnerabilitySettingsProps {
 export const VulnerabilitySettings: React.NamedExoticComponent<VulnerabilitySettingsProps> = memo(
   function vulnerabilitySettings({ settings, setSettings, status }: VulnerabilitySettingsProps) {
     const { t } = useTranslation('settings');
+    const { t: tCommon } = useTranslation('common');
     const [scanStatus, setScanStatus] = useState<VulnerabilityScanStatus | null>(null);
     const [statusLoading, setStatusLoading] = useState(false);
 
@@ -168,15 +169,18 @@ export const VulnerabilitySettings: React.NamedExoticComponent<VulnerabilitySett
       [t],
     );
 
-    // Format update interval for display
+    // Format update interval for display. Plural rules differ by
+    // locale; the i18next _one/_other keys handle that correctly for
+    // the days case. Hours/minutes use a uniform suffix that's the
+    // same singular and plural in both EN and ES.
     const formatInterval = (seconds: number): string => {
       if (seconds < 3600) {
-        return `${Math.floor(seconds / 60)} min`;
+        return tCommon('plurals.intervalMinutes', { count: Math.floor(seconds / 60) });
       }
       if (seconds < 86400) {
-        return `${Math.floor(seconds / 3600)} hr`;
+        return tCommon('plurals.intervalHours', { count: Math.floor(seconds / 3600) });
       }
-      return `${Math.floor(seconds / 86400)} day${seconds >= 172800 ? 's' : ''}`;
+      return tCommon('plurals.intervalDays', { count: Math.floor(seconds / 86400) });
     };
 
     // Helper to get status banner background class

--- a/ui/src/hooks/useLocale.ts
+++ b/ui/src/hooks/useLocale.ts
@@ -1,0 +1,28 @@
+/**
+ * useLocale — single source for the active i18next language code.
+ *
+ * Returns a BCP-47 tag suitable for `Intl.*` constructors. i18next
+ * gives us the short code ('en' / 'es'); we normalise to the regional
+ * tags 'en-US' / 'es-ES' so number/date formatters get a sensible
+ * default (decimal separators, weekday names) without each call site
+ * having to pick.
+ *
+ * Use this whenever you'd otherwise call `Intl.NumberFormat(undefined,
+ * …)` or hardcode `'en-US'`. The hook re-renders consumers when the
+ * user switches language, so formatted strings flip automatically.
+ *
+ * Mirrors NIAC/Stem hooks/useLocale.ts (Phase 5/7) for cross-product
+ * consistency.
+ */
+
+import { useTranslation } from 'react-i18next';
+
+const REGION_BY_LANGUAGE: Record<string, string> = {
+  en: 'en-US',
+  es: 'es-ES',
+};
+
+export function useLocale(): string {
+  const { i18n } = useTranslation();
+  return REGION_BY_LANGUAGE[i18n.language] ?? i18n.language ?? 'en-US';
+}


### PR DESCRIPTION
## Summary

Phase 7 cross-repo backfill — ports the i18n patterns from
niac-go#719 and stem PR #324 over to seed so the three products stay
in sync.

- New \`ui/src/hooks/useLocale.ts\` — single source for the active
  BCP-47 tag (\`en\` → \`en-US\`, \`es\` → \`es-ES\`). Mirrors niac/stem
  verbatim. Use wherever code would otherwise hardcode a locale or
  call \`Intl.*\` with undefined locale.
- New \`common.plurals.{intervalMinutes,intervalHours,intervalDays_
  one/_other}\` keys.
- \`VulnerabilitySettings.tsx\`: \`formatInterval\` helper migrated
  from hand-rolled \`\${n} day\${n!==1?'s':''}\` to i18next plural
  keys. Uses two \`useTranslation\` hooks (\`settings\` + \`common\`)
  so the per-second plural rule still resolves through the right
  namespace.

## Out of scope (separate Phase 7 follow-up PRs)

- 3 hardcoded \`toLocaleString('en-US')\` sites in \`PerformanceCard\`
  + \`useLogs.ts\`. Should be replaced with \`useLocale\` or a
  \`useFormatTime\` hook — but they need the unified \`utils/format.ts\`
  module that seed doesn't have yet (each card has its own duplicate
  formatter).

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx biome check\` on touched files — clean
- [ ] Manual smoke: Settings → Vulnerability scan interval. Confirm:
  - 30s value shows \"0 min\" (EN) / \"0 min\" (ES)
  - 600s shows \"10 min\" both locales
  - 7200s shows \"2 hr\" (EN) / \"2 h\" (ES)
  - 86400s shows \"1 day\" (EN) / \"1 día\" (ES)
  - 172800s shows \"2 days\" (EN) / \"2 días\" (ES)