### PR TITLE
fix(ui): users settings TS error blocking CI strict tsc check

### DIFF
--- a/ui/src/components/settings/sections/UsersSettings.tsx
+++ b/ui/src/components/settings/sections/UsersSettings.tsx
@@ -14,6 +14,7 @@
  * rows.
  */
 
+import type { TFunction } from 'i18next';
 import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -50,7 +51,14 @@ function formatLastLogin(value: string | undefined): string {
   }
 }
 
-function statusOf(u: UserRow, t: (k: string) => string): string {
+// i18next's TFunction carries the namespace tuple as a generic so the
+// keys are typed against the loaded resource bundles. Use the project's
+// concrete TFunction type rather than the loose (k: string) => string
+// signature — that older helper signature is no longer assignable from
+// useTranslation's return value under stricter TS.
+type StatusT = TFunction<readonly ['settings', 'errors']>;
+
+function statusOf(u: UserRow, t: StatusT): string {
   if (!u.isActive) return t('settings:users.status.disabled');
   if (u.lockedUntilFuture) return t('settings:users.status.locked');
   return t('settings:users.status.active');


### PR DESCRIPTION
## Summary

\`UsersSettings.tsx\` had a TS error blocking the Frontend job (\`tsc --noEmit\`). Pre-existing on seed main, masked behind other failures until this round.

\`\`\`
src/components/settings/sections/UsersSettings.tsx(307,60): error TS2345:
  Argument of type 'TFunction<readonly ["settings", "errors"], undefined>'
  is not assignable to parameter of type '(k: string) => string'.
\`\`\`

\`statusOf()\` declared a loose \`t: (k: string) => string\` parameter that's no longer assignable from \`useTranslation(['settings', 'errors'])\`. Switched the helper to use i18next's \`TFunction<readonly ['settings', 'errors']>\` type — pure typing fix, no runtime change.

Unblocks seed Phase 2 (#1227) and seed main itself.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — PASS
- [ ] CI Frontend job — should pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)