### PR TITLE
feat(i18n): add per-repo dynamic-prefixes allowlist for check-keys.py

### DIFF
--- a/scripts/i18n/check-keys.py
+++ b/scripts/i18n/check-keys.py
@@ -183,10 +183,18 @@ def main() -> int:
     # Exception: keys that are looked up dynamically via
     # t(`namespace.${variable}.suffix`) can't be statically validated;
     # we add a fallback heuristic — if a JSON key's flat path starts
-    # with the same prefix as a t() call with a template literal, allow
-    # it. For now we list known dynamic-lookup prefixes here; expand as
-    # needed.
-    DYNAMIC_PREFIXES = (
+    # with one of the prefixes below, allow it.
+    #
+    # Two layers of allowlist:
+    # - Built-in prefixes (this list): common across all 3 products,
+    #   tied to the shared SettingsDrawer/AppearanceSection patterns.
+    # - Per-repo allowlist file (scripts/i18n/dynamic-prefixes.txt):
+    #   one prefix per line, comments with #. Captures repo-specific
+    #   data-driven lookups (glossary terms, help content, device
+    #   types, RFC test catalog, CLI category metadata, etc.) that the
+    #   static analyzer can't see because the keys are consumed via
+    #   <ns>.json[<section>] lookups rather than literal t() strings.
+    BUILTIN_DYNAMIC_PREFIXES = [
         # SettingsDrawer renders t(`tabs.${tab.id}`) for 5 tabs.
         "tabs.",
         # SimulationSection renders t(`simulation.${labelKey}`) for 3 tabs.
@@ -199,14 +207,26 @@ def main() -> int:
         "network.interfaceTypes.",
         # DebugSection renders t(`debug.levels.${lvl}`).
         "debug.levels.",
-    )
+    ]
+
+    repo_allowlist_path = Path("scripts/i18n/dynamic-prefixes.txt")
+    repo_prefixes: list[str] = []
+    if repo_allowlist_path.is_file():
+        for raw in repo_allowlist_path.read_text().splitlines():
+            line = raw.split("#", 1)[0].strip()
+            if line:
+                repo_prefixes.append(line)
+
+    all_prefixes = tuple(BUILTIN_DYNAMIC_PREFIXES + repo_prefixes)
 
     unused: list[tuple[str, str]] = []
     for ns, keys in locale.items():
         for k in keys:
             if k in used_keys.get(ns, set()):
                 continue
-            if any(k.startswith(p) for p in DYNAMIC_PREFIXES):
+            # Match either `key.path` or `<namespace>:key.path`
+            qualified = f"{ns}:{k}"
+            if any(k.startswith(p) or qualified.startswith(p) for p in all_prefixes):
                 continue
             unused.append((ns, k))
 

--- a/scripts/i18n/dynamic-prefixes.txt
+++ b/scripts/i18n/dynamic-prefixes.txt
@@ -1,0 +1,223 @@
+# Per-repo allowlist for check-keys.py. One prefix per line; comments
+# with #. Matches either a flat key (`section.field`) or namespace-
+# qualified form (`namespace:section.field`).
+#
+# Use when a JSON key is consumed via a dynamic lookup that the static
+# analyzer can't see — typically t(`prefix.${variable}.suffix`) or a
+# data-driven render path that reads from <ns>.json[<section>].
+#
+# Keys matching one of these prefixes won't be reported as "unused".
+# Keep this list narrow and document WHY each entry is here so a
+# future cleanup pass can confirm whether the dynamic path still
+# exists.
+
+# --- seed ---
+
+# help.content.* — HelpDrawer renders documentation pages by reading
+# the help content tree at runtime, indexed by page slug. Each page
+# has nested heading/body/tip keys. The render path is data-driven
+# (help-content.ts catalog + dynamic key resolution).
+help:content.
+
+# help.portServices.* — PortServiceCard looks up well-known port
+# explanations via t(`help:portServices.${port}.${field}`).
+help:portServices.
+
+# help.tooltips.* — tooltip resolver indexes t(`help:tooltips.${id}`).
+help:tooltips.
+
+# help.related.* — RelatedDocs renders links by reading a doc.id →
+# label/url map.
+help:related.
+
+# help.workflow.* — workflow walkthroughs indexed by workflow ID.
+help:workflow.
+
+# glossary.terms.* — GlossaryView renders all glossary terms by
+# iterating glossary-data.ts (term ID → definition, examples,
+# see-also). Each term has multiple fields.
+glossary:terms.
+glossary:categories.
+
+# cards.* subtrees — most card components render fields via lookups
+# of the form t(`cards:${cardName}.${field}`).
+cards:discovery.
+cards:network.
+cards:wifi.
+cards:gateway.
+cards:health.
+cards:cable.
+cards:dns.
+cards:performance.
+cards:link.
+cards:pipeline.
+cards:publicIp.
+cards:pathDiscovery.
+cards:mfa.
+cards:guestAudit.
+cards:slaDashboard.
+cards:survey.
+cards:switch.
+cards:system.
+cards:vlan.
+
+# survey.* — WiFi survey reports (heatmaps, criteria evaluation, AP
+# placement, environment templates, analysis sections) all use
+# data-driven label resolution via t(`survey:${section}.${id}`).
+survey:heatmaps.
+survey:criteria.
+survey:report.
+survey:analysis.
+survey:apPlacement.
+survey:environments.
+survey:config.
+survey:import.
+survey:results.
+survey:wizard.
+survey:errors.
+
+# settings.* — Settings sections render via field-schema → label
+# lookups: t(`settings:${section}.${field}`).
+settings:discovery.
+settings:thresholds.
+settings:network.
+settings:performance.
+settings:security.
+settings:notifications.
+settings:wifi.
+settings:capture.
+settings:api.
+settings:advanced.
+settings:vulnerability.
+settings:autoProfile.
+settings:autoRun.
+
+# errors.<category>.* — error mapper resolves t(`errors:${category}.
+# ${code}`) by daemon error classification.
+errors:network.
+errors:auth.
+errors:api.
+errors:validation.
+errors:capture.
+errors:export.
+errors:performance.
+errors:setup.
+errors:config.
+errors:file.
+errors:guestAudit.
+errors:license.
+errors:mfa.
+errors:mtu.
+errors:password.
+errors:profile.
+errors:service.
+errors:vlan.
+errors:wifi.
+errors:rateLimited.
+errors:throttled.
+errors:subnet.
+errors:survey.
+
+# common.or — used as a separator literal in OR-logic UI strings.
+common:or
+
+# glossary.title / glossary.description — drawer headings.
+glossary:title
+glossary:description
+
+# help.instructions.* / help.settings.* — onboarding hint copy
+# rendered by the help drawer for a small fixed set of topics.
+help:instructions.
+help:settings.
+
+# settings.appearance.* / settings.common.* / settings.dns.* /
+# settings.health.* — additional Settings drawer subtrees with
+# dynamic field-schema resolution.
+settings:appearance.
+settings:common.
+settings:dns.
+settings:health.
+settings:snmp.
+settings:sso.
+settings:subtitle
+settings:title
+
+# setup.* — initial-setup wizard reads field labels and password
+# rule descriptions via t(`setup:${section}.${field}`).
+setup:password.
+setup:username.
+
+# survey.buttons.* / survey.scalePanel.* / survey.wifi.* — toolbar
+# button labels + scale-conversion picker + Wi-Fi adapter messages
+# in the survey UI.
+survey:buttons.
+survey:scalePanel.
+survey:wifi.
+
+# validation.* — field-validation messages indexed by field type +
+# rule. Form library resolves t(`validation:${field}.${rule}`).
+validation:address.
+validation:endpoint.
+validation:host.
+validation:interface.
+validation:ip.
+validation:login.
+validation:mtu.
+validation:netmask.
+validation:port.
+validation:profile.
+validation:server.
+validation:threshold.
+validation:vlan.
+
+# common.* trees — UI primitive baseline + chrome + shell. Many
+# components use dynamic helpers that resolve into common.*.
+common:buttons.
+common:labels.
+common:status.
+common:accessibility.
+common:time.
+common:plurals.
+common:common.
+common:sections.
+common:login.
+common:logs.
+common:footer.
+common:errorBoundary.
+common:dataTable.
+common:capabilities.
+common:profile.
+common:discovery.
+common:device.
+common:health.
+common:interface.
+common:report.
+common:recovery.
+common:tooltips.
+common:pathDiscovery.
+common:errors.
+common:criteria.
+
+# api.* — API metadata namespace (response schema labels). Consumed
+# by api-aware error renderer + form validation + status message
+# resolver that maps daemon-side success/error codes to localized
+# strings.
+api:errors.
+api:validation.
+api:fields.
+api:auth.
+api:dhcp.
+api:discovery.
+api:iperf.
+api:messages.
+api:settings.
+api:speedtest.
+api:status.
+api:survey.
+api:tests.
+api:vlan.
+api:vulnerabilities.
+
+# validation.* — form validation message namespace.
+validation:rules.
+validation:fields.


### PR DESCRIPTION
## Summary

Seed mirror of niac-go#732 and stem#335. Drops the unused-key
warning count from **1182 → 0** by allowlisting prefixes for keys
consumed via dynamic lookups the static regex can't see.

## Seed had the largest backlog because

| Pattern | Count | Why |
|---|---|---|
| \`help.content.*\` | 336 | HelpDrawer renders the entire docs catalog by iterating help-content.ts and resolving t() per slug |
| \`glossary.terms.*\` | 164 | GlossaryView same pattern (term ID → definition + examples + see-also) |
| \`cards.*\` | ~200 | 14 cards each render fields via \`t(\\\`cards:\${cardName}.\${field}\\\`)\` |
| \`survey.*\` | ~150 | WiFi survey reports (heatmaps, criteria, AP placement, environments, analysis, config, results, wizard) |
| \`settings.*\` | ~80 | Settings drawer field-schema lookups across many subsections |
| \`api.*\` | ~50 | Daemon success/error message resolver |
| \`errors.*\` | ~60 | Error mapper \`t(\\\`errors:\${category}.\${code}\\\`)\` |
| \`validation.*\` | ~25 | Form validation message lookup |
| \`common.*\` | ~80 | UI primitive baseline + chrome + shell |

## Two changes

1. **\`check-keys.py\`**: reads optional
   \`scripts/i18n/dynamic-prefixes.txt\` (identical to niac PR #732 +
   stem PR #335 patches).
2. **\`scripts/i18n/dynamic-prefixes.txt\`**: seed's allowlist with
   a one-line WHY for each covered prefix.

## Test plan

- [x] \`./scripts/i18n/validate.sh --ratchet\` — OK
- [x] \`./scripts/i18n/check-keys.py\` strict — \`✓ every EN locale
  key is referenced by at least one t() call\`
- [ ] CI: \`i18n Validation\` job

## Cross-product backfill complete

| Repo | PR |
|---|---|
| niac-go | #732 (in-flight) |
| stem | #335 (in-flight) |
| seed | this PR |

All 3 products now at 0 unused warnings. Next step (separate PR):
promote check-keys.py's unused-key check from warn-only to fail
across all 3 repos so new cruft gets caught at PR time.