### PR TITLE
fix(security): rate-limit /auth/refresh (#1224)

### DIFF
--- a/internal/api/handlers_auth.go
+++ b/internal/api/handlers_auth.go
@@ -255,11 +255,20 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Rate-limit refresh on the same per-IP bucket as login (#1224).
+	// Refresh tokens are signed JWTs so a valid one can't be brute-forced,
+	// but limiting still blunts CPU-abuse and refresh-token-stuffing if a
+	// token ever leaks. Bail early if this IP is already blocked.
+	clientIP := s.getClientIP(r)
+	if s.handleLoginRateLimited(w, logger, localizer, clientIP) {
+		return
+	}
+
 	// Get refresh token from cookie
 	refreshToken, err := auth.GetRefreshTokenFromCookie(r)
 	if err != nil {
 		// Security audit log: refresh token not found (fixes #697)
-		clientIP := s.getClientIP(r)
+		s.loginRateLimiter().RecordAttempt(clientIP, false)
 		logger.WarnContext(r.Context(), "Token refresh failed - token not found",
 			"client_ip", clientIP,
 			"event", "auth.refresh.failed",
@@ -274,7 +283,7 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request) {
 	newAccessToken, err := s.authManager().RefreshAccessToken(r.Context(), refreshToken)
 	if err != nil {
 		// Security audit log: invalid/expired refresh token (fixes #697)
-		clientIP := s.getClientIP(r)
+		s.loginRateLimiter().RecordAttempt(clientIP, false)
 		logger.WarnContext(r.Context(), "Token refresh failed - invalid or expired token",
 			"client_ip", clientIP,
 			"event", "auth.refresh.failed",
@@ -285,8 +294,10 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Successful refresh resets the per-IP attempt counter (#1224).
+	s.loginRateLimiter().RecordAttempt(clientIP, true)
+
 	// Security audit log: successful token refresh (fixes #697)
-	clientIP := s.getClientIP(r)
 	logger.InfoContext(r.Context(), "Token refresh successful",
 		"client_ip", clientIP,
 		"event", "auth.refresh.success")

--- a/internal/api/handlers_auth_test.go
+++ b/internal/api/handlers_auth_test.go
@@ -382,3 +382,37 @@ func TestHandleSetupStatus(t *testing.T) {
 		})
 	}
 }
+
+// TestRefreshToken_RateLimited is the #1224 regression test: repeated
+// failed refreshes from one IP must trip the shared login rate limiter
+// (5 attempts/window) and return 429, not an unbounded stream of 401s.
+func TestRefreshToken_RateLimited(t *testing.T) {
+	server := api.NewTestServer()
+	defer server.Close()
+
+	// Fire invalid-token refreshes from the same IP until blocked. The
+	// limiter blocks after defaultMaxAttempts (5); the next request must
+	// be 429.
+	const attempts = 7
+	var got429 bool
+	for i := range attempts {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", http.NoBody)
+		req.AddCookie(&http.Cookie{Name: auth.CookieNameRefresh, Value: "invalid-token"})
+		w := httptest.NewRecorder()
+		server.HandleRefreshToken(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			got429 = true
+			if w.Header().Get("Retry-After") == "" {
+				t.Error("429 response missing Retry-After header")
+			}
+			break
+		}
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: expected 401 or 429, got %d", i+1, w.Code)
+		}
+	}
+
+	if !got429 {
+		t.Errorf("refresh endpoint never rate-limited after %d failed attempts", attempts)
+	}
+}


### PR DESCRIPTION
Audit correction: seed already has comprehensive rate limiting
(loginRateLimiter on /auth/login + /recovery/complete, MFA checks,
endpointRateLimiter on expensive survey endpoints). The original issue
premise ("no rate limit on /auth/login") was wrong — my first-pass
grep missed it because seed calls limiters inside handlers rather than
via stem's middleware idiom.

The one genuine gap was /auth/refresh, which had no limiter. Refresh
tokens are signed JWTs (a valid one can't be brute-forced), but the
endpoint should still be limited as defense-in-depth against CPU abuse
from repeated refresh attempts and refresh-token-stuffing if a token
leaks.

Reuses the existing per-IP loginRateLimiter (no new limiter, no
middleware change):
- bail early via handleLoginRateLimited if the IP is already blocked
- RecordAttempt(false) on missing-cookie and invalid/expired-token
- RecordAttempt(true) on success (resets the counter)

Also hoists the duplicated clientIP computation to the top of the
handler.

Test: TestRefreshToken_RateLimited — 7 failed refreshes from one IP,
asserts a 429 with Retry-After once the 5-attempt threshold trips.

Refs #1224.
