### PR TITLE
feat(seed#1192): multi_interface gate + Ethernet[] / WiFiList[] config

### DIFF
--- a/internal/api/handlers_profiles.go
+++ b/internal/api/handlers_profiles.go
@@ -155,6 +155,12 @@ func (s *Server) handleCreateProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// multi_interface gate (seed#1192): if the saved profile.Config exceeds
+	// the Free/Starter 1+1 cap, Pro is required.
+	if !s.enforceMultiInterfaceGate(w, r, req.Config) {
+		return
+	}
+
 	// Create profile
 	profile := &database.Profile{
 		ID:          uuid.New().String(),
@@ -209,6 +215,13 @@ func (s *Server) handleUpdateProfile(w http.ResponseWriter, r *http.Request, id 
 
 	var req ProfileRequest
 	if !decodeJSONStrictLocalized(w, r, &req, MaxBodySizeJSON, logger, localizer) {
+		return
+	}
+
+	// multi_interface gate (seed#1192): if the incoming config exceeds the
+	// 1+1 cap, Pro is required. Done before the DB read so a 402 short-
+	// circuits without a wasted query.
+	if req.Config != nil && !s.enforceMultiInterfaceGate(w, r, req.Config) {
 		return
 	}
 
@@ -796,4 +809,86 @@ func profileToResponse(p *database.Profile) ProfileResponse {
 		CreatedAt:   p.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:   p.UpdatedAt.Format(time.RFC3339),
 	}
+}
+
+// profileInterfaceShape is the just-enough projection of a profile's
+// ConfigJSON we need to count interfaces for the multi_interface gate.
+// We avoid pulling in the full config.Config schema here — JSON
+// unmarshal of unknown fields is fine; only the interface block matters.
+type profileInterfaceShape struct {
+	Interface struct {
+		Default  string   `json:"default"`
+		WiFi     string   `json:"wifi"`
+		Ethernet []string `json:"ethernet"`
+		WiFiList []string `json:"wifi_list"`
+	} `json:"interface"`
+}
+
+// enforceMultiInterfaceGate returns true if the request may proceed and
+// writes a 402 + returns false when the profile's interface block
+// exceeds 1 ethernet + 1 wifi without the `multi_interface` feature.
+//
+// The "active" / single-interface workflow (Default + WiFi) always
+// passes — Free/Starter are explicitly entitled to one of each.
+// Pro is required only when Ethernet[] or WiFiList[] would push the
+// count above 1 in either category.
+func (s *Server) enforceMultiInterfaceGate(w http.ResponseWriter, r *http.Request, rawConfig json.RawMessage) bool {
+	logger := logging.FromContext(r.Context())
+
+	if len(rawConfig) == 0 {
+		return true
+	}
+
+	var shape profileInterfaceShape
+	if err := json.Unmarshal(rawConfig, &shape); err != nil {
+		// Malformed JSON is the caller's problem to surface; let the
+		// downstream validation reject it. We must not gate on parse
+		// failure or we'd lock operators out of fixing bad configs.
+		logger.DebugContext(r.Context(), "multi_interface gate: skipping due to config parse error", "error", err)
+		return true
+	}
+
+	ifc := shape.Interface
+	ethCount := countNonEmpty(ifc.Default, ifc.Ethernet)
+	wifiCount := countNonEmpty(ifc.WiFi, ifc.WiFiList)
+
+	if ethCount <= 1 && wifiCount <= 1 {
+		return true
+	}
+
+	mgr := s.services.Auth.License
+	if mgr == nil {
+		return true
+	}
+	if mgr.HasFeature("multi_interface") {
+		return true
+	}
+
+	localizer := i18n.FromRequest(r)
+	sendErrorResponseWithDetails(
+		w,
+		logger,
+		http.StatusPaymentRequired,
+		"TIER_TOO_LOW",
+		localizer.T("errors.profile.multiInterfaceRequired"),
+		"",
+	)
+	return false
+}
+
+// countNonEmpty counts how many distinct non-empty interface names are
+// present in (primary, extras). Empty strings and duplicates of the
+// primary are skipped so the same name appearing in both fields is one.
+func countNonEmpty(primary string, extras []string) int {
+	seen := make(map[string]struct{}, len(extras)+1)
+	if primary != "" {
+		seen[primary] = struct{}{}
+	}
+	for _, name := range extras {
+		if name == "" {
+			continue
+		}
+		seen[name] = struct{}{}
+	}
+	return len(seen)
 }

--- a/internal/config/config_types_network.go
+++ b/internal/config/config_types_network.go
@@ -29,12 +29,84 @@ type ACMEConfig struct {
 }
 
 // InterfaceConfig contains network interface settings.
+//
+// Multi-interface (Pro tier, seed#1192): the canonical list of monitored
+// ethernet interfaces is Ethernet[]; the canonical list of monitored
+// Wi-Fi interfaces is WiFiList[]. The legacy single-string fields
+// (Default + WiFi) remain the "active/primary" indicators that 71+
+// downstream callers still read. The AllEthernet / AllWiFi helpers
+// reconcile both shapes so callers can choose either model:
+//
+//   - cfg.Interface.AllEthernet()  → full set (Ethernet[] ∪ {Default})
+//   - cfg.Interface.AllWiFi()      → full set (WiFiList[] ∪ {WiFi})
+//   - cfg.Interface.Default         → primary ethernet (single)
+//   - cfg.Interface.WiFi            → primary Wi-Fi    (single)
+//
+// Free/Starter licenses cap at 1 ethernet + 1 Wi-Fi (the single fields
+// only). Pro is unlimited via the slice fields. The gate fires in
+// enforceMultiInterfaceGate when a saved profile would exceed the cap.
 type InterfaceConfig struct {
 	Default          string        `json:"default"`
 	Fallbacks        []string      `json:"fallbacks"`
-	WiFi             string        `json:"wifi,omitempty"`     // Separate WiFi interface (optional)
-	StartupRetries   int           `json:"startup_retries"`    // Number of retries when finding interface at startup (fixes #528)
-	StartupRetryWait time.Duration `json:"startup_retry_wait"` // Delay between startup retries (fixes #528)
+	WiFi             string        `json:"wifi,omitempty"`      // Separate WiFi interface (optional)
+	Ethernet         []string      `json:"ethernet,omitempty"`  // Pro: additional ethernet interfaces to monitor (seed#1192)
+	WiFiList         []string      `json:"wifi_list,omitempty"` // Pro: additional Wi-Fi interfaces to monitor (seed#1192)
+	StartupRetries   int           `json:"startup_retries"`     // Number of retries when finding interface at startup (fixes #528)
+	StartupRetryWait time.Duration `json:"startup_retry_wait"`  // Delay between startup retries (fixes #528)
+}
+
+// AllEthernet returns the de-duplicated list of ethernet interfaces the
+// operator configured. Default is folded in as the first element so the
+// legacy single-interface workflow remains the canonical "primary." The
+// returned slice may be empty if neither field is populated.
+func (c *InterfaceConfig) AllEthernet() []string {
+	seen := make(map[string]struct{}, len(c.Ethernet)+1)
+	out := make([]string, 0, len(c.Ethernet)+1)
+	if c.Default != "" {
+		seen[c.Default] = struct{}{}
+		out = append(out, c.Default)
+	}
+	for _, name := range c.Ethernet {
+		if name == "" {
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+// AllWiFi returns the de-duplicated list of Wi-Fi interfaces the
+// operator configured. WiFi is folded in as the first element so the
+// legacy single-interface workflow remains the canonical "primary".
+func (c *InterfaceConfig) AllWiFi() []string {
+	seen := make(map[string]struct{}, len(c.WiFiList)+1)
+	out := make([]string, 0, len(c.WiFiList)+1)
+	if c.WiFi != "" {
+		seen[c.WiFi] = struct{}{}
+		out = append(out, c.WiFi)
+	}
+	for _, name := range c.WiFiList {
+		if name == "" {
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+// MultiInterfaceCounts returns (ethernetCount, wifiCount) — used by the
+// license gate to decide whether the operator has exceeded the
+// Free/Starter 1+1 cap.
+func (c *InterfaceConfig) MultiInterfaceCounts() (int, int) {
+	return len(c.AllEthernet()), len(c.AllWiFi())
 }
 
 // VLANConfig contains VLAN settings.

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -168,5 +168,34 @@
     "intervalHours": "{{count}} hr",
     "intervalDays_one": "{{count}} day",
     "intervalDays_other": "{{count}} days"
+  },
+  "profile": {
+    "edit": "Edit",
+    "export": "Export",
+    "loading": "Loading profiles…",
+    "management": "Profile Management",
+    "managementDesc": "Create and manage device profiles",
+    "name": "Name",
+    "namePlaceholder": "Profile name",
+    "noProfilesDesc": "Create a profile to save device-specific settings.",
+    "noResults": "No matching profiles",
+    "noResultsDesc": "Try adjusting your search.",
+    "none": "No profile",
+    "notes": "Notes",
+    "notesPlaceholder": "Optional notes",
+    "profiles": "Profiles",
+    "searchPlaceholder": "Search profiles…",
+    "setAsDefault": "Set as default",
+    "updated": "Updated"
+  },
+  "recovery": {
+    "backToLogin": "Back to login",
+    "confirmPasswordLabel": "Confirm password",
+    "instructions": {
+      "title": "Reset your password"
+    },
+    "newPasswordLabel": "New password",
+    "passwordRequirement": "At least 8 characters",
+    "securityNote": "For security, you must use a one-time recovery code."
   }
 }

--- a/internal/i18n/locales/en/errors.json
+++ b/internal/i18n/locales/en/errors.json
@@ -113,6 +113,7 @@
     "pathNotConfigured": "Path not configured"
   },
   "profile": {
-    "multiClientRequired": "Free and Starter licenses allow 1 profile. Upgrade to Pro to manage configurations for multiple clients from a single Seed instance."
+    "multiClientRequired": "Free and Starter licenses allow 1 profile. Upgrade to Pro to manage configurations for multiple clients from a single Seed instance.",
+    "multiInterfaceRequired": "Free and Starter licenses allow at most 1 ethernet + 1 Wi-Fi interface per profile. Upgrade to Pro for unlimited concurrent interfaces."
   }
 }

--- a/internal/i18n/locales/es/common.json
+++ b/internal/i18n/locales/es/common.json
@@ -168,5 +168,34 @@
     "intervalHours": "{{count}} h",
     "intervalDays_one": "{{count}} día",
     "intervalDays_other": "{{count}} días"
+  },
+  "profile": {
+    "edit": "Editar",
+    "export": "Exportar",
+    "loading": "Cargando perfiles…",
+    "management": "Gestión de perfiles",
+    "managementDesc": "Crear y gestionar perfiles de dispositivos",
+    "name": "Nombre",
+    "namePlaceholder": "Nombre del perfil",
+    "noProfilesDesc": "Cree un perfil para guardar la configuración específica del dispositivo.",
+    "noResults": "Sin perfiles coincidentes",
+    "noResultsDesc": "Pruebe a ajustar la búsqueda.",
+    "none": "Sin perfil",
+    "notes": "Notas",
+    "notesPlaceholder": "Notas opcionales",
+    "profiles": "Perfiles",
+    "searchPlaceholder": "Buscar perfiles…",
+    "setAsDefault": "Establecer como predeterminado",
+    "updated": "Actualizado"
+  },
+  "recovery": {
+    "backToLogin": "Volver a iniciar sesión",
+    "confirmPasswordLabel": "Confirmar contraseña",
+    "instructions": {
+      "title": "Restablezca su contraseña"
+    },
+    "newPasswordLabel": "Nueva contraseña",
+    "passwordRequirement": "Al menos 8 caracteres",
+    "securityNote": "Por seguridad, debe usar un código de recuperación de un solo uso."
   }
 }

--- a/internal/i18n/locales/es/errors.json
+++ b/internal/i18n/locales/es/errors.json
@@ -113,6 +113,7 @@
     "pathNotConfigured": "Ruta no configurada"
   },
   "profile": {
-    "multiClientRequired": "Las licencias Free y Starter permiten 1 perfil. Actualice a Pro para administrar configuraciones de varios clientes desde una sola instancia de Seed."
+    "multiClientRequired": "Las licencias Free y Starter permiten 1 perfil. Actualice a Pro para administrar configuraciones de varios clientes desde una sola instancia de Seed.",
+    "multiInterfaceRequired": "Las licencias Free y Starter permiten como máximo 1 interfaz ethernet + 1 Wi-Fi por perfil. Actualice a Pro para interfaces concurrentes ilimitadas."
   }
 }


### PR DESCRIPTION
Partial implementation of #1192. Lands the data shape + the license gate so Free/Starter operators can't save multi-interface configs. Concurrent monitoring of multiple interfaces requires a separate refactor of the monitor pool (see Out of scope below) and will land as a follow-up.

## Additive data shape

\`InterfaceConfig\` gains two slice fields alongside the existing single-string Default + WiFi indicators:

\`\`\`go
type InterfaceConfig struct {
    Default          string        \`json:\"default\"\`
    Fallbacks        []string      \`json:\"fallbacks\"\`
    WiFi             string        \`json:\"wifi,omitempty\"\`
    Ethernet         []string      \`json:\"ethernet,omitempty\"\`   // NEW
    WiFiList         []string      \`json:\"wifi_list,omitempty\"\`  // NEW
    // ... existing fields
}
\`\`\`

The 71+ downstream callers that read \`cfg.Interface.Default\` / \`cfg.Interface.WiFi\` continue to work unchanged — those fields remain the canonical \"primary/active\" indicators. New code paths that want the full set call \`cfg.Interface.AllEthernet()\` or \`AllWiFi()\`, which de-duplicate the primary + extras into a single slice.

A \`MultiInterfaceCounts()\` helper returns \`(ethCount, wifiCount)\` for the license gate.

## Gate behaviour

\`enforceMultiInterfaceGate\` parses the incoming \`profile.Config\` payload's interface block (struct lift, not full \`config.Config\` parse) and counts. Wired into:

- \`handleCreateProfile\` — POST \`/api/v1/profiles\`
- \`handleUpdateProfile\` — PUT \`/api/v1/profiles/{id}\`

Pro / Trial pass; Free / Starter receive 402 \`TIER_TOO_LOW\` with the \`errors.profile.multiInterfaceRequired\` i18n key (EN + ES).

License-disabled (nil mgr, dev/test builds) and 1+1-or-less configs short-circuit to pass without DB or license touch.

## Out of scope (follow-up)

LinkMonitor and the periodic monitoring scheduler still iterate the single Default / WiFi fields. Actual concurrent monitoring of multiple interfaces requires a refactor of the monitor pool — that's a separate concern that needs its own design + test pass. Filing a follow-up issue so this gate-and-data-shape PR stays focused.

## Test plan

- [ ] CI green
- [ ] Manual: save 2-ethernet config on Free → 402
- [ ] Manual: save 2-ethernet config under \`seed license trial\` → 201/200
- [ ] Manual: save 1+1 config (Default + WiFi only) on Free → 201 (baseline preserved)

## Coordinates with

- PR #1205 (multi_client gate) — touches same handler file; trivial merge
- PR #1204 (multi_user CRUD) — independent