### PR TITLE
chore(security): add output-escaping/XSS regression gate (#1225)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,9 @@ jobs:
       - name: Verify generated TS types are up to date
         run: ./scripts/check-types-drift.sh
 
+      - name: Output-escaping / XSS gate (#1225)
+        run: ./scripts/check-output-escaping.sh
+
       - name: Run staticcheck
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/scripts/check-output-escaping.sh
+++ b/scripts/check-output-escaping.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# check-output-escaping.sh — output-escaping / XSS regression gate (#1225).
+#
+# Audited 2026-05-28: classified all 3 fmt.Fprintf(w, ...) sites — all in
+# internal/api/handlers_sse.go:
+#   - "data: %s\n\n", message  — SSE data frame; payload is a
+#     JSON-marshaled message, Content-Type text/event-stream, consumed
+#     by EventSource as data (not rendered as HTML).
+#   - ": heartbeat\n\n"        — literal SSE comment.
+# seed also uses html/template (auto-escaping) and has no
+# text/template-for-HTML. No site renders user data as HTML.
+#
+# Two checks:
+#   1. No raw innerHTML injection in ui/src (React XSS vector).
+#   2. No NEW value-interpolating fmt.Fprintf(w, "...%s...") in
+#      internal/api outside the audited allow-list (handlers_sse.go).
+#      HTTP responses should use sendJSONResponse / json.Encode or
+#      html/template, never raw format strings.
+#
+# Run locally: scripts/check-output-escaping.sh
+
+set -uo pipefail
+
+FAIL=0
+INNER_HTML_RE='dangerously[S]etInnerHTML'
+
+# handlers_sse.go: SSE data frames carry JSON payloads over
+# text/event-stream, consumed by EventSource — not an HTML sink.
+ALLOWLIST_RE='internal/api/handlers_sse\.go'
+
+UI_DIR=""
+if [ -d "ui/src" ]; then
+  UI_DIR="ui/src"
+elif [ -d "src" ] && [ -f "package.json" ]; then
+  UI_DIR="src"
+fi
+
+if [ -n "$UI_DIR" ]; then
+  DANGER=$(grep -rEn "$INNER_HTML_RE" "$UI_DIR" \
+    --include='*.tsx' --include='*.ts' 2>/dev/null \
+    | grep -vE '\.(test|spec|stories)\.(ts|tsx):' || true)
+  if [ -n "$DANGER" ]; then
+    echo "============================================================"
+    echo "[XSS] raw innerHTML injection found in UI app code:"
+    echo "$DANGER"
+    echo "Use plain text/JSX, or sanitize with DOMPurify and justify in review."
+    echo ""
+    FAIL=1
+  fi
+fi
+
+if [ -d "internal/api" ]; then
+  HTTP_FMT=$(grep -rEn 'fmt\.Fprintf\(w,[^)]*%[svqd]' internal/api 2>/dev/null \
+    | grep -v '_test.go' \
+    | grep -vE "$ALLOWLIST_RE" || true)
+  if [ -n "$HTTP_FMT" ]; then
+    echo "============================================================"
+    echo "[XSS] value-interpolating fmt.Fprintf(w, ...) in internal/api —"
+    echo "HTTP responses must use sendJSONResponse / json.Encode or"
+    echo "html/template, not raw format strings:"
+    echo "$HTTP_FMT"
+    echo ""
+    echo "If a new site is deliberately safe (SSE/JSON wire format),"
+    echo "add it to ALLOWLIST_RE with a justification note."
+    echo ""
+    FAIL=1
+  fi
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "FAIL: output-escaping gate (#1225)."
+  exit 1
+fi
+
+echo "OK: no raw innerHTML injection; internal/api Fprintf sites are within the audited allow-list."


### PR DESCRIPTION
Audit (2026-05-28): all 3 fmt.Fprintf(w, ...) sites are in
internal/api/handlers_sse.go — SSE data frames ("data: %s\n\n" with
JSON-marshaled payloads over text/event-stream, consumed by
EventSource) plus a literal heartbeat comment. seed also uses
html/template (auto-escaping) and no text/template-for-HTML. Zero
sites render user data as HTML. No code fix needed.

Adds scripts/check-output-escaping.sh + CI wiring:
- fails on raw innerHTML injection in ui/src
- fails on NEW value-interpolating fmt.Fprintf(w, "...%s...") in
  internal/api outside the audited allow-list (handlers_sse.go)

Closes #1225.
