### PR TITLE
feat(ui): converge Tooltip to shared text/side design (Phase 3a)

### DIFF
--- a/ui/src/components/cards/DiscoveryModalDeviceRow.tsx
+++ b/ui/src/components/cards/DiscoveryModalDeviceRow.tsx
@@ -170,8 +170,8 @@ export function DeviceRow({
         <td className="px-3 py-row">
           {device.vendor === 'LAA' ? (
             <Tooltip
-              content="Locally Administered Address - MAC assigned locally rather than by manufacturer"
-              position="bottom"
+              text="Locally Administered Address - MAC assigned locally rather than by manufacturer"
+              side="bottom"
             >
               <span className="text-xs text-text-muted underline decoration-dotted cursor-help">
                 LAA

--- a/ui/src/components/cards/HealthCheckCard.tsx
+++ b/ui/src/components/cards/HealthCheckCard.tsx
@@ -354,8 +354,8 @@ export const HealthCheckCard: React.MemoExoticComponent<
           {segments.map((seg) => (
             <Tooltip
               key={seg.label}
-              content={HTTP_TIMING_HELP[seg.label.toLowerCase()] || seg.label}
-              position="bottom"
+              text={HTTP_TIMING_HELP[seg.label.toLowerCase()] || seg.label}
+              side="bottom"
             >
               <span
                 className={cn(

--- a/ui/src/components/settings/sections/ThresholdsSettings.tsx
+++ b/ui/src/components/settings/sections/ThresholdsSettings.tsx
@@ -129,7 +129,7 @@ export const ThresholdsSettings: React.NamedExoticComponent<ThresholdsSettingsPr
               <span className="body-small font-medium text-text-primary">
                 {t('thresholds.dnsLookup')}
               </span>
-              <Tooltip content={THRESHOLD_HELP.dnsLookup} position="top">
+              <Tooltip text={THRESHOLD_HELP.dnsLookup} side="top">
                 <Info
                   className={cn(
                     iconTokens.size.xs,
@@ -195,7 +195,7 @@ export const ThresholdsSettings: React.NamedExoticComponent<ThresholdsSettingsPr
               <span className="body-small font-medium text-text-primary">
                 {t('thresholds.gatewayPing')}
               </span>
-              <Tooltip content={THRESHOLD_HELP.gatewayPing} position="top">
+              <Tooltip text={THRESHOLD_HELP.gatewayPing} side="top">
                 <Info
                   className={cn(
                     iconTokens.size.xs,
@@ -261,7 +261,7 @@ export const ThresholdsSettings: React.NamedExoticComponent<ThresholdsSettingsPr
               <span className="body-small font-medium text-text-primary">
                 {t('thresholds.wifiSignal')}
               </span>
-              <Tooltip content={THRESHOLD_HELP.wifiSignal} position="top">
+              <Tooltip text={THRESHOLD_HELP.wifiSignal} side="top">
                 <Info
                   className={cn(
                     iconTokens.size.xs,
@@ -327,7 +327,7 @@ export const ThresholdsSettings: React.NamedExoticComponent<ThresholdsSettingsPr
               <span className="body-small font-medium text-text-primary">
                 {t('thresholds.healthPing')}
               </span>
-              <Tooltip content={THRESHOLD_HELP.healthCheckPing} position="top">
+              <Tooltip text={THRESHOLD_HELP.healthCheckPing} side="top">
                 <Info
                   className={cn(
                     iconTokens.size.xs,
@@ -393,7 +393,7 @@ export const ThresholdsSettings: React.NamedExoticComponent<ThresholdsSettingsPr
               <span className="body-small font-medium text-text-primary">
                 {t('thresholds.healthTcp')}
               </span>
-              <Tooltip content={THRESHOLD_HELP.healthCheckTcp} position="top">
+              <Tooltip text={THRESHOLD_HELP.healthCheckTcp} side="top">
                 <Info
                   className={cn(
                     iconTokens.size.xs,
@@ -470,7 +470,7 @@ export const ThresholdsSettings: React.NamedExoticComponent<ThresholdsSettingsPr
                 <span className="caption font-medium text-text-primary">
                   {t('thresholds.totalResponseTime')}
                 </span>
-                <Tooltip content={THRESHOLD_HELP.httpTotal} position="top">
+                <Tooltip text={THRESHOLD_HELP.httpTotal} side="top">
                   <Info
                     className={cn(
                       iconTokens.size.xs,
@@ -540,7 +540,7 @@ export const ThresholdsSettings: React.NamedExoticComponent<ThresholdsSettingsPr
                 <span className="caption font-medium text-text-primary">
                   {t('thresholds.dnsLookupPhase')}
                 </span>
-                <Tooltip content={THRESHOLD_HELP.httpDns} position="top">
+                <Tooltip text={THRESHOLD_HELP.httpDns} side="top">
                   <Info
                     className={cn(
                       iconTokens.size.xs,
@@ -599,7 +599,7 @@ export const ThresholdsSettings: React.NamedExoticComponent<ThresholdsSettingsPr
                 <span className="caption font-medium text-text-primary">
                   {t('thresholds.tcpConnect')}
                 </span>
-                <Tooltip content={THRESHOLD_HELP.httpTcp} position="top">
+                <Tooltip text={THRESHOLD_HELP.httpTcp} side="top">
                   <Info
                     className={cn(
                       iconTokens.size.xs,
@@ -658,7 +658,7 @@ export const ThresholdsSettings: React.NamedExoticComponent<ThresholdsSettingsPr
                 <span className="caption font-medium text-text-primary">
                   {t('thresholds.tlsHandshake')}
                 </span>
-                <Tooltip content={THRESHOLD_HELP.httpTls} position="top">
+                <Tooltip text={THRESHOLD_HELP.httpTls} side="top">
                   <Info
                     className={cn(
                       iconTokens.size.xs,
@@ -717,7 +717,7 @@ export const ThresholdsSettings: React.NamedExoticComponent<ThresholdsSettingsPr
                 <span className="caption font-medium text-text-primary">
                   {t('thresholds.ttfb')}
                 </span>
-                <Tooltip content={THRESHOLD_HELP.httpTtfb} position="top">
+                <Tooltip text={THRESHOLD_HELP.httpTtfb} side="top">
                   <Info
                     className={cn(
                       iconTokens.size.xs,

--- a/ui/src/components/ui/tooltip.stories.tsx
+++ b/ui/src/components/ui/tooltip.stories.tsx
@@ -15,11 +15,11 @@ const meta: Meta<typeof Tooltip> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    position: {
+    side: {
       control: 'radio',
       options: ['top', 'bottom'],
     },
-    content: {
+    text: {
       control: 'text',
     },
   },
@@ -30,30 +30,30 @@ type Story = StoryObj<typeof Tooltip>;
 
 export const Default: Story = {
   args: {
-    content: 'This is helpful information',
+    text: 'This is helpful information',
     children: <Info className="w-5 h-5 text-text-secondary cursor-help" />,
   },
 };
 
 export const PositionTop: Story = {
   args: {
-    content: 'Tooltip appears above the element',
-    position: 'top',
+    text: 'Tooltip appears above the element',
+    side: 'top',
     children: <span className="text-text-secondary cursor-help underline">Hover me (top)</span>,
   },
 };
 
 export const PositionBottom: Story = {
   args: {
-    content: 'Tooltip appears below the element',
-    position: 'bottom',
+    text: 'Tooltip appears below the element',
+    side: 'bottom',
     children: <span className="text-text-secondary cursor-help underline">Hover me (bottom)</span>,
   },
 };
 
 export const WithIcon: Story = {
   args: {
-    content: 'Click to access settings',
+    text: 'Click to access settings',
     children: (
       <button
         type="button"
@@ -67,8 +67,7 @@ export const WithIcon: Story = {
 
 export const LongContent: Story = {
   args: {
-    content:
-      'This is a much longer tooltip that explains a complex concept in detail. It will wrap to multiple lines if needed.',
+    text: 'This is a much longer tooltip that explains a complex concept in detail. It will wrap to multiple lines if needed.',
     children: <HelpCircle className="w-5 h-5 text-text-secondary cursor-help" />,
   },
 };
@@ -77,7 +76,7 @@ export const InContext: Story = {
   render: () => (
     <div className={cn('flex items-center', spacing.gap.compact)}>
       <span className="text-text-primary">Upload limit</span>
-      <Tooltip content="Maximum file size for uploads is 10MB">
+      <Tooltip text="Maximum file size for uploads is 10MB">
         <HelpCircle className="w-4 h-4 text-text-muted cursor-help" />
       </Tooltip>
     </div>

--- a/ui/src/components/ui/tooltip.tsx
+++ b/ui/src/components/ui/tooltip.tsx
@@ -1,91 +1,81 @@
 /**
- * Tooltip Component
+ * Tooltip primitive — shared design across seed / stem / niac.
  *
- * Purpose: Displays contextual help text on hover or focus. Provides accessible tooltips
- * for explaining UI elements with customizable position (top/bottom).
+ * Minimal CSS-only tooltip with proper a11y wiring. Use native `title=` for
+ * plain strings; reach for this primitive when the tooltip holds formatted,
+ * multi-line, or linked content. The wrapper exposes `aria-describedby`
+ * pointing at the bubble so screen readers announce it; hover OR keyboard
+ * focus on the trigger reveals it.
  *
- * Key Features:
- * - Position control: top (default) or bottom positioning
- * - Hover and focus triggers: shows on mouseEnter or focus events
- * - Accessible: uses role="tooltip" for screen readers
- * - Max-width constraint: prevents long text from wrapping excessively
- * - Smooth positioning: uses CSS transforms for centering
- * - Theme-aware: uses surface-raised background and text-primary color
- * - Z-layer management: uses z-50 to appear above other content
- *
- * Usage:
- * ```typescript
- * <Tooltip content="Click here to start scanning">
- *   <button>Start</button>
- * </Tooltip>
- *
- * <Tooltip content="CPU usage %" position="bottom">
- *   <div>{cpuPercent}%</div>
- * </Tooltip>
- * ```
- *
- * Dependencies: React, theme utilities (cn, radius, border)
- * State: Manages show/hide state on hover and focus
+ * Behavior/API is kept consistent with the stem and niac copies (each repo
+ * owns its own file; no master). Visuals use this repo's theme tokens.
  */
-
 import type React from 'react';
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useId, useState } from 'react';
 import { border, cn, radius, spacing } from '../../styles/theme';
 
-interface TooltipProps {
-  content: string;
+export interface TooltipProps {
+  /** Hover/focus content. If omitted, the wrapper renders children unchanged. */
+  text?: ReactNode;
+  /** Where to place the bubble relative to the trigger. Defaults to "top". */
+  side?: 'top' | 'bottom' | 'left' | 'right';
+  /** Trigger element(s). */
   children: ReactNode;
-  position?: 'top' | 'bottom';
+  /** Optional class on the wrapper. */
+  className?: string;
 }
 
+const sideClass: Record<NonNullable<TooltipProps['side']>, string> = {
+  top: cn('bottom-full left-1/2 -translate-x-1/2', spacing.margin.bottom.inline),
+  bottom: cn('top-full left-1/2 -translate-x-1/2', spacing.margin.top.inline),
+  left: cn('right-full top-1/2 -translate-y-1/2', spacing.margin.right.inline),
+  right: cn('left-full top-1/2 -translate-y-1/2', spacing.margin.left.inline),
+};
+
 /**
- * Hover-triggered tooltip that displays additional information for an element.
+ * Hover/focus-triggered tooltip that enriches an element with extra context.
  */
-export function Tooltip({ content, children, position = 'top' }: TooltipProps): React.JSX.Element {
-  const [show, setShow] = useState(false);
+export function Tooltip({
+  text,
+  side = 'top',
+  children,
+  className = '',
+}: TooltipProps): React.JSX.Element {
+  const id = useId();
+  const [open, setOpen] = useState(false);
 
-  const positionClasses =
-    position === 'top'
-      ? cn('bottom-full left-1/2 -translate-x-1/2', spacing.margin.bottom.inline)
-      : cn('top-full left-1/2 -translate-x-1/2', spacing.margin.top.inline);
-
-  const handleMouseEnter = (): void => setShow(true);
-  const handleMouseLeave = (): void => setShow(false);
-  const handleFocus = (): void => setShow(true);
-  const handleBlur = (): void => setShow(false);
+  if (text === undefined || text === null || text === '') {
+    return <>{children}</>;
+  }
 
   return (
-    <div className="relative inline-flex items-center">
-      {/* biome-ignore lint/a11y/useSemanticElements: Tooltip trigger wraps arbitrary content - cannot use semantic button */}
-      <div
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        className="cursor-help"
-        tabIndex={0}
-        role="button"
-        aria-describedby={show ? 'tooltip-content' : undefined}
-      >
+    // biome-ignore lint/a11y/noStaticElementInteractions: hover-only enrichment; a11y comes from aria-describedby below
+    <span
+      className={cn('relative inline-flex', className)}
+      onMouseEnter={(): void => setOpen(true)}
+      onMouseLeave={(): void => setOpen(false)}
+      onFocus={(): void => setOpen(true)}
+      onBlur={(): void => setOpen(false)}
+    >
+      <span aria-describedby={id} className="inline-flex">
         {children}
-      </div>
-      {show ? (
-        <div
-          id="tooltip-content"
-          className={cn(
-            'absolute z-50 shadow-lg max-w-xs',
-            spacing.cell.px,
-            spacing.compact.pyMd,
-            positionClasses,
-            radius.default,
-            border.card,
-            'bg-surface-raised text-text-primary caption',
-          )}
-          role="tooltip"
-        >
-          {content}
-        </div>
-      ) : null}
-    </div>
+      </span>
+      <span
+        id={id}
+        role="tooltip"
+        className={cn(
+          'pointer-events-none absolute z-50 max-w-xs whitespace-normal shadow-lg transition-opacity duration-100',
+          spacing.cell.px,
+          spacing.compact.pyMd,
+          radius.default,
+          border.card,
+          'bg-surface-raised text-text-primary caption',
+          sideClass[side],
+          open ? 'opacity-100' : 'opacity-0',
+        )}
+      >
+        {text}
+      </span>
+    </span>
   );
 }

--- a/ui/src/styles/themeSpacing.ts
+++ b/ui/src/styles/themeSpacing.ts
@@ -89,6 +89,9 @@ export const spacing = {
       content: 'ml-content', // 16px - content indentation
       spacious: 'ml-spacious', // 24px - large indentation (lists)
     },
+    right: {
+      inline: 'mr-2', // 8px - inline content (e.g. side-anchored tooltips)
+    },
   },
 
   // Padding utilities for dividers/sections


### PR DESCRIPTION
## Summary
Phase 3a — converge the Tooltip primitive. seed's copy had diverged (string-only `content`, 2-way `position`, **hardcoded element id** → duplicate ids, top/bottom only). Bring it up to the shared design that stem and niac already use, each repo owning its own file (no master):

- **API**: `text?: ReactNode` + `side?: top|bottom|left|right` (replaces `content`/`position`); renders children unchanged when empty.
- **a11y**: `useId()` for a unique `aria-describedby`; hover *or* focus reveals.
- **Behavior**: opacity fade, `pointer-events-none`, four-side placement.
- **Visuals**: stay on seed's theme tokens; added a `spacing.margin.right` token for the left side.
- Migrated all 12 call sites + Storybook to the new API.

## Test plan
- [x] `tsc --noEmit` clean; biome clean; token-discipline clean
- [x] no `content=`/`position=` Tooltip props remain
- [ ] CI green