### PR TITLE
fix(ui): stale brand green in canvas/PDF; wire canvas markers to tokens (PR 4/6)

### DIFF
--- a/ui/src/components/survey/FloorPlanCanvas.tsx
+++ b/ui/src/components/survey/FloorPlanCanvas.tsx
@@ -49,6 +49,7 @@ import type {
 type SampleData = PassiveSample | ActiveSample | ThroughputSample;
 
 import { cn, radius } from '../../styles/theme';
+import { readTokens } from '../../styles/tokens';
 
 export interface CalibrationPoint {
   x: number;
@@ -173,6 +174,14 @@ export function FloorPlanCanvas({
       }
       ctx.drawImage(img, 0, 0, dimensions.width, dimensions.height);
 
+      // Resolve theme colors for the marker/affordance fills. Canvas needs
+      // string color values, so we read the live CSS variables via tokens.ts
+      // (this is the supported way to use design tokens on a canvas). The
+      // white/black strokes and the orange calibration markers below stay
+      // fixed on purpose — they guarantee contrast over arbitrary floor-plan
+      // imagery regardless of the active theme.
+      const tone = readTokens(['brandPrimary', 'cat6', 'onBrand']);
+
       // Calculate scale factor
       const scaleX = dimensions.width / floorPlan.width;
       const scaleY = dimensions.height / floorPlan.height;
@@ -194,7 +203,7 @@ export function FloorPlanCanvas({
 
         // Draw signal rings for selected AP
         if (isSelected) {
-          ctx.strokeStyle = 'rgba(34, 197, 94, 0.3)'; // green-500 with opacity
+          ctx.strokeStyle = `${tone.brandPrimary}4d`; // brand green @ 30%
           ctx.lineWidth = 2;
           for (const r of [20, 35, 50]) {
             ctx.beginPath();
@@ -210,10 +219,10 @@ export function FloorPlanCanvas({
         ctx.lineTo(8, 6);
         ctx.closePath();
         ctx.fillStyle = isSelected
-          ? 'rgba(34, 197, 94, 0.9)' // green-500
-          : 'rgba(168, 85, 247, 0.9)'; // purple-500
+          ? `${tone.brandPrimary}e6` // brand green @ 90%
+          : `${tone.cat6}e6`; // data-viz purple @ 90%
         ctx.fill();
-        ctx.strokeStyle = '#ffffff';
+        ctx.strokeStyle = '#ffffff'; // fixed white outline for contrast over imagery
         ctx.lineWidth = 2;
         ctx.stroke();
 
@@ -221,14 +230,14 @@ export function FloorPlanCanvas({
         ctx.beginPath();
         ctx.moveTo(0, -12);
         ctx.lineTo(0, -18);
-        ctx.strokeStyle = isSelected ? '#22c55e' : '#a855f7';
+        ctx.strokeStyle = isSelected ? tone.brandPrimary : tone.cat6;
         ctx.lineWidth = 2;
         ctx.stroke();
 
         // Draw antenna top
         ctx.beginPath();
         ctx.arc(0, -18, 3, 0, 2 * Math.PI);
-        ctx.fillStyle = isSelected ? '#22c55e' : '#a855f7';
+        ctx.fillStyle = isSelected ? tone.brandPrimary : tone.cat6;
         ctx.fill();
 
         ctx.restore();
@@ -251,23 +260,22 @@ export function FloorPlanCanvas({
         const x = sample.x * scaleX;
         const y = sample.y * scaleY;
 
-        // Draw point
-        // Note: Canvas API requires direct color values - CSS variables don't work
-        // These colors are intentionally hardcoded for Canvas compatibility
-        // See: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillStyle
+        // Draw point. The dot fill comes from the brand token (read above);
+        // over a heatmap it's white for legibility. The white stroke is a
+        // fixed contrast outline (see note where `tone` is read).
         ctx.beginPath();
         ctx.arc(x, y, 8, 0, 2 * Math.PI);
         ctx.fillStyle = heatmapMetric
           ? 'rgba(255, 255, 255, 0.8)' // white for visibility on heatmap
-          : 'rgba(5, 104, 57, 0.8)'; // brand-primary green (#056839 at 80% opacity)
+          : `${tone.brandPrimary}cc`; // brand green @ 80%
         ctx.fill();
         ctx.strokeStyle = 'rgba(255, 255, 255, 1)'; // white border for visibility
         ctx.lineWidth = 2;
         ctx.stroke();
 
-        // Draw point number - high contrast text for visibility
-        // Canvas API limitation: must use direct color values
-        ctx.fillStyle = heatmapMetric ? '#1e293b' : '#f8fafc'; // slate-800 / slate-50
+        // Point number — on-brand dark reads cleanly on both the white heatmap
+        // dot and the brand-green dot (AA in both cases).
+        ctx.fillStyle = tone.onBrand;
         ctx.font = 'bold 10px sans-serif';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';

--- a/ui/src/utils/reportRenderer.ts
+++ b/ui/src/utils/reportRenderer.ts
@@ -24,7 +24,16 @@ import type { SurveyReport } from './reportGenerator';
 /** Translation function type */
 type TranslateFunction = (key: string, options?: Record<string, unknown>) => string;
 
-/** Report style configuration */
+/**
+ * Report style configuration.
+ *
+ * This is a self-contained print stylesheet for an exported HTML/PDF document,
+ * which is ALWAYS light (printed on white) and independent of the app's theme.
+ * Its palette is therefore an intentional fixed light palette rather than the
+ * app's CSS theme variables — this file is allowlisted from the design-token
+ * lint rule. The only value that must track the brand is the seed green
+ * (#2d7a3e = canonical seed-600, the strong green for light surfaces).
+ */
 const REPORT_STYLES = `
   @page {
     size: A4;
@@ -66,7 +75,7 @@ const REPORT_STYLES = `
 
   .report-header {
     text-align: center;
-    border-bottom: 2px solid #056839; /* brand-primary green */
+    border-bottom: 2px solid #2d7a3e; /* canonical seed-600 brand green */
     padding-bottom: 20px;
     margin-bottom: 30px;
   }
@@ -108,7 +117,7 @@ const REPORT_STYLES = `
     display: inline-block;
     width: 24px;
     height: 24px;
-    background: #056839; /* brand-primary green */
+    background: #2d7a3e; /* canonical seed-600 brand green */
     color: white;
     border-radius: 50%;
     text-align: center;


### PR DESCRIPTION
## Summary

PR 4/6. Fixes a **stale brand color** and tokenizes the canvas affordance colors. The survey floor-plan canvas and the exported HTML/PDF report both carried `#056839` — the *pre-2026-05-22* dark brand green. Both files are intentionally fixed-palette renderers (canvas draws over arbitrary user imagery; the report is an always-light print document) and are allowlisted from the token rule — but the brand value still has to be canonical.

- **`FloorPlanCanvas`**: AP markers (selected → `brandPrimary`, unselected → `cat-6`), signal rings, and survey sample points now read the **live design tokens via `styles/tokens.ts`** — the supported way to use tokens on a `<canvas>` (`getComputedStyle` of the CSS vars). Sample-point numbers use `on-brand` dark, which is AA on both the white heatmap dot and the brand-green dot. Corrected the inaccurate "CSS variables don't work in canvas" comment. White strokes + the orange calibration markers stay fixed on purpose (contrast over arbitrary floor-plan images).
- **`reportRenderer`**: the two `#056839` → `#2d7a3e` (canonical seed-600, AA for the header bar's white text). Documented the report as an intentional fixed **light print palette** (allowlisted); its grays/status colors are a print stylesheet, not app theme colors — deliberately *not* wired to live theme vars (a report must stay light even if the app is in dark mode).

This is the first real consumer of the `styles/tokens.ts` reader added in #1246.

## Test plan
- [x] `biome check src/` — clean
- [x] `tsc --noEmit` — passes
- [x] `vitest` — 117/117 pass
- [x] `vite build` — succeeds
- [x] grep: no `#056839` / `rgba(5,104,57,…)` left in `src`
- [ ] Reviewer: spot-check a survey floor plan (AP markers, sample points, calibration) in both themes, and export a report (header bar green)

Net +34 / −17. Next: PR 5 — typography `<h*>`→`.heading-*`, the `cableWire` domain map, hand-rolled card swaps, z-scale.