### PR TITLE
chore(i18n): promote check-keys.py unused-key check from warn to fail

### DIFF
--- a/scripts/i18n/check-keys.py
+++ b/scripts/i18n/check-keys.py
@@ -246,12 +246,22 @@ def main() -> int:
         print("✓ every t() call has a matching EN locale key")
 
     if unused:
-        print(f"::warning::{len(unused)} EN locale key(s) not referenced by any t() call:")
+        # All 3 repos hit 0 unused via per-repo dynamic-prefixes.txt
+        # allowlist files (see scripts/i18n/dynamic-prefixes.txt).
+        # Promoted from warn-only to fail so new cruft is caught at
+        # PR time. To allow a genuinely dynamic-lookup key that the
+        # static analyzer can't see, add a prefix entry to
+        # dynamic-prefixes.txt with a one-line WHY comment.
+        # --ratchet downgrades to warn for callers that want to defer
+        # cleanup; the validator passes --ratchet through.
+        level = "warning" if ratchet else "error"
+        print(f"::{level}::{len(unused)} EN locale key(s) not referenced by any t() call:")
         for ns, key in sorted(unused)[:30]:
             print(f"  {ns}.json: {key}")
         if len(unused) > 30:
             print(f"  … and {len(unused) - 30} more")
-        # Don't fail on unused yet — too noisy until we catch up. Demote to warn.
+        if not ratchet:
+            code = 1
     else:
         print("✓ every EN locale key is referenced by at least one t() call")
 


### PR DESCRIPTION
## Summary

All 3 products now hit 0 unused EN locale keys via the per-repo
`dynamic-prefixes.txt` allowlists (niac-go#732 + stem#335 +
seed#1216). Promoting the unused-key check from warn-only to fail
so future cruft gets caught at PR time.

## How to fix a new "unused" failure

If a key shows up as unused but is genuinely consumed via a
dynamic lookup the static analyzer can't see, add a prefix entry
to `scripts/i18n/dynamic-prefixes.txt` with a one-line WHY
comment:

```
# foo.bar.* — Bar component renders via t(`foo:bar.${id}`).
foo:bar.
```

If a key is genuinely dead, delete it from EN+ES locale JSON.

## Escape hatch

`--ratchet` downgrades the check back to warn for callers that
want to defer cleanup. The shared validator passes `--ratchet`
through, so CI invocations using `./scripts/i18n/validate.sh
--ratchet` still get the lenient behaviour.

## Test plan

- [x] `python3 scripts/i18n/check-keys.py` strict — exits 0
- [x] CI: `i18n Validation` job