### PR TITLE
refactor(ui): isolate T568B wire palette + tokenize stray headings/z-index (PR 5/6)

### DIFF
--- a/ui/src/components/cards/CableCard.tsx
+++ b/ui/src/components/cards/CableCard.tsx
@@ -41,6 +41,7 @@ import type { UnitSystem } from '../../types/settings';
 import { CardDivider, CardRow, CardValue, type Status } from '../ui/card';
 import { Cable } from '../ui/icons';
 import { SimpleBaseCard } from './BaseCard';
+import { wireColorMap } from './cableWire';
 
 /** Per-pair TDR test result */
 interface CablePairResult {
@@ -87,18 +88,6 @@ const statusMap: Record<string, Status> = {
   crosstalk: 'warning',
   splitPair: 'warning',
   unknown: 'unknown',
-};
-
-// Wire color to CSS class mapping for visual display (keys are lowercase for lookup)
-const wireColorMap: Record<string, string> = {
-  'white/orange': 'bg-orange-100 border-orange-400',
-  orange: 'bg-orange-500',
-  'white/green': 'bg-green-100 border-green-400',
-  green: 'bg-green-500',
-  'white/blue': 'bg-blue-100 border-blue-400',
-  blue: 'bg-blue-500',
-  'white/brown': 'bg-amber-100 border-amber-600',
-  brown: 'bg-amber-700',
 };
 
 function getCardStatus(data: CableData | null): Status {

--- a/ui/src/components/cards/SlaDashboardCard.tsx
+++ b/ui/src/components/cards/SlaDashboardCard.tsx
@@ -364,7 +364,7 @@ export const SLADashboardCard: React.NamedExoticComponent<SLADashboardCardProps>
             <div className="grid grid-cols-2 gap-comfortable">
               {data.alerts ? (
                 <div>
-                  <h4 className="text-xs text-text-muted mb-2">
+                  <h4 className="caption mb-2">
                     {t('slaDashboard.activeAlerts', 'Active Alerts')}
                   </h4>
                   <div className="flex items-center gap-compact">
@@ -391,9 +391,7 @@ export const SLADashboardCard: React.NamedExoticComponent<SLADashboardCardProps>
               ) : null}
 
               <div>
-                <h4 className="text-xs text-text-muted mb-2">
-                  {t('slaDashboard.anomalies', 'Anomalies')}
-                </h4>
+                <h4 className="caption mb-2">{t('slaDashboard.anomalies', 'Anomalies')}</h4>
                 <div className="flex items-center gap-compact">
                   <span
                     className={cn(

--- a/ui/src/components/cards/cableWire.ts
+++ b/ui/src/components/cards/cableWire.ts
@@ -1,0 +1,23 @@
+/**
+ * T568A/B Ethernet wire-pair colors — a DOMAIN palette, not UI theme colors.
+ *
+ * These deliberately use raw Tailwind palette classes because each value
+ * represents the PHYSICAL insulation color of a conductor in an 8P8C cable: a
+ * green wire must render green, a blue wire blue, a brown wire brown, etc.
+ * Mapping them onto the brand/semantic tokens would be wrong (it would, e.g.,
+ * turn the blue pair green). They are therefore intentionally exempt from the
+ * design-token rule, and this file is allowlisted from the raw-palette lint
+ * check. Keep it limited to literal wire colors.
+ *
+ * Keys are lowercased pair labels for case-insensitive lookup.
+ */
+export const wireColorMap: Record<string, string> = {
+  'white/orange': 'bg-orange-100 border-orange-400',
+  orange: 'bg-orange-500',
+  'white/green': 'bg-green-100 border-green-400',
+  green: 'bg-green-500',
+  'white/blue': 'bg-blue-100 border-blue-400',
+  blue: 'bg-blue-500',
+  'white/brown': 'bg-amber-100 border-amber-600',
+  brown: 'bg-amber-700',
+};

--- a/ui/src/components/ui/CommandPalette.tsx
+++ b/ui/src/components/ui/CommandPalette.tsx
@@ -82,7 +82,7 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
       open={open}
       onOpenChange={onOpenChange}
       label="Command palette"
-      className="fixed inset-0 z-[60] flex items-start justify-center pt-[10vh]"
+      className="fixed inset-0 z-overlay flex items-start justify-center pt-[10vh]"
       shouldFilter={true}
     >
       <button

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -312,7 +312,7 @@ const SidebarBody: FC<SidebarBodyProps> = ({
         {groups.map((group, groupIndex) => (
           <div key={group.label || `nav-group-${String(groupIndex)}`}>
             {!collapsed && group.label ? (
-              <h3 className="px-3 mb-2 text-xs font-semibold text-text-muted uppercase tracking-wider">
+              <h3 className="section-title font-semibold px-3 mb-2">
                 {translateLabel(group.label)}
               </h3>
             ) : null}


### PR DESCRIPTION
## Summary

PR 5/6 — final consolidation cleanup. **Scope shrank after inspecting the code**: most "raw headings" were false positives (already on `heading-*`/`body-*`/`caption` tokens — they only matched because `text-text-primary` contains `text-`), and the "hand-rolled cards" were **not** `<Card>` candidates (`<Card>` is a purpose-built status card requiring `title`/`status` and rendering a badge header, not a generic container — confirming the earlier "cards are ~97% componentized" finding).

- **`cableWire.ts`** (new): extract CableCard's wire-color map to a dedicated, documented module. These are **physical T568B insulation colors** (a green wire must render green), so they stay raw Tailwind palette *by design*. Isolating them lets PR 6's lint guard allowlist this one file while keeping `CableCard.tsx` itself fully checked. `CableCard.tsx` is now palette-free.
- **`Sidebar`** nav-group label → `section-title` (canonical uppercase label token), keeping its semibold weight.
- **`SlaDashboardCard`** two small chart headings → `caption`.
- **`CommandPalette`** `z-[60]` → `z-overlay` (the named z utility from #1246). The Sidebar skip-link keeps `focus:z-[100]` — a focus-variant can't reference a component-layer custom class, and it's not palette/hex so the guard ignores it.

Headings that don't map cleanly to a tier (e.g. `DiscoveryModalDeviceRow`'s `text-xs font-semibold`) were intentionally left rather than force-fit.

## Test plan
- [x] `biome check src/` — clean (322 files)
- [x] `tsc --noEmit` — passes
- [x] `vitest` — 117/117 pass
- [x] `vite build` — succeeds
- [x] grep: `CableCard.tsx` palette-free; wire colors isolated in `cableWire.ts`
- [ ] Reviewer: sidebar group labels, SLA card headings, command palette (⌘K) layering, cable card pinout colors

Net small (−18/+28 incl. the new file). Next: PR 6 — the Biome lint guard (warn-only) blocking raw palette/hex, with `tokens.ts`, `reportRenderer.ts`, `FloorPlanCanvas.tsx`, and `cableWire.ts` on the allowlist.