### PR TITLE
ci(e2e): shard browser tests; keep advisory tier from blocking release-please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -799,6 +799,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, backend, frontend]
     timeout-minutes: 30
+    # Advisory tier — "CI Complete" does NOT gate on this job. Sharded by
+    # browser so each leg finishes inside the 30-min budget instead of the
+    # combined run overrunning and being cancelled. continue-on-error keeps a
+    # slow or failing full-suite leg from flipping the overall workflow run to
+    # a non-success conclusion, which would otherwise skip the release-please
+    # workflow (it triggers on workflow_run.conclusion == 'success'). The
+    # required, blocking E2E gate is the separate E2E Smoke job.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [chromium, webkit]
     # Skipped on draft PRs (slow); also skipped if no frontend/backend changed.
     # always() lets the if: evaluate when backend was skipped upstream.
     if: |
@@ -872,13 +884,13 @@ jobs:
         # avoid duplicate runtime. See seed#1053.
         # Both chromium and webkit run per E2E_CONVENTIONS — the projects
         # array in playwright.config.ts is now exactly [chromium, webkit].
-        run: npx playwright test --reporter=html --grep-invert "@smoke"
+        run: npx playwright test --reporter=html --project=${{ matrix.project }} --grep-invert "@smoke"
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.project }}
           path: ui/playwright-report/
           retention-days: 7
 
@@ -886,7 +898,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: server-logs
+          name: server-logs-${{ matrix.project }}
           path: server.log
           retention-days: 7
 


### PR DESCRIPTION
## Summary
The **E2E Browser Tests** job ran the full non-smoke suite across both browsers in a single 30-min job, overran the cap, and was **cancelled**. Because `release-please.yml` triggers on `workflow_run.conclusion == 'success'`, a cancelled run **silently skipped release-please** — freezing the release PR so it stopped picking up merged fixes (this is why seed #1220 had to be unblocked by a manual `workflow_dispatch`).

The job is already advisory — the required **CI Complete** gate does not depend on it.

- **Shard by browser** (`matrix: project: [chromium, webkit]`, `fail-fast: false`) so each leg finishes inside 30 min and yields real pass/fail signal instead of always timing out.
- **`continue-on-error: true`** so a slow/failing advisory leg can't flip the overall run to non-success and skip release-please. The required, blocking E2E gate stays the separate **E2E Smoke** job (unchanged).
- Per-project artifact names so the legs don't collide.

Nothing `needs: e2e`, so the split doesn't affect other jobs.

## Test plan
- [x] YAML parses; e2e job has the matrix + `continue-on-error`
- [x] No job depends on `e2e`
- [ ] CI green; next main run concludes `success` so release-please runs automatically (no more manual dispatch)