### PR TITLE
fix(ui): re-sync shell from stem (page-header-title testid)

### DIFF
--- a/ui/src/ui/.shell-sync.lock
+++ b/ui/src/ui/.shell-sync.lock
@@ -1,3 +1,3 @@
-# SOURCE_SHA: 2b6604246970750e83e6fee5b5d0b3d3c1b6d48c  (chore/phase1-canonical-shell-modernize)
-781da6243dcbff582cfd446c401b8672d4142712dad203806b72b3072e606e74  ui/src/ui/Sidebar.tsx
-77dedb9669e2970233ab5d2fbc0ba40ebef78c16b314c0b49245eacd177fd470  ui/src/ui/PageHeader.tsx
+# SOURCE_SHA: 6a5de95ca0a18b1ea93be20e07cc09553b6b758f  (main)
+e5e9f13438301a29ff4256eb92ff04af61d293570f4a38fdc7565bd0a59374c9  ui/src/ui/Sidebar.tsx
+e9cb0a27bec49013a11b0412a2a22dfb4c40965e657982e2f8dcefca44b36020  ui/src/ui/PageHeader.tsx

--- a/ui/src/ui/PageHeader.tsx
+++ b/ui/src/ui/PageHeader.tsx
@@ -1,4 +1,4 @@
-// SYNCED FROM stem@2b6604246970 — DO NOT EDIT.
+// SYNCED FROM stem@6a5de95ca0a1 — DO NOT EDIT.
 // Edits in this repo will be overwritten on next `make sync-shell`.
 // To change this file, send a PR to stem then re-sync.
 /**
@@ -142,7 +142,9 @@ export const PageHeader: FC<PageHeaderProps> = ({
         <div className="flex items-center gap-default">
           {icon ? createElement(icon, { className: `h-8 w-8 ${iconColorClass}` }) : null}
           <div>
-            <h1 className="heading-1 font-display">{title}</h1>
+            <h1 className="heading-1 font-display" data-testid="page-header-title">
+              {title}
+            </h1>
             {description ? <p className="body-small mt-tight max-w-2xl">{description}</p> : null}
           </div>
         </div>

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -1,4 +1,4 @@
-// SYNCED FROM stem@2b6604246970 — DO NOT EDIT.
+// SYNCED FROM stem@6a5de95ca0a1 — DO NOT EDIT.
 // Edits in this repo will be overwritten on next `make sync-shell`.
 // To change this file, send a PR to stem then re-sync.
 /**
@@ -26,6 +26,7 @@ import {
   X,
 } from 'lucide-react';
 import { createElement, type FC, type ReactNode, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { iconSizes } from '../constants/sizes';
 import { prefetchRoute } from '../utils/prefetch';
@@ -297,43 +298,51 @@ const SidebarBody: FC<SidebarBodyProps> = ({
   onOpenSettings,
   onOpenHistory,
   onOpenProfiles,
-}) => (
-  <>
-    <SidebarHeader collapsed={collapsed} onCollapse={onCollapse} />
-    <nav className="flex-1 overflow-y-auto py-4 px-cell stack-xl">
-      {groups.map((group, groupIndex) => (
-        <div key={group.label || `nav-group-${String(groupIndex)}`}>
-          {!collapsed && group.label ? (
-            <h3 className="px-3 mb-2 text-xs font-semibold text-text-muted uppercase tracking-wider">
-              {group.label}
-            </h3>
-          ) : null}
-          {collapsed ? <div className="h-px bg-surface-border mx-2 mb-2" /> : null}
-          <div className="stack-xs">
-            {group.items.map((item) => (
-              <NavItemButton
-                key={item.path}
-                item={item}
-                active={isActive(item.path)}
-                collapsed={collapsed}
-                onNavigate={onNavigate}
-              />
-            ))}
+}) => {
+  const { t } = useTranslation();
+  // group.label is either a plain display string ("Account") or an
+  // i18n key ("common:sections.modules"). t() returns the translation
+  // if the key resolves; otherwise the defaultValue (label itself).
+  const translateLabel = (label: string): string =>
+    label ? t(label, { defaultValue: label }) : '';
+  return (
+    <>
+      <SidebarHeader collapsed={collapsed} onCollapse={onCollapse} />
+      <nav className="flex-1 overflow-y-auto py-4 px-cell stack-xl">
+        {groups.map((group, groupIndex) => (
+          <div key={group.label || `nav-group-${String(groupIndex)}`}>
+            {!collapsed && group.label ? (
+              <h3 className="px-3 mb-2 text-xs font-semibold text-text-muted uppercase tracking-wider">
+                {translateLabel(group.label)}
+              </h3>
+            ) : null}
+            {collapsed ? <div className="h-px bg-surface-border mx-2 mb-2" /> : null}
+            <div className="stack-xs">
+              {group.items.map((item) => (
+                <NavItemButton
+                  key={item.path}
+                  item={item}
+                  active={isActive(item.path)}
+                  collapsed={collapsed}
+                  onNavigate={onNavigate}
+                />
+              ))}
+            </div>
           </div>
-        </div>
-      ))}
-    </nav>
-    <SidebarFooter
-      collapsed={collapsed}
-      version={version}
-      onOpenHelp={onOpenHelp}
-      onOpenSettings={onOpenSettings}
-      onOpenHistory={onOpenHistory}
-      onOpenProfiles={onOpenProfiles}
-      onExpand={onExpand}
-    />
-  </>
-);
+        ))}
+      </nav>
+      <SidebarFooter
+        collapsed={collapsed}
+        version={version}
+        onOpenHelp={onOpenHelp}
+        onOpenSettings={onOpenSettings}
+        onOpenHistory={onOpenHistory}
+        onOpenProfiles={onOpenProfiles}
+        onExpand={onExpand}
+      />
+    </>
+  );
+};
 
 interface MobileTopBarProps {
   mobileOpen: boolean;


### PR DESCRIPTION
## Summary

Seed's E2E Smoke fails on \`getByTestId('page-header-title')\` because seed's synced \`PageHeader.tsx\` predates the testid added in stem #347. Re-syncing from current stem main pulls it in.

- \`ui/src/ui/PageHeader.tsx\` — now has \`data-testid="page-header-title"\` on the \`<h1>\`
- \`ui/src/ui/Sidebar.tsx\` — picks up stem's i18n \`translateLabel\` for nav-group headings (canonical advanced since seed's last sync)
- \`.shell-sync.lock\` — updated to new stem SHA

Fixes the E2E Smoke failure on seed main. Affected specs: theme-and-help, fab, responsive.

## Test plan
- [x] `make sync-shell` + `sync-shell.sh --verify` — clean
- [x] `npm run build` — PASS
- [ ] CI E2E Smoke — should find the testid now

🤖 Generated with [Claude Code](https://claude.com/claude-code)