### PR TITLE
fix(help-modal): add esc handler + testid; fix e2e selectors

### DIFF
--- a/ui/e2e/theme-and-help.spec.ts
+++ b/ui/e2e/theme-and-help.spec.ts
@@ -165,31 +165,24 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const initialCards = await page.getByTestId('card').count();
       expect(initialCards).toBeGreaterThan(0);
 
-      // Open settings
       const settingsButton = page.getByTestId('header-open-settings');
-
-      await settingsButton.click();
-
-      // Toggle theme
-      await page
-        .getByRole('button', { name: /appearance/i })
-        .first()
-        .click();
+      const appearanceAccordion = page.getByRole('button', { name: /appearance/i }).first();
       const themeToggle = page.getByTestId('theme-toggle');
-
-      await themeToggle.click();
-
-      // Close settings
       const closeButton = page.getByTestId('settings-drawer-close');
 
+      // Open settings → expand Appearance → toggle theme → close
+      await settingsButton.click();
+      await appearanceAccordion.click();
+      await themeToggle.click();
       await closeButton.click();
 
       // Verify all cards still visible
       const cardsAfterToggle = await page.getByTestId('card').count();
       expect(cardsAfterToggle).toBeGreaterThanOrEqual(initialCards - 1); // Allow for minor variance
 
-      // Toggle back
+      // Toggle back — reopen drawer + re-expand accordion (accordion collapses on close)
       await settingsButton.click();
+      await appearanceAccordion.click();
       await themeToggle.click();
       await closeButton.click();
 
@@ -289,8 +282,8 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
 
       await helpButton.click();
 
-      // Find and click close button
-      const closeButton = page.getByTestId('settings-drawer-close');
+      // Find and click close button (help modal's own close, not the settings drawer's)
+      const closeButton = page.getByTestId('help-modal-close');
 
       await closeButton.click();
 
@@ -496,32 +489,29 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const helpButton = page.getByTestId('header-open-help');
 
       await helpButton.click();
+      const modal = page.getByRole('dialog').or(page.locator('[role="dialog"]'));
+      await expect(modal).toBeVisible();
 
-      // Open settings (if possible with modal open)
+      // Help modal blocks header buttons via backdrop. Close help with ESC,
+      // then exercise the theme toggle path — verifying the two surfaces
+      // don't deadlock each other.
+      await page.keyboard.press('Escape');
+      await expect(modal).not.toBeVisible({ timeout: 3000 });
+
       const settingsButton = page.getByTestId('header-open-settings');
+      await settingsButton.click();
+      await page
+        .getByRole('button', { name: /appearance/i })
+        .first()
+        .click();
+      const themeToggle = page.getByTestId('theme-toggle');
+      await themeToggle.click();
 
-      const settingsVisible = await settingsButton.isVisible();
-
-      if (settingsVisible) {
-        await settingsButton.click();
-
-        // Toggle theme
-        await page
-          .getByRole('button', { name: /appearance/i })
-          .first()
-          .click();
-        const themeToggle = page.getByTestId('theme-toggle');
-
-        const toggleVisible = await themeToggle.isVisible();
-
-        if (toggleVisible) {
-          await themeToggle.click();
-
-          // Help modal should still be open
-          const modal = page.getByRole('dialog').or(page.locator('[role="dialog"]'));
-          await expect(modal).toBeVisible();
-        }
-      }
+      // Reopen help modal — should still render after theme switch.
+      const closeSettings = page.getByTestId('settings-drawer-close');
+      await closeSettings.click();
+      await helpButton.click();
+      await expect(modal).toBeVisible();
     });
 
     test('should maintain help modal state when toggling theme', async ({ page }) => {

--- a/ui/src/components/ui/HelpModal.tsx
+++ b/ui/src/components/ui/HelpModal.tsx
@@ -31,7 +31,7 @@
  */
 
 import type React from 'react';
-import type { ReactNode } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import { cn, icon as iconTokens, layout, modal, radius, spacing } from '../../styles/theme';
 
 interface HelpModalProps {
@@ -50,6 +50,20 @@ export function HelpModal({
   title,
   children,
 }: HelpModalProps): React.JSX.Element | null {
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [isOpen, onClose]);
+
   if (!isOpen) {
     return null;
   }
@@ -90,6 +104,7 @@ export function HelpModal({
           <button
             type="button"
             onClick={onClose}
+            data-testid="help-modal-close"
             className={cn(
               spacing.iconBtn.sm,
               'text-text-muted',


### PR DESCRIPTION
## Summary

Unblocks the 0.200.0 release (#1220). The E2E @smoke job started running on main for the first time in a while after #1221 (Phase 0 tokenization) touched enough UI files to trip the path filter, and exposed 14 failures (7 unique tests × chromium + webkit) in `theme-and-help.spec.ts` that had been latent — none of them were Phase 0 regressions, they were pre-existing test/product gaps masked by the E2E path filter.

### Real product gaps fixed in `HelpModal.tsx`

1. **No Escape-key handler** — WAI-ARIA requires modal dialogs to close on Escape. Adds a `document.addEventListener('keydown', ...)` while the modal is mounted.
2. **No `data-testid` on the close button** — the test suite was selecting `getByTestId('settings-drawer-close')` to try to close the help modal, which actually targets the *settings drawer's* close button (different component). Adds `data-testid="help-modal-close"`.

### E2E test selector fixes in `theme-and-help.spec.ts`

- `close help modal with close button` — switched from `settings-drawer-close` → `help-modal-close`.
- `should render all cards correctly in both themes` — re-expand the Appearance accordion when reopening the drawer for the toggle-back step (accordion collapses on drawer close, so the cached `theme-toggle` locator was timing out).
- `should allow theme toggle while help modal is open` — the help modal backdrop blocks clicks on header buttons by design. Test now closes the help modal with ESC first, runs the theme toggle, then reopens help to verify the modal still renders after a theme switch (better expresses the actual integration contract).
- The remaining ESC-press tests (`should close help modal with ESC key`, `should maintain scroll position when reopening`, `should display help modal in both light and dark themes`) should now pass via the new ESC handler — no spec changes needed.

## Test plan

- [x] `npm run build` — clean
- [x] Local typecheck — HelpModal/spec clean (pre-existing tsc warning in UsersSettings is unrelated and was green on the prior CI run)
- [ ] CI E2E @smoke job — primary verification
- [ ] CI Full E2E — secondary