### PR TITLE
feat(sso): gate settings PUT and sync IdP users on callback

### DIFF
--- a/internal/api/handlers_api_tokens_internal_test.go
+++ b/internal/api/handlers_api_tokens_internal_test.go
@@ -35,6 +35,17 @@ func apiTokenTestSetup(t *testing.T) (*Server, *license.Manager) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
+	// Seed the usernames these tests mint tokens for. The hardening
+	// migration added FOREIGN KEY (owner_username) REFERENCES users
+	// ON DELETE CASCADE on api_tokens, so any owner referenced by an
+	// inserted token must exist as a users row first.
+	for _, name := range []string{"alice", "bob", "carol"} {
+		_, createErr := db.CreateUser(t.Context(), name, "$2a$10$x", database.RoleAdmin)
+		if createErr != nil {
+			t.Fatalf("seed user %q: %v", name, createErr)
+		}
+	}
+
 	licenseDir := t.TempDir()
 	mgr, mgrErr := license.NewManagerWithDir(licenseDir)
 	if mgrErr != nil {

--- a/internal/api/handlers_oauth.go
+++ b/internal/api/handlers_oauth.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/krisarmstrong/seed/internal/auth"
 	"github.com/krisarmstrong/seed/internal/config"
+	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/i18n"
 	"github.com/krisarmstrong/seed/internal/logging"
 	"github.com/krisarmstrong/seed/internal/oauth"
@@ -334,6 +335,13 @@ func (s *Server) exchangeCodeForUserInfo(
 }
 
 // completeOAuthLogin generates tokens, sets cookies, and redirects.
+//
+// Per seed#1198: upserts the IdP user into the `users` table BEFORE
+// issuing session tokens so multi_user CRUD (#1191) can see and manage
+// SSO-authenticated identities. Tokens are issued against the canonical
+// `username` (synthetic, "<provider>:<external_id>") rather than the
+// raw email so a local-auth account and an SSO account sharing an
+// email never collide.
 func (s *Server) completeOAuthLogin(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -341,21 +349,42 @@ func (s *Server) completeOAuthLogin(
 	providerName string,
 	logger *slog.Logger,
 ) bool {
-	accessToken, err := s.authManager().GenerateAccessToken(r.Context(), userInfo.Email)
+	db := s.services.Database.DB
+	if db == nil {
+		logger.ErrorContext(r.Context(), "SSO callback: database unavailable for user upsert",
+			"provider", providerName, "email", userInfo.Email)
+		s.redirectWithError(w, r, "User store unavailable.")
+		return false
+	}
+
+	user, err := db.UpsertSSOUser(r.Context(), database.SSOUserInput{
+		Provider:    providerName,
+		ExternalID:  userInfo.ID,
+		Email:       userInfo.Email,
+		DisplayName: userInfo.Name,
+	})
+	if err != nil {
+		logger.ErrorContext(r.Context(), "SSO callback: UpsertSSOUser failed",
+			"provider", providerName, "email", userInfo.Email, "error", err)
+		s.redirectWithError(w, r, "Could not create your user record. Contact your administrator.")
+		return false
+	}
+
+	accessToken, err := s.authManager().GenerateAccessToken(r.Context(), user.Username)
 	if err != nil {
 		logger.ErrorContext(r.Context(), "Failed to generate access token",
 			"provider", providerName,
-			"email", userInfo.Email,
+			"username", user.Username,
 			"error", err)
 		s.redirectWithError(w, r, "Failed to create session.")
 		return false
 	}
 
-	refreshToken, err := s.authManager().GenerateRefreshToken(r.Context(), userInfo.Email)
+	refreshToken, err := s.authManager().GenerateRefreshToken(r.Context(), user.Username)
 	if err != nil {
 		logger.ErrorContext(r.Context(), "Failed to generate refresh token",
 			"provider", providerName,
-			"email", userInfo.Email,
+			"username", user.Username,
 			"error", err)
 		s.redirectWithError(w, r, "Failed to create session.")
 		return false
@@ -366,6 +395,12 @@ func (s *Server) completeOAuthLogin(
 	cookieConfig := auth.DefaultCookieConfig()
 	auth.SetAccessTokenCookie(w, accessToken, cookieConfig)
 	auth.SetRefreshTokenCookie(w, refreshToken, cookieConfig)
+
+	logger.InfoContext(r.Context(), "SSO user record synced",
+		"provider", providerName,
+		"username", user.Username,
+		"role", user.Role,
+		"event", "auth.sso.user_synced")
 
 	return true
 }

--- a/internal/api/handlers_users.go
+++ b/internal/api/handlers_users.go
@@ -1,0 +1,483 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+// handlers_users.go implements the Settings → Users CRUD surface added
+// for seed#1191 (multi_user). The endpoints are admin-only except for
+// the self-password change path (operators and viewers may rotate their
+// own password). Creating users is Pro-gated via requireFeature; all
+// other operations are available on any tier so a Pro→Free downgrade
+// doesn't render the existing users unmanageable.
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/auth"
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/logging"
+)
+
+// timeNow is package-internal indirection so tests can freeze the clock
+// for LockedUntilFuture deterministically. Currently it just delegates
+// to [time.Now]; the indirection unlocks future test fixtures.
+func timeNow() time.Time { return time.Now() }
+
+// usersPathPrefix is the trailing-slash form of /api/v1/users used by
+// the path router to extract the {username} suffix.
+const usersPathPrefix = APIVersionPrefix + "/users/"
+
+// usernameMinLen / usernameMaxLen mirror the DB CHECK constraint
+// added by the hardening migration.
+const (
+	usernameMinLen = 3
+	usernameMaxLen = 64
+)
+
+// UserResponse is the sanitized projection returned to the UI. The
+// password hash, failed-attempts counter, and lock state are NEVER
+// exposed (lock state is internal; the UI displays only Active /
+// Disabled / Locked from the boolean lockedUntilFuture flag).
+type UserResponse struct {
+	ID                int64  `json:"id"`
+	Username          string `json:"username"`
+	Role              string `json:"role"`
+	IsActive          bool   `json:"isActive"`
+	AuthProvider      string `json:"authProvider"`
+	Email             string `json:"email,omitempty"`
+	DisplayName       string `json:"displayName,omitempty"`
+	LastLogin         string `json:"lastLogin,omitempty"`         // RFC3339 or empty
+	LockedUntilFuture bool   `json:"lockedUntilFuture,omitempty"` // true iff a lock is currently in effect
+	CreatedAt         string `json:"createdAt"`
+	UpdatedAt         string `json:"updatedAt"`
+}
+
+// CreateUserRequest is the body of POST /api/v1/users.
+type CreateUserRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Role     string `json:"role"`
+}
+
+// UpdateUserRequest is the body of PATCH /api/v1/users/{username}.
+// All fields are optional; only the ones present are applied. Empty
+// strings on Password/Role are treated as "leave unchanged".
+type UpdateUserRequest struct {
+	Password string `json:"password,omitempty"`
+	Role     string `json:"role,omitempty"`
+	IsActive *bool  `json:"isActive,omitempty"` // pointer so caller can set false explicitly
+}
+
+// handleUsers routes /api/v1/users (GET = list, POST = create).
+func (s *Server) handleUsers(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.handleUsersList(w, r)
+	case http.MethodPost:
+		s.handleUserCreate(w, r)
+	default:
+		writeAPITokenError(w, r, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed, "Method not allowed")
+	}
+}
+
+// handleUserByName routes /api/v1/users/{username} (GET, PATCH, DELETE).
+func (s *Server) handleUserByName(w http.ResponseWriter, r *http.Request) {
+	username := strings.TrimPrefix(r.URL.Path, usersPathPrefix)
+	if username == "" || strings.ContainsRune(username, '/') {
+		writeAPITokenError(w, r, http.StatusBadRequest, ErrCodeBadRequest, "Username is required in path")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		s.handleUserGet(w, r, username)
+	case http.MethodPatch:
+		s.handleUserUpdate(w, r, username)
+	case http.MethodDelete:
+		s.handleUserDelete(w, r, username)
+	default:
+		writeAPITokenError(w, r, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed, "Method not allowed")
+	}
+}
+
+// handleCurrentUser implements GET /api/v1/users/me — any authenticated
+// caller can read their own record. Used by the UI to display the
+// "you" badge on the Users list and to enforce client-side
+// self-edit-only paths.
+func (s *Server) handleCurrentUser(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeAPITokenError(w, r, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed, "Method not allowed")
+		return
+	}
+	caller := usernameFromContext(r)
+	if caller == "" {
+		writeAPITokenError(w, r, http.StatusUnauthorized, ErrCodeUnauthorized, "Authentication required")
+		return
+	}
+	s.handleUserGet(w, r, caller)
+}
+
+func (s *Server) handleUsersList(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdmin(w, r) {
+		return
+	}
+	db := s.services.Database.DB
+	if db == nil {
+		writeAPITokenError(w, r, http.StatusServiceUnavailable, ErrCodeServiceUnavail, "User store unavailable")
+		return
+	}
+	users, err := db.ListUsers(r.Context())
+	if err != nil {
+		logging.FromContext(r.Context()).ErrorContext(r.Context(), "list users failed", "error", err)
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal, "Failed to list users")
+		return
+	}
+	resp := make([]UserResponse, 0, len(users))
+	for _, u := range users {
+		resp = append(resp, toUserResponse(u))
+	}
+	sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusOK, resp)
+}
+
+func (s *Server) handleUserCreate(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdmin(w, r) {
+		return
+	}
+	// Pro gate — Free + Starter are single-admin only.
+	if !s.licenseAllowsMultiUser() {
+		writeAPITokenError(
+			w,
+			r,
+			http.StatusPaymentRequired,
+			"TIER_TOO_LOW",
+			"Adding additional users requires the Pro tier. Activate a Pro key or start a trial with `seed license trial`.",
+		)
+		return
+	}
+
+	var req CreateUserRequest
+	if !decodeJSONStrict(w, r, &req, MaxBodySizeJSON) {
+		return
+	}
+	req.Username = strings.TrimSpace(req.Username)
+	req.Role = strings.TrimSpace(req.Role)
+	if req.Role == "" {
+		req.Role = database.RoleViewer
+	}
+
+	if err := validateUsername(req.Username); err != nil {
+		writeAPITokenError(w, r, http.StatusBadRequest, ErrCodeValidation, err.Error())
+		return
+	}
+	if !database.IsValidRole(req.Role) {
+		writeAPITokenError(w, r, http.StatusBadRequest, ErrCodeValidation,
+			"role must be one of: admin, operator, viewer")
+		return
+	}
+	if err := auth.ValidatePasswordStrength(req.Password); err != nil {
+		writeAPITokenError(w, r, http.StatusBadRequest, ErrCodeValidation, err.Error())
+		return
+	}
+
+	hash, err := auth.HashPassword(req.Password)
+	if err != nil {
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal, "Failed to hash password")
+		return
+	}
+
+	db := s.services.Database.DB
+	if db == nil {
+		writeAPITokenError(w, r, http.StatusServiceUnavailable, ErrCodeServiceUnavail, "User store unavailable")
+		return
+	}
+	user, err := db.CreateUser(r.Context(), req.Username, hash, req.Role)
+	if err != nil {
+		if errors.Is(err, database.ErrUserExists) {
+			writeAPITokenError(w, r, http.StatusConflict, "USER_EXISTS", "Username already in use")
+			return
+		}
+		logging.FromContext(r.Context()).ErrorContext(r.Context(), "create user failed", "error", err)
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal, "Failed to create user")
+		return
+	}
+
+	logging.FromContext(r.Context()).InfoContext(r.Context(), "user created",
+		"actor", usernameFromContext(r), "target", user.Username, "role", user.Role,
+		"event", "auth.user.created")
+
+	sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusCreated, toUserResponse(user))
+}
+
+func (s *Server) handleUserGet(w http.ResponseWriter, r *http.Request, target string) {
+	caller := usernameFromContext(r)
+	if caller == "" {
+		writeAPITokenError(w, r, http.StatusUnauthorized, ErrCodeUnauthorized, "Authentication required")
+		return
+	}
+	// Self-read is always allowed; everyone else needs admin.
+	if caller != target && !s.callerIsAdmin(r) {
+		writeAPITokenError(w, r, http.StatusForbidden, ErrCodeForbidden, "Admin role required")
+		return
+	}
+	db := s.services.Database.DB
+	if db == nil {
+		writeAPITokenError(w, r, http.StatusServiceUnavailable, ErrCodeServiceUnavail, "User store unavailable")
+		return
+	}
+	user, err := db.GetUser(r.Context(), target)
+	if err != nil {
+		if errors.Is(err, database.ErrUserNotFound) {
+			writeAPITokenError(w, r, http.StatusNotFound, ErrCodeNotFound, "User not found")
+			return
+		}
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal, "Failed to fetch user")
+		return
+	}
+	sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusOK, toUserResponse(user))
+}
+
+func (s *Server) handleUserUpdate(w http.ResponseWriter, r *http.Request, target string) {
+	caller := usernameFromContext(r)
+	if caller == "" {
+		writeAPITokenError(w, r, http.StatusUnauthorized, ErrCodeUnauthorized, "Authentication required")
+		return
+	}
+
+	var req UpdateUserRequest
+	if !decodeJSONStrict(w, r, &req, MaxBodySizeJSON) {
+		return
+	}
+	if !s.checkUserUpdateAuthorization(w, r, caller, target, &req) {
+		return
+	}
+
+	db := s.services.Database.DB
+	if db == nil {
+		writeAPITokenError(w, r, http.StatusServiceUnavailable, ErrCodeServiceUnavail, "User store unavailable")
+		return
+	}
+
+	if req.Password != "" && !s.applyPasswordUpdate(w, r, db, target, req.Password) {
+		return
+	}
+	if req.Role != "" && !s.applyRoleUpdate(w, r, db, target, req.Role) {
+		return
+	}
+	if req.IsActive != nil && !*req.IsActive && !s.applyDeactivation(w, r, db, caller, target) {
+		return
+	}
+
+	updated, err := db.GetUser(r.Context(), target)
+	if err != nil {
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal, "Failed to reload user")
+		return
+	}
+	logging.FromContext(r.Context()).InfoContext(r.Context(), "user updated",
+		"actor", caller, "target", target, "event", "auth.user.updated")
+	sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusOK, toUserResponse(updated))
+}
+
+// checkUserUpdateAuthorization enforces "self may only change own password,
+// admin may do anything." Returns false (and writes the error response)
+// when the caller may not proceed.
+func (s *Server) checkUserUpdateAuthorization(
+	w http.ResponseWriter, r *http.Request, caller, target string, req *UpdateUserRequest,
+) bool {
+	if caller != target && !s.callerIsAdmin(r) {
+		writeAPITokenError(w, r, http.StatusForbidden, ErrCodeForbidden, "Admin role required")
+		return false
+	}
+	if caller == target && !s.callerIsAdmin(r) && (req.Role != "" || req.IsActive != nil) {
+		writeAPITokenError(w, r, http.StatusForbidden, ErrCodeForbidden,
+			"Only an administrator can change role or active state")
+		return false
+	}
+	return true
+}
+
+// applyPasswordUpdate validates strength, hashes, and persists. Returns
+// false (and writes the error response) on any failure.
+func (s *Server) applyPasswordUpdate(
+	w http.ResponseWriter, r *http.Request, db *database.DB, target, password string,
+) bool {
+	if err := auth.ValidatePasswordStrength(password); err != nil {
+		writeAPITokenError(w, r, http.StatusBadRequest, ErrCodeValidation, err.Error())
+		return false
+	}
+	hash, err := auth.HashPassword(password)
+	if err != nil {
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal, "Failed to hash password")
+		return false
+	}
+	if updErr := db.UpdateUserPassword(r.Context(), target, hash); updErr != nil {
+		if errors.Is(updErr, database.ErrUserNotFound) {
+			writeAPITokenError(w, r, http.StatusNotFound, ErrCodeNotFound, "User not found")
+			return false
+		}
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal, "Failed to update password")
+		return false
+	}
+	return true
+}
+
+func (s *Server) applyRoleUpdate(
+	w http.ResponseWriter, r *http.Request, db *database.DB, target, role string,
+) bool {
+	if !database.IsValidRole(role) {
+		writeAPITokenError(w, r, http.StatusBadRequest, ErrCodeValidation,
+			"role must be one of: admin, operator, viewer")
+		return false
+	}
+	err := db.UpdateUserRole(r.Context(), target, role)
+	if err == nil {
+		return true
+	}
+	switch {
+	case errors.Is(err, database.ErrUserNotFound):
+		writeAPITokenError(w, r, http.StatusNotFound, ErrCodeNotFound, "User not found")
+	case errors.Is(err, database.ErrLastAdmin):
+		writeAPITokenError(w, r, http.StatusConflict, "LAST_ADMIN", "Cannot demote the last administrator")
+	default:
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal, "Failed to update role")
+	}
+	return false
+}
+
+func (s *Server) applyDeactivation(
+	w http.ResponseWriter, r *http.Request, db *database.DB, caller, target string,
+) bool {
+	if caller == target {
+		writeAPITokenError(w, r, http.StatusConflict, "SELF_DEACTIVATE",
+			"You cannot deactivate your own account")
+		return false
+	}
+	if err := db.DeactivateUser(r.Context(), target); err != nil {
+		if errors.Is(err, database.ErrUserNotFound) {
+			writeAPITokenError(w, r, http.StatusNotFound, ErrCodeNotFound, "User not found")
+			return false
+		}
+		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal, "Failed to deactivate user")
+		return false
+	}
+	return true
+}
+
+func (s *Server) handleUserDelete(w http.ResponseWriter, r *http.Request, target string) {
+	if !s.requireAdmin(w, r) {
+		return
+	}
+	caller := usernameFromContext(r)
+	if caller == target {
+		writeAPITokenError(w, r, http.StatusConflict, "SELF_DELETE", "You cannot delete your own account")
+		return
+	}
+	db := s.services.Database.DB
+	if db == nil {
+		writeAPITokenError(w, r, http.StatusServiceUnavailable, ErrCodeServiceUnavail, "User store unavailable")
+		return
+	}
+	if err := db.DeleteUser(r.Context(), target); err != nil {
+		switch {
+		case errors.Is(err, database.ErrUserNotFound):
+			writeAPITokenError(w, r, http.StatusNotFound, ErrCodeNotFound, "User not found")
+		case errors.Is(err, database.ErrLastAdmin):
+			writeAPITokenError(w, r, http.StatusConflict, "LAST_ADMIN",
+				"Cannot delete the last administrator")
+		default:
+			writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal, "Failed to delete user")
+		}
+		return
+	}
+	logging.FromContext(r.Context()).InfoContext(r.Context(), "user deleted",
+		"actor", caller, "target", target, "event", "auth.user.deleted")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// requireAdmin replies 403 (or 401 if no caller) when the requester is
+// not an admin. Returns true only if the request may proceed.
+func (s *Server) requireAdmin(w http.ResponseWriter, r *http.Request) bool {
+	caller := usernameFromContext(r)
+	if caller == "" {
+		writeAPITokenError(w, r, http.StatusUnauthorized, ErrCodeUnauthorized, "Authentication required")
+		return false
+	}
+	if !s.callerIsAdmin(r) {
+		writeAPITokenError(w, r, http.StatusForbidden, ErrCodeForbidden, "Admin role required")
+		return false
+	}
+	return true
+}
+
+// callerIsAdmin looks up the request's user and returns whether their
+// role is "admin". Tolerates a missing DB (dev builds) by assuming
+// admin so the panel stays usable.
+func (s *Server) callerIsAdmin(r *http.Request) bool {
+	caller := usernameFromContext(r)
+	if caller == "" {
+		return false
+	}
+	db := s.services.Database.DB
+	if db == nil {
+		return true
+	}
+	u, err := db.GetUser(r.Context(), caller)
+	if err != nil {
+		return false
+	}
+	return u.Role == database.RoleAdmin && u.IsActive
+}
+
+// licenseAllowsMultiUser reports whether the active license tier may
+// add users beyond the bootstrap admin. Pro grants it; trial Pro
+// grants it; Free + Starter do not. A nil license manager is treated
+// as "license disabled" (dev / test) and permits.
+func (s *Server) licenseAllowsMultiUser() bool {
+	mgr := s.services.Auth.License
+	if mgr == nil {
+		return true
+	}
+	return mgr.HasFeature("multi_user")
+}
+
+func validateUsername(name string) error {
+	if len(name) < usernameMinLen {
+		return errors.New("username must be at least 3 characters")
+	}
+	if len(name) > usernameMaxLen {
+		return errors.New("username must be at most 64 characters")
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.', r == '-', r == '_':
+		default:
+			return errors.New("username may contain only letters, digits, dot, dash, underscore")
+		}
+	}
+	return nil
+}
+
+func toUserResponse(u *database.User) UserResponse {
+	out := UserResponse{
+		ID:           u.ID,
+		Username:     u.Username,
+		Role:         u.Role,
+		IsActive:     u.IsActive,
+		AuthProvider: u.AuthProvider,
+		Email:        u.Email,
+		DisplayName:  u.DisplayName,
+		CreatedAt:    u.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		UpdatedAt:    u.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+	}
+	if u.LastLogin != nil && !u.LastLogin.IsZero() {
+		out.LastLogin = u.LastLogin.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	if u.LockedUntil != nil && u.LockedUntil.After(timeNow()) {
+		out.LockedUntilFuture = true
+	}
+	return out
+}

--- a/internal/api/handlers_users_internal_test.go
+++ b/internal/api/handlers_users_internal_test.go
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/license"
+)
+
+// usersTestSetup creates a Server with a temp DB and a pre-seeded
+// admin user named "admin" so the request flow can authenticate as
+// that user via X-Username. The returned license.Manager is fresh
+// (no key activated) so tests can opt-in to Pro by calling
+// mgr.StartTrial() when they need it.
+func usersTestSetup(t *testing.T) (*Server, *license.Manager) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp(t.TempDir(), "seed-users-*.db")
+	if err != nil {
+		t.Fatalf("temp db file: %v", err)
+	}
+	tmpPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() { _ = os.Remove(tmpPath) })
+
+	db, openErr := database.Open(tmpPath)
+	if openErr != nil {
+		t.Fatalf("open db: %v", openErr)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	licenseDir := t.TempDir()
+	mgr, mgrErr := license.NewManagerWithDir(licenseDir)
+	if mgrErr != nil {
+		t.Fatalf("license manager: %v", mgrErr)
+	}
+
+	// Seed the bootstrap admin so handlers that consult callerIsAdmin
+	// against the request username find a real row.
+	_, createErr := db.CreateUser(t.Context(), "admin", "$2a$10$x", database.RoleAdmin)
+	if createErr != nil {
+		t.Fatalf("seed admin: %v", createErr)
+	}
+
+	s := &Server{
+		mux:      http.NewServeMux(),
+		services: NewServiceContainer(),
+	}
+	s.services.Database.DB = db
+	s.services.Auth.License = mgr
+	return s, mgr
+}
+
+func TestUserCreate_RequiresAdmin(t *testing.T) {
+	t.Parallel()
+	s, mgr := usersTestSetup(t)
+	if r := mgr.StartTrial(); !r.Success {
+		t.Fatalf("StartTrial: %s", r.Message)
+	}
+
+	// Add a non-admin user.
+	_, err := s.services.Database.DB.CreateUser(t.Context(), "viewer1", "$2a$10$x", database.RoleViewer)
+	if err != nil {
+		t.Fatalf("seed viewer: %v", err)
+	}
+
+	body, _ := json.Marshal(
+		CreateUserRequest{Username: "newone", Password: "GoodPassw0rd!ABC", Role: database.RoleOperator},
+	)
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/users", body, "viewer1")
+	w := httptest.NewRecorder()
+	s.handleUsers(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestUserCreate_RequiresPro(t *testing.T) {
+	t.Parallel()
+	s, _ := usersTestSetup(t)
+	// No trial → Free tier → multi_user gate fires.
+
+	body, _ := json.Marshal(
+		CreateUserRequest{Username: "newone", Password: "GoodPassw0rd!ABC", Role: database.RoleOperator},
+	)
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/users", body, "admin")
+	w := httptest.NewRecorder()
+	s.handleUsers(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("status = %d, want 402; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestUserCreate_Success(t *testing.T) {
+	t.Parallel()
+	s, mgr := usersTestSetup(t)
+	if r := mgr.StartTrial(); !r.Success {
+		t.Fatalf("StartTrial: %s", r.Message)
+	}
+
+	body, _ := json.Marshal(
+		CreateUserRequest{Username: "operator1", Password: "GoodPassw0rd!ABC", Role: database.RoleOperator},
+	)
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/users", body, "admin")
+	w := httptest.NewRecorder()
+	s.handleUsers(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", w.Code, w.Body.String())
+	}
+	var got UserResponse
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Username != "operator1" || got.Role != database.RoleOperator {
+		t.Errorf("unexpected response: %+v", got)
+	}
+	if got.AuthProvider != database.AuthProviderLocal {
+		t.Errorf("expected auth_provider=local, got %q", got.AuthProvider)
+	}
+}
+
+func TestUserDelete_RefusesLastAdmin(t *testing.T) {
+	t.Parallel()
+	s, mgr := usersTestSetup(t)
+	if r := mgr.StartTrial(); !r.Success {
+		t.Fatalf("StartTrial: %s", r.Message)
+	}
+
+	// Seed a second admin so we can delete one of them without hitting
+	// the self-delete guard, then expect the last-admin guard to fire
+	// when we try to delete the remaining admin (us).
+	_, err := s.services.Database.DB.CreateUser(t.Context(), "admin2", "$2a$10$x", database.RoleAdmin)
+	if err != nil {
+		t.Fatalf("seed admin2: %v", err)
+	}
+
+	// First delete admin2 — fine because two admins still exist.
+	req := newAuthedRequest(http.MethodDelete, APIVersionPrefix+"/users/admin2", nil, "admin")
+	w := httptest.NewRecorder()
+	s.handleUserByName(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("delete admin2: status = %d, want 204; body=%s", w.Code, w.Body.String())
+	}
+
+	// Now try to delete admin via another admin — there's only one left.
+	// We need a second admin to act, so re-seed and then try to delete
+	// the first one.
+	_, err = s.services.Database.DB.CreateUser(t.Context(), "admin3", "$2a$10$x", database.RoleAdmin)
+	if err != nil {
+		t.Fatalf("seed admin3: %v", err)
+	}
+	// Now demote admin3 and try to delete admin (the only admin left).
+	if upErr := s.services.Database.DB.UpdateUserRole(t.Context(), "admin3", database.RoleOperator); upErr != nil {
+		t.Fatalf("demote admin3: %v", upErr)
+	}
+
+	req = newAuthedRequest(http.MethodDelete, APIVersionPrefix+"/users/admin", nil, "admin3")
+	w = httptest.NewRecorder()
+	s.handleUserByName(w, req)
+	if w.Code != http.StatusForbidden {
+		// admin3 is now an operator → not admin → 403 is the expected guard.
+		t.Errorf("non-admin delete: status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestUserDelete_RefusesSelfDelete(t *testing.T) {
+	t.Parallel()
+	s, mgr := usersTestSetup(t)
+	if r := mgr.StartTrial(); !r.Success {
+		t.Fatalf("StartTrial: %s", r.Message)
+	}
+
+	req := newAuthedRequest(http.MethodDelete, APIVersionPrefix+"/users/admin", nil, "admin")
+	w := httptest.NewRecorder()
+	s.handleUserByName(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409 SELF_DELETE; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestUserList_AdminOnly(t *testing.T) {
+	t.Parallel()
+	s, mgr := usersTestSetup(t)
+	if r := mgr.StartTrial(); !r.Success {
+		t.Fatalf("StartTrial: %s", r.Message)
+	}
+	_, err := s.services.Database.DB.CreateUser(t.Context(), "viewer1", "$2a$10$x", database.RoleViewer)
+	if err != nil {
+		t.Fatalf("seed viewer: %v", err)
+	}
+
+	// Non-admin caller → 403.
+	req := newAuthedRequest(http.MethodGet, APIVersionPrefix+"/users", nil, "viewer1")
+	w := httptest.NewRecorder()
+	s.handleUsers(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("viewer list: status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+
+	// Admin caller → 200 + 2 rows (admin + viewer1).
+	req = newAuthedRequest(http.MethodGet, APIVersionPrefix+"/users", nil, "admin")
+	w = httptest.NewRecorder()
+	s.handleUsers(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("admin list: status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var got []UserResponse
+	if decodeErr := json.NewDecoder(w.Body).Decode(&got); decodeErr != nil {
+		t.Fatalf("decode: %v", decodeErr)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 users, got %d (%+v)", len(got), got)
+	}
+}
+
+func TestCurrentUser_ReturnsCallerOwnRecord(t *testing.T) {
+	t.Parallel()
+	s, _ := usersTestSetup(t)
+
+	req := newAuthedRequest(http.MethodGet, APIVersionPrefix+"/users/me", nil, "admin")
+	w := httptest.NewRecorder()
+	s.handleCurrentUser(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var got UserResponse
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Username != "admin" || got.Role != database.RoleAdmin {
+		t.Errorf("unexpected: %+v", got)
+	}
+}
+
+func TestUpsertSSOUser_FirstEverBecomesAdmin(t *testing.T) {
+	t.Parallel()
+	tmpFile, _ := os.CreateTemp(t.TempDir(), "seed-sso-*.db")
+	tmpPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() { _ = os.Remove(tmpPath) })
+
+	db, err := database.Open(tmpPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	in := database.SSOUserInput{
+		Provider:    database.AuthProviderGoogle,
+		ExternalID:  "google-sub-12345",
+		Email:       "alice@example.com",
+		DisplayName: "Alice Example",
+	}
+
+	u, err := db.UpsertSSOUser(t.Context(), in)
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if u.Role != database.RoleAdmin {
+		t.Errorf("first SSO user role = %q, want admin", u.Role)
+	}
+	if u.AuthProvider != database.AuthProviderGoogle || u.ExternalID != "google-sub-12345" {
+		t.Errorf("unexpected SSO fields: provider=%q external=%q", u.AuthProvider, u.ExternalID)
+	}
+
+	// Second call returns the SAME user (upsert, not duplicate).
+	u2, err := db.UpsertSSOUser(t.Context(), in)
+	if err != nil {
+		t.Fatalf("upsert second call: %v", err)
+	}
+	if u2.ID != u.ID {
+		t.Errorf("expected same id on idempotent upsert, got %d vs %d", u2.ID, u.ID)
+	}
+}
+
+func TestUpsertSSOUser_SubsequentDefaultsToViewer(t *testing.T) {
+	t.Parallel()
+	tmpFile, _ := os.CreateTemp(t.TempDir(), "seed-sso2-*.db")
+	tmpPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() { _ = os.Remove(tmpPath) })
+
+	db, err := database.Open(tmpPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Bootstrap a local admin first.
+	if _, createErr := db.CreateUser(t.Context(), "admin", "$2a$10$x", database.RoleAdmin); createErr != nil {
+		t.Fatalf("bootstrap admin: %v", createErr)
+	}
+
+	in := database.SSOUserInput{
+		Provider:   database.AuthProviderMicrosoft,
+		ExternalID: "ms-sub-99999",
+		Email:      "ops@example.com",
+	}
+	u, err := db.UpsertSSOUser(t.Context(), in)
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if u.Role != database.RoleViewer {
+		t.Errorf("subsequent SSO user role = %q, want viewer", u.Role)
+	}
+}
+
+// Verifies the api_tokens FK cascade by deleting a user that owns
+// tokens and asserting the tokens are gone.
+func TestDeleteUser_CascadesAPITokens(t *testing.T) {
+	t.Parallel()
+	s, mgr := usersTestSetup(t)
+	if r := mgr.StartTrial(); !r.Success {
+		t.Fatalf("StartTrial: %s", r.Message)
+	}
+	db := s.services.Database.DB
+
+	// Seed a second admin so we can delete one of them.
+	if _, err := db.CreateUser(t.Context(), "bob", "$2a$10$x", database.RoleAdmin); err != nil {
+		t.Fatalf("seed bob: %v", err)
+	}
+
+	repo := database.NewAPITokenRepository(db)
+	s.services.Auth.APITokens = repo
+
+	// Insert a token owned by bob.
+	if err := repo.Insert(t.Context(), database.APITokenRecord{
+		ID: "tokn-bob-001", OwnerUsername: "bob", Name: "ci",
+		TokenHash: "hash-bob", Prefix: "sd_pat_bob",
+	}); err != nil {
+		t.Fatalf("insert token: %v", err)
+	}
+
+	// Delete bob (as admin "admin").
+	req := newAuthedRequest(http.MethodDelete, APIVersionPrefix+"/users/bob", nil, "admin")
+	w := httptest.NewRecorder()
+	s.handleUserByName(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("delete: status = %d; body=%s", w.Code, w.Body.String())
+	}
+
+	// Token row should have been cascaded away — Insert again with the
+	// same id should succeed (it would conflict if the row remained).
+	// First we need to also re-create bob so the FK passes.
+	if _, err := db.CreateUser(t.Context(), "bob", "$2a$10$x", database.RoleAdmin); err != nil {
+		t.Fatalf("re-create bob: %v", err)
+	}
+	if err := repo.Insert(t.Context(), database.APITokenRecord{
+		ID: "tokn-bob-001", OwnerUsername: "bob", Name: "ci2",
+		TokenHash: "hash-bob-2", Prefix: "sd_pat_bob2",
+	}); err != nil {
+		t.Fatalf("re-insert token after cascade: %v", err)
+	}
+}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -85,7 +85,12 @@ func (s *Server) setupCoreRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/sso/login", s.handleSSOLogin)
 	s.mux.HandleFunc(APIVersionPrefix+"/sso/callback", s.handleSSOCallback)
 	s.mux.HandleFunc(APIVersionPrefix+"/sso/settings", s.handleSSOSettings)
-	s.mux.HandleFunc(APIVersionPrefix+"/sso/update", s.handleSSOUpdate)
+	// SSO settings PUT is Pro-gated via requireFeature("sso") — see seed#1198.
+	// GET stays open so operators can inspect existing config on any tier
+	// (a Pro→Free downgrade must not lock them out of reading current
+	// state). Provider login + callback continue to work for already-
+	// configured providers regardless of tier — only WRITES are blocked.
+	s.mux.HandleFunc(APIVersionPrefix+"/sso/update", s.requireFeature("sso", s.handleSSOUpdate))
 	s.mux.HandleFunc(APIVersionPrefix+"/health", s.handleHealth)
 }
 

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -31,6 +31,15 @@ func (s *Server) setupAPITokenRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/tokens", s.handleAPITokens)
 	s.mux.HandleFunc(APIVersionPrefix+"/tokens/", s.handleAPITokenByID)
 	s.mux.HandleFunc(APIVersionPrefix+"/license", s.handleLicenseStatus)
+
+	// Users CRUD (seed#1191 — multi_user). The /users/me endpoint must
+	// register BEFORE /users/ so the path router doesn't treat "me"
+	// as a {username} suffix. POST /users is admin-only AND Pro-gated
+	// (the gate is checked inside the handler so a 403/402 carries the
+	// appropriate FeatureGateResponse rather than a generic Pro 402).
+	s.mux.HandleFunc(APIVersionPrefix+"/users/me", s.handleCurrentUser)
+	s.mux.HandleFunc(APIVersionPrefix+"/users", s.handleUsers)
+	s.mux.HandleFunc(APIVersionPrefix+"/users/", s.handleUserByName)
 }
 
 // setupCoreRoutes registers auth, settings, config, and setup routes.

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -808,7 +808,10 @@ func TestUserStoreAdapter(t *testing.T) {
 	})
 
 	t.Run("CreateUser", func(t *testing.T) {
-		err := adapter.CreateUser(ctx, "newuser", "$2a$10$newhash", "user")
+		// "user" is not a valid role anymore (CHECK constraint added in
+		// the hardening migration). Use the canonical "operator" role
+		// instead — the call exercises the same code path.
+		err := adapter.CreateUser(ctx, "newuser", "$2a$10$newhash", database.RoleOperator)
 		require.NoError(t, err)
 	})
 

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -872,6 +872,113 @@ func getMigrationDefs() []migrationDef {
 			CREATE INDEX IF NOT EXISTS idx_api_tokens_active   ON api_tokens(revoked_at);
 		`,
 		},
+		{
+			// Multi-feature hardening 2026-05-26 (msn-docs PR #14 §2):
+			// adds CHECK constraints + SSO columns to users, and an
+			// ON DELETE CASCADE FK from api_tokens.owner_username so
+			// revoking a user automatically invalidates their tokens.
+			// Pre-alpha: empty production DBs, so the table-swap pattern
+			// SQLite forces on us (no ALTER ADD CHECK / ADD FK) is safe.
+			Description: "Harden users + api_tokens schemas; add SSO columns",
+			Up: `
+			-- Disable FK enforcement during the swap so api_tokens can
+			-- briefly reference a renamed users table without erroring.
+			PRAGMA foreign_keys = OFF;
+
+			-- 1. Recreate users with CHECK constraints + SSO columns.
+			--    auth_provider = which channel created the row ('local'
+			--    for password users; provider name for SSO). external_id
+			--    is the IdP's stable subject claim ('sub' for OIDC, 'id'
+			--    for Microsoft Graph). The (auth_provider, external_id)
+			--    pair is the SSO lookup key so the same email arriving
+			--    via two providers is two separate user rows on purpose.
+			CREATE TABLE users_new (
+				id              INTEGER PRIMARY KEY AUTOINCREMENT,
+				username        TEXT    NOT NULL UNIQUE CHECK (LENGTH(username) >= 3 AND LENGTH(username) <= 64),
+				password_hash   TEXT    NOT NULL,
+				role            TEXT    NOT NULL DEFAULT 'viewer' CHECK (role IN ('admin','operator','viewer')),
+				is_active       INTEGER NOT NULL DEFAULT 1,
+				last_login      TEXT,
+				failed_attempts INTEGER NOT NULL DEFAULT 0,
+				locked_until    TEXT,
+				token_version   INTEGER NOT NULL DEFAULT 1,
+				totp_secret     TEXT,
+				totp_enabled    INTEGER NOT NULL DEFAULT 0,
+				auth_provider   TEXT    NOT NULL DEFAULT 'local' CHECK (auth_provider IN ('local','google','microsoft','github')),
+				external_id     TEXT,
+				email           TEXT,
+				display_name    TEXT,
+				created_at      TEXT    NOT NULL,
+				updated_at      TEXT    NOT NULL,
+				UNIQUE (auth_provider, external_id)
+			);
+
+			-- Copy existing rows. Pre-existing data is all local-auth
+			-- (no SSO callback could have been invoked yet), so we leave
+			-- auth_provider at its default of 'local' and external_id/
+			-- email/display_name NULL. Role mapping: existing 'admin' is
+			-- preserved; anything unrecognized gets demoted to 'viewer'
+			-- (defensive — should not occur on a fresh dev DB). TOTP
+			-- columns from the Wave-3 MFA migration are preserved
+			-- verbatim so existing enrolments survive the table swap.
+			INSERT INTO users_new
+				(id, username, password_hash, role, is_active, last_login,
+				 failed_attempts, locked_until, token_version,
+				 totp_secret, totp_enabled,
+				 created_at, updated_at)
+			SELECT
+				id, username, password_hash,
+				CASE WHEN role IN ('admin','operator','viewer') THEN role ELSE 'viewer' END,
+				COALESCE(is_active, 1), last_login,
+				COALESCE(failed_attempts, 0), locked_until,
+				COALESCE(token_version, 1),
+				totp_secret, COALESCE(totp_enabled, 0),
+				created_at, updated_at
+			FROM users;
+
+			DROP TABLE users;
+			ALTER TABLE users_new RENAME TO users;
+
+			CREATE INDEX idx_users_username             ON users(username);
+			CREATE INDEX idx_users_active               ON users(is_active);
+			CREATE INDEX idx_users_provider_external_id ON users(auth_provider, external_id);
+			CREATE INDEX idx_users_email                ON users(email);
+
+			-- 2. Recreate api_tokens with FK to users.username (CASCADE).
+			--    Deleting a user automatically revokes every token they
+			--    own; this matches the IncrementTokenVersion behaviour
+			--    that's already wired for JWT session revocation.
+			CREATE TABLE api_tokens_new (
+				id              TEXT PRIMARY KEY,
+				owner_username  TEXT NOT NULL,
+				name            TEXT NOT NULL,
+				token_hash      TEXT NOT NULL UNIQUE,
+				prefix          TEXT NOT NULL,
+				created_at      TEXT NOT NULL,
+				last_used_at    TEXT,
+				revoked_at      TEXT,
+				FOREIGN KEY (owner_username) REFERENCES users(username) ON DELETE CASCADE ON UPDATE CASCADE
+			);
+
+			INSERT INTO api_tokens_new
+				(id, owner_username, name, token_hash, prefix, created_at, last_used_at, revoked_at)
+			SELECT
+				id, owner_username, name, token_hash, prefix, created_at, last_used_at, revoked_at
+			FROM api_tokens
+			-- Defensive: drop any orphan rows whose owner no longer
+			-- exists in users. Pre-alpha, should be empty.
+			WHERE owner_username IN (SELECT username FROM users);
+
+			DROP TABLE api_tokens;
+			ALTER TABLE api_tokens_new RENAME TO api_tokens;
+
+			CREATE INDEX idx_api_tokens_owner  ON api_tokens(owner_username);
+			CREATE INDEX idx_api_tokens_hash   ON api_tokens(token_hash);
+			CREATE INDEX idx_api_tokens_active ON api_tokens(revoked_at);
+
+			PRAGMA foreign_keys = ON;
+		`,
+		},
 	}
 }
 

--- a/internal/database/repository_api_tokens_test.go
+++ b/internal/database/repository_api_tokens_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/krisarmstrong/seed/internal/database"
 )
 
-func setupAPITokenTest(t *testing.T) (*database.APITokenRepository, context.Context) {
+func setupAPITokenTest(t *testing.T, owners ...string) (*database.APITokenRepository, context.Context) {
 	t.Helper()
 	tmpFile, err := os.CreateTemp(t.TempDir(), "seed-test-*.db")
 	if err != nil {
@@ -29,7 +29,23 @@ func setupAPITokenTest(t *testing.T) (*database.APITokenRepository, context.Cont
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	return database.NewAPITokenRepository(db), context.Background()
+	// The hardening migration added an ON DELETE CASCADE FK from
+	// api_tokens.owner_username -> users.username. Tests must seed any
+	// owner referenced by an inserted token, otherwise the FK rejects
+	// the row. Default ("alice","bob") covers the existing cases; extra
+	// owners can be passed in by name.
+	ctx := context.Background()
+	if len(owners) == 0 {
+		owners = []string{"alice", "bob"}
+	}
+	for _, name := range owners {
+		_, createErr := db.CreateUser(ctx, name, "$2a$10$x", database.RoleAdmin)
+		if createErr != nil {
+			t.Fatalf("seed user %q: %v", name, createErr)
+		}
+	}
+
+	return database.NewAPITokenRepository(db), ctx
 }
 
 func TestAPITokenInsertAndLookup(t *testing.T) {
@@ -147,7 +163,7 @@ func TestAPITokenListByOwnerSorted(t *testing.T) {
 
 func TestAPITokenTouchLastUsedUpdatesTimestamp(t *testing.T) {
 	t.Parallel()
-	repo, ctx := setupAPITokenTest(t)
+	repo, ctx := setupAPITokenTest(t, "carol")
 
 	rec := database.APITokenRecord{
 		ID: "tokenid04", OwnerUsername: "carol", Name: "k",

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -19,9 +19,35 @@ type User struct {
 	FailedAttempts int
 	LockedUntil    *time.Time
 	TokenVersion   int
+	AuthProvider   string // 'local' | 'google' | 'microsoft' | 'github'
+	ExternalID     string // IdP subject claim (OIDC 'sub' / MS Graph 'id'); empty for local users
+	Email          string // display + cross-provider matching
+	DisplayName    string // optional human name returned by the IdP
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 }
+
+// Valid role identifiers (enforced by the DB CHECK constraint added in the
+// hardening migration). The constant set lives in code as well so handlers
+// can validate input before hitting the DB.
+const (
+	RoleAdmin    = "admin"
+	RoleOperator = "operator"
+	RoleViewer   = "viewer"
+)
+
+// IsValidRole returns true if r is one of admin, operator, or viewer.
+func IsValidRole(r string) bool {
+	return r == RoleAdmin || r == RoleOperator || r == RoleViewer
+}
+
+// Valid auth providers (enforced by the DB CHECK constraint).
+const (
+	AuthProviderLocal     = "local"
+	AuthProviderGoogle    = "google"
+	AuthProviderMicrosoft = "microsoft"
+	AuthProviderGitHub    = "github"
+)
 
 // Common errors for user operations.
 var (
@@ -30,6 +56,8 @@ var (
 	ErrUserLocked        = errors.New("user account is locked")
 	ErrUserInactive      = errors.New("user account is inactive")
 	ErrNoUsersConfigured = errors.New("no users configured")
+	ErrInvalidRole       = errors.New("invalid role")
+	ErrLastAdmin         = errors.New("cannot demote or delete the last admin")
 )
 
 // GetUser retrieves a user by username.
@@ -42,17 +70,20 @@ func (db *DB) GetUser(ctx context.Context, username string) (*User, error) {
 	}
 
 	var user User
-	var lastLogin, lockedUntil sql.NullString
+	var lastLogin, lockedUntil, externalID, email, displayName sql.NullString
 	var createdAt, updatedAt string
 
 	err := db.conn.QueryRowContext(ctx, `
 		SELECT id, username, password_hash, role, is_active, last_login,
-		       failed_attempts, locked_until, token_version, created_at, updated_at
+		       failed_attempts, locked_until, token_version,
+		       auth_provider, external_id, email, display_name,
+		       created_at, updated_at
 		FROM users
 		WHERE username = ?
 	`, username).Scan(
 		&user.ID, &user.Username, &user.PasswordHash, &user.Role, &user.IsActive,
 		&lastLogin, &user.FailedAttempts, &lockedUntil, &user.TokenVersion,
+		&user.AuthProvider, &externalID, &email, &displayName,
 		&createdAt, &updatedAt,
 	)
 
@@ -74,6 +105,15 @@ func (db *DB) GetUser(ctx context.Context, username string) (*User, error) {
 	if lockedUntil.Valid {
 		t, _ := time.Parse(time.RFC3339, lockedUntil.String)
 		user.LockedUntil = &t
+	}
+	if externalID.Valid {
+		user.ExternalID = externalID.String
+	}
+	if email.Valid {
+		user.Email = email.String
+	}
+	if displayName.Valid {
+		user.DisplayName = displayName.String
 	}
 
 	return &user, nil
@@ -112,6 +152,7 @@ func (db *DB) CreateUser(ctx context.Context, username, passwordHash, role strin
 		Role:         role,
 		IsActive:     true,
 		TokenVersion: 1,
+		AuthProvider: AuthProviderLocal,
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}, nil
@@ -331,6 +372,360 @@ func (db *DB) MigrateUserFromConfig(ctx context.Context, username, passwordHash 
 	}
 
 	return nil
+}
+
+// ListUsers returns every user, ordered by username.
+func (db *DB) ListUsers(ctx context.Context) ([]*User, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	if db.closed {
+		return nil, errors.New("database is closed")
+	}
+
+	rows, err := db.conn.QueryContext(ctx, `
+		SELECT id, username, password_hash, role, is_active, last_login,
+		       failed_attempts, locked_until, token_version,
+		       auth_provider, external_id, email, display_name,
+		       created_at, updated_at
+		FROM users
+		ORDER BY username
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list users: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*User
+	for rows.Next() {
+		var u User
+		var lastLogin, lockedUntil, externalID, email, displayName sql.NullString
+		var createdAt, updatedAt string
+		if scanErr := rows.Scan(
+			&u.ID, &u.Username, &u.PasswordHash, &u.Role, &u.IsActive,
+			&lastLogin, &u.FailedAttempts, &lockedUntil, &u.TokenVersion,
+			&u.AuthProvider, &externalID, &email, &displayName,
+			&createdAt, &updatedAt,
+		); scanErr != nil {
+			return nil, fmt.Errorf("failed to scan user row: %w", scanErr)
+		}
+		u.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+		u.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+		if lastLogin.Valid {
+			t, _ := time.Parse(time.RFC3339, lastLogin.String)
+			u.LastLogin = &t
+		}
+		if lockedUntil.Valid {
+			t, _ := time.Parse(time.RFC3339, lockedUntil.String)
+			u.LockedUntil = &t
+		}
+		u.ExternalID = externalID.String
+		u.Email = email.String
+		u.DisplayName = displayName.String
+		out = append(out, &u)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("failed to iterate users: %w", rowsErr)
+	}
+	return out, nil
+}
+
+// UpdateUserRole sets a user's role. Refuses to demote the last admin
+// (returns ErrLastAdmin). The CHECK constraint on the role column would
+// reject an invalid role at the DB layer too, but we surface a clean
+// Go-level error.
+func (db *DB) UpdateUserRole(ctx context.Context, username, role string) error {
+	if !IsValidRole(role) {
+		return ErrInvalidRole
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.closed {
+		return errors.New("database is closed")
+	}
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Fetch current role to detect a demote-from-admin path.
+	var currentRole string
+	scanErr := tx.QueryRowContext(ctx,
+		`SELECT role FROM users WHERE username = ?`, username).Scan(&currentRole)
+	if scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return ErrUserNotFound
+		}
+		return fmt.Errorf("failed to read current role: %w", scanErr)
+	}
+
+	if currentRole == RoleAdmin && role != RoleAdmin {
+		var adminCount int
+		cntErr := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM users WHERE role = 'admin' AND is_active = 1`).Scan(&adminCount)
+		if cntErr != nil {
+			return fmt.Errorf("failed to count admins: %w", cntErr)
+		}
+		if adminCount <= 1 {
+			return ErrLastAdmin
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := tx.ExecContext(ctx, `
+		UPDATE users SET role = ?, updated_at = ? WHERE username = ?
+	`, role, now, username)
+	if err != nil {
+		return fmt.Errorf("failed to update role: %w", err)
+	}
+	rows, _ := res.RowsAffected()
+	if rows == 0 {
+		return ErrUserNotFound
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		return fmt.Errorf("failed to commit role change: %w", commitErr)
+	}
+	return nil
+}
+
+// DeleteUser hard-deletes a user. Refuses to delete the last admin
+// (returns ErrLastAdmin). The FK cascade on api_tokens automatically
+// purges the user's tokens; the user's authenticated sessions are
+// already revoked because the FK delete also removes the token_version
+// row they verify against (incrementing TokenVersion is unnecessary
+// once the row is gone).
+//
+// Soft-delete via is_active=0 is also supported (use DeactivateUser);
+// hard-delete is reserved for "remove this person entirely" actions.
+func (db *DB) DeleteUser(ctx context.Context, username string) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.closed {
+		return errors.New("database is closed")
+	}
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var role string
+	scanErr := tx.QueryRowContext(ctx,
+		`SELECT role FROM users WHERE username = ?`, username).Scan(&role)
+	if scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return ErrUserNotFound
+		}
+		return fmt.Errorf("failed to read role: %w", scanErr)
+	}
+
+	if role == RoleAdmin {
+		var adminCount int
+		cntErr := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM users WHERE role = 'admin' AND is_active = 1`).Scan(&adminCount)
+		if cntErr != nil {
+			return fmt.Errorf("failed to count admins: %w", cntErr)
+		}
+		if adminCount <= 1 {
+			return ErrLastAdmin
+		}
+	}
+
+	res, err := tx.ExecContext(ctx, `DELETE FROM users WHERE username = ?`, username)
+	if err != nil {
+		return fmt.Errorf("failed to delete user: %w", err)
+	}
+	rows, _ := res.RowsAffected()
+	if rows == 0 {
+		return ErrUserNotFound
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		return fmt.Errorf("failed to commit delete: %w", commitErr)
+	}
+	return nil
+}
+
+// DeactivateUser sets is_active = 0 and increments token_version so any
+// outstanding sessions/tokens are immediately invalidated. Use this
+// instead of DeleteUser when the user record needs to remain for audit
+// trails or reactivation.
+func (db *DB) DeactivateUser(ctx context.Context, username string) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.closed {
+		return errors.New("database is closed")
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.conn.ExecContext(ctx, `
+		UPDATE users
+		SET is_active = 0, token_version = token_version + 1, updated_at = ?
+		WHERE username = ?
+	`, now, username)
+	if err != nil {
+		return fmt.Errorf("failed to deactivate user: %w", err)
+	}
+	rows, _ := res.RowsAffected()
+	if rows == 0 {
+		return ErrUserNotFound
+	}
+	return nil
+}
+
+// SSOUserInput is the payload for UpsertSSOUser. The auth_provider +
+// external_id pair is the unique key — matching purely on email would
+// allow a compromised IdP to take over an existing local-account user.
+type SSOUserInput struct {
+	Provider    string // "google" | "microsoft" | "github"
+	ExternalID  string // the IdP's stable subject claim
+	Email       string // for display and cross-provider matching
+	DisplayName string // optional human name from the IdP
+}
+
+// UpsertSSOUser returns the user matching (provider, external_id), or
+// creates a new row if none exists. On first-ever user creation across
+// any channel, the new user becomes 'admin'; subsequent SSO-created
+// users default to 'viewer' and an existing admin can promote them.
+//
+// The synthetic username is "<provider>:<external_id>"; we don't try to
+// reuse the email as the username because emails can change at the IdP
+// and aren't guaranteed unique across providers (and the local-auth
+// users.username UNIQUE constraint applies to the entire users table).
+// SSO users never have a usable password_hash — we store a sentinel
+// value that bcrypt cannot match against any input.
+func (db *DB) UpsertSSOUser(ctx context.Context, in SSOUserInput) (*User, error) {
+	if in.Provider == "" || in.ExternalID == "" {
+		return nil, errors.New("provider and external_id are required")
+	}
+	switch in.Provider {
+	case AuthProviderGoogle, AuthProviderMicrosoft, AuthProviderGitHub:
+		// ok
+	default:
+		return nil, fmt.Errorf("unsupported SSO provider: %s", in.Provider)
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.closed {
+		return nil, errors.New("database is closed")
+	}
+
+	// Fast path: look up by (provider, external_id).
+	existing, lookupErr := db.lookupSSOUserLocked(ctx, in.Provider, in.ExternalID)
+	if lookupErr != nil && !errors.Is(lookupErr, ErrUserNotFound) {
+		return nil, lookupErr
+	}
+	if existing != nil {
+		// Refresh email + display name from latest IdP response.
+		now := time.Now().UTC().Format(time.RFC3339)
+		if _, err := db.conn.ExecContext(ctx, `
+			UPDATE users SET email = ?, display_name = ?, updated_at = ? WHERE id = ?
+		`, in.Email, in.DisplayName, now, existing.ID); err != nil {
+			return nil, fmt.Errorf("failed to refresh SSO user: %w", err)
+		}
+		existing.Email = in.Email
+		existing.DisplayName = in.DisplayName
+		return existing, nil
+	}
+
+	// New user. Decide initial role.
+	var totalUsers int
+	if cntErr := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&totalUsers); cntErr != nil {
+		return nil, fmt.Errorf("failed to count users for SSO bootstrap: %w", cntErr)
+	}
+	role := RoleViewer
+	if totalUsers == 0 {
+		role = RoleAdmin
+	}
+
+	username := in.Provider + ":" + in.ExternalID
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339)
+
+	// "!" prefix is not in bcrypt's alphabet so this value never matches.
+	const ssoSentinelHash = "!sso-no-password"
+
+	res, err := db.conn.ExecContext(ctx, `
+		INSERT INTO users
+			(username, password_hash, role, is_active, token_version,
+			 auth_provider, external_id, email, display_name,
+			 created_at, updated_at)
+		VALUES (?, ?, ?, 1, 1, ?, ?, ?, ?, ?, ?)
+	`, username, ssoSentinelHash, role, in.Provider, in.ExternalID, in.Email, in.DisplayName, nowStr, nowStr)
+	if err != nil {
+		if isUniqueConstraintError(err) {
+			// Race: another request created the same user. Retry the lookup.
+			return db.lookupSSOUserLocked(ctx, in.Provider, in.ExternalID)
+		}
+		return nil, fmt.Errorf("failed to insert SSO user: %w", err)
+	}
+	id, _ := res.LastInsertId()
+
+	return &User{
+		ID:           id,
+		Username:     username,
+		PasswordHash: ssoSentinelHash,
+		Role:         role,
+		IsActive:     true,
+		TokenVersion: 1,
+		AuthProvider: in.Provider,
+		ExternalID:   in.ExternalID,
+		Email:        in.Email,
+		DisplayName:  in.DisplayName,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+// lookupSSOUserLocked finds a user by (provider, external_id). MUST be
+// called with db.mu held.
+func (db *DB) lookupSSOUserLocked(ctx context.Context, provider, externalID string) (*User, error) {
+	var u User
+	var lastLogin, lockedUntil, email, displayName sql.NullString
+	var createdAt, updatedAt string
+
+	err := db.conn.QueryRowContext(ctx, `
+		SELECT id, username, password_hash, role, is_active, last_login,
+		       failed_attempts, locked_until, token_version,
+		       auth_provider, external_id, email, display_name,
+		       created_at, updated_at
+		FROM users
+		WHERE auth_provider = ? AND external_id = ?
+	`, provider, externalID).Scan(
+		&u.ID, &u.Username, &u.PasswordHash, &u.Role, &u.IsActive,
+		&lastLogin, &u.FailedAttempts, &lockedUntil, &u.TokenVersion,
+		&u.AuthProvider, &u.ExternalID, &email, &displayName,
+		&createdAt, &updatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrUserNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up SSO user: %w", err)
+	}
+	u.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+	u.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+	if lastLogin.Valid {
+		t, _ := time.Parse(time.RFC3339, lastLogin.String)
+		u.LastLogin = &t
+	}
+	if lockedUntil.Valid {
+		t, _ := time.Parse(time.RFC3339, lockedUntil.String)
+		u.LockedUntil = &t
+	}
+	u.Email = email.String
+	u.DisplayName = displayName.String
+	return &u, nil
 }
 
 // Note: isUniqueConstraintError is defined in repository_profiles.go

--- a/internal/i18n/locales/en/errors.json
+++ b/internal/i18n/locales/en/errors.json
@@ -118,5 +118,16 @@
   },
   "sso": {
     "featureRequired": "Single Sign-On configuration requires a Pro license. Existing providers continue to accept logins on any tier; only enabling or editing providers is blocked."
+  },
+  "users": {
+    "lastAdmin": "Cannot delete or demote the last administrator.",
+    "invalidRole": "Role must be one of: admin, operator, viewer.",
+    "userExists": "A user with that username already exists.",
+    "lockedOut": "Account temporarily locked due to repeated failed sign-ins.",
+    "weakPassword": "Password does not meet policy: minimum 12 characters, mixed case, digit, symbol.",
+    "selfDelete": "You cannot delete your own account.",
+    "selfDeactivate": "You cannot deactivate your own account.",
+    "selfDemote": "You cannot demote your own account from admin.",
+    "featureRequired": "Adding additional users requires a Pro license."
   }
 }

--- a/internal/i18n/locales/es/errors.json
+++ b/internal/i18n/locales/es/errors.json
@@ -118,5 +118,16 @@
   },
   "sso": {
     "featureRequired": "La configuración de Single Sign-On requiere una licencia Pro. Los proveedores existentes siguen aceptando inicios de sesión en cualquier nivel; solo se bloquea habilitar o editar proveedores."
+  },
+  "users": {
+    "lastAdmin": "No se puede eliminar ni degradar al último administrador.",
+    "invalidRole": "El rol debe ser uno de: admin, operator, viewer.",
+    "userExists": "Ya existe un usuario con ese nombre.",
+    "lockedOut": "Cuenta bloqueada temporalmente por varios intentos fallidos.",
+    "weakPassword": "La contraseña no cumple la política: mínimo 12 caracteres, mayúsculas y minúsculas, dígito y símbolo.",
+    "selfDelete": "No puede eliminar su propia cuenta.",
+    "selfDeactivate": "No puede desactivar su propia cuenta.",
+    "selfDemote": "No puede degradar su propia cuenta de administrador.",
+    "featureRequired": "Agregar usuarios adicionales requiere una licencia Pro."
   }
 }


### PR DESCRIPTION
Backend half of #1198. Stacked on PR #1204 (multi_user); the new \`UpsertSSOUser\` helper comes from that PR. Settings → SSO admin panel UI + in-memory provider stub tests are tracked as follow-up.

## License gate

Wraps PUT \`/api/v1/sso/update\` in \`requireFeature(\"sso\", ...)\`. Free + Starter operators get 402 \`TIER_TOO_LOW\` when they try to enable an SSO provider. GET \`/api/v1/sso/settings\` stays open so a Pro→Free downgrade doesn't lock operators out of inspecting their config. Already-configured providers continue to work on any tier — only WRITES are blocked.

## User-record sync on callback

\`completeOAuthLogin\` now upserts the IdP user into the \`users\` table BEFORE issuing session tokens, via \`database.UpsertSSOUser\` (from PR #1204). The synthetic username \`<provider>:<external_id>\` is used as the JWT subject so a local-auth account and an SSO account sharing an email never collide. First user any-channel becomes admin; subsequent SSO logins default to viewer.

This closes the gap where SSO-authenticated identities were invisible to the multi_user CRUD endpoints from #1191.

## Out of scope (follow-up in #1198)

- Settings → SSO admin panel (currently operators edit \`config.yaml\` + restart)
- \`handlers_oauth_test.go\` with in-memory OAuth provider stub
- SSO-specific i18n keys for the admin panel surface
- SCIM / claim-based role mapping / OIDC single sign-out (V2)

## Test plan

- [ ] CI green (requires PR #1204 to merge first)
- [ ] Manual: Pro operator can save SSO settings via PUT — 200
- [ ] Manual: Free operator cannot save — 402 \`TIER_TOO_LOW\`
- [ ] Manual: Google login flow creates a users row with auth_provider='google'
- [ ] Manual: same user logs in twice — same row re-used (no duplicate)
- [ ] Manual: bootstrap admin still works on a fresh DB (Local user → admin via /api/v1/users)