### PR TITLE
refactor(ui): migrate component palette leaks to tokens (PR 3/6)

### DIFF
--- a/ui/src/components/cards/LogViewerModal.tsx
+++ b/ui/src/components/cards/LogViewerModal.tsx
@@ -124,13 +124,7 @@ function LogEntryRow({ entry, expanded, onToggle, onClose }: LogEntryRowProps): 
 
         {/* Component badge */}
         {entry.component ? (
-          <span
-            className={cn(
-              'px-3 py-compact',
-              radius.default,
-              'bg-purple-500/20 text-purple-600 dark:text-purple-400 text-sm',
-            )}
-          >
+          <span className={cn('px-3 py-compact', radius.default, 'bg-cat-6/20 text-cat-6 text-sm')}>
             {entry.component}
           </span>
         ) : null}

--- a/ui/src/components/settings/sections/ApiTokensSettings.tsx
+++ b/ui/src/components/settings/sections/ApiTokensSettings.tsx
@@ -137,7 +137,7 @@ export function ApiTokensSettings(): React.ReactElement {
         </p>
 
         {!canMint && (
-          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 pad-sm text-sm text-amber-200">
+          <div className="rounded-lg border border-status-warning/30 bg-status-warning/5 pad-sm text-sm text-status-warning">
             Current tier: <strong>{tierLabel}</strong>. Minting API tokens requires Pro. Start a
             14-day trial with <code>seed license trial</code>, or activate a Pro key with{' '}
             <code>seed license activate -k &lt;KEY&gt;</code>.

--- a/ui/src/components/settings/sections/InterfacesSettings.tsx
+++ b/ui/src/components/settings/sections/InterfacesSettings.tsx
@@ -121,7 +121,7 @@ export function InterfacesSettings(): React.ReactElement {
         <p className="text-sm text-text-secondary">{t('settings:interfaces.description')}</p>
 
         {(!canAddEthernet || !canAddWifi) && (
-          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 pad-sm text-sm text-amber-200">
+          <div className="rounded-lg border border-status-warning/30 bg-status-warning/5 pad-sm text-sm text-status-warning">
             {t('settings:interfaces.limitReachedFreeStarter')}
           </div>
         )}

--- a/ui/src/components/settings/sections/SsoSettings.tsx
+++ b/ui/src/components/settings/sections/SsoSettings.tsx
@@ -149,7 +149,7 @@ export function SsoSettings(): React.ReactElement {
         <p className="text-sm text-text-secondary">{t('settings:sso.description')}</p>
 
         {!canEdit && (
-          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 pad-sm text-sm text-amber-200">
+          <div className="rounded-lg border border-status-warning/30 bg-status-warning/5 pad-sm text-sm text-status-warning">
             {t('errors:sso.featureRequired')}
           </div>
         )}

--- a/ui/src/components/settings/sections/UpdateSettings.tsx
+++ b/ui/src/components/settings/sections/UpdateSettings.tsx
@@ -192,11 +192,11 @@ export const UpdateSettings: React.NamedExoticComponent<UpdateSettingsProps> = m
             <div
               className={cn(
                 spacing.pad.sm,
-                'bg-red-500/10 border border-red-500/30',
+                'bg-status-error/10 border border-status-error/30',
                 radius.default,
               )}
             >
-              <span className="body-small text-red-500">{error}</span>
+              <span className="body-small text-status-error">{error}</span>
             </div>
           ) : null}
 
@@ -206,15 +206,15 @@ export const UpdateSettings: React.NamedExoticComponent<UpdateSettingsProps> = m
               className={cn(
                 'stack-sm',
                 spacing.pad.sm,
-                'bg-green-500/10 border border-green-500/30',
+                'bg-status-success/10 border border-status-success/30',
                 radius.default,
               )}
             >
               <div className={layout.flex.between}>
-                <span className="body-small text-green-500 font-medium">
+                <span className="body-small text-status-success font-medium">
                   {t('updates.updateAvailable', 'Update Available')}
                 </span>
-                <span className="body-small text-green-500 font-mono">
+                <span className="body-small text-status-success font-mono">
                   v{updateInfo.latestVersion}
                 </span>
               </div>
@@ -250,7 +250,7 @@ export const UpdateSettings: React.NamedExoticComponent<UpdateSettingsProps> = m
                     layout.flex.center,
                     spacing.gap.compact,
                     spacing.pad.sm,
-                    'bg-green-500 hover:bg-green-600 text-white',
+                    'bg-status-success hover:bg-status-success/90 text-on-brand',
                     radius.default,
                     'transition-colors',
                     'disabled:opacity-50 disabled:cursor-not-allowed',
@@ -287,7 +287,7 @@ export const UpdateSettings: React.NamedExoticComponent<UpdateSettingsProps> = m
                     layout.flex.center,
                     spacing.gap.compact,
                     spacing.pad.sm,
-                    'bg-blue-500 hover:bg-blue-600 text-white',
+                    'bg-status-info hover:bg-status-info/90 text-on-info',
                     radius.default,
                     'transition-colors',
                     'disabled:opacity-50 disabled:cursor-not-allowed',
@@ -323,7 +323,7 @@ export const UpdateSettings: React.NamedExoticComponent<UpdateSettingsProps> = m
                 'border border-surface-border',
               )}
             >
-              <CheckCircle className={cn(iconTokens.size.sm, 'text-green-500')} />
+              <CheckCircle className={cn(iconTokens.size.sm, 'text-status-success')} />
               <span className="body-small text-text-secondary">
                 {t('updates.upToDate', "You're up to date!")}
               </span>
@@ -423,7 +423,7 @@ export const UpdateSettings: React.NamedExoticComponent<UpdateSettingsProps> = m
                   'bg-surface-base',
                   radius.default,
                   'border border-surface-border hover:bg-surface-hover transition-colors',
-                  'text-orange-500',
+                  'text-status-warning',
                 )}
               >
                 <span className="body-small">

--- a/ui/src/components/settings/sections/UsersSettings.tsx
+++ b/ui/src/components/settings/sections/UsersSettings.tsx
@@ -176,7 +176,7 @@ export function UsersSettings(): React.ReactElement {
         <p className="text-sm text-text-secondary">{t('settings:users.description')}</p>
 
         {isAdmin && !canCreate && (
-          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm text-amber-200">
+          <div className="rounded-lg border border-status-warning/30 bg-status-warning/5 p-3 text-sm text-status-warning">
             {t('errors:users.featureRequired')} <strong>{tierLabel}</strong>
           </div>
         )}

--- a/ui/src/components/survey/AirMapperImport.tsx
+++ b/ui/src/components/survey/AirMapperImport.tsx
@@ -330,18 +330,18 @@ export function AirMapperImport({ onImport, onCancel }: AirMapperImportProps): R
           {/* Location counts */}
           <div className={cn(layout.inline.default, spacing.margin.top.content, 'flex-wrap')}>
             <div className={cn(layout.inline.default, 'caption')}>
-              <MapPin className="w-3 h-3 text-green-500" />
+              <MapPin className="w-3 h-3 text-cat-4" />
               <span>{summary.apCount} APs</span>
             </div>
             <div className={cn(layout.inline.default, 'caption')}>
-              <Users className="w-3 h-3 text-blue-500" />
+              <Users className="w-3 h-3 text-cat-1" />
               <span>
                 {summary.clientCount} {t('import.clients')}
               </span>
             </div>
             {summary.hasBothModes ? (
               <div className={cn(layout.inline.default, 'caption')}>
-                <Radio className="w-3 h-3 text-purple-500" />
+                <Radio className="w-3 h-3 text-cat-6" />
                 <span>{t('import.passiveAndActive')}</span>
               </div>
             ) : null}

--- a/ui/src/components/survey/SurveyConfigPanel.tsx
+++ b/ui/src/components/survey/SurveyConfigPanel.tsx
@@ -50,9 +50,9 @@ const CHANNELS: Record<WiFiBand, number[]> = {
 
 /** Band display info */
 const BAND_INFO: Record<WiFiBand, { label: string; color: string }> = {
-  '2.4': { label: '2.4 GHz', color: 'bg-blue-500' },
-  '5': { label: '5 GHz', color: 'bg-green-500' },
-  '6': { label: '6 GHz', color: 'bg-purple-500' },
+  '2.4': { label: '2.4 GHz', color: 'bg-cat-1' },
+  '5': { label: '5 GHz', color: 'bg-cat-4' },
+  '6': { label: '6 GHz', color: 'bg-cat-6' },
 };
 
 function getBandInfo(band: WiFiBand): { label: string; color: string } {

--- a/ui/src/components/ui/InputModal.tsx
+++ b/ui/src/components/ui/InputModal.tsx
@@ -68,7 +68,7 @@ export const InputModal: FC<InputModalProps> = ({
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+          className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
         />
         <div className="flex justify-end gap-default pt-2">
           <Button variant="outline" onClick={onCancel}>

--- a/ui/src/hooks/useLogs.ts
+++ b/ui/src/hooks/useLogs.ts
@@ -292,28 +292,28 @@ export function useLogs({
  */
 export const LOG_LEVEL_COLORS = {
   ERROR: {
-    bg: 'bg-red-50 dark:bg-red-950',
-    text: 'text-red-700 dark:text-red-300',
+    bg: 'bg-log-error-bg',
+    text: 'text-log-error-fg',
     badge: 'bg-status-error text-text-inverse',
     border: 'border-l-4 border-status-error',
   },
   WARN: {
-    bg: 'bg-yellow-50 dark:bg-yellow-950',
-    text: 'text-yellow-700 dark:text-yellow-300',
+    bg: 'bg-log-warn-bg',
+    text: 'text-log-warn-fg',
     badge: 'bg-status-warning text-text-inverse',
     border: 'border-l-4 border-status-warning',
   },
   INFO: {
-    bg: 'bg-blue-50 dark:bg-blue-950',
-    text: 'text-blue-700 dark:text-blue-300',
+    bg: 'bg-log-info-bg',
+    text: 'text-log-info-fg',
     badge: 'bg-status-info text-text-inverse',
     border: 'border-l-4 border-status-info',
   },
   DEBUG: {
-    bg: 'bg-surface-secondary dark:bg-dark-surface-secondary',
-    text: 'text-content-secondary dark:text-dark-content-secondary',
-    badge: 'bg-surface-tertiary text-text-inverse',
-    border: 'border-l-4 border-border',
+    bg: 'bg-log-debug-bg',
+    text: 'text-log-debug-fg',
+    badge: 'bg-surface-sunken text-text-primary',
+    border: 'border-l-4 border-surface-border',
   },
 } as const;
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -97,6 +97,7 @@
    * same hue in both). Replaces hardcoded text-zinc-900 / text-white. */
   --color-on-brand: var(--color-on-brand);
   --color-on-danger: var(--color-on-danger);
+  --color-on-info: var(--color-on-info);
 
   /* Categorical data-viz palette — a fixed qualitative set for "N distinct
    * categories" (discovery methods, timing phases, device types, progress
@@ -203,6 +204,7 @@
   /* On-color foregrounds — constant across modes (no .dark override). */
   --color-on-brand: #18181b; /* zinc-900 — AA on brand/success fills */
   --color-on-danger: #ffffff; /* white — AA on status-error fills */
+  --color-on-info: #ffffff; /* white — AA on status-info fills */
 
   /* Categorical data-viz palette — LIGHT (≈600 weight, AA on warm cream). */
   --color-cat-1: #2563eb; /* blue */

--- a/ui/src/pages/PathAnalysisPage.tsx
+++ b/ui/src/pages/PathAnalysisPage.tsx
@@ -30,7 +30,7 @@ export function PathAnalysisPage() {
             description="L2/L3 path discovery, traceroute hops, and on-link device discovery."
             iconColorClass="text-module-roots"
           />
-          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 pad text-sm text-amber-200">
+          <div className="rounded-lg border border-status-warning/30 bg-status-warning/5 pad text-sm text-status-warning">
             Path Analysis is a Pro-tier feature. Start a 14-day Pro trial with
             <code className="mx-1 px-1 rounded bg-surface-raised">seed license trial</code>
             or activate a Pro key with

--- a/ui/src/pages/ReportsPage.tsx
+++ b/ui/src/pages/ReportsPage.tsx
@@ -18,7 +18,7 @@ export function ReportsPage() {
             description="Aggregated SLA dashboard, compliance tracking, and historical reporting."
             iconColorClass="text-module-harvest"
           />
-          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 pad text-sm text-amber-200">
+          <div className="rounded-lg border border-status-warning/30 bg-status-warning/5 pad text-sm text-status-warning">
             Reports require the Starter tier or higher. Start a 14-day Pro trial with
             <code className="mx-1 px-1 rounded bg-surface-raised">seed license trial</code>
             or activate a Starter / Pro key with


### PR DESCRIPTION
## Summary

PR 3/6. Replaces the remaining raw Tailwind palette in **component code** with the token system established in #1246 / #1247. After this, the only raw palette left in components is `CableCard`'s T568B wire colors (a physical domain palette — PR 5).

- **`UpdateSettings`**: error/success banners, text, and icons → `status-*`; the Download/Apply actions (shown in mutually-exclusive states) → status fills with AA-safe on-color text (`text-on-brand` / new `text-on-info`).
- **`useLogs` `LOG_LEVEL_COLORS`**: ERROR/WARN/INFO/DEBUG row bg+text → the `--color-log-*-bg/-fg` pairs. Also **repairs DEBUG**, which referenced undefined legacy tokens (`surface-secondary`, `content-secondary`, …) and was rendering wrong.
- **Tier-gate warning banners** (ReportsPage, PathAnalysisPage, Users/Sso/Interfaces/ApiTokens settings): amber → `status-warning`.
- **Categorical**: Wi-Fi bands (`SurveyConfigPanel`), AirMapper summary icons, LogViewer component badge → `--color-cat-*`.
- **`InputModal`**: `placeholder-gray-500` → `placeholder:text-text-muted`.
- Adds **`--color-on-info`** (white, AA on `status-info` fills), parallel to `on-brand`/`on-danger`.

## ⚠️ Visible changes to eyeball
- The **"Apply Update & Restart"** action shifts **blue → green** (it's a success/go action; white-on-blue was preserved via `on-info` for the info status elsewhere). The Download action stays green.
- **Tier-gate banners** now use mustard (`status-warning`) instead of amber, and are now theme-correct (the old `text-amber-200` only worked on dark).

## Test plan
- [x] `biome check src/` — clean (321 files)
- [x] `tsc --noEmit` — passes
- [x] `vitest` — 117/117 pass
- [x] `vite build` — succeeds; `log-*`/`cat`/`on-info` utilities emit
- [x] grep: **zero** raw palette left in components (excl. `CableCard` domain colors)
- [ ] Reviewer: Settings → Updates (banners + buttons), Logs viewer (level rows + badges), tier-gate banners, both themes

Net −39 / +35. Next: PR 4 points the canvas/PDF renderers at `tokens.ts` and fixes the stale `#056839` brand green.