### PR TITLE
fix(ui): re-sync shell — sidebar shows "The Seed" not "The Stem"

### DIFF
--- a/ui/src/ui/.shell-sync.lock
+++ b/ui/src/ui/.shell-sync.lock
@@ -1,3 +1,3 @@
-# SOURCE_SHA: 6a5de95ca0a18b1ea93be20e07cc09553b6b758f  (main)
-e5e9f13438301a29ff4256eb92ff04af61d293570f4a38fdc7565bd0a59374c9  ui/src/ui/Sidebar.tsx
-e9cb0a27bec49013a11b0412a2a22dfb4c40965e657982e2f8dcefca44b36020  ui/src/ui/PageHeader.tsx
+# SOURCE_SHA: 446b6390f4353378d0b8b55c2d6721a39d1807b2  (main)
+97305633aafc625cf225c5ec13eb2a16b89e185865f486087612b2d4911d8fa3  ui/src/ui/Sidebar.tsx
+8117cbffb0ab32f90880415d4dea586ec299e68139049ceb0f574e22193dfb48  ui/src/ui/PageHeader.tsx

--- a/ui/src/ui/PageHeader.tsx
+++ b/ui/src/ui/PageHeader.tsx
@@ -1,4 +1,4 @@
-// SYNCED FROM stem@6a5de95ca0a1 — DO NOT EDIT.
+// SYNCED FROM stem@446b6390f435 — DO NOT EDIT.
 // Edits in this repo will be overwritten on next `make sync-shell`.
 // To change this file, send a PR to stem then re-sync.
 /**

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -1,4 +1,4 @@
-// SYNCED FROM stem@6a5de95ca0a1 — DO NOT EDIT.
+// SYNCED FROM stem@446b6390f435 — DO NOT EDIT.
 // Edits in this repo will be overwritten on next `make sync-shell`.
 // To change this file, send a PR to stem then re-sync.
 /**
@@ -140,38 +140,41 @@ interface SidebarHeaderProps {
   onCollapse: () => void;
 }
 
-const SidebarHeader: FC<SidebarHeaderProps> = ({ collapsed, onCollapse }) => (
-  <div
-    className={`flex items-center ${
-      collapsed ? 'justify-center' : 'justify-between'
-    } px-3 py-4 border-b border-surface-border`}
-  >
-    <div className={`flex items-center gap-compact ${collapsed ? 'justify-center' : ''}`}>
-      <div className="relative flex-shrink-0">
-        <div className="h-9 w-9 rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center shadow-lg">
-          <Activity className={`${iconSizes.lg} text-text-inverse`} />
+const SidebarHeader: FC<SidebarHeaderProps> = ({ collapsed, onCollapse }) => {
+  const { t } = useTranslation();
+  return (
+    <div
+      className={`flex items-center ${
+        collapsed ? 'justify-center' : 'justify-between'
+      } px-3 py-4 border-b border-surface-border`}
+    >
+      <div className={`flex items-center gap-compact ${collapsed ? 'justify-center' : ''}`}>
+        <div className="relative flex-shrink-0">
+          <div className="h-9 w-9 rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center shadow-lg">
+            <Activity className={`${iconSizes.lg} text-text-inverse`} />
+          </div>
+          <div className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-status-success border-2 border-surface-raised" />
         </div>
-        <div className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-status-success border-2 border-surface-raised" />
+        {!collapsed ? (
+          <span className="font-display font-bold text-lg text-text-primary tracking-tight">
+            {t('app.title')}
+          </span>
+        ) : null}
       </div>
       {!collapsed ? (
-        <span className="font-display font-bold text-lg text-text-primary tracking-tight">
-          The Stem
-        </span>
+        <button
+          type="button"
+          onClick={onCollapse}
+          className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors lg:flex hidden"
+          title="Collapse sidebar"
+          aria-label="Collapse sidebar"
+        >
+          <ChevronLeft className={iconSizes.md} />
+        </button>
       ) : null}
     </div>
-    {!collapsed ? (
-      <button
-        type="button"
-        onClick={onCollapse}
-        className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors lg:flex hidden"
-        title="Collapse sidebar"
-        aria-label="Collapse sidebar"
-      >
-        <ChevronLeft className={iconSizes.md} />
-      </button>
-    ) : null}
-  </div>
-);
+  );
+};
 
 interface SidebarFooterProps {
   collapsed: boolean;
@@ -349,25 +352,28 @@ interface MobileTopBarProps {
   toggleMobile: () => void;
 }
 
-const MobileTopBar: FC<MobileTopBarProps> = ({ mobileOpen, toggleMobile }) => (
-  <header className="lg:hidden fixed top-0 left-0 right-0 z-50 flex-between px-4 py-row-lg bg-surface-raised/95 backdrop-blur-xl border-b border-surface-border">
-    <div className="flex items-center gap-compact">
-      <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center">
-        <Activity className={`${iconSizes.md} text-text-inverse`} />
+const MobileTopBar: FC<MobileTopBarProps> = ({ mobileOpen, toggleMobile }) => {
+  const { t } = useTranslation();
+  return (
+    <header className="lg:hidden fixed top-0 left-0 right-0 z-50 flex-between px-4 py-row-lg bg-surface-raised/95 backdrop-blur-xl border-b border-surface-border">
+      <div className="flex items-center gap-compact">
+        <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center">
+          <Activity className={`${iconSizes.md} text-text-inverse`} />
+        </div>
+        <span className="font-display font-bold text-text-primary">{t('app.title')}</span>
       </div>
-      <span className="font-display font-bold text-text-primary">The Stem</span>
-    </div>
-    <button
-      type="button"
-      onClick={toggleMobile}
-      className="pad-xs rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors"
-      title={mobileOpen ? 'Close menu' : 'Open menu'}
-      aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
-    >
-      {mobileOpen ? <X className={iconSizes.lg} /> : <Menu className={iconSizes.lg} />}
-    </button>
-  </header>
-);
+      <button
+        type="button"
+        onClick={toggleMobile}
+        className="pad-xs rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors"
+        title={mobileOpen ? 'Close menu' : 'Open menu'}
+        aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+      >
+        {mobileOpen ? <X className={iconSizes.lg} /> : <Menu className={iconSizes.lg} />}
+      </button>
+    </header>
+  );
+};
 
 export const SidebarLayout: FC<SidebarLayoutProps> = ({
   groups,


### PR DESCRIPTION
## Summary
Re-syncs the canonical shell from **stem@446b639** (PR stem#350), which renders the sidebar product name from `t('app.title')` rather than a hardcoded "The Stem". seed's `app.title` is **"The Seed"**, so the sidebar header + mobile top bar now show the correct brand instead of leaking "The Stem".

- `Sidebar.tsx`: synced (now uses `t('app.title')`).
- `PageHeader.tsx`: banner SHA bump only (no content change).
- `.shell-sync.lock`: updated checksums.

## Test plan
- [x] `sync-shell.sh` clean; `tsc --noEmit` clean
- [x] no "The Stem" hardcode remains; renders `t('app.title')` → "The Seed"
- [ ] CI green (incl. `sync-shell.sh --verify`)