### PR TITLE
feat(seed#1196): wire multi_client gate on profile-create paths

### DIFF
--- a/internal/api/handlers_profiles.go
+++ b/internal/api/handlers_profiles.go
@@ -136,6 +136,13 @@ func (s *Server) handleCreateProfile(w http.ResponseWriter, r *http.Request) {
 	localizer := i18n.FromRequest(r)
 	ctx := r.Context()
 
+	// multi_client gate: Free/Starter may keep their bootstrap profile,
+	// but a SECOND (or later) profile requires Pro. Checked before body
+	// decode so we return 402 without scanning the request payload.
+	if !s.enforceMultiClientGate(w, r) {
+		return
+	}
+
 	var req ProfileRequest
 	if !decodeJSONStrictLocalized(w, r, &req, MaxBodySizeJSON, logger, localizer) {
 		return
@@ -479,6 +486,12 @@ func (s *Server) handleDuplicateProfile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// multi_client gate: duplicating always creates a NEW profile, which by
+	// definition pushes the operator over the Free/Starter 1-profile cap.
+	if !s.enforceMultiClientGate(w, r) {
+		return
+	}
+
 	if r.Method != http.MethodPost {
 		sendErrorResponseWithDetails(
 			w,
@@ -562,6 +575,13 @@ func (s *Server) handleImportProfiles(w http.ResponseWriter, r *http.Request) {
 	if s.db() == nil {
 		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
 			ErrCodeServiceUnavail, localizer.T("errors.profile.dbNotAvailable"), "") // fixes #694
+		return
+	}
+
+	// multi_client gate: any import that would land >1 profile total
+	// requires Pro. We gate at entry rather than mid-loop so partial
+	// imports don't leave the operator in an inconsistent state.
+	if !s.enforceMultiClientGate(w, r) {
 		return
 	}
 
@@ -704,6 +724,58 @@ func (s *Server) handleExportProfiles(w http.ResponseWriter, r *http.Request) {
 		Set("Content-Disposition", fmt.Sprintf("attachment; filename=seed-profiles-%s.json", time.Now().Format("2006-01-02")))
 
 	sendJSONResponse(w, logger, http.StatusOK, response)
+}
+
+// enforceMultiClientGate returns true if the request may proceed and
+// writes a 402 FeatureGateResponse + returns false when the operator
+// has reached the Free/Starter 1-profile cap and lacks the `multi_client`
+// feature. The first profile (bootstrap) is always allowed so a fresh
+// install is functional on any tier; this gate fires only when creating
+// a 2nd or later profile.
+//
+// MSP positioning: customer-facing copy always calls these "client
+// profiles." The internal feature key stays `multi_client`.
+func (s *Server) enforceMultiClientGate(w http.ResponseWriter, r *http.Request) bool {
+	logger := logging.FromContext(r.Context())
+
+	if s.db() == nil {
+		// No DB → no profile count to compare; fall through. The
+		// downstream handler returns a service-unavailable error.
+		return true
+	}
+
+	count, err := s.db().Profiles().Count(r.Context())
+	if err != nil {
+		logger.WarnContext(r.Context(), "multi_client gate: failed to count profiles", "error", err)
+		// Fail open — refusing to gate is safer than blocking the
+		// operator when the DB hiccups. CI catches it as a real error.
+		return true
+	}
+	if count < 1 {
+		// First-ever profile is always free.
+		return true
+	}
+
+	// 2nd+ profile. Check the license.
+	mgr := s.services.Auth.License
+	if mgr == nil {
+		// License disabled (dev / test builds) — permit.
+		return true
+	}
+	if mgr.HasFeature("multi_client") {
+		return true
+	}
+
+	localizer := i18n.FromRequest(r)
+	sendErrorResponseWithDetails(
+		w,
+		logger,
+		http.StatusPaymentRequired,
+		"TIER_TOO_LOW",
+		localizer.T("errors.profile.multiClientRequired"),
+		"",
+	)
+	return false
 }
 
 // profileToResponse converts a database profile to an API response.

--- a/internal/i18n/locales/en/errors.json
+++ b/internal/i18n/locales/en/errors.json
@@ -111,5 +111,8 @@
   "file": {
     "failedToRead": "Failed to read file",
     "pathNotConfigured": "Path not configured"
+  },
+  "profile": {
+    "multiClientRequired": "Free and Starter licenses allow 1 profile. Upgrade to Pro to manage configurations for multiple clients from a single Seed instance."
   }
 }

--- a/internal/i18n/locales/es/errors.json
+++ b/internal/i18n/locales/es/errors.json
@@ -111,5 +111,8 @@
   "file": {
     "failedToRead": "Error al leer archivo",
     "pathNotConfigured": "Ruta no configurada"
+  },
+  "profile": {
+    "multiClientRequired": "Las licencias Free y Starter permiten 1 perfil. Actualice a Pro para administrar configuraciones de varios clientes desde una sola instancia de Seed."
   }
 }


### PR DESCRIPTION
Closes #1196

Wraps the three profile-create code paths in \`handlers_profiles.go\` with a tier check that fires when an operator tries to create a 2nd or later profile without a \`multi_client\`-bearing license:

- \`handleCreateProfile\`     — POST \`/api/v1/profiles\`
- \`handleDuplicateProfile\`  — POST \`/api/v1/profiles/{id}/duplicate\`
- \`handleImportProfiles\`    — POST \`/api/v1/profiles/import\`

## Gate behaviour

- **First profile (bootstrap) always allowed** regardless of tier so fresh installs remain functional on Free
- **Free + Starter** → 402 \`FeatureGateResponse\` (code \`TIER_TOO_LOW\`) on the 2nd+ profile
- **Pro / Trial mode** → unlimited
- **License disabled** (nil mgr, dev/test builds) → permits

Shared helper \`enforceMultiClientGate\` is local to the file rather than in middleware so the three callers can write i18n-localized error bodies via their existing localizer/logger context. Matches the pattern from \`licenseAllowsAPITokens\`.

## i18n

\`errors.profile.multiClientRequired\` added in EN + ES. Customer-facing copy uses \"profiles\" / \"clients\" — the internal feature key stays \`multi_client\`.

## Test plan

- [ ] CI green
- [ ] Manual: create 2nd profile on Free license → 402
- [ ] Manual: create 2nd profile on Pro license → 201
- [ ] Manual: create 2nd profile under \`seed license trial\` → 201
- [ ] Manual: duplicate a profile on Free → 402
- [ ] Manual: import 5-profile bundle on Free → 402 (no partial state)