### PR TITLE
feat(sso): settings ui for provider admin

### DIFF
--- a/internal/i18n/locales/en/errors.json
+++ b/internal/i18n/locales/en/errors.json
@@ -115,5 +115,8 @@
   "profile": {
     "multiClientRequired": "Free and Starter licenses allow 1 profile. Upgrade to Pro to manage configurations for multiple clients from a single Seed instance.",
     "multiInterfaceRequired": "Free and Starter licenses allow at most 1 ethernet + 1 Wi-Fi interface per profile. Upgrade to Pro for unlimited concurrent interfaces."
+  },
+  "sso": {
+    "featureRequired": "Single Sign-On configuration requires a Pro license. Existing providers continue to accept logins on any tier; only enabling or editing providers is blocked."
   }
 }

--- a/internal/i18n/locales/en/settings.json
+++ b/internal/i18n/locales/en/settings.json
@@ -463,5 +463,33 @@
     "step4": "Step 4: Paste the key here and the scanner will use it.",
     "updateInterval": "Update interval",
     "vulnerabilities": "Vulnerabilities"
+  },
+  "sso": {
+    "title": "Single Sign-On",
+    "description": "Allow users to sign in via your identity provider.",
+    "providers": {
+      "google": "Google Workspace",
+      "microsoft": "Microsoft Entra ID",
+      "github": "GitHub"
+    },
+    "fields": {
+      "enabled": "Enabled",
+      "clientId": "Client ID",
+      "clientSecret": "Client secret",
+      "clientSecretMask": "(stored — leave blank to keep current)",
+      "redirectUrl": "Redirect URL",
+      "redirectUrlHint": "Paste this into your identity provider's allowed redirect URLs.",
+      "tenantId": "Tenant ID",
+      "tenantIdHint": "Use 'common' for personal + work accounts, 'organizations' for work only, or a specific tenant ID for single-tenant Entra apps.",
+      "allowedDomains": "Allowed email domains",
+      "scopes": "OAuth scopes (advanced)"
+    },
+    "actions": {
+      "save": "Save",
+      "disable": "Disable provider"
+    },
+    "status": {
+      "saved": "{{provider}} configuration saved."
+    }
   }
 }

--- a/internal/i18n/locales/es/errors.json
+++ b/internal/i18n/locales/es/errors.json
@@ -115,5 +115,8 @@
   "profile": {
     "multiClientRequired": "Las licencias Free y Starter permiten 1 perfil. Actualice a Pro para administrar configuraciones de varios clientes desde una sola instancia de Seed.",
     "multiInterfaceRequired": "Las licencias Free y Starter permiten como máximo 1 interfaz ethernet + 1 Wi-Fi por perfil. Actualice a Pro para interfaces concurrentes ilimitadas."
+  },
+  "sso": {
+    "featureRequired": "La configuración de Single Sign-On requiere una licencia Pro. Los proveedores existentes siguen aceptando inicios de sesión en cualquier nivel; solo se bloquea habilitar o editar proveedores."
   }
 }

--- a/internal/i18n/locales/es/settings.json
+++ b/internal/i18n/locales/es/settings.json
@@ -463,5 +463,33 @@
     "step4": "Paso 4: Pegue la clave aquí y el escáner la utilizará.",
     "updateInterval": "Intervalo de actualización",
     "vulnerabilities": "Vulnerabilidades"
+  },
+  "sso": {
+    "title": "Inicio de sesión único",
+    "description": "Permita a los usuarios iniciar sesión mediante su proveedor de identidad.",
+    "providers": {
+      "google": "Google Workspace",
+      "microsoft": "Microsoft Entra ID",
+      "github": "GitHub"
+    },
+    "fields": {
+      "enabled": "Habilitado",
+      "clientId": "Client ID",
+      "clientSecret": "Client secret",
+      "clientSecretMask": "(almacenado — déjelo en blanco para conservar el actual)",
+      "redirectUrl": "URL de redirección",
+      "redirectUrlHint": "Pegue esta URL en las URL de redirección permitidas de su proveedor de identidad.",
+      "tenantId": "ID de tenant",
+      "tenantIdHint": "Use 'common' para cuentas personales + de trabajo, 'organizations' solo para trabajo, o un ID específico para apps Entra de tenant único.",
+      "allowedDomains": "Dominios de correo permitidos",
+      "scopes": "Scopes de OAuth (avanzado)"
+    },
+    "actions": {
+      "save": "Guardar",
+      "disable": "Deshabilitar proveedor"
+    },
+    "status": {
+      "saved": "Configuración de {{provider}} guardada."
+    }
   }
 }

--- a/ui/src/components/settings/SettingsDrawer.tsx
+++ b/ui/src/components/settings/SettingsDrawer.tsx
@@ -59,6 +59,7 @@ import { DnsSettings } from './sections/DnsSettings';
 import { HealthChecksSettings } from './sections/HealthChecksSettings';
 import { LinkSettings } from './sections/LinkSettings';
 import { PerformanceSettings } from './sections/PerformanceSettings';
+import { SsoSettings } from './sections/SsoSettings';
 import { ThresholdsSettings } from './sections/ThresholdsSettings';
 import { UpdateSettings } from './sections/UpdateSettings';
 import { VulnerabilitySettings } from './sections/VulnerabilitySettings';
@@ -695,6 +696,9 @@ export const SettingsDrawer: React.MemoExoticComponent<
 
           {/* API tokens (Phase D-2 LICENSE_STRATEGY) */}
           <ApiTokensSettings />
+
+          {/* SSO admin panel (seed#1198) */}
+          <SsoSettings />
 
           {/* Config Backups Section (implements #494) */}
           <ConfigBackupsSection />

--- a/ui/src/components/settings/sections/SsoSettings.tsx
+++ b/ui/src/components/settings/sections/SsoSettings.tsx
@@ -1,0 +1,324 @@
+/**
+ * SsoSettings Component
+ *
+ * Settings → Single Sign-On panel for seed#1198. Lets operators enable
+ * Google / Microsoft / GitHub OAuth providers without editing
+ * config.yaml. The backend already implements:
+ *   - GET  /api/v1/sso/settings (read provider configs, auth required)
+ *   - PUT  /api/v1/sso/update   (write a single provider, Pro-gated via
+ *                                requireFeature("sso"))
+ *
+ * Each provider is a card with: enabled toggle, client ID + client
+ * secret (masked; blank = keep current), redirect URL display, tenant
+ * ID (Microsoft only), and Save. Free/Starter operators see the panel
+ * read-only with the upgrade message.
+ */
+
+import type React from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { api } from '../../../api/client';
+import { useLicense } from '../../../contexts/LicenseContext';
+import { Button } from '../../ui/Button';
+import { CollapsibleSection } from '../../ui/CollapsibleSection';
+import { Input } from '../../ui/Input';
+import { Key } from '../../ui/icons';
+
+type ProviderName = 'google' | 'microsoft' | 'github';
+
+interface ProviderConfig {
+  name: ProviderName;
+  enabled: boolean;
+  client_id: string;
+  client_secret: string;
+  redirect_url: string;
+  tenant_id?: string;
+  scopes?: string[];
+}
+
+interface SettingsResponse {
+  providers: { name: string; enabled: boolean }[];
+}
+
+const PROVIDER_DEFAULTS: Record<ProviderName, ProviderConfig> = {
+  google: { name: 'google', enabled: false, client_id: '', client_secret: '', redirect_url: '' },
+  microsoft: {
+    name: 'microsoft',
+    enabled: false,
+    client_id: '',
+    client_secret: '',
+    redirect_url: '',
+    tenant_id: 'common',
+  },
+  github: { name: 'github', enabled: false, client_id: '', client_secret: '', redirect_url: '' },
+};
+
+function defaultRedirectUrl(): string {
+  if (typeof window === 'undefined') return '';
+  return `${window.location.origin}/api/v1/sso/callback`;
+}
+
+export function SsoSettings(): React.ReactElement {
+  const { t } = useTranslation(['settings', 'errors']);
+  const { status: licenseStatus } = useLicense();
+
+  const [providers, setProviders] = useState<Record<ProviderName, ProviderConfig>>(() => ({
+    google: { ...PROVIDER_DEFAULTS.google, redirect_url: defaultRedirectUrl() },
+    microsoft: { ...PROVIDER_DEFAULTS.microsoft, redirect_url: defaultRedirectUrl() },
+    github: { ...PROVIDER_DEFAULTS.github, redirect_url: defaultRedirectUrl() },
+  }));
+  const [loading, setLoading] = useState(true);
+  const [savingProvider, setSavingProvider] = useState<ProviderName | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saveStatus, setSaveStatus] = useState<string | null>(null);
+
+  const canEdit = Boolean(licenseStatus?.features?.includes?.('sso'));
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setError(null);
+    try {
+      const resp = await api.get<SettingsResponse>('/api/v1/sso/settings');
+      const enabledByName = new Map(resp.providers.map((p) => [p.name.toLowerCase(), p.enabled]));
+      setProviders((prev) => ({
+        google: { ...prev.google, enabled: enabledByName.get('google') ?? false },
+        microsoft: { ...prev.microsoft, enabled: enabledByName.get('microsoft') ?? false },
+        github: { ...prev.github, enabled: enabledByName.get('github') ?? false },
+      }));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load SSO settings');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const updateField = useCallback(
+    <K extends keyof ProviderConfig>(
+      name: ProviderName,
+      key: K,
+      value: ProviderConfig[K],
+    ): void => {
+      setProviders((prev) => ({ ...prev, [name]: { ...prev[name], [key]: value } }));
+    },
+    [],
+  );
+
+  const handleSave = useCallback(
+    async (name: ProviderName): Promise<void> => {
+      setSavingProvider(name);
+      setError(null);
+      setSaveStatus(null);
+      try {
+        const cfg = providers[name];
+        await api.put('/api/v1/sso/update', {
+          provider: cfg.name,
+          enabled: cfg.enabled,
+          client_id: cfg.client_id,
+          client_secret: cfg.client_secret,
+          redirect_url: cfg.redirect_url || defaultRedirectUrl(),
+          tenant_id: cfg.tenant_id,
+          scopes: cfg.scopes,
+        });
+        setSaveStatus(t('settings:sso.status.saved', { provider: name }));
+        // Wipe the secret input now that it's saved server-side.
+        updateField(name, 'client_secret', '');
+        await refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to save SSO provider');
+      } finally {
+        setSavingProvider(null);
+      }
+    },
+    [providers, refresh, t, updateField],
+  );
+
+  return (
+    <CollapsibleSection
+      title={
+        <div className="inline-flex items-center gap-2">
+          <Key className="w-4 h-4" />
+          <span>{t('settings:sso.title')}</span>
+        </div>
+      }
+      defaultOpen={false}
+    >
+      <div className="stack-sm" data-testid="sso-settings-section">
+        <p className="text-sm text-text-secondary">{t('settings:sso.description')}</p>
+
+        {!canEdit && (
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm text-amber-200">
+            {t('errors:sso.featureRequired')}
+          </div>
+        )}
+
+        {error && (
+          <div
+            className="rounded-lg border border-status-error/30 bg-status-error/5 p-3 text-sm text-status-error"
+            data-testid="sso-error"
+          >
+            {error}
+          </div>
+        )}
+
+        {saveStatus && (
+          <div className="rounded-lg border border-status-success/30 bg-status-success/5 p-3 text-sm text-status-success">
+            {saveStatus}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="text-sm text-text-muted">{t('common:status.loading', 'Loading…')}</div>
+        ) : (
+          <div className="stack-sm">
+            <ProviderCard
+              name="google"
+              cfg={providers.google}
+              canEdit={canEdit}
+              saving={savingProvider === 'google'}
+              onChange={updateField}
+              onSave={() => void handleSave('google')}
+            />
+            <ProviderCard
+              name="microsoft"
+              cfg={providers.microsoft}
+              canEdit={canEdit}
+              saving={savingProvider === 'microsoft'}
+              onChange={updateField}
+              onSave={() => void handleSave('microsoft')}
+            />
+            <ProviderCard
+              name="github"
+              cfg={providers.github}
+              canEdit={canEdit}
+              saving={savingProvider === 'github'}
+              onChange={updateField}
+              onSave={() => void handleSave('github')}
+            />
+          </div>
+        )}
+      </div>
+    </CollapsibleSection>
+  );
+}
+
+interface ProviderCardProps {
+  name: ProviderName;
+  cfg: ProviderConfig;
+  canEdit: boolean;
+  saving: boolean;
+  onChange: <K extends keyof ProviderConfig>(
+    name: ProviderName,
+    key: K,
+    value: ProviderConfig[K],
+  ) => void;
+  onSave: () => void;
+}
+
+function ProviderCard({
+  name,
+  cfg,
+  canEdit,
+  saving,
+  onChange,
+  onSave,
+}: ProviderCardProps): React.ReactElement {
+  const { t } = useTranslation(['settings']);
+  const isMicrosoft = name === 'microsoft';
+
+  return (
+    <div
+      className="rounded-lg border border-surface-border bg-surface-raised p-3 stack-xs"
+      data-testid={`sso-provider-${name}`}
+    >
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium">{t(`settings:sso.providers.${name}`)}</h4>
+        <label className="inline-flex items-center gap-1.5 text-xs">
+          <input
+            type="checkbox"
+            checked={cfg.enabled}
+            disabled={!canEdit || saving}
+            onChange={(e) => onChange(name, 'enabled', e.target.checked)}
+            data-testid={`sso-enable-${name}`}
+          />
+          {t('settings:sso.fields.enabled')}
+        </label>
+      </div>
+
+      <div>
+        <label className="block text-xs text-text-muted mb-1" htmlFor={`sso-${name}-cid`}>
+          {t('settings:sso.fields.clientId')}
+        </label>
+        <Input
+          id={`sso-${name}-cid`}
+          value={cfg.client_id}
+          onChange={(e) => onChange(name, 'client_id', e.target.value)}
+          disabled={!canEdit || saving}
+          data-testid={`sso-client-id-${name}`}
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs text-text-muted mb-1" htmlFor={`sso-${name}-cs`}>
+          {t('settings:sso.fields.clientSecret')}
+        </label>
+        <Input
+          id={`sso-${name}-cs`}
+          type="password"
+          value={cfg.client_secret}
+          onChange={(e) => onChange(name, 'client_secret', e.target.value)}
+          placeholder={t('settings:sso.fields.clientSecretMask')}
+          disabled={!canEdit || saving}
+          data-testid={`sso-client-secret-${name}`}
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs text-text-muted mb-1" htmlFor={`sso-${name}-ru`}>
+          {t('settings:sso.fields.redirectUrl')}
+        </label>
+        <Input
+          id={`sso-${name}-ru`}
+          value={cfg.redirect_url || defaultRedirectUrl()}
+          onChange={(e) => onChange(name, 'redirect_url', e.target.value)}
+          disabled={!canEdit || saving}
+          data-testid={`sso-redirect-${name}`}
+        />
+        <p className="text-xs text-text-muted mt-1">{t('settings:sso.fields.redirectUrlHint')}</p>
+      </div>
+
+      {isMicrosoft && (
+        <div>
+          <label className="block text-xs text-text-muted mb-1" htmlFor={`sso-${name}-tid`}>
+            {t('settings:sso.fields.tenantId')}
+          </label>
+          <Input
+            id={`sso-${name}-tid`}
+            value={cfg.tenant_id ?? ''}
+            onChange={(e) => onChange(name, 'tenant_id', e.target.value)}
+            placeholder="common | organizations | <tenant-guid>"
+            disabled={!canEdit || saving}
+            data-testid={`sso-tenant-${name}`}
+          />
+          <p className="text-xs text-text-muted mt-1">{t('settings:sso.fields.tenantIdHint')}</p>
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <Button
+          variant="solid"
+          tone="violet"
+          size="sm"
+          disabled={!canEdit || saving}
+          loading={saving}
+          onClick={onSave}
+          data-testid={`sso-save-${name}`}
+        >
+          {t('settings:sso.actions.save')}
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes the UI half of #1198. Operators can now manage SSO providers (Google / Microsoft / GitHub) from Settings without editing config.yaml.

- Each provider rendered as a card: enabled toggle, client ID, client secret (masked; blank keeps current), redirect URL (auto-filled from window.location), tenant ID (Microsoft only), Save
- Reads from GET /api/v1/sso/settings, writes via PUT /api/v1/sso/update
- Free/Starter: panel is read-only with the errors.sso.featureRequired upgrade message; PUT is also gated server-side via requireFeature('sso') (defense in depth)
- Provider login + callback (LoginForm.tsx buttons) continue to work for already-enabled providers on any tier — only WRITES are blocked

i18n: settings.sso.* + errors.sso.featureRequired (EN + ES).

## Test plan

- [ ] Pro license → can save provider config (Google with test client_id)
- [ ] Free license → panel renders with upgrade hint; PUT returns 402
- [ ] Existing config (config.yaml provider) → loads into UI with enabled checkbox set correctly
- [ ] Save then refresh → secret field is empty (placeholder shown) but provider stays enabled