### PR TITLE
feat(ui): semantic design-token foundation (PR 1/6)

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -91,6 +91,40 @@
   /* Constant-across-modes utility colors. */
   --color-scrim: var(--color-scrim);
   --color-knob: var(--color-knob);
+
+  /* On-color foregrounds — text/icon color that sits ON a filled brand or
+   * status surface and passes AA. Constant across modes (the surface is the
+   * same hue in both). Replaces hardcoded text-zinc-900 / text-white. */
+  --color-on-brand: var(--color-on-brand);
+  --color-on-danger: var(--color-on-danger);
+
+  /* Categorical data-viz palette — a fixed qualitative set for "N distinct
+   * categories" (discovery methods, timing phases, device types, progress
+   * series). NOT for status/meaning (use status-* for that). Values flip
+   * light↔dark in :root/.dark for AA on each surface. */
+  --color-cat-1: var(--color-cat-1);
+  --color-cat-2: var(--color-cat-2);
+  --color-cat-3: var(--color-cat-3);
+  --color-cat-4: var(--color-cat-4);
+  --color-cat-5: var(--color-cat-5);
+  --color-cat-6: var(--color-cat-6);
+  --color-cat-7: var(--color-cat-7);
+  --color-cat-8: var(--color-cat-8);
+
+  /* Log-level tinted bg + readable fg pairs (extends the solid --color-log-*
+   * above). For row highlights / chips in the log viewer. */
+  --color-log-trace-bg: var(--color-log-trace-bg);
+  --color-log-trace-fg: var(--color-log-trace-fg);
+  --color-log-debug-bg: var(--color-log-debug-bg);
+  --color-log-debug-fg: var(--color-log-debug-fg);
+  --color-log-info-bg: var(--color-log-info-bg);
+  --color-log-info-fg: var(--color-log-info-fg);
+  --color-log-warn-bg: var(--color-log-warn-bg);
+  --color-log-warn-fg: var(--color-log-warn-fg);
+  --color-log-error-bg: var(--color-log-error-bg);
+  --color-log-error-fg: var(--color-log-error-fg);
+  --color-log-fatal-bg: var(--color-log-fatal-bg);
+  --color-log-fatal-fg: var(--color-log-fatal-fg);
 }
 
 /* Source detection for Tailwind */
@@ -162,6 +196,34 @@
   --color-scrim: #000000;
   --color-knob: #ffffff;
 
+  /* On-color foregrounds — constant across modes (no .dark override). */
+  --color-on-brand: #18181b; /* zinc-900 — AA on brand/success fills */
+  --color-on-danger: #ffffff; /* white — AA on status-error fills */
+
+  /* Categorical data-viz palette — LIGHT (≈600 weight, AA on warm cream). */
+  --color-cat-1: #2563eb; /* blue */
+  --color-cat-2: #0891b2; /* cyan */
+  --color-cat-3: #4f46e5; /* indigo */
+  --color-cat-4: #16a34a; /* green */
+  --color-cat-5: #ea580c; /* orange */
+  --color-cat-6: #9333ea; /* purple */
+  --color-cat-7: #0d9488; /* teal */
+  --color-cat-8: #e11d48; /* rose */
+
+  /* Log-level bg/fg pairs — LIGHT (tint bg + dark fg). */
+  --color-log-trace-bg: #f8fafc;
+  --color-log-trace-fg: #334155;
+  --color-log-debug-bg: #ecfeff;
+  --color-log-debug-fg: #0e7490;
+  --color-log-info-bg: #eff6ff;
+  --color-log-info-fg: #1d4ed8;
+  --color-log-warn-bg: #fefce8;
+  --color-log-warn-fg: #a16207;
+  --color-log-error-bg: #fef2f2;
+  --color-log-error-fg: #b91c1c;
+  --color-log-fatal-bg: #fee2e2;
+  --color-log-fatal-fg: #991b1b;
+
   /* Gauge/Progress Colors (for SVG) */
   --gauge-amber: #d97706;
   --gauge-orange: #ea580c;
@@ -212,6 +274,30 @@
   --color-module-shell: #fb923c; /* Lighter Orange - security, protection */
   --color-module-sap: #22d3ee; /* Lighter Cyan - telemetry, data flow */
   --color-module-harvest: #fbbf24; /* Lighter Gold - reports, results */
+
+  /* Categorical data-viz palette — DARK (≈400 weight, AA on deep green-black). */
+  --color-cat-1: #60a5fa; /* blue */
+  --color-cat-2: #22d3ee; /* cyan */
+  --color-cat-3: #818cf8; /* indigo */
+  --color-cat-4: #4ade80; /* green */
+  --color-cat-5: #fb923c; /* orange */
+  --color-cat-6: #c084fc; /* purple */
+  --color-cat-7: #2dd4bf; /* teal */
+  --color-cat-8: #fb7185; /* rose */
+
+  /* Log-level bg/fg pairs — DARK (deep bg + light fg). */
+  --color-log-trace-bg: #020617;
+  --color-log-trace-fg: #cbd5e1;
+  --color-log-debug-bg: #083344;
+  --color-log-debug-fg: #67e8f9;
+  --color-log-info-bg: #172554;
+  --color-log-info-fg: #93c5fd;
+  --color-log-warn-bg: #422006;
+  --color-log-warn-fg: #fde047;
+  --color-log-error-bg: #450a0a;
+  --color-log-error-fg: #fca5a5;
+  --color-log-fatal-bg: #450a0a;
+  --color-log-fatal-fg: #fecaca;
 
   /* Gauge/Progress Colors (for SVG) */
   --gauge-amber: #fbbf24;
@@ -438,6 +524,19 @@ body {
   /* Focus states */
   .focus-ring {
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base;
+  }
+
+  /* ========================================================================
+     Z-INDEX SCALE
+     ========================================================================
+     Named stacking levels — use instead of arbitrary z-[..] values.
+     Tailwind's z-50 remains the modal/drawer level; these sit above it.
+     ======================================================================== */
+  .z-overlay {
+    z-index: 60; /* command palette, transient overlays above modals */
+  }
+  .z-max {
+    z-index: 100; /* skip links, always-on-top affordances */
   }
 
   /* ========================================================================

--- a/ui/src/styles/DESIGN_SYSTEM.md
+++ b/ui/src/styles/DESIGN_SYSTEM.md
@@ -3,6 +3,37 @@
 This design system ensures consistent styling across the application. Instead of scattered utility classes, use the
 centralized theme tokens and component utilities.
 
+## Token Architecture (read first)
+
+Three tiers, **one** source of truth for values, **one** derivation direction:
+
+```
+Primitive   Tailwind's built-in palette (green-500 = #4caf50)   ← never referenced directly in app code
+   ↓ alias
+Semantic    index.css @theme + :root/.dark                      ← THE source of truth for VALUES
+            brand-*, status-*, surface-*, text-*, cat-1..8,
+            log-*-bg/-fg, on-brand, on-danger, z-overlay/z-max
+   ↓ alias
+Component   components/ui/* (<Button>, <Card>, <Input> …)        ← consumes semantic tokens
+            + TS class-token objects in styles/theme (status.*, layout.* …)
+```
+
+**Two invariants (enforced by lint):**
+
+1. **Values flow one direction** — defined once in `index.css`, everything else
+   references them. Never hand-copy a hex sideways into a `.ts`/`.tsx` file.
+2. **App code names only semantic / component tokens** — never a primitive
+   palette utility (`bg-green-500`) and never a raw hex.
+
+**When you can't use a class** (`<canvas>` drawing, generated HTML/PDF reports),
+read the value at runtime from `styles/tokens.ts` (`token('brandPrimary')`),
+which reads the CSS variable — so there's still a single source of truth.
+
+**Legitimate exceptions** (allowlisted): `styles/tokens.ts`,
+`utils/reportRenderer.ts`, `components/survey/FloorPlanCanvas.tsx`, and named
+domain-palette maps (e.g. T568B Ethernet wire colors), which represent physical
+reality and are intentionally outside the brand palette.
+
 ## Quick Start
 
 ````tsx
@@ -21,7 +52,7 @@ import { buttonClass, cardClass, cn } from '../styles/theme';
 
 ## Color System
 
-Colors are defined as CSS variables in `index.css` and mapped in `tailwind.config.js`.
+Colors are defined as CSS variables in `index.css` (`:root` / `.dark`) and exposed to Tailwind via the `@theme` block in the same file (Tailwind v4 is CSS-first — there is no `tailwind.config.js`).
 
 ### Brand Colors
 

--- a/ui/src/styles/tokens.ts
+++ b/ui/src/styles/tokens.ts
@@ -1,0 +1,84 @@
+/**
+ * tokens.ts — runtime-readable design-token VALUES.
+ *
+ * The single source of truth for token VALUES is index.css (@theme + :root /
+ * .dark). This module READS those CSS custom properties at runtime; it never
+ * hardcodes hex. Use it ONLY where Tailwind utility classes cannot reach:
+ *   - <canvas> drawing (ctx.fillStyle / strokeStyle need a color string)
+ *   - generated HTML/PDF reports (a standalone document, no Tailwind classes)
+ *
+ * Everywhere else, use the utility classes / TS class-token objects in
+ * styles/theme. This keeps a single derivation direction (CSS → here), so a
+ * token value is defined in exactly one place and can never drift.
+ */
+
+/**
+ * CSS custom-property names, grouped by tier. The values live in index.css;
+ * these are just the addresses. Extend as canvas/report consumers need more.
+ */
+export const tokenVar = {
+  // Brand
+  brandPrimary: '--color-brand-primary',
+  brandGold: '--color-brand-gold',
+  // Text
+  textPrimary: '--color-text-primary',
+  textMuted: '--color-text-muted',
+  textAccent: '--color-text-accent', // seed-600 strong green — AA on light
+  textInverse: '--color-text-inverse',
+  // Surfaces
+  surfaceBase: '--color-surface-base',
+  surfaceRaised: '--color-surface-raised',
+  surfaceBorder: '--color-surface-border',
+  // Status
+  statusSuccess: '--color-status-success',
+  statusWarning: '--color-status-warning',
+  statusError: '--color-status-error',
+  statusInfo: '--color-status-info',
+  // On-color foregrounds
+  onBrand: '--color-on-brand',
+  onDanger: '--color-on-danger',
+  // Categorical data-viz palette
+  cat1: '--color-cat-1',
+  cat2: '--color-cat-2',
+  cat3: '--color-cat-3',
+  cat4: '--color-cat-4',
+  cat5: '--color-cat-5',
+  cat6: '--color-cat-6',
+  cat7: '--color-cat-7',
+  cat8: '--color-cat-8',
+} as const;
+
+export type TokenName = keyof typeof tokenVar;
+
+/**
+ * Read a resolved CSS custom-property value from :root for the active theme.
+ * Returns '' when no DOM is available (SSR / tests without a document).
+ */
+export function cssVar(name: string): string {
+  if (typeof document === 'undefined') {
+    return '';
+  }
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+/**
+ * Read a design token's current value.
+ * @example token('brandPrimary') // '#4caf50'
+ */
+export function token(name: TokenName): string {
+  return cssVar(tokenVar[name]);
+}
+
+/**
+ * Batch-read several tokens with a single getComputedStyle call — preferred in
+ * canvas render loops where many colors are needed per frame.
+ */
+export function readTokens<K extends TokenName>(names: readonly K[]): Record<K, string> {
+  if (typeof document === 'undefined') {
+    return Object.fromEntries(names.map((name) => [name, ''])) as Record<K, string>;
+  }
+  const styles = getComputedStyle(document.documentElement);
+  return Object.fromEntries(
+    names.map((name) => [name, styles.getPropertyValue(tokenVar[name]).trim()]),
+  ) as Record<K, string>;
+}


### PR DESCRIPTION
## Summary

First PR in a 6-part effort to consolidate hardcoded design values into the existing token system (see analysis below). **Foundation only — no component changes**, so it's safe to land independently.

Establishes the missing **semantic token tiers** so app code never has to reach for a raw palette utility (`bg-green-500`) or a hand-copied hex:

- **`--color-cat-1..8`** — qualitative data-viz palette (light/dark) for "N distinct categories" (discovery methods, timing phases, device types, progress series). Distinct from `status-*` meaning colors.
- **`--color-log-{level}-bg/-fg`** — tinted bg + readable fg pairs extending the existing solid `--color-log-*`, for log-viewer row highlights.
- **`--color-on-brand` / `--color-on-danger`** — AA foregrounds on filled surfaces, replacing hardcoded `text-zinc-900` / `text-white`.
- **`.z-overlay` (60) / `.z-max` (100)** — named z-index levels replacing arbitrary `z-[..]`.
- **`styles/tokens.ts`** — runtime reader of the CSS custom properties for the few consumers that can't use classes (`<canvas>`, the generated HTML/PDF report). It *reads* the vars, so `index.css` stays the single source of truth.
- **`DESIGN_SYSTEM.md`** — documents the three-tier architecture + two invariants; corrects a stale `tailwind.config.js` reference (v4 is CSS-first).

## Architecture (the contract for all later PRs)

```
Primitive  Tailwind palette            ← never referenced directly in app code
   ↓ alias
Semantic   index.css @theme/:root/.dark ← THE source of truth for VALUES
   ↓ alias
Component  components/ui/* + styles/theme class-tokens
```
Invariants (to be lint-enforced in PR 6): values flow one direction (CSS → everything); app code names only semantic/component tokens.

## Test plan

- [x] `biome check src/` — clean (321 files)
- [x] `tsc --noEmit` — passes
- [x] `vitest` — 117/117 pass
- [x] `vite build` — succeeds; all new tokens verified present in emitted CSS for **both** light and dark themes; `.z-overlay`/`.z-max` emitted
- [ ] Reviewer: confirm token values match the locked 2026-05-22 brand map

## Follow-ups (this series)
2. Remove dead `buttonClass/cardClass/inputClass`; de-leak `themeColors.ts`
3. Migrate status/log palette leaks (UpdateSettings, settings sections, useLogs…)
4. Point canvas/PDF (`reportRenderer`, `FloorPlanCanvas`) at `tokens.ts`; fix stale `#056839`
5. Typography (`<h*>`→`.heading-*`), `cableWire` domain map, hand-rolled cards
6. Lint guard (warn→error) against raw palette/hex

Same pattern will be applied **independently** to stem and niac (own values, own files, no shared modules).