### PR TITLE
refactor(ui): remove dead class-helpers; design-system colors onto tokens (PR 2/6)

### DIFF
--- a/ui/src/components/setup/SetupWizard.tsx
+++ b/ui/src/components/setup/SetupWizard.tsx
@@ -34,11 +34,10 @@ import { evaluatePassword, type PasswordRule } from '../../lib/passwordPolicy';
 import { SetupWizardSchema } from '../../schemas/auth';
 import {
   button,
-  buttonClass,
-  cardClass,
+  card,
   cn,
   icon as iconTokens,
-  inputClass,
+  input,
   layout,
   radius,
   spacing,
@@ -241,7 +240,10 @@ export function SetupWizard({
           <p className={cn('body-small', spacing.margin.top.inline)}>{t('welcome.subtitle')}</p>
         </div>
 
-        <form onSubmit={handleSubmit(onSubmit)} className={cardClass('default', 'lg')}>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className={cn(card.base, card.variant.default, card.padding.lg)}
+        >
           <div className={spacing.margin.bottom.content}>
             <p className={cn('body-small', spacing.margin.bottom.content)}>
               {t('username.label')} <strong>{username}</strong> {t('username.cannotChange')}
@@ -384,7 +386,12 @@ export function SetupWizard({
                     required={true}
                     minLength={12}
                     {...register('password')}
-                    className={cn(inputClass('default', 'md'), spacing.padding.right.icon)}
+                    className={cn(
+                      input.base,
+                      input.state.default,
+                      input.size.md,
+                      spacing.padding.right.icon,
+                    )}
                     placeholder={t('password.placeholder')}
                   />
                   <button
@@ -441,7 +448,7 @@ export function SetupWizard({
                   type={showPassword ? 'text' : 'password'}
                   required={true}
                   {...register('confirmPassword')}
-                  className={inputClass('default', 'md')}
+                  className={cn(input.base, input.state.default, input.size.md)}
                   placeholder={t('password.confirm.placeholder')}
                 />
                 {errors.confirmPassword ? (
@@ -484,7 +491,7 @@ export function SetupWizard({
           <button
             type="submit"
             disabled={isSubmitting}
-            className={buttonClass('primary', 'md', 'w-full')}
+            className={cn(button.base, button.variant.primary, button.size.md, 'w-full')}
           >
             {isSubmitting ? t('buttons.settingUp') : t('buttons.completeSetup')}
           </button>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -111,6 +111,10 @@
   --color-cat-7: var(--color-cat-7);
   --color-cat-8: var(--color-cat-8);
 
+  /* Severity scale extension — CVSS "high" has no status-* equivalent (sits
+   * between status-warning and status-error). Semantic, not categorical. */
+  --color-severity-high: var(--color-severity-high);
+
   /* Log-level tinted bg + readable fg pairs (extends the solid --color-log-*
    * above). For row highlights / chips in the log viewer. */
   --color-log-trace-bg: var(--color-log-trace-bg);
@@ -210,6 +214,9 @@
   --color-cat-7: #0d9488; /* teal */
   --color-cat-8: #e11d48; /* rose */
 
+  /* Severity "high" — LIGHT (orange-600, between warning and error). */
+  --color-severity-high: #ea580c;
+
   /* Log-level bg/fg pairs — LIGHT (tint bg + dark fg). */
   --color-log-trace-bg: #f8fafc;
   --color-log-trace-fg: #334155;
@@ -284,6 +291,9 @@
   --color-cat-6: #c084fc; /* purple */
   --color-cat-7: #2dd4bf; /* teal */
   --color-cat-8: #fb7185; /* rose */
+
+  /* Severity "high" — DARK (orange-400). */
+  --color-severity-high: #fb923c;
 
   /* Log-level bg/fg pairs — DARK (deep bg + light fg). */
   --color-log-trace-bg: #020617;

--- a/ui/src/styles/DESIGN_SYSTEM.md
+++ b/ui/src/styles/DESIGN_SYSTEM.md
@@ -37,17 +37,15 @@ reality and are intentionally outside the brand palette.
 ## Quick Start
 
 ````tsx
-import { buttonClass, cardClass, cn } from '../styles/theme';
+import { Button } from '../components/ui/Button';
 
-// ❌ Bad - scattered utilities, hard to maintain
+// ❌ Bad - scattered utilities, hard to maintain, raw palette
 <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
   Click me
 </button>
 
-// ✅ Good - uses design system
-<button className={buttonClass('primary', 'md')}>
-  Click me
-</button>
+// ✅ Good - the component is the source of truth for button styling
+<Button>Click me</Button>
 ```python
 
 ## Color System
@@ -141,123 +139,75 @@ import { typography } from '../styles/theme';
 
 ## Component Variants
 
+> The `<Button>`, `<Card>`, `<Input>`, `<Modal>`, and `<StatusBadge>` components in
+> `components/ui/*` are the source of truth for component styling. Prefer them.
+> The `button` / `card` / `input` / `badge` / `modal` token objects in
+> `styles/theme` remain for ad-hoc composition with `cn()` when a component
+> can't apply (e.g. styling a `<form>` like a card).
+
 ### Buttons
 
 ```tsx
-import { buttonClass } from '../styles/theme';
+import { Button } from '../components/ui/Button';
 
-// Primary action button
-<button className={buttonClass('primary', 'md')}>
-  Save Changes
-</button>
-
-// Secondary button
-<button className={buttonClass('secondary', 'md')}>
-  Cancel
-</button>
-
-// Ghost button (no background)
-<button className={buttonClass('ghost', 'sm')}>
-  View Details
-</button>
-
-// Danger button
-<button className={buttonClass('danger', 'md')}>
-  Delete
-</button>
-
-// Custom additions
-<button className={buttonClass('primary', 'lg', 'w-full')}>
-  Full Width Button
-</button>
+<Button>Save Changes</Button>                          // solid / violet (brand)
+<Button variant="secondary">Cancel</Button>
+<Button variant="ghost" size="sm">View Details</Button>
+<Button tone="red">Delete</Button>
+<Button className="w-full">Full Width Button</Button>
 ```python
 
-**Sizes**: `sm` | `md` | `lg`
+**variant**: `solid` | `outline` | `ghost` | `secondary` · **tone**: `violet` | `red` | `green` | `blue` | `gray` · **size**: `xs` | `sm` | `md` | `lg`
 
-**Variants**: `primary` | `secondary` | `ghost` | `danger` | `success`
+Ad-hoc (non-`<button>` element): `cn(button.base, button.variant.primary, button.size.md)`.
 
 ### Inputs
 
 ```tsx
-import { inputClass } from '../styles/theme';
+import { Input } from '../components/ui/Input';
 
-// Default input
-<input className={inputClass('default', 'md')} />
-
-// Error state
-<input className={inputClass('error', 'md')} />
-
-// Success state
-<input className={inputClass('success', 'md')} />
-
-// Custom additions
-<input className={inputClass('default', 'md', 'font-mono')} />
+<Input label="Email" placeholder="you@example.com" />
+<Input label="Email" error="Required" />
+<Input label="Host" hint="IP or hostname" rightIcon={<Search />} />
 ```python
 
-**Sizes**: `sm` | `md` | `lg`
-
-**States**: `default` | `error` | `success`
+For bespoke inputs (custom label/affordance layout) compose the token object:
+`cn(input.base, input.state.default, input.size.md)` — states `default` | `error` | `success`.
 
 ### Cards
 
 ```tsx
-import { cardClass } from '../styles/theme';
+import { Card } from '../components/ui/card';
 
-// Default card
-<div className={cardClass('default', 'md')}>
-  <h3 className="font-semibold mb-2">Card Title</h3>
-  <p>Card content</p>
-</div>
-
-// Elevated card (with shadow)
-<div className={cardClass('elevated', 'lg')}>
-  Content
-</div>
-
-// Interactive card (hover effect)
-<div className={cardClass('interactive', 'md')}>
-  Clickable card
-</div>
+<Card>Card content</Card>
 ```python
 
-**Variants**: `default` | `elevated` | `interactive`
-
-**Padding**: `none` | `sm` | `md` | `lg`
+For a non-`<div>` element that should look like a card (e.g. a `<form>`):
+`cn(card.base, card.variant.default, card.padding.lg)` — variants `default` | `elevated` | `interactive`, padding `none` | `sm` | `md` | `lg`.
 
 ### Badges
 
 ```tsx
-import { badgeClass } from '../styles/theme';
+import { StatusBadge } from '../components/ui/StatusBadge';
 
-<span className={badgeClass('success')}>Active</span>
-<span className={badgeClass('warning')}>Pending</span>
-<span className={badgeClass('error')}>Failed</span>
-<span className={badgeClass('info')}>Info</span>
-<span className={badgeClass('primary')}>New</span>
+<StatusBadge status="success">Active</StatusBadge>
 ```python
 
-**Variants**: `default` | `success` | `warning` | `error` | `info` | `primary`
+Or compose the token object: `cn(badge.base, badge.variant.success)` — variants
+`default` | `success` | `warning` | `error` | `info` | `primary`.
 
 ### Modals
 
 ```tsx
-import { modal, modalClass } from "../styles/theme";
+import { Modal } from '../components/ui/Modal';
 
-<div className={modal.overlay}>
-  <div className={modalClass("md", "md")}>
-    <h2 className="text-xl font-semibold mb-4">Modal Title</h2>
-    <p className="mb-6">Modal content</p>
-    <div className="flex justify-end gap-3">
-      <button className={buttonClass("secondary", "md")}>Cancel</button>
-      <button className={buttonClass("primary", "md")}>Confirm</button>
-    </div>
-  </div>
-</div>;
+<Modal open={open} onClose={close} title="Modal Title" size="md">
+  <p>Modal content</p>
+</Modal>
 ```python
 
-**Sizes**: `sm` | `md` | `lg` | `xl` | `full`
-
-**Padding**: `sm` | `md` | `lg`
+Sizes `sm` | `md` | `lg` | `xl` | `full`. The `modal` token object (overlay /
+backdrop / content) remains for fully custom dialogs.
 
 ### Status Indicators
 
@@ -325,15 +275,14 @@ import { cn } from '../styles/theme';
 ### After (design system)
 
 ```tsx
-import { buttonClass, cardClass } from '../styles/theme';
+import { Button } from '../components/ui/Button';
+import { Card } from '../components/ui/card';
 
-<button className={buttonClass('primary', 'md')}>
-  Save
-</button>
+<Button>Save</Button>
 
-<div className={cardClass('default', 'lg')}>
-  <h3 className="text-xl font-semibold mb-2">Title</h3>
-</div>
+<Card>
+  <h3 className="heading-3 mb-heading">Title</h3>
+</Card>
 ```text
 
 ## Benefits

--- a/ui/src/styles/theme.ts
+++ b/ui/src/styles/theme.ts
@@ -1,7 +1,5 @@
 import { twMerge } from 'tailwind-merge';
 
-import { button, card, input } from './themeComponents';
-
 /**
  * =============================================================================
  * THE SEED DESIGN SYSTEM - Mustard Seed Networks
@@ -12,7 +10,9 @@ import { button, card, input } from './themeComponents';
  * ARCHITECTURE:
  * 1. CSS Variables (index.css) - Core color tokens for light/dark modes
  * 2. This file (theme.ts) - Barrel that re-exports the per-domain token
- *    modules + the class-name composition helpers (cn, buttonClass, etc.)
+ *    modules + the cn() class-name helper. For component STYLING use the
+ *    components in components/ui/* (<Button>, <Card>, <Input>); for ad-hoc
+ *    composition use the token objects directly (cn(button.base, ...)).
  * 3. Tailwind Classes - CSS-first configuration using @theme directive
  *
  * Token modules:
@@ -63,66 +63,4 @@ export { typography } from './themeTypography';
  */
 export function cn(...classes: (string | boolean | undefined | null)[]): string {
   return twMerge(classes.filter(Boolean).join(' '));
-}
-
-// Type-safe Maps for dynamic lookups
-const buttonVariantMap: Map<keyof typeof button.variant, string> = new Map<
-  keyof typeof button.variant,
-  string
->(Object.entries(button.variant) as [keyof typeof button.variant, string][]);
-const buttonSizeMap: Map<keyof typeof button.size, string> = new Map<
-  keyof typeof button.size,
-  string
->(Object.entries(button.size) as [keyof typeof button.size, string][]);
-
-/**
- * Build a button class string
- */
-export function buttonClass(
-  variant: keyof typeof button.variant = 'primary',
-  size: keyof typeof button.size = 'md',
-  className?: string,
-): string {
-  return cn(button.base, buttonVariantMap.get(variant), buttonSizeMap.get(size), className);
-}
-
-// Type-safe Maps for input lookups
-const inputStateMap: Map<keyof typeof input.state, string> = new Map<
-  keyof typeof input.state,
-  string
->(Object.entries(input.state) as [keyof typeof input.state, string][]);
-const inputSizeMap: Map<keyof typeof input.size, string> = new Map<keyof typeof input.size, string>(
-  Object.entries(input.size) as [keyof typeof input.size, string][],
-);
-
-/**
- * Build an input class string
- */
-export function inputClass(
-  state: keyof typeof input.state = 'default',
-  size: keyof typeof input.size = 'md',
-  className?: string,
-): string {
-  return cn(input.base, inputStateMap.get(state), inputSizeMap.get(size), className);
-}
-
-// Type-safe Maps for card lookups
-const cardVariantMap: Map<keyof typeof card.variant, string> = new Map<
-  keyof typeof card.variant,
-  string
->(Object.entries(card.variant) as [keyof typeof card.variant, string][]);
-const cardPaddingMap: Map<keyof typeof card.padding, string> = new Map<
-  keyof typeof card.padding,
-  string
->(Object.entries(card.padding) as [keyof typeof card.padding, string][]);
-
-/**
- * Build a card class string
- */
-export function cardClass(
-  variant: keyof typeof card.variant = 'default',
-  padding: keyof typeof card.padding = 'md',
-  className?: string,
-): string {
-  return cn(card.base, cardVariantMap.get(variant), cardPaddingMap.get(padding), className);
 }

--- a/ui/src/styles/themeColors.ts
+++ b/ui/src/styles/themeColors.ts
@@ -6,27 +6,28 @@
  */
 
 /**
- * Discovery method colors - for network discovery badges
- * Use dark: variants for proper dark mode support
+ * Discovery method colors - for network discovery badges.
+ * Backed by the categorical data-viz palette (--color-cat-*), which flips
+ * light/dark automatically — no dark: variants needed.
  */
 export const discoveryMethod = {
-  arp: 'bg-blue-500/20 text-blue-600 dark:text-blue-400',
-  ping: 'bg-cyan-500/20 text-cyan-600 dark:text-cyan-400',
-  ndp: 'bg-indigo-500/20 text-indigo-600 dark:text-indigo-400',
-  lldp: 'bg-green-500/20 text-green-600 dark:text-green-400',
-  cdp: 'bg-orange-500/20 text-orange-600 dark:text-orange-400',
-  snmp: 'bg-purple-500/20 text-purple-600 dark:text-purple-400',
-  edp: 'bg-teal-500/20 text-teal-600 dark:text-teal-400',
-  mdns: 'bg-rose-500/20 text-rose-600 dark:text-rose-400',
+  arp: 'bg-cat-1/20 text-cat-1',
+  ping: 'bg-cat-2/20 text-cat-2',
+  ndp: 'bg-cat-3/20 text-cat-3',
+  lldp: 'bg-cat-4/20 text-cat-4',
+  cdp: 'bg-cat-5/20 text-cat-5',
+  snmp: 'bg-cat-6/20 text-cat-6',
+  edp: 'bg-cat-7/20 text-cat-7',
+  mdns: 'bg-cat-8/20 text-cat-8',
 } as const;
 
 /**
  * Progress bar colors - for timing/performance visualization
  */
 export const progressBar = {
-  http: 'bg-blue-500 dark:bg-blue-400',
-  tcp: 'bg-amber-500 dark:bg-amber-400',
-  success: 'bg-green-500 dark:bg-green-400',
+  http: 'bg-cat-1',
+  tcp: 'bg-cat-5',
+  success: 'bg-status-success',
 } as const;
 
 /**
@@ -123,10 +124,10 @@ export const severity = {
     dot: 'bg-status-error',
   },
   high: {
-    bg: 'bg-orange-500/15 dark:bg-orange-400/15',
-    text: 'text-orange-600 dark:text-orange-400',
-    border: 'border-orange-500/30 dark:border-orange-400/30',
-    dot: 'bg-orange-500 dark:bg-orange-400',
+    bg: 'bg-severity-high/15',
+    text: 'text-severity-high',
+    border: 'border-severity-high/30',
+    dot: 'bg-severity-high',
   },
   medium: {
     bg: 'bg-status-warning/15',
@@ -154,24 +155,24 @@ export const severity = {
  */
 export const timing = {
   dns: {
-    bg: 'bg-blue-500 dark:bg-blue-400',
-    text: 'text-blue-600 dark:text-blue-400',
+    bg: 'bg-cat-1',
+    text: 'text-cat-1',
   },
   tcp: {
-    bg: 'bg-cyan-500 dark:bg-cyan-400',
-    text: 'text-cyan-600 dark:text-cyan-400',
+    bg: 'bg-cat-2',
+    text: 'text-cat-2',
   },
   tls: {
-    bg: 'bg-purple-500 dark:bg-purple-400',
-    text: 'text-purple-600 dark:text-purple-400',
+    bg: 'bg-cat-6',
+    text: 'text-cat-6',
   },
   wait: {
-    bg: 'bg-amber-500 dark:bg-amber-400',
-    text: 'text-amber-600 dark:text-amber-400',
+    bg: 'bg-cat-5',
+    text: 'text-cat-5',
   },
   download: {
-    bg: 'bg-green-500 dark:bg-green-400',
-    text: 'text-green-600 dark:text-green-400',
+    bg: 'bg-cat-4',
+    text: 'text-cat-4',
   },
 } as const;
 
@@ -179,12 +180,12 @@ export const timing = {
  * Category colors - for device types, network segments
  */
 export const category = {
-  router: 'text-blue-500 dark:text-blue-400',
-  server: 'text-purple-500 dark:text-purple-400',
-  workstation: 'text-green-500 dark:text-green-400',
-  printer: 'text-orange-500 dark:text-orange-400',
-  mobile: 'text-cyan-500 dark:text-cyan-400',
-  network: 'text-teal-500 dark:text-teal-400',
+  router: 'text-cat-1',
+  server: 'text-cat-6',
+  workstation: 'text-cat-4',
+  printer: 'text-cat-5',
+  mobile: 'text-cat-2',
+  network: 'text-cat-7',
   unknown: 'text-text-muted',
 } as const;
 
@@ -261,7 +262,7 @@ export const gauge = {
       return 'var(--color-status-warning)';
     }
     if (percentage < 75) {
-      return 'var(--gauge-amber, #eab308)';
+      return 'var(--gauge-amber)';
     }
     return 'var(--color-status-success)';
   },
@@ -269,7 +270,7 @@ export const gauge = {
   className: {
     critical: 'text-status-error',
     warning: 'text-status-warning',
-    caution: 'text-amber-500 dark:text-amber-400',
+    caution: 'text-cat-5',
     good: 'text-status-success',
   },
 } as const;

--- a/ui/src/styles/themeComponents.ts
+++ b/ui/src/styles/themeComponents.ts
@@ -12,16 +12,16 @@ export const button = {
 
   variant: {
     // Seed anchor is seed-500 (#4caf50) — needs DARK text (white fails AA).
-    // text-zinc-900 is constant across modes (text-text-inverse flips and
-    // would fail one of them). Opacity hover avoids the lighten-to-accent
-    // trap. Per Phase 7 of the 2026-05-22 brand audit.
-    primary: 'bg-brand-primary text-zinc-900 hover:bg-brand-primary/90',
+    // text-on-brand is the AA-safe, mode-constant foreground for filled brand
+    // surfaces (text-text-inverse flips and would fail one mode). Opacity hover
+    // avoids the lighten-to-accent trap. Per Phase 7 of the 2026-05-22 audit.
+    primary: 'bg-brand-primary text-on-brand hover:bg-brand-primary/90',
     secondary: 'border border-surface-border bg-surface-raised hover:bg-surface-hover',
     ghost: 'hover:bg-surface-hover',
     // Status danger/success buttons also fail AA with text-inverse in some
-    // mode; use a constant.
-    danger: 'bg-status-error text-white hover:bg-status-error/90',
-    success: 'bg-status-success text-zinc-900 hover:bg-status-success/90',
+    // mode; use the on-* tokens (constant across modes).
+    danger: 'bg-status-error text-on-danger hover:bg-status-error/90',
+    success: 'bg-status-success text-on-brand hover:bg-status-success/90',
   },
 
   size: {


### PR DESCRIPTION
## Summary

PR 2/6 of the design-token consolidation. Builds on the tokens from #1246 (now merged). Two themes: **kill the duplicate styling path**, and **de-leak the design-system files** so they reference semantic tokens, not raw Tailwind palette.

- **Remove `buttonClass`/`cardClass`/`inputClass`** from `theme.ts`. Their only consumer, `SetupWizard.tsx`, now composes the retained `button`/`card`/`input` token objects via `cn()` — **zero visual change** (same classes the helpers produced). The components in `components/ui/*` remain the source of truth for component styling; the helpers were a parallel, near-dead path. (The bespoke password inputs with visibility toggles don't fit the `<Input>` component, so token composition is the exact-equivalent move.)
- **`themeColors.ts` de-leak** → `discoveryMethod`, `timing`, `category`, `progressBar`, and the gauge `caution` color now use the `--color-cat-*` data-viz palette (auto-flips light/dark, so the `dark:` variants disappear). `progressBar.success` → `status-success`. Dropped a `#eab308` hex fallback.
- **`severity.high`** now uses a new semantic `--color-severity-high` token (CVSS "high" has no `status-*` equivalent — it sits between warning and error), added to `index.css` for both themes. The other severity levels already used `status-*`.
- **`themeComponents.ts`**: button `primary`/`success` `text-zinc-900` → `text-on-brand`, `danger` `text-white` → `text-on-danger` — **same hex**, now tokens (consumes the `on-*` tokens added in #1246).
- **`DESIGN_SYSTEM.md`**: examples now show `<Button>/<Card>/<Input>/<Modal>/<StatusBadge>`; removed references to the deleted helpers and to `badgeClass`/`modalClass` (which never actually existed).

## ⚠️ One visible change to eyeball

`timing.wait`, `timing.tcp`, `progressBar.tcp`, and the gauge `caution` band shift **amber → orange** — the categorical palette has no amber slot. Hues stay fully distinguishable; all other data-viz colors map 1:1. Surfaces: timing waterfalls (Performance / Path Analysis), speed gauges.

## Test plan

- [x] `biome check src/` — clean (321 files)
- [x] `tsc --noEmit` — passes
- [x] `vitest` — 117/117 pass
- [x] `vite build` — succeeds; `bg/text-cat-*` utilities now generate, `--color-severity-high` present in both themes
- [x] grep: zero remaining `buttonClass`/`cardClass`/`inputClass` usages; zero raw palette in `themeColors.ts`/`themeComponents.ts`
- [ ] Reviewer: glance at network discovery badges, timing waterfalls, CVE severity chips in both themes

## Net
−209 / +114 (removing duplication).

Next: PR 3 migrates the remaining component-level palette leaks (`UpdateSettings`, settings sections, `useLogs`, …) onto these tokens.