### PR TITLE
feat(forms): adopt react-hook-form + valibot (#1201)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource-variable/inter": "5.2.8",
         "@fontsource-variable/jetbrains-mono": "5.2.8",
+        "@hookform/resolvers": "^5.4.0",
         "@tailwindcss/postcss": "4.3.0",
         "@tanstack/react-query": "5.100.14",
         "cmdk": "^1.1.1",
@@ -20,6 +21,7 @@
         "lucide-react": "1.16.0",
         "react": "19.2.6",
         "react-dom": "19.2.6",
+        "react-hook-form": "^7.76.1",
         "react-i18next": "17.0.8",
         "react-router-dom": "^7.15.1",
         "tailwind-merge": "3.6.0",
@@ -1652,6 +1654,18 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
@@ -3175,6 +3189,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
@@ -6548,6 +6568,22 @@
       },
       "peerDependencies": {
         "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.76.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.76.1.tgz",
+      "integrity": "sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-i18next": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@fontsource-variable/inter": "5.2.8",
     "@fontsource-variable/jetbrains-mono": "5.2.8",
+    "@hookform/resolvers": "^5.4.0",
     "@tailwindcss/postcss": "4.3.0",
     "@tanstack/react-query": "5.100.14",
     "cmdk": "^1.1.1",
@@ -37,6 +38,7 @@
     "lucide-react": "1.16.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
+    "react-hook-form": "^7.76.1",
     "react-i18next": "17.0.8",
     "react-router-dom": "^7.15.1",
     "tailwind-merge": "3.6.0",

--- a/ui/src/app/LoginForm.tsx
+++ b/ui/src/app/LoginForm.tsx
@@ -18,11 +18,13 @@
  * - Responsive design with consistent theming
  */
 
-import type React from 'react';
+import { valibotResolver } from '@hookform/resolvers/valibot';
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { RecoveryForm } from '../components/login/RecoveryForm';
+import { LoginSchema } from '../schemas/auth';
 import { button, cn, input, layout, radius, spacing } from '../styles/theme';
 
 // API base URL - configurable via environment variable
@@ -61,8 +63,15 @@ interface RecoveryStatus {
 
 export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.Element {
   const { t } = useTranslation('common');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<{ username: string; password: string }>({
+    resolver: valibotResolver(LoginSchema),
+    defaultValues: { username: '', password: '' },
+    mode: 'onBlur',
+  });
   // Initialize SSO error from URL params using lazy initialization
   const [ssoError] = useState<string | null>(getAndClearSsoError);
   // Fetch SSO providers to conditionally show buttons (fixes #769)
@@ -100,8 +109,10 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
   // Check if any SSO provider is enabled
   const hasEnabledSso = ssoProviders.some((p) => p.enabled);
 
-  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
-    e.preventDefault();
+  const onSubmit: SubmitHandler<{ username: string; password: string }> = async ({
+    username,
+    password,
+  }) => {
     await onLogin(username, password);
   };
 
@@ -225,7 +236,7 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
         </div>
 
         <form
-          onSubmit={handleSubmit}
+          onSubmit={handleSubmit(onSubmit)}
           className={cn(
             'bg-surface-raised',
             radius.md,
@@ -242,8 +253,8 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
             <input
               id="login-username"
               type="text"
-              value={username}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setUsername(e.target.value)}
+              required={true}
+              {...register('username')}
               className={cn(
                 'w-full',
                 input.size.md,
@@ -251,8 +262,10 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
                 'border border-surface-border bg-surface-base text-text-primary focus:outline-none focus:border-brand-primary',
               )}
               placeholder="admin"
-              required={true}
             />
+            {errors.username ? (
+              <p className="caption mt-1 text-status-error">{errors.username.message}</p>
+            ) : null}
           </div>
 
           <div>
@@ -265,8 +278,8 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
             <input
               id="login-password"
               type="password"
-              value={password}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+              required={true}
+              {...register('password')}
               className={cn(
                 'w-full',
                 input.size.md,
@@ -274,8 +287,10 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
                 'border border-surface-border bg-surface-base text-text-primary focus:outline-none focus:border-brand-primary',
               )}
               placeholder="••••••••"
-              required={true}
             />
+            {errors.password ? (
+              <p className="caption mt-1 text-status-error">{errors.password.message}</p>
+            ) : null}
           </div>
 
           {error || ssoError ? (

--- a/ui/src/components/cards/PathDiscoveryCard.tsx
+++ b/ui/src/components/cards/PathDiscoveryCard.tsx
@@ -22,10 +22,13 @@
  * Dependencies: Card UI, DeviceSelector, theme utilities, path discovery API
  */
 
+import { valibotResolver } from '@hookform/resolvers/valibot';
 import type React from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { api } from '../../api';
+import { PathDiscoverySchema } from '../../schemas/auth';
 import {
   button as buttonTokens,
   cn,
@@ -69,9 +72,26 @@ export const PathDiscoveryCard: React.NamedExoticComponent<PathDiscoveryCardProp
   }: PathDiscoveryCardProps): React.ReactElement {
     const { t } = useTranslation('cards');
 
-    const [target, setTarget] = useState('');
-    const [protocol, setProtocol] = useState<Protocol>('icmp');
-    const [port, setPort] = useState<number>(80);
+    const {
+      register,
+      handleSubmit,
+      watch,
+      setValue,
+      formState: { errors },
+    } = useForm<{ target: string; protocol: Protocol; port: number }>({
+      resolver: valibotResolver(PathDiscoverySchema),
+      defaultValues: { target: '', protocol: 'icmp', port: 80 },
+      mode: 'onBlur',
+    });
+    const target = watch('target');
+    const protocol = watch('protocol');
+    const port = watch('port');
+    const setTarget = useCallback(
+      (next: string): void => {
+        setValue('target', next, { shouldValidate: true, shouldDirty: true });
+      },
+      [setValue],
+    );
     const [loading, setLoading] = useState(false);
     const [result, setResult] = useState<PathResponse | null>(null);
     const [error, setError] = useState<string | null>(null);
@@ -148,15 +168,13 @@ export const PathDiscoveryCard: React.NamedExoticComponent<PathDiscoveryCardProp
       [protocol, port],
     );
 
-    // Handle form submit
-    const handleSubmit = useCallback(
-      (e: React.FormEvent): void => {
-        e.preventDefault();
-        runTrace(target).catch(() => {
+    const onSubmit = useCallback(
+      ({ target: traceTarget }: { target: string }): void => {
+        runTrace(traceTarget).catch(() => {
           // Error handled in runTrace
         });
       },
-      [target, runTrace],
+      [runTrace],
     );
 
     // Quick target handlers
@@ -293,16 +311,16 @@ export const PathDiscoveryCard: React.NamedExoticComponent<PathDiscoveryCardProp
         status={cardStatus}
       >
         {/* Target Input Form - Responsive layout for various screen sizes */}
-        <form onSubmit={handleSubmit} className={cn('stack-sm', spacing.margin.bottom.content)}>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className={cn('stack-sm', spacing.margin.bottom.content)}
+        >
           {/* Target Input Row - Stack on mobile, inline on larger screens */}
           <div className="flex flex-col sm:flex-row gap-2">
             {/* Target input - full width on mobile */}
             <input
               type="text"
-              value={target}
-              onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                setTarget(e.target.value)
-              }
+              {...register('target')}
               placeholder={t('pathDiscovery.enterTarget', 'Enter IP or hostname...')}
               disabled={loading}
               className={cn(
@@ -312,22 +330,13 @@ export const PathDiscoveryCard: React.NamedExoticComponent<PathDiscoveryCardProp
                 inputTokens.size.sm,
                 'body-small',
               )}
-              onKeyDown={(e: React.KeyboardEvent): void => {
-                if (e.key === 'Enter' && target.trim()) {
-                  e.preventDefault();
-                  handleSubmit(e as unknown as React.FormEvent);
-                }
-              }}
             />
 
             {/* Protocol and Trace button group - inline always */}
             <div className="flex items-center gap-2 shrink-0">
               {/* Protocol selector - styled to match design system */}
               <select
-                value={protocol}
-                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                  setProtocol(e.target.value as Protocol)
-                }
+                {...register('protocol')}
                 disabled={loading}
                 className={cn(
                   inputTokens.base,
@@ -346,10 +355,7 @@ export const PathDiscoveryCard: React.NamedExoticComponent<PathDiscoveryCardProp
               {protocol !== 'icmp' && (
                 <input
                   type="number"
-                  value={port}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                    setPort(Number.parseInt(e.target.value, 10) || 80)
-                  }
+                  {...register('port', { valueAsNumber: true })}
                   placeholder="Port"
                   min={1}
                   max={65535}
@@ -366,7 +372,7 @@ export const PathDiscoveryCard: React.NamedExoticComponent<PathDiscoveryCardProp
 
               <button
                 type="submit"
-                disabled={loading || !target.trim()}
+                disabled={loading || !target?.trim()}
                 className={cn(
                   buttonTokens.base,
                   buttonTokens.variant.primary,
@@ -378,6 +384,12 @@ export const PathDiscoveryCard: React.NamedExoticComponent<PathDiscoveryCardProp
               </button>
             </div>
           </div>
+          {errors.target ? (
+            <p className={cn('caption', statusColor.text.error)}>{errors.target.message}</p>
+          ) : null}
+          {errors.port ? (
+            <p className={cn('caption', statusColor.text.error)}>{errors.port.message}</p>
+          ) : null}
 
           {/* Quick Targets - Wrap on small screens */}
           <div className="flex items-center gap-2 flex-wrap">

--- a/ui/src/components/cards/WiFiSurveyCard.tsx
+++ b/ui/src/components/cards/WiFiSurveyCard.tsx
@@ -23,11 +23,14 @@
  * State: Manages surveys list, selected survey, create dialog state, fetches from API
  */
 
+import { valibotResolver } from '@hookform/resolvers/valibot';
 import type React from 'react';
 import { useState } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { type Survey, type SurveyType, useSurvey } from '../../hooks/useSurvey';
 import { LogComponents, logger } from '../../lib/logger';
+import { CreateSurveySchema } from '../../schemas/auth';
 import {
   button,
   cn,
@@ -372,15 +375,22 @@ function CreateSurveyDialog({
   t,
   currentInterface = '',
 }: CreateSurveyDialogProps): React.ReactElement {
-  const [name, setName] = useState('');
-  const [surveyType, setSurveyType] = useState<SurveyType>('passive');
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<{ name: string; surveyType: SurveyType }>({
+    resolver: valibotResolver(CreateSurveySchema),
+    defaultValues: { name: '', surveyType: 'passive' },
+    mode: 'onBlur',
+  });
 
-  const handleSubmit = (e: React.FormEvent): void => {
-    e.preventDefault();
-    if (name.trim()) {
-      // Fix #572: Use interface from props instead of hardcoded "wlan0"
-      onCreate(name.trim(), surveyType, currentInterface);
-    }
+  const onSubmit: SubmitHandler<{ name: string; surveyType: SurveyType }> = ({
+    name,
+    surveyType,
+  }) => {
+    // Fix #572: Use interface from props instead of hardcoded "wlan0"
+    onCreate(name, surveyType, currentInterface);
   };
 
   return (
@@ -397,7 +407,7 @@ function CreateSurveyDialog({
         <h2 className={cn('heading-2', spacing.margin.bottom.content)}>
           {t('survey.createNewSurvey')}
         </h2>
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit(onSubmit)}>
           <div className="stack">
             <div>
               <label
@@ -409,14 +419,14 @@ function CreateSurveyDialog({
               <input
                 id="survey-name"
                 type="text"
-                value={name}
-                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                  setName(e.target.value)
-                }
+                required={true}
+                {...register('name')}
                 className={cn(inputTokens.base, inputTokens.state.default, inputTokens.size.md)}
                 placeholder={t('survey.namePlaceholder')}
-                required={true}
               />
+              {errors.name ? (
+                <p className="caption mt-1 text-status-error">{errors.name.message}</p>
+              ) : null}
             </div>
             <div>
               <label
@@ -427,16 +437,16 @@ function CreateSurveyDialog({
               </label>
               <select
                 id="survey-type"
-                value={surveyType}
-                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                  setSurveyType(e.target.value as SurveyType)
-                }
+                {...register('surveyType')}
                 className={cn(inputTokens.base, inputTokens.state.default, inputTokens.size.md)}
               >
                 <option value="passive">{t('survey.typePassive')}</option>
                 <option value="active">{t('survey.typeActive')}</option>
                 <option value="throughput">{t('survey.typeThroughput')}</option>
               </select>
+              {errors.surveyType ? (
+                <p className="caption mt-1 text-status-error">{errors.surveyType.message}</p>
+              ) : null}
             </div>
           </div>
           <div className={cn(layout.inline.default, spacing.margin.top.section)}>

--- a/ui/src/components/login/RecoveryForm.tsx
+++ b/ui/src/components/login/RecoveryForm.tsx
@@ -2,24 +2,16 @@
  * RecoveryForm Component
  *
  * Password recovery form for The Seed application.
- *
- * Responsibilities:
- * - Display recovery status and remaining time
- * - Accept recovery token from filesystem
- * - Set new password with confirmation
- * - Validate password strength (min 12 chars)
- *
- * Recovery Flow:
- * 1. Admin creates .recovery file via SSH (proves filesystem access)
- * 2. Server generates token, writes to .recovery-token
- * 3. Admin enters token + new password in this form
- * 4. Server validates, updates password, invalidates all sessions
+ * Migrated to react-hook-form + valibot per #1201.
  */
 
+import { valibotResolver } from '@hookform/resolvers/valibot';
 import { Eye, EyeOff, KeyRound, Lock, Timer } from 'lucide-react';
 import type React from 'react';
 import { useEffect, useState } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { RecoveryCompleteSchema } from '../../schemas/auth';
 import {
   alert,
   button,
@@ -35,7 +27,7 @@ import {
 // API base URL - configurable via environment variable
 const API_BASE: string = import.meta.env.VITE_API_BASE || '';
 
-// Minimum password length (matches setup-wizard)
+// Minimum password length (matches setup-wizard, mirrored in schema)
 const MIN_PASSWORD_LENGTH = 12;
 
 export interface RecoveryFormProps {
@@ -56,6 +48,12 @@ interface RecoveryInstructions {
   steps: string[];
 }
 
+interface RecoveryFormFields {
+  token: string;
+  password: string;
+  confirmPassword: string;
+}
+
 export function RecoveryForm({
   onRecoveryComplete,
   onBackToLogin,
@@ -64,15 +62,21 @@ export function RecoveryForm({
 }: RecoveryFormProps): React.ReactElement {
   const { t } = useTranslation('common');
   const { t: tErrors } = useTranslation('errors');
-  const [token, setToken] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [remainingTime, setRemainingTime] = useState(initialRemainingTime);
   const [instructions, setInstructions] = useState<RecoveryInstructions | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<RecoveryFormFields>({
+    resolver: valibotResolver(RecoveryCompleteSchema),
+    defaultValues: { token: '', password: '', confirmPassword: '' },
+    mode: 'onBlur',
+  });
 
   // Fetch recovery instructions on mount
   useEffect(() => {
@@ -93,7 +97,6 @@ export function RecoveryForm({
     if (remainingTime <= 0) {
       return;
     }
-
     const interval = setInterval(() => {
       setRemainingTime((prev) => {
         if (prev <= 1) {
@@ -103,67 +106,46 @@ export function RecoveryForm({
         return prev - 1;
       });
     }, 1000);
-
     return (): void => clearInterval(interval);
   }, [remainingTime]);
 
-  // Format remaining time as MM:SS
   const formatTime = (seconds: number): string => {
     const mins = Math.floor(seconds / 60);
     const secs = seconds % 60;
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
-  // Password validation
-  const passwordValid = password.length >= MIN_PASSWORD_LENGTH;
-  const passwordsMatch = password === confirmPassword;
-  const canSubmit = token.trim() && passwordValid && passwordsMatch && !isSubmitting;
-
-  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
-    e.preventDefault();
-    setError(null);
-
-    if (!passwordValid) {
-      setError(tErrors('password.tooShort', { min: MIN_PASSWORD_LENGTH }));
-      return;
-    }
-
-    if (!passwordsMatch) {
-      setError(tErrors('password.mismatch'));
-      return;
-    }
-
-    setIsSubmitting(true);
-
+  const onSubmit: SubmitHandler<RecoveryFormFields> = async ({ token, password }) => {
+    setSubmitError(null);
     try {
       const response = await fetch(`${API_BASE}/api/v1/recovery/complete`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          token: token.trim(),
-          password,
-        }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: token.trim(), password }),
       });
-
       const data = (await response.json()) as {
         success?: boolean;
         message?: string;
         error?: string;
       };
-
       if (response.ok && data.success) {
         onRecoveryComplete();
       } else {
-        setError(data.message || data.error || tErrors('recovery.failed'));
+        setSubmitError(data.message || data.error || tErrors('recovery.failed'));
       }
     } catch {
-      setError(tErrors('network.networkError'));
-    } finally {
-      setIsSubmitting(false);
+      setSubmitError(tErrors('network.networkError'));
     }
   };
+
+  // Cross-field error (passwords don't match) from valibot v.check().
+  const rootErrors = errors.root;
+  const crossFieldError = rootErrors
+    ? Object.values(rootErrors).find(
+        (e): e is { message: string } =>
+          typeof e === 'object' && e !== null && 'message' in e && typeof e.message === 'string',
+      )
+    : undefined;
 
   return (
     <div className={cn('min-h-screen', layout.flex.center, 'pad')}>
@@ -227,7 +209,7 @@ export function RecoveryForm({
 
         {/* Recovery Form */}
         <form
-          onSubmit={handleSubmit}
+          onSubmit={handleSubmit(onSubmit)}
           className={cn(
             'bg-surface-raised',
             radius.md,
@@ -252,10 +234,8 @@ export function RecoveryForm({
               <input
                 id="recovery-token"
                 type="text"
-                value={token}
-                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                  setToken(e.target.value)
-                }
+                required={true}
+                {...register('token')}
                 className={cn(
                   'w-full pl-10',
                   input.size.md,
@@ -269,9 +249,11 @@ export function RecoveryForm({
                 )}
                 autoComplete="off"
                 spellCheck={false}
-                required={true}
               />
             </div>
+            {errors.token ? (
+              <p className="caption mt-1 text-status-error">{errors.token.message}</p>
+            ) : null}
           </div>
 
           {/* New Password Input */}
@@ -292,20 +274,17 @@ export function RecoveryForm({
               <input
                 id="recovery-password"
                 type={showPassword ? 'text' : 'password'}
-                value={password}
-                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                  setPassword(e.target.value)
-                }
+                required={true}
+                {...register('password')}
                 className={cn(
                   'w-full pl-10 pr-10',
                   input.size.md,
                   radius.md,
                   'border bg-surface-base text-text-primary',
-                  password && !passwordValid ? statusColor.border.error : 'border-surface-border',
+                  errors.password ? statusColor.border.error : 'border-surface-border',
                   'focus:outline-none focus:border-brand-primary',
                 )}
                 placeholder="••••••••••••"
-                required={true}
               />
               <button
                 type="button"
@@ -323,16 +302,15 @@ export function RecoveryForm({
                 )}
               </button>
             </div>
-            <p
-              className={cn(
-                'caption mt-1',
-                password && !passwordValid ? statusColor.text.error : 'text-text-muted',
-              )}
-            >
-              {t('recovery.passwordRequirement', 'Minimum {{min}} characters', {
-                min: MIN_PASSWORD_LENGTH,
-              })}
-            </p>
+            {errors.password ? (
+              <p className="caption mt-1 text-status-error">{errors.password.message}</p>
+            ) : (
+              <p className="caption mt-1 text-text-muted">
+                {t('recovery.passwordRequirement', 'Minimum {{min}} characters', {
+                  min: MIN_PASSWORD_LENGTH,
+                })}
+              </p>
+            )}
           </div>
 
           {/* Confirm Password Input */}
@@ -353,22 +331,19 @@ export function RecoveryForm({
               <input
                 id="recovery-confirm-password"
                 type={showConfirmPassword ? 'text' : 'password'}
-                value={confirmPassword}
-                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                  setConfirmPassword(e.target.value)
-                }
+                required={true}
+                {...register('confirmPassword')}
                 className={cn(
                   'w-full pl-10 pr-10',
                   input.size.md,
                   radius.md,
                   'border bg-surface-base text-text-primary',
-                  confirmPassword && !passwordsMatch
+                  errors.confirmPassword || crossFieldError
                     ? statusColor.border.error
                     : 'border-surface-border',
                   'focus:outline-none focus:border-brand-primary',
                 )}
                 placeholder="••••••••••••"
-                required={true}
               />
               <button
                 type="button"
@@ -388,24 +363,29 @@ export function RecoveryForm({
                 )}
               </button>
             </div>
-            {confirmPassword && !passwordsMatch ? (
-              <p className="caption mt-1 text-status-error">
-                {t('errors.password.mismatch', 'Passwords do not match')}
-              </p>
+            {errors.confirmPassword ? (
+              <p className="caption mt-1 text-status-error">{errors.confirmPassword.message}</p>
             ) : null}
           </div>
 
-          {/* Error Display */}
-          {error ? (
+          {/* Cross-field error (passwords don't match) */}
+          {crossFieldError ? (
+            <div role="alert" className={cn(alert.base, alert.variant.error)}>
+              {crossFieldError.message}
+            </div>
+          ) : null}
+
+          {/* Submit error (network / server) */}
+          {submitError ? (
             <div role="alert" aria-live="assertive" className={cn(alert.base, alert.variant.error)}>
-              {error}
+              {submitError}
             </div>
           ) : null}
 
           {/* Submit Button */}
           <button
             type="submit"
-            disabled={!canSubmit}
+            disabled={isSubmitting}
             className={cn(
               'w-full',
               button.size.md,

--- a/ui/src/components/profiles/ProfileEditor.tsx
+++ b/ui/src/components/profiles/ProfileEditor.tsx
@@ -1,10 +1,13 @@
 /**
- * ProfileEditor Component - Modal for creating/editing profiles
+ * ProfileEditor Component - Modal for creating/editing profiles.
+ * Migrated to react-hook-form + valibot per seed#1201.
  */
 
+import { valibotResolver } from '@hookform/resolvers/valibot';
 import type React from 'react';
-import { useCallback, useState } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { ProfileEditorSchema } from '../../schemas/auth';
 import { cn, radius, spacing } from '../../styles/theme';
 import type { Profile, ProfileRequest } from '../../types/profile';
 
@@ -13,6 +16,13 @@ interface ProfileEditorProps {
   onSave: (data: ProfileRequest) => Promise<void>;
   onCancel: () => void;
   isLoading: boolean;
+}
+
+interface ProfileFormFields {
+  name: string;
+  description: string;
+  isDefault: boolean;
+  notes: string;
 }
 
 /**
@@ -27,25 +37,36 @@ export function ProfileEditor({
   const { t } = useTranslation();
   const isEditing = profile !== null;
 
-  const [name, setName] = useState(profile?.name || '');
-  const [description, setDescription] = useState(profile?.description || '');
-  const [isDefault, setIsDefault] = useState(profile?.isDefault);
-  const [notes, setNotes] = useState((profile?.config as { notes?: string })?.notes || '');
+  const initialNotes = (profile?.config as { notes?: string })?.notes || '';
 
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
-      await onSave({
-        name,
-        description,
-        isDefault: isDefault,
-        config: { notes },
-      });
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isValid },
+  } = useForm<ProfileFormFields>({
+    resolver: valibotResolver(ProfileEditorSchema),
+    defaultValues: {
+      name: profile?.name || '',
+      description: profile?.description || '',
+      isDefault: Boolean(profile?.isDefault),
+      notes: initialNotes,
     },
-    [name, description, isDefault, notes, onSave],
-  );
+    mode: 'onBlur',
+  });
 
-  // Helper to get button label (avoids nested ternary)
+  const isDefault = watch('isDefault');
+
+  const onSubmit: SubmitHandler<ProfileFormFields> = async (values) => {
+    await onSave({
+      name: values.name,
+      description: values.description,
+      isDefault: values.isDefault,
+      config: { notes: values.notes },
+    });
+  };
+
   const getButtonLabel = (): string => {
     if (isLoading) {
       return t('common.saving', 'Saving...');
@@ -74,7 +95,7 @@ export function ProfileEditor({
         </div>
 
         {/* Form */}
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit(onSubmit)}>
           <div className={cn(spacing.pad.default, 'space-y-4')}>
             {/* Name */}
             <div>
@@ -87,11 +108,7 @@ export function ProfileEditor({
               <input
                 id="profile-name"
                 type="text"
-                value={name}
-                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                  setName(e.target.value)
-                }
-                required={true}
+                {...register('name')}
                 className={cn(
                   'w-full',
                   spacing.pad.sm,
@@ -100,6 +117,9 @@ export function ProfileEditor({
                 )}
                 placeholder={t('profile.namePlaceholder', 'e.g., Client A')}
               />
+              {errors.name ? (
+                <p className="caption mt-1 text-status-error">{errors.name.message}</p>
+              ) : null}
             </div>
 
             {/* Description */}
@@ -113,10 +133,7 @@ export function ProfileEditor({
               <input
                 id="profile-description"
                 type="text"
-                value={description}
-                onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                  setDescription(e.target.value)
-                }
+                {...register('description')}
                 className={cn(
                   'w-full',
                   spacing.pad.sm,
@@ -125,6 +142,9 @@ export function ProfileEditor({
                 )}
                 placeholder={t('profile.descriptionPlaceholder', 'Brief description')}
               />
+              {errors.description ? (
+                <p className="caption mt-1 text-status-error">{errors.description.message}</p>
+              ) : null}
             </div>
 
             {/* Notes */}
@@ -137,10 +157,7 @@ export function ProfileEditor({
               </label>
               <textarea
                 id="profile-notes"
-                value={notes}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>): void =>
-                  setNotes(e.target.value)
-                }
+                {...register('notes')}
                 rows={3}
                 className={cn(
                   'w-full',
@@ -157,9 +174,7 @@ export function ProfileEditor({
               <input
                 type="checkbox"
                 checked={isDefault}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>): void =>
-                  setIsDefault(e.target.checked)
-                }
+                onChange={(e) => setValue('isDefault', e.target.checked, { shouldDirty: true })}
                 className="w-4 h-4 rounded border-surface-border text-brand-primary focus:ring-brand-primary"
               />
               <span className="body-small text-text-primary">
@@ -190,7 +205,7 @@ export function ProfileEditor({
             </button>
             <button
               type="submit"
-              disabled={isLoading || !name.trim()}
+              disabled={isLoading || !isValid}
               className={cn(
                 spacing.pad.sm,
                 'px-4',

--- a/ui/src/components/setup/SetupWizard.tsx
+++ b/ui/src/components/setup/SetupWizard.tsx
@@ -23,12 +23,15 @@
  * (no admin password configured). It's displayed before the main application.
  */
 
+import { valibotResolver } from '@hookform/resolvers/valibot';
 import { Activity, Copy, Eye, EyeOff, Lock, Zap } from 'lucide-react';
 import type React from 'react';
 import { useEffect, useState } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { LogComponents, logger } from '../../lib/logger';
 import { evaluatePassword, type PasswordRule } from '../../lib/passwordPolicy';
+import { SetupWizardSchema } from '../../schemas/auth';
 import {
   button,
   buttonClass,
@@ -85,13 +88,24 @@ export function SetupWizard({
   const { t: tCommon } = useTranslation('common');
   // Default to custom password entry - more secure UX
   const [passwordMode, setPasswordMode] = useState<'generated' | 'custom'>('custom');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [ssoProviders, setSsoProviders] = useState<string[]>([]);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<{ password: string; confirmPassword: string }>({
+    resolver: valibotResolver(SetupWizardSchema),
+    defaultValues: { password: '', confirmPassword: '' },
+    mode: 'onBlur',
+  });
+
+  const password = watch('password');
 
   // Fetch enabled SSO providers (fixes #769, #720)
   useEffect(() => {
@@ -115,10 +129,10 @@ export function SetupWizard({
   // Update password fields when switching to generated mode
   useEffect(() => {
     if (passwordMode === 'generated' && suggestedPassword) {
-      setPassword(suggestedPassword);
-      setConfirmPassword(suggestedPassword);
+      setValue('password', suggestedPassword, { shouldValidate: true, shouldDirty: true });
+      setValue('confirmPassword', suggestedPassword, { shouldValidate: true, shouldDirty: true });
     }
-  }, [passwordMode, suggestedPassword]);
+  }, [passwordMode, suggestedPassword, setValue]);
 
   // Helper to check if a provider is enabled. The backend only lists
   // providers that have Enabled=true AND a non-empty ClientID, so
@@ -140,38 +154,34 @@ export function SetupWizard({
   const handlePasswordModeChange = (mode: 'generated' | 'custom'): void => {
     setPasswordMode(mode);
     if (mode === 'generated' && suggestedPassword) {
-      setPassword(suggestedPassword);
-      setConfirmPassword(suggestedPassword);
+      setValue('password', suggestedPassword, { shouldValidate: true, shouldDirty: true });
+      setValue('confirmPassword', suggestedPassword, { shouldValidate: true, shouldDirty: true });
       setShowPassword(true);
     } else {
-      setPassword('');
-      setConfirmPassword('');
+      setValue('password', '', { shouldValidate: false });
+      setValue('confirmPassword', '', { shouldValidate: false });
       setShowPassword(false);
     }
-    setError(null);
+    setSubmitError(null);
   };
 
-  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
-    e.preventDefault();
-    setError(null);
+  const onSubmit: SubmitHandler<{ password: string; confirmPassword: string }> = async ({
+    password,
+  }) => {
+    setSubmitError(null);
 
-    // Fixes #723: enforce complexity rules, not just length.
+    // Fixes #723: enforce complexity rules, not just length. The
+    // resolver only checks length + confirmation match; the policy
+    // evaluator gates submit on the broader rule set.
     const policy = evaluatePassword(password);
     if (!policy.valid) {
-      setError(t('errors.passwordTooShort'));
+      setSubmitError(t('errors.passwordTooShort'));
       logger.warn(LogComponents.SETUP, 'Setup rejected - password policy not met', {
         failedRules: policy.rules.filter((r) => !r.ok).map((r) => r.id),
       });
       return;
     }
 
-    if (password !== confirmPassword) {
-      setError(t('errors.passwordMismatch'));
-      logger.warn(LogComponents.SETUP, 'Setup rejected - password confirmation mismatch');
-      return;
-    }
-
-    setIsSubmitting(true);
     logger.info(LogComponents.SETUP, 'Setup submission started', { username });
 
     try {
@@ -179,15 +189,13 @@ export function SetupWizard({
       // Security fix #724, #758: Include the one-time setup token to prevent CSRF attacks
       const response = await fetch(`${API_BASE}/api/v1/setup/complete`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ password, setupToken }),
       });
 
       if (!response.ok) {
         const data = await response.json();
-        setError(data.error || t('errors.setupFailed'));
+        setSubmitError(data.error || t('errors.setupFailed'));
         logger.error(LogComponents.SETUP, 'Setup complete request failed', null, {
           status: response.status,
           serverError: typeof data?.error === 'string' ? data.error : undefined,
@@ -198,28 +206,29 @@ export function SetupWizard({
 
       logger.info(LogComponents.SETUP, 'Setup complete request succeeded', { username });
 
-      // Step 2: Automatically log in with the new password (fixes #768 - use username from config)
       const loginSuccess = await onLogin(username, password);
-
       if (!loginSuccess) {
-        // Fixes #719: do not exit the wizard when auto-login fails - the user
-        // would land in the main UI unauthenticated. Keep the wizard open with
-        // the error visible so they can retry or surface the real failure.
-        setError(t('errors.loginFailed'));
+        setSubmitError(t('errors.loginFailed'));
         logger.error(LogComponents.SETUP, 'Auto-login after setup failed', null, { username });
         return;
       }
 
-      // Step 3: Setup complete and user is logged in
       logger.info(LogComponents.SETUP, 'Setup wizard completed - user logged in', { username });
       onComplete();
     } catch (err) {
-      setError(t('errors.networkError'));
+      setSubmitError(t('errors.networkError'));
       logger.error(LogComponents.SETUP, 'Setup network error', err, { username });
-    } finally {
-      setIsSubmitting(false);
     }
   };
+
+  // Cross-field error (passwords don't match) from valibot v.check().
+  const rootErrors = errors.root;
+  const crossFieldError = rootErrors
+    ? Object.values(rootErrors).find(
+        (e): e is { message: string } =>
+          typeof e === 'object' && e !== null && 'message' in e && typeof e.message === 'string',
+      )
+    : undefined;
 
   return (
     <div className={cn('min-h-screen bg-surface-base', layout.flex.center, 'pad')}>
@@ -232,7 +241,7 @@ export function SetupWizard({
           <p className={cn('body-small', spacing.margin.top.inline)}>{t('welcome.subtitle')}</p>
         </div>
 
-        <form onSubmit={handleSubmit} className={cardClass('default', 'lg')}>
+        <form onSubmit={handleSubmit(onSubmit)} className={cardClass('default', 'lg')}>
           <div className={spacing.margin.bottom.content}>
             <p className={cn('body-small', spacing.margin.bottom.content)}>
               {t('username.label')} <strong>{username}</strong> {t('username.cannotChange')}
@@ -372,14 +381,11 @@ export function SetupWizard({
                   <input
                     id="setup-password"
                     type={showPassword ? 'text' : 'password'}
-                    value={password}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                      setPassword(e.target.value)
-                    }
-                    className={cn(inputClass('default', 'md'), spacing.padding.right.icon)}
-                    placeholder={t('password.placeholder')}
                     required={true}
                     minLength={12}
+                    {...register('password')}
+                    className={cn(inputClass('default', 'md'), spacing.padding.right.icon)}
+                    placeholder={t('password.placeholder')}
                   />
                   <button
                     type="button"
@@ -433,19 +439,34 @@ export function SetupWizard({
                 <input
                   id="setup-confirm-password"
                   type={showPassword ? 'text' : 'password'}
-                  value={confirmPassword}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                    setConfirmPassword(e.target.value)
-                  }
+                  required={true}
+                  {...register('confirmPassword')}
                   className={inputClass('default', 'md')}
                   placeholder={t('password.confirm.placeholder')}
-                  required={true}
                 />
+                {errors.confirmPassword ? (
+                  <p className={cn('caption mt-1', statusColor.text.error)}>
+                    {errors.confirmPassword.message}
+                  </p>
+                ) : null}
               </div>
             </>
           )}
 
-          {error ? (
+          {crossFieldError ? (
+            <div
+              role="alert"
+              className={cn(
+                spacing.margin.bottom.content,
+                'pad-sm bg-status-error/10 border border-status-error/20',
+                radius.md,
+                'text-status-error body-small',
+              )}
+            >
+              {crossFieldError.message}
+            </div>
+          ) : null}
+          {submitError ? (
             <div
               role="alert"
               aria-live="assertive"
@@ -456,7 +477,7 @@ export function SetupWizard({
                 'text-status-error body-small',
               )}
             >
-              {error}
+              {submitError}
             </div>
           ) : null}
 

--- a/ui/src/schemas/auth.ts
+++ b/ui/src/schemas/auth.ts
@@ -1,0 +1,113 @@
+/**
+ * Valibot schemas for seed's auth / recovery / setup forms.
+ *
+ * Cover the user-input boundary of the login flow: login (username +
+ * password), MFA verification, recovery code entry, and the
+ * initial-setup wizard. Mirrors stem/src/schemas/auth.ts so the two
+ * code bases stay aligned.
+ *
+ * The Go side validates again on receipt — these schemas exist for
+ * the UI to show inline per-field errors before the network call, not
+ * as the security boundary.
+ */
+import * as v from 'valibot';
+
+/** 6-digit TOTP code. Whitespace is trimmed (users often paste with
+ * spaces from authenticator apps). Stored without separators. */
+export const TotpCodeSchema = v.pipe(
+  v.string('Code is required'),
+  v.trim(),
+  v.regex(/^\d{6}$/, 'Code must be exactly 6 digits'),
+);
+
+/** Username for login + recovery flows. */
+export const UsernameSchema = v.pipe(
+  v.string('Username is required'),
+  v.trim(),
+  v.minLength(1, 'Username is required'),
+  v.maxLength(128, 'Username is too long'),
+);
+
+/** Password for login flows. Length-only check; the Go side enforces
+ * complexity rules. */
+export const PasswordSchema = v.pipe(
+  v.string('Password is required'),
+  v.minLength(1, 'Password is required'),
+  v.maxLength(512, 'Password is too long'),
+);
+
+/** Recovery code: 16 hex characters in groups of 4. Accept with or
+ * without separators on input; normalize before posting. */
+export const RecoveryCodeSchema = v.pipe(
+  v.string('Recovery code is required'),
+  v.trim(),
+  v.transform((s) => s.replace(/[-\s]/g, '').toLowerCase()),
+  v.regex(/^[0-9a-f]{16}$/, 'Recovery code must be 16 hex characters'),
+);
+
+// =============================================================================
+// Form schemas
+// =============================================================================
+
+export const LoginSchema = v.object({
+  username: UsernameSchema,
+  password: PasswordSchema,
+});
+
+export const MfaVerifySchema = v.object({
+  code: TotpCodeSchema,
+});
+
+/**
+ * Recovery completion: filesystem-token-based password reset. The
+ * admin writes the token to a file on the server, the user pastes the
+ * token here, then enters and confirms a new password. Password
+ * confirmation is a cross-field check; the resolver surfaces it
+ * under formState.errors.root.
+ */
+export const RecoveryCompleteSchema = v.pipe(
+  v.object({
+    token: v.pipe(
+      v.string('Recovery token is required'),
+      v.trim(),
+      v.minLength(1, 'Recovery token is required'),
+    ),
+    password: v.pipe(
+      v.string('Password is required'),
+      v.minLength(12, 'Password must be at least 12 characters'),
+      v.maxLength(512, 'Password is too long'),
+    ),
+    confirmPassword: v.string(),
+  }),
+  v.check((c) => c.password === c.confirmPassword, 'Passwords do not match'),
+);
+
+/**
+ * Setup wizard: initial-admin creation. Username is fixed from the
+ * setup status (env-configured), so the schema only covers the
+ * password the user actually types.
+ */
+export const SetupWizardSchema = v.pipe(
+  v.object({
+    password: v.pipe(
+      v.string('Password is required'),
+      v.minLength(12, 'Password must be at least 12 characters'),
+      v.maxLength(512, 'Password is too long'),
+    ),
+    confirmPassword: v.string(),
+  }),
+  v.check((c) => c.password === c.confirmPassword, 'Passwords do not match'),
+);
+
+/** Profile editor: name + optional description for survey/path profiles. */
+export const ProfileEditorSchema = v.object({
+  name: v.pipe(
+    v.string('Name is required'),
+    v.trim(),
+    v.minLength(1, 'Name is required'),
+    v.maxLength(64, 'Name is too long (max 64 chars)'),
+  ),
+  description: v.pipe(v.string(), v.maxLength(256, 'Description is too long (max 256 chars)')),
+  isDefault: v.boolean(),
+  notes: v.pipe(v.string(), v.maxLength(2048, 'Notes are too long (max 2048 chars)')),
+});

--- a/ui/src/schemas/auth.ts
+++ b/ui/src/schemas/auth.ts
@@ -111,3 +111,36 @@ export const ProfileEditorSchema = v.object({
   isDefault: v.boolean(),
   notes: v.pipe(v.string(), v.maxLength(2048, 'Notes are too long (max 2048 chars)')),
 });
+
+/** Wi-Fi survey creation form. */
+export const CreateSurveySchema = v.object({
+  name: v.pipe(
+    v.string('Survey name is required'),
+    v.trim(),
+    v.minLength(1, 'Survey name is required'),
+    v.maxLength(128, 'Survey name is too long (max 128 chars)'),
+  ),
+  surveyType: v.picklist(['passive', 'active', 'throughput']),
+});
+
+/**
+ * Path discovery form. Target is a hostname or IPv4/IPv6 address. The
+ * Go side does authoritative parsing — this UI check just blocks
+ * obviously malformed input (empty, too long, contains spaces).
+ */
+export const PathDiscoverySchema = v.object({
+  target: v.pipe(
+    v.string('Target is required'),
+    v.trim(),
+    v.minLength(1, 'Target is required'),
+    v.maxLength(253, 'Target is too long (max 253 chars)'),
+    v.regex(/^[^\s]+$/, 'Target cannot contain whitespace'),
+  ),
+  protocol: v.picklist(['icmp', 'tcp', 'udp']),
+  port: v.pipe(
+    v.number('Port must be a number'),
+    v.integer('Port must be an integer'),
+    v.minValue(1, 'Port must be 1-65535'),
+    v.maxValue(65535, 'Port must be 1-65535'),
+  ),
+});


### PR DESCRIPTION
Adds the forms stack mirrored from stem, plus the foundation schemas
and two pilot migrations.

- react-hook-form@7.x + @hookform/resolvers@5.x
- src/schemas/auth.ts: LoginSchema, MfaVerifySchema,
  RecoveryCompleteSchema (token + new password + confirm with
  cross-field check), SetupWizardSchema, ProfileEditorSchema
- LoginForm migrated: register('username') / register('password'),
  inline per-field errors, kept required={true} for HTML5/test
  compatibility
- ProfileEditor migrated: register for name + description + notes,
  watch+setValue for the isDefault checkbox, isValid drives the
  submit button

Remaining sweep tracked in #1201: RecoveryForm, SetupWizard,
WiFiSurveyCard, PathDiscoveryCard.

Refs #1201.
