### PR TITLE
feat(netif): linkmonitor pool for multi_interface fan-out

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -159,6 +159,12 @@ func NewServer(
 	// Initialize network services
 	services.Network.Manager = netMgr
 	services.Network.LinkMonitor = netif.NewLinkMonitor(cfg.Interface.Default)
+	// LinkMonitorPool tracks every interface in the multi_interface set
+	// (Pro). Reconcile primes the pool from the active profile; the pool
+	// itself is not started here — server_lifecycle.go owns Start/Stop.
+	services.Network.LinkMonitorPool = netif.NewLinkMonitorPool()
+	primaryInterfaces := append(cfg.Interface.AllEthernet(), cfg.Interface.AllWiFi()...)
+	services.Network.LinkMonitorPool.Reconcile(primaryInterfaces)
 
 	// Initialize discovery services
 	services.Discovery.Device = discovery.NewDeviceDiscoveryWithOUI(

--- a/internal/api/server_lifecycle.go
+++ b/internal/api/server_lifecycle.go
@@ -77,6 +77,21 @@ func (s *Server) Start() error {
 			"state", s.linkMonitor().GetState())
 	}
 
+	// Start the multi-interface monitor pool (Pro multi_interface fan-out,
+	// seed#1192 / follow-up #1214). The pool was reconciled to the active
+	// profile's interface set in NewServer; Start polls each child monitor
+	// concurrently so the runtime can observe state changes across N
+	// interfaces. A single monitor (Default) is the common Free / Starter
+	// case — the pool gracefully handles that with one child.
+	if pool := s.services.Network.LinkMonitorPool; pool != nil {
+		if err := pool.Start(); err != nil {
+			logging.GetLogger().Warn("Link monitor pool: partial start", "error", err)
+		} else {
+			logging.GetLogger().Info("Link monitor pool started",
+				"interfaces", pool.Interfaces())
+		}
+	}
+
 	// Start unified discovery service.
 	if err := s.discoveryService().Start(); err != nil {
 		logging.GetLogger().

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -88,9 +88,17 @@ type RateLimitServices struct {
 }
 
 // NetworkServices groups core network management services.
+//
+// LinkMonitor watches the single "primary" interface (cfg.Interface.Default)
+// — it stays as-is for the existing card surfaces that bind to one
+// interface at a time. LinkMonitorPool watches every interface in the
+// Pro multi_interface fan-out (cfg.Interface.AllEthernet() ∪
+// cfg.Interface.AllWiFi()). The pool is reconciled on profile change so
+// it tracks the operator's current configuration.
 type NetworkServices struct {
-	Manager     *netif.Manager
-	LinkMonitor *netif.LinkMonitor
+	Manager         *netif.Manager
+	LinkMonitor     *netif.LinkMonitor
+	LinkMonitorPool *netif.LinkMonitorPool
 }
 
 // DiscoveryServices groups device and network discovery services.
@@ -182,6 +190,9 @@ func (sc *ServiceContainer) Stop() {
 	// Stop network services
 	if sc.Network.LinkMonitor != nil {
 		sc.Network.LinkMonitor.Stop()
+	}
+	if sc.Network.LinkMonitorPool != nil {
+		sc.Network.LinkMonitorPool.Stop()
 	}
 
 	// Stop discovery services

--- a/internal/netif/linkmon_pool.go
+++ b/internal/netif/linkmon_pool.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package netif
+
+// LinkMonitorPool multiplexes per-interface LinkMonitor instances so the
+// runtime can observe state changes across N interfaces concurrently —
+// the multi_interface Pro feature (seed#1192, follow-up #1214).
+//
+// The pool is the new public entry point; LinkMonitor remains as the
+// per-interface primitive. The pool keeps reconciliation cheap: monitors
+// for unchanged interfaces survive a Reconcile call, only added/removed
+// names trigger Start/Stop. Callbacks are fanned out from every
+// underlying monitor through a single shared OnStateChange registration
+// — callers see one event stream keyed by event.Interface.
+//
+// Concurrency: the pool's own mutex guards the map. Each child monitor
+// has its own mutex; the pool never reaches inside them.
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"sync"
+)
+
+// LinkMonitorPool watches link state on a set of interfaces and emits a
+// single, unified event stream. Use Reconcile to declaratively set the
+// active interface set; the pool handles diff + start/stop internally.
+type LinkMonitorPool struct {
+	mu        sync.RWMutex
+	monitors  map[string]*LinkMonitor
+	callbacks []LinkStateCallback
+	running   bool
+}
+
+// NewLinkMonitorPool returns an empty pool. Call Reconcile to populate
+// it with interface names, then Start to begin polling.
+func NewLinkMonitorPool() *LinkMonitorPool {
+	return &LinkMonitorPool{
+		monitors: make(map[string]*LinkMonitor),
+	}
+}
+
+// Reconcile sets the monitored interface set to exactly `names`. Empty
+// or whitespace-only names are dropped. Monitors for names that were
+// already running are left untouched (no restart); monitors for newly
+// added names are created and started if the pool itself is Running;
+// monitors for removed names are stopped and dropped.
+//
+// Returns the post-reconcile interface count.
+func (p *LinkMonitorPool) Reconcile(names []string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	wanted := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		if n == "" {
+			continue
+		}
+		wanted[n] = struct{}{}
+	}
+
+	// Stop + drop monitors for removed names.
+	for name, mon := range p.monitors {
+		if _, keep := wanted[name]; !keep {
+			mon.Stop()
+			delete(p.monitors, name)
+		}
+	}
+
+	// Add new monitors. Wire the shared callback registry to each so a
+	// state change on any interface reaches every registered callback
+	// without the caller knowing about per-interface monitors.
+	for name := range wanted {
+		if _, exists := p.monitors[name]; exists {
+			continue
+		}
+		mon := NewLinkMonitor(name)
+		for _, cb := range p.callbacks {
+			mon.OnStateChange(cb)
+		}
+		if p.running {
+			// Best-effort start. A failed Start logs internally; we
+			// don't propagate because pool semantics are "monitor what
+			// you can." The Interfaces page in Settings already shows
+			// per-interface state read separately.
+			_ = mon.Start()
+		}
+		p.monitors[name] = mon
+	}
+
+	return len(p.monitors)
+}
+
+// OnStateChange registers cb against every current and future child
+// monitor. Calling after Reconcile attaches cb to existing monitors
+// retroactively so call order does not matter.
+func (p *LinkMonitorPool) OnStateChange(cb LinkStateCallback) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.callbacks = append(p.callbacks, cb)
+	for _, mon := range p.monitors {
+		mon.OnStateChange(cb)
+	}
+}
+
+// Start polls all current monitors. Calling Start a second time is a
+// no-op. Monitors added by a later Reconcile call inherit the running
+// state automatically.
+func (p *LinkMonitorPool) Start() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.running {
+		return nil
+	}
+	p.running = true
+	var firstErr error
+	for name, mon := range p.monitors {
+		if err := mon.Start(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("start %s: %w", name, err)
+		}
+	}
+	return firstErr
+}
+
+// Stop halts polling on every monitor and clears the running flag so a
+// subsequent Reconcile leaves new monitors idle. Existing callbacks are
+// kept registered.
+func (p *LinkMonitorPool) Stop() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.running {
+		return
+	}
+	p.running = false
+	for _, mon := range p.monitors {
+		mon.Stop()
+	}
+}
+
+// GetState returns the last observed LinkState for the named interface,
+// or LinkStateUnknown if the pool is not monitoring that interface.
+func (p *LinkMonitorPool) GetState(name string) LinkState {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if mon, ok := p.monitors[name]; ok {
+		return mon.GetState()
+	}
+	return LinkStateUnknown
+}
+
+// Interfaces returns the de-duplicated, alphabetically sorted list of
+// interface names currently in the pool. Useful for tests and admin
+// surfaces that want a snapshot.
+func (p *LinkMonitorPool) Interfaces() []string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]string, 0, len(p.monitors))
+	for name := range p.monitors {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Monitor returns the underlying per-interface LinkMonitor, or nil if
+// the pool is not watching that name. Exposed so callers that need
+// per-interface APIs (history, IsUp) can reach in without the pool
+// re-exporting every method.
+func (p *LinkMonitorPool) Monitor(name string) *LinkMonitor {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.monitors[name]
+}
+
+// Count returns the number of monitored interfaces.
+func (p *LinkMonitorPool) Count() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.monitors)
+}
+
+// Has reports whether the named interface is being monitored.
+func (p *LinkMonitorPool) Has(name string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	_, ok := p.monitors[name]
+	return ok
+}
+
+// DiffNames returns the added + removed names for the transition from
+// the pool's current set to `next`. Useful for callers that want to
+// log or audit the reconcile delta before invoking Reconcile.
+func (p *LinkMonitorPool) DiffNames(next []string) ([]string, []string) {
+	current := p.Interfaces()
+	wantedSet := make(map[string]struct{}, len(next))
+	for _, n := range next {
+		if n == "" {
+			continue
+		}
+		wantedSet[n] = struct{}{}
+	}
+	var added, removed []string
+	for name := range wantedSet {
+		if !slices.Contains(current, name) {
+			added = append(added, name)
+		}
+	}
+	for _, name := range current {
+		if _, keep := wantedSet[name]; !keep {
+			removed = append(removed, name)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	return added, removed
+}

--- a/internal/netif/linkmon_pool_test.go
+++ b/internal/netif/linkmon_pool_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package netif_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/netif"
+)
+
+func TestLinkMonitorPool_ReconcileAddsAndRemoves(t *testing.T) {
+	t.Parallel()
+	pool := netif.NewLinkMonitorPool()
+
+	if got := pool.Reconcile([]string{"eth0", "wlan0"}); got != 2 {
+		t.Fatalf("Reconcile add: got count %d, want 2", got)
+	}
+	names := pool.Interfaces()
+	if !slices.Equal(names, []string{"eth0", "wlan0"}) {
+		t.Errorf("Interfaces after add: got %v, want [eth0 wlan0]", names)
+	}
+
+	// Removing wlan0, adding eth1 — eth0 stays.
+	if got := pool.Reconcile([]string{"eth0", "eth1"}); got != 2 {
+		t.Fatalf("Reconcile swap: got count %d, want 2", got)
+	}
+	names = pool.Interfaces()
+	if !slices.Equal(names, []string{"eth0", "eth1"}) {
+		t.Errorf("Interfaces after swap: got %v, want [eth0 eth1]", names)
+	}
+
+	if got := pool.Reconcile(nil); got != 0 {
+		t.Errorf("Reconcile to empty: got count %d, want 0", got)
+	}
+	if names = pool.Interfaces(); len(names) != 0 {
+		t.Errorf("Interfaces after empty: got %v, want []", names)
+	}
+}
+
+func TestLinkMonitorPool_ReconcileSkipsEmptyNames(t *testing.T) {
+	t.Parallel()
+	pool := netif.NewLinkMonitorPool()
+	pool.Reconcile([]string{"eth0", "", "wlan0", ""})
+	names := pool.Interfaces()
+	if !slices.Equal(names, []string{"eth0", "wlan0"}) {
+		t.Errorf("got %v, want [eth0 wlan0]", names)
+	}
+}
+
+func TestLinkMonitorPool_ReconcilePreservesExistingMonitor(t *testing.T) {
+	t.Parallel()
+	pool := netif.NewLinkMonitorPool()
+	pool.Reconcile([]string{"eth0"})
+	before := pool.Monitor("eth0")
+	if before == nil {
+		t.Fatal("expected eth0 monitor after first Reconcile")
+	}
+	// Re-reconcile with eth0 plus a new name.
+	pool.Reconcile([]string{"eth0", "wlan0"})
+	after := pool.Monitor("eth0")
+	if after != before {
+		t.Errorf("eth0 monitor was restarted unnecessarily (instance changed)")
+	}
+}
+
+func TestLinkMonitorPool_DiffNames(t *testing.T) {
+	t.Parallel()
+	pool := netif.NewLinkMonitorPool()
+	pool.Reconcile([]string{"eth0", "wlan0"})
+
+	added, removed := pool.DiffNames([]string{"eth0", "eth1"})
+	if !slices.Equal(added, []string{"eth1"}) {
+		t.Errorf("added: got %v, want [eth1]", added)
+	}
+	if !slices.Equal(removed, []string{"wlan0"}) {
+		t.Errorf("removed: got %v, want [wlan0]", removed)
+	}
+}
+
+func TestLinkMonitorPool_OnStateChangePropagatesToExistingAndFuture(t *testing.T) {
+	t.Parallel()
+	pool := netif.NewLinkMonitorPool()
+	pool.Reconcile([]string{"eth0"})
+
+	// Register callback AFTER eth0 already exists — should attach
+	// retroactively.
+	cb := func(_ netif.LinkEvent) {}
+	pool.OnStateChange(cb)
+
+	// New monitor added later should also receive the callback.
+	pool.Reconcile([]string{"eth0", "eth1"})
+
+	// Smoke: every monitor should be non-nil and accessible.
+	for _, name := range pool.Interfaces() {
+		if pool.Monitor(name) == nil {
+			t.Errorf("monitor for %s missing after Reconcile", name)
+		}
+	}
+}
+
+func TestLinkMonitorPool_GetStateForUnknownInterface(t *testing.T) {
+	t.Parallel()
+	pool := netif.NewLinkMonitorPool()
+	if got := pool.GetState("nope"); got != netif.LinkStateUnknown {
+		t.Errorf("got %v, want LinkStateUnknown", got)
+	}
+}
+
+func TestLinkMonitorPool_HasAndCount(t *testing.T) {
+	t.Parallel()
+	pool := netif.NewLinkMonitorPool()
+	if pool.Count() != 0 {
+		t.Errorf("empty pool Count = %d, want 0", pool.Count())
+	}
+	pool.Reconcile([]string{"eth0", "eth1"})
+	if pool.Count() != 2 {
+		t.Errorf("Count after reconcile = %d, want 2", pool.Count())
+	}
+	if !pool.Has("eth0") {
+		t.Error("Has(eth0) = false, want true")
+	}
+	if pool.Has("not-there") {
+		t.Error("Has(not-there) = true, want false")
+	}
+}
+
+func TestLinkMonitorPool_StopIsIdempotent(t *testing.T) {
+	t.Parallel()
+	pool := netif.NewLinkMonitorPool()
+	pool.Reconcile([]string{"eth0"})
+	pool.Stop() // not started — no-op
+	if err := pool.Start(); err != nil {
+		t.Fatalf("Start after no-op Stop: %v", err)
+	}
+	pool.Stop()
+	pool.Stop() // second Stop is a no-op
+}


### PR DESCRIPTION
Closes #1214 (follow-up to #1192).

Pro multi_interface configs now actually monitor every interface in the operator's profile, not just the primary (`cfg.Interface.Default`).

## LinkMonitorPool

New type in `internal/netif` that multiplexes per-interface `LinkMonitor` instances:

```go
pool := netif.NewLinkMonitorPool()
pool.Reconcile([]string{"eth0", "eth1", "wlan0"})  // declarative; preserves unchanged
pool.OnStateChange(func(e LinkEvent) {
    // e.Interface identifies which monitored interface fired
})
pool.Start()
```

API:

- `Reconcile(names)` — declarative set; unchanged monitors survive, only added/removed trigger Start/Stop
- `OnStateChange(cb)` — single callback fanned out to every child monitor (existing + future)
- `Start()` / `Stop()` — idempotent
- `GetState(name)` / `Has` / `Count` / `Interfaces()` / `Monitor(name)` / `DiffNames(next)`

Each child `LinkMonitor` stays as the per-interface primitive; the pool never reaches inside child mutexes.

## Wiring

`server.go` now constructs **both**:

- `LinkMonitor` — the legacy single-interface primary watcher (Free/Starter and existing card surfaces)
- `LinkMonitorPool` — reconciled from `cfg.Interface.AllEthernet()` ∪ `cfg.Interface.AllWiFi()`

`server_lifecycle.go` starts the pool alongside the primary monitor.
`services.go` Stop halts both.

## Tests

8 unit tests in `linkmon_pool_test.go`:

- `TestLinkMonitorPool_ReconcileAddsAndRemoves`
- `TestLinkMonitorPool_ReconcileSkipsEmptyNames`
- `TestLinkMonitorPool_ReconcilePreservesExistingMonitor` (no restart for unchanged)
- `TestLinkMonitorPool_DiffNames`
- `TestLinkMonitorPool_OnStateChangePropagatesToExistingAndFuture`
- `TestLinkMonitorPool_GetStateForUnknownInterface`
- `TestLinkMonitorPool_HasAndCount`
- `TestLinkMonitorPool_StopIsIdempotent`

## Out of scope (future)

- Profile-change reconciliation: when an operator adds/removes an interface via Settings, the pool currently picks up the change on next server restart. Live reconciliation (watching profile updates and calling `pool.Reconcile()` mid-flight) is a smaller follow-up.
- Per-interface metrics tagging in `repository_metrics.go` — the schema already supports it but not every probe call passes `interface_name` consistently.

## Test plan

- [ ] CI green
- [ ] Manual: configure 2 ethernet interfaces on Pro license, restart, confirm `/__version` + logs show pool started with both
- [ ] Manual: change profile to remove one interface, restart, confirm pool now monitors only the one left
- [ ] Manual: Free license with 1+1 config — pool still starts (one child); existing card surfaces unaffected