### PR TITLE
fix(ui): settings drawer focus trap — drop stopPropagation that defeated it

### DIFF
--- a/ui/src/components/settings/SettingsDrawer.tsx
+++ b/ui/src/components/settings/SettingsDrawer.tsx
@@ -498,7 +498,7 @@ export const SettingsDrawer: React.MemoExoticComponent<
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40"
+        className="fixed inset-0 bg-scrim/50 backdrop-blur-sm z-40"
         onClick={onClose}
         aria-hidden="true"
       />
@@ -509,8 +509,6 @@ export const SettingsDrawer: React.MemoExoticComponent<
         aria-modal="true"
         aria-labelledby="settings-drawer-title"
         data-testid="settings-drawer"
-        onClick={(e: React.MouseEvent): void => e.stopPropagation()}
-        onKeyDown={(e: React.KeyboardEvent): void => e.stopPropagation()}
         className="fixed right-0 top-0 h-full w-full sm:w-96 lg:w-lg bg-surface-raised border-l border-surface-border z-50 overflow-y-auto shadow-xl animate-slide-in"
       >
         {/* Header */}


### PR DESCRIPTION
The settings convergence (#1236) added `useFocusTrap` (ESC + tab-trap + focus restore) via a document-level keydown listener, but seed's drawer also had `onClick`/`onKeyDown` stopPropagation on the dialog container — swallowing Escape/Tab before they reached the document, so the trap never engaged. The backdrop is a sibling, so those handlers were vestigial. Remove both (stem/niac never had them) + use the `scrim` backdrop token. Same fix just shipped for the help drawer (#1239). tsc/biome clean.