### PR TITLE
refactor(ui): a11y brand-fill text + tokenize inset shadow + guard rgb/hsl

### DIFF
--- a/scripts/check-token-discipline.sh
+++ b/scripts/check-token-discipline.sh
@@ -44,7 +44,7 @@ else
 fi
 
 # Definition sites, tests, and the documented fixed-palette exceptions.
-EXCLUDE_RE='\.(test|spec|stories|mock)\.(ts|tsx):|/styles/|/constants/|/cableWire\.ts:|/reportRenderer\.ts:|/FloorPlanCanvas\.tsx:|/logger\.ts:'
+EXCLUDE_RE='\.(test|spec|stories|mock)\.(ts|tsx):|/styles/|/constants/|/cableWire\.ts:|/reportRenderer\.ts:|/FloorPlanCanvas\.tsx:|/HeatmapLegend\.tsx:|/logger\.ts:'
 
 FAIL_COUNT=0
 
@@ -89,6 +89,9 @@ block ARBITRARY_COLOR_VAR \
 block RAW_HEX_COLOR \
   '#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?\b' \
   'Use a CSS theme variable; for <canvas>/PDF read it via styles/tokens.ts'
+block RGB_HSL_COLOR \
+  '\b(rgba?|hsla?)\([0-9]' \
+  'Use a CSS theme variable; for white/black overlays use color-mix(var(--color-knob|scrim))'
 
 # ── ADVISORY: spacing / typography / flex (warn-only) ───────────────────────
 advise RAW_SPACE_Y '(?<![-\w])space-y-(1|2|3|4|6)(?![-\w])' 'Use stack-xs/sm/[default]/lg/xl'

--- a/ui/src/app/LoginForm.tsx
+++ b/ui/src/app/LoginForm.tsx
@@ -313,7 +313,7 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
             className={cn(
               'w-full',
               button.size.md,
-              'bg-brand-primary text-text-inverse',
+              'bg-brand-primary text-on-brand',
               radius.md,
               'font-medium hover:bg-brand-accent focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2 focus:ring-offset-surface-base disabled:opacity-50',
             )}

--- a/ui/src/components/ErrorBoundary.tsx
+++ b/ui/src/components/ErrorBoundary.tsx
@@ -126,7 +126,7 @@ export class ErrorBoundary extends Component<Props, State> {
                   onClick={this.handleRetry}
                   className={cn(
                     button.size.md,
-                    'bg-brand-primary text-text-inverse',
+                    'bg-brand-primary text-on-brand',
                     radius.md,
                     'hover:bg-brand-accent focus:outline-none focus:ring-2 focus:ring-brand-primary',
                   )}

--- a/ui/src/components/cards/DiscoveryModal.tsx
+++ b/ui/src/components/cards/DiscoveryModal.tsx
@@ -438,7 +438,7 @@ export function DiscoveryModal({
                 radius.md,
                 'transition-colors',
                 showLocalOnly
-                  ? 'bg-brand-primary text-text-inverse'
+                  ? 'bg-brand-primary text-on-brand'
                   : 'bg-surface-hover text-text-secondary hover:text-text-primary',
               )}
             >

--- a/ui/src/components/cards/GuestNetworkAuditCard.tsx
+++ b/ui/src/components/cards/GuestNetworkAuditCard.tsx
@@ -80,7 +80,7 @@ export function GuestNetworkAuditCard(): JSX.Element | null {
               disabled={running}
               className={cn(
                 button.size.md,
-                'bg-brand-primary text-text-inverse',
+                'bg-brand-primary text-on-brand',
                 radius.md,
                 'font-medium hover:bg-brand-primary/90 disabled:opacity-50 disabled:cursor-not-allowed',
               )}

--- a/ui/src/components/cards/LogViewerModal.tsx
+++ b/ui/src/components/cards/LogViewerModal.tsx
@@ -64,7 +64,7 @@ function FilterBadge({ label, active, onClick, color }: FilterBadgeProps): React
         radius.md,
         'text-sm font-medium cursor-pointer transition-all',
         active
-          ? color || 'bg-brand-primary text-text-inverse'
+          ? color || 'bg-brand-primary text-on-brand'
           : 'bg-surface-base text-text-secondary hover:bg-surface-hover',
       )}
       onClick={onClick}

--- a/ui/src/components/cards/NetworkDiscoveryCard.tsx
+++ b/ui/src/components/cards/NetworkDiscoveryCard.tsx
@@ -117,7 +117,7 @@ export const NetworkDiscoveryCard: React.NamedExoticComponent<NetworkDiscoveryCa
                 spacing.margin.top.heading,
                 'w-full',
                 button.size.md,
-                'bg-brand-primary text-text-inverse',
+                'bg-brand-primary text-on-brand',
                 radius.md,
                 'hover:bg-brand-primary/90 transition-colors font-medium body-small',
               )}
@@ -198,7 +198,7 @@ export const NetworkDiscoveryCard: React.NamedExoticComponent<NetworkDiscoveryCa
                 disabled={status.scanning || isPipelineRunning}
                 className={cn(
                   spacing.chip.sm,
-                  'bg-brand-primary text-text-inverse',
+                  'bg-brand-primary text-on-brand',
                   radius.md,
                   'hover:bg-brand-primary/90 transition-colors font-medium caption disabled:opacity-50 disabled:cursor-not-allowed flex items-center',
                   spacing.inline.sm,

--- a/ui/src/components/cards/PipelineProgress.tsx
+++ b/ui/src/components/cards/PipelineProgress.tsx
@@ -191,7 +191,7 @@ export const PipelineProgress: React.NamedExoticComponent<PipelineProgressProps>
                     'flex-center w-8 h-8',
                     radius.full,
                     isComplete && 'bg-status-success text-text-inverse',
-                    isCurrent && 'bg-brand-primary text-text-inverse',
+                    isCurrent && 'bg-brand-primary text-on-brand',
                     isPending && 'bg-surface-sunken text-text-muted',
                   )}
                 >

--- a/ui/src/components/cards/WiFiChannelGraph.tsx
+++ b/ui/src/components/cards/WiFiChannelGraph.tsx
@@ -431,7 +431,7 @@ export function WifiChannelGraph({
                     'rounded',
                     'transition-colors',
                     selectedBand === band
-                      ? 'bg-brand-primary text-text-inverse'
+                      ? 'bg-brand-primary text-on-brand'
                       : 'bg-surface-hover text-text-primary hover:bg-surface-border',
                   )}
                 >

--- a/ui/src/components/cards/WiFiSurveyCard.tsx
+++ b/ui/src/components/cards/WiFiSurveyCard.tsx
@@ -468,7 +468,7 @@ function CreateSurveyDialog({
               className={cn(
                 'flex-1',
                 button.size.md,
-                'bg-brand-primary text-text-inverse',
+                'bg-brand-primary text-on-brand',
                 radius.md,
                 'hover:bg-brand-primary/90',
               )}

--- a/ui/src/components/login/RecoveryForm.tsx
+++ b/ui/src/components/login/RecoveryForm.tsx
@@ -389,7 +389,7 @@ export function RecoveryForm({
             className={cn(
               'w-full',
               button.size.md,
-              'bg-brand-primary text-text-inverse',
+              'bg-brand-primary text-on-brand',
               radius.md,
               'font-medium hover:bg-brand-accent',
               'focus:outline-none focus:ring-2 focus:ring-brand-primary',

--- a/ui/src/components/profiles/ProfileEditor.tsx
+++ b/ui/src/components/profiles/ProfileEditor.tsx
@@ -210,7 +210,7 @@ export function ProfileEditor({
                 spacing.pad.sm,
                 'px-4',
                 radius.md,
-                'bg-brand-primary hover:bg-brand-primary-hover text-text-inverse body-small font-medium disabled:opacity-50',
+                'bg-brand-primary hover:bg-brand-primary-hover text-on-brand body-small font-medium disabled:opacity-50',
               )}
             >
               {getButtonLabel()}

--- a/ui/src/components/profiles/ProfileManagement.tsx
+++ b/ui/src/components/profiles/ProfileManagement.tsx
@@ -213,7 +213,7 @@ export function ProfileManagement({ onClose }: ProfileManagementProps): React.Re
                 spacing.pad.sm,
                 'px-4',
                 radius.md,
-                'bg-brand-primary hover:bg-brand-primary-hover text-text-inverse body-small font-medium flex items-center gap-compact',
+                'bg-brand-primary hover:bg-brand-primary-hover text-on-brand body-small font-medium flex items-center gap-compact',
               )}
             >
               <svg
@@ -353,7 +353,7 @@ export function ProfileManagement({ onClose }: ProfileManagementProps): React.Re
                       spacing.pad.sm,
                       'px-4',
                       radius.md,
-                      'bg-brand-primary hover:bg-brand-primary-hover text-text-inverse body-small font-medium',
+                      'bg-brand-primary hover:bg-brand-primary-hover text-on-brand body-small font-medium',
                     )}
                   >
                     {t('profile.createFirst', 'Create Your First Profile')}
@@ -562,7 +562,7 @@ function ProfileCard({
               className={cn(
                 spacing.chip.sm,
                 radius.md,
-                'bg-brand-primary hover:bg-brand-primary-hover text-text-inverse caption font-medium flex items-center gap-1.5 ml-auto',
+                'bg-brand-primary hover:bg-brand-primary-hover text-on-brand caption font-medium flex items-center gap-1.5 ml-auto',
               )}
               title={t('profile.activate', 'Activate')}
             >

--- a/ui/src/components/settings/SettingsDrawerNetworkSection.tsx
+++ b/ui/src/components/settings/SettingsDrawerNetworkSection.tsx
@@ -76,7 +76,7 @@ export function SettingsDrawerNetworkSection({
               radius.md,
               'body-small font-medium transition-colors',
               ipSettings.mode === 'dhcp'
-                ? 'bg-brand-primary text-text-inverse'
+                ? 'bg-brand-primary text-on-brand'
                 : 'bg-surface-base border border-surface-border text-text-primary hover:bg-surface-hover',
             )}
           >
@@ -90,7 +90,7 @@ export function SettingsDrawerNetworkSection({
               radius.md,
               'body-small font-medium transition-colors',
               ipSettings.mode === 'static'
-                ? 'bg-brand-primary text-text-inverse'
+                ? 'bg-brand-primary text-on-brand'
                 : 'bg-surface-base border border-surface-border text-text-primary hover:bg-surface-hover',
             )}
           >
@@ -217,7 +217,7 @@ export function SettingsDrawerNetworkSection({
           className={cn(
             'w-full',
             button.size.md,
-            'bg-brand-primary text-text-inverse',
+            'bg-brand-primary text-on-brand',
             radius.md,
             'font-medium hover:bg-brand-accent disabled:opacity-50 transition-colors',
           )}

--- a/ui/src/components/settings/sections/ConfigBackupsSection.tsx
+++ b/ui/src/components/settings/sections/ConfigBackupsSection.tsx
@@ -323,7 +323,7 @@ export const ConfigBackupsSection: React.NamedExoticComponent<Record<string, nev
             className={cn(
               'w-full',
               button.size.md,
-              'bg-brand-primary text-text-inverse',
+              'bg-brand-primary text-on-brand',
               radius.md,
               'font-medium hover:bg-brand-primary-hover transition-colors flex-center',
               spacing.gap.compact,

--- a/ui/src/components/settings/sections/MtuControl.tsx
+++ b/ui/src/components/settings/sections/MtuControl.tsx
@@ -97,7 +97,7 @@ export const MtuControl: React.NamedExoticComponent<Record<string, never>> = mem
             disabled={loading}
             className={cn(
               button.size.md,
-              'bg-brand-primary text-text-inverse',
+              'bg-brand-primary text-on-brand',
               radius.md,
               'body-small font-medium hover:bg-brand-accent disabled:opacity-50',
             )}

--- a/ui/src/components/settings/sections/PerformanceSettings.tsx
+++ b/ui/src/components/settings/sections/PerformanceSettings.tsx
@@ -472,7 +472,7 @@ export const PerformanceSettings: React.NamedExoticComponent<PerformanceSettings
                           radius.full,
                           'border body-small font-medium transition-colors',
                           checked
-                            ? 'bg-brand-primary text-text-inverse border-brand-primary'
+                            ? 'bg-brand-primary text-on-brand border-brand-primary'
                             : 'bg-surface-base border-surface-border text-text-primary hover:bg-surface-hover',
                         )}
                       >
@@ -523,7 +523,7 @@ export const PerformanceSettings: React.NamedExoticComponent<PerformanceSettings
                           radius.full,
                           'border body-small font-medium transition-colors',
                           checked
-                            ? 'bg-brand-primary text-text-inverse border-brand-primary'
+                            ? 'bg-brand-primary text-on-brand border-brand-primary'
                             : 'bg-surface-base border-surface-border text-text-primary hover:bg-surface-hover',
                         )}
                       >

--- a/ui/src/components/settings/sections/VlanControl.tsx
+++ b/ui/src/components/settings/sections/VlanControl.tsx
@@ -101,7 +101,7 @@ export const VlanControl: React.NamedExoticComponent<Record<string, never>> = me
             disabled={loading || !vlanId}
             className={cn(
               button.size.sm,
-              'bg-brand-primary text-text-inverse',
+              'bg-brand-primary text-on-brand',
               radius.md,
               'body-small font-medium hover:bg-brand-accent disabled:opacity-50',
             )}

--- a/ui/src/components/settings/sections/WiFiSettings.tsx
+++ b/ui/src/components/settings/sections/WiFiSettings.tsx
@@ -450,7 +450,7 @@ export const WiFiSettings: React.NamedExoticComponent<WiFiSettingsProps> = memo(
                         'body-small font-medium',
                         spacing.chip.lg,
                         radius.default,
-                        'bg-brand-primary text-text-inverse',
+                        'bg-brand-primary text-on-brand',
                         'hover:bg-brand-accent disabled:opacity-50',
                       )}
                     >

--- a/ui/src/components/settings/sections/discovery/SubnetManager.tsx
+++ b/ui/src/components/settings/sections/discovery/SubnetManager.tsx
@@ -134,7 +134,7 @@ export const SubnetManager: React.NamedExoticComponent<SubnetManagerProps> = mem
             className={cn(
               'w-full',
               spacing.pad.sm,
-              'bg-brand-primary hover:bg-brand-accent text-text-inverse',
+              'bg-brand-primary hover:bg-brand-accent text-on-brand',
               radius.default,
               'body-small',
             )}

--- a/ui/src/components/setup/SetupWizard.tsx
+++ b/ui/src/components/setup/SetupWizard.tsx
@@ -233,7 +233,7 @@ export function SetupWizard({
     <div className={cn('min-h-screen bg-surface-base', layout.flex.center, 'pad')}>
       <div className="w-full max-w-md">
         <div className={cn('text-center', spacing.margin.bottom.sectionLg)}>
-          <div className="w-16 h-16 mx-auto flex-center rounded-2xl bg-brand-primary text-text-inverse">
+          <div className="w-16 h-16 mx-auto flex-center rounded-2xl bg-brand-primary text-on-brand">
             <Activity className="w-8 h-8" />
           </div>
           <h1 className={cn('heading-2', spacing.margin.top.heading)}>{t('welcome.title')}</h1>

--- a/ui/src/components/survey/AirMapperImport.tsx
+++ b/ui/src/components/survey/AirMapperImport.tsx
@@ -210,7 +210,7 @@ export function AirMapperImport({ onImport, onCancel }: AirMapperImportProps): R
           <label
             className={cn(
               button.size.sm,
-              'bg-brand-primary text-text-inverse',
+              'bg-brand-primary text-on-brand',
               radius.md,
               'hover:bg-brand-primary/90 cursor-pointer',
             )}
@@ -442,7 +442,7 @@ export function AirMapperImport({ onImport, onCancel }: AirMapperImportProps): R
             onClick={handleConfirmImport}
             className={cn(
               button.size.sm,
-              'bg-brand-primary text-text-inverse',
+              'bg-brand-primary text-on-brand',
               radius.md,
               'hover:bg-brand-primary/90',
               layout.inline.default,

--- a/ui/src/components/survey/ScaleCalibrationPanel.tsx
+++ b/ui/src/components/survey/ScaleCalibrationPanel.tsx
@@ -271,7 +271,7 @@ export function ScaleCalibrationPanel({
               disabled={!dimensionValue}
               className={cn(
                 button.size.sm,
-                'bg-brand-primary text-text-inverse',
+                'bg-brand-primary text-on-brand',
                 radius.md,
                 'hover:bg-brand-primary/90 disabled:opacity-50 disabled:cursor-not-allowed',
               )}
@@ -330,7 +330,7 @@ export function ScaleCalibrationPanel({
                   radius.md,
                   'border',
                   selectedPreset === preset.id
-                    ? 'bg-brand-primary text-text-inverse border-brand-primary'
+                    ? 'bg-brand-primary text-on-brand border-brand-primary'
                     : 'border-surface-border hover:bg-surface-hover',
                 )}
               >

--- a/ui/src/components/survey/SurveyAnalysisPanel.tsx
+++ b/ui/src/components/survey/SurveyAnalysisPanel.tsx
@@ -536,7 +536,7 @@ export function SurveyAnalysisPanel({
               onClick={() => onGenerateReport(findings)}
               className={cn(
                 button.size.sm,
-                'bg-brand-primary text-text-inverse',
+                'bg-brand-primary text-on-brand',
                 radius.md,
                 'hover:opacity-90',
                 layout.inline.tight,

--- a/ui/src/components/survey/SurveyConfigPanel.tsx
+++ b/ui/src/components/survey/SurveyConfigPanel.tsx
@@ -569,7 +569,7 @@ export function SurveyConfigPanel({
                               radius.sm,
                               'min-w-[2.5rem]',
                               selectedChannels.includes(channel)
-                                ? 'bg-brand-primary text-text-inverse'
+                                ? 'bg-brand-primary text-on-brand'
                                 : 'bg-surface-base border border-surface-border hover:bg-surface-hover',
                             )}
                           >

--- a/ui/src/components/survey/SurveyViewFloorPlanPanel.tsx
+++ b/ui/src/components/survey/SurveyViewFloorPlanPanel.tsx
@@ -87,7 +87,7 @@ export function SurveyViewFloorPlanPanel({
               onClick={() => setHeatmapMetric(null)}
               className={cn(
                 button.size.sm,
-                'body-small bg-brand-primary text-text-inverse',
+                'body-small bg-brand-primary text-on-brand',
                 radius.md,
                 'hover:bg-brand-primary/90',
               )}
@@ -205,7 +205,7 @@ export function SurveyViewFloorPlanPanel({
                       disabled={calibrationPoints.length !== 2 || !calibrationDistance}
                       className={cn(
                         button.size.sm,
-                        'bg-brand-primary text-text-inverse',
+                        'bg-brand-primary text-on-brand',
                         radius.md,
                         'hover:bg-brand-primary/90 disabled:opacity-50 disabled:cursor-not-allowed',
                       )}
@@ -326,7 +326,7 @@ export function SurveyViewFloorPlanPanel({
               className={cn(
                 'inline-block',
                 button.size.md,
-                'bg-brand-primary text-text-inverse',
+                'bg-brand-primary text-on-brand',
                 radius.md,
                 'cursor-pointer hover:bg-brand-primary/90',
               )}

--- a/ui/src/components/survey/SurveyViewHeader.tsx
+++ b/ui/src/components/survey/SurveyViewHeader.tsx
@@ -64,7 +64,7 @@ export function SurveyViewHeader({
               title={getStartButtonTitle()}
               className={cn(
                 button.size.md,
-                'bg-brand-primary text-text-inverse',
+                'bg-brand-primary text-on-brand',
                 radius.md,
                 'hover:bg-brand-primary/90',
                 layout.inline.default,
@@ -130,7 +130,7 @@ export function SurveyViewHeader({
                 title={getStartButtonTitle()}
                 className={cn(
                   button.size.md,
-                  'bg-brand-primary text-text-inverse',
+                  'bg-brand-primary text-on-brand',
                   radius.md,
                   'hover:bg-brand-primary/90',
                   layout.inline.default,

--- a/ui/src/components/survey/SurveyViewSidePanel.tsx
+++ b/ui/src/components/survey/SurveyViewSidePanel.tsx
@@ -226,7 +226,7 @@ export function SurveyViewSidePanel({
               className={cn(
                 'w-full',
                 button.size.md,
-                'bg-brand-primary text-text-inverse',
+                'bg-brand-primary text-on-brand',
                 radius.md,
                 'hover:bg-brand-primary/90 disabled:opacity-50',
               )}

--- a/ui/src/components/ui/Button.tsx
+++ b/ui/src/components/ui/Button.tsx
@@ -42,11 +42,11 @@ const sizeStyles: Record<ButtonSize, string> = {
 const variantStyles: Record<ButtonVariant, Record<ButtonTone, string>> = {
   solid: {
     violet:
-      'bg-brand-primary hover:bg-brand-accent text-text-inverse shadow-lg shadow-brand-primary/25 focus:ring-brand-primary',
-    red: 'bg-status-error hover:bg-status-error/85 text-text-inverse shadow-lg shadow-status-error/25 focus:ring-status-error',
+      'bg-brand-primary hover:bg-brand-accent text-on-brand shadow-lg shadow-brand-primary/25 focus:ring-brand-primary',
+    red: 'bg-status-error hover:bg-status-error/85 text-on-danger shadow-lg shadow-status-error/25 focus:ring-status-error',
     green:
-      'bg-status-success hover:bg-status-success/85 text-text-inverse shadow-lg shadow-status-success/25 focus:ring-status-success',
-    blue: 'bg-status-info hover:bg-status-info/85 text-text-inverse shadow-lg shadow-status-info/25 focus:ring-status-info',
+      'bg-status-success hover:bg-status-success/85 text-on-brand shadow-lg shadow-status-success/25 focus:ring-status-success',
+    blue: 'bg-status-info hover:bg-status-info/85 text-on-info shadow-lg shadow-status-info/25 focus:ring-status-info',
     gray: 'bg-surface-hover hover:bg-surface-sunken text-text-primary shadow-lg shadow-surface-border/25 focus:ring-border-muted',
   },
   outline: {

--- a/ui/src/components/ui/DeviceSelector.tsx
+++ b/ui/src/components/ui/DeviceSelector.tsx
@@ -401,7 +401,7 @@ function DeviceSelectorComponent({
                   className={cn(
                     'flex-1 px-3 py-compact-md',
                     'body-small font-medium',
-                    'bg-brand-primary text-text-inverse',
+                    'bg-brand-primary text-on-brand',
                     radius.md,
                     'hover:bg-brand-primary/90 focus:outline-none focus:ring-2 focus:ring-brand-primary',
                   )}

--- a/ui/src/components/ui/fab.tsx
+++ b/ui/src/components/ui/fab.tsx
@@ -85,7 +85,7 @@ export function Fab({ className = '' }: FabProps): React.JSX.Element {
       onClick={handleClick}
       disabled={isRunning}
       className={cn(
-        'w-14 h-14 bg-brand-primary text-text-inverse shadow-lg hover:bg-brand-accent active:scale-95 transition-all touch-manipulation focus:outline-none focus:ring-4 focus:ring-brand-primary/50 focus:ring-offset-2 focus:ring-offset-surface-base',
+        'w-14 h-14 bg-brand-primary text-on-brand shadow-lg hover:bg-brand-accent active:scale-95 transition-all touch-manipulation focus:outline-none focus:ring-4 focus:ring-brand-primary/50 focus:ring-offset-2 focus:ring-offset-surface-base',
         layout.flex.center,
         radius.full,
         isRunning && 'opacity-75 cursor-not-allowed',

--- a/ui/src/components/ui/toast.constants.tsx
+++ b/ui/src/components/ui/toast.constants.tsx
@@ -31,7 +31,7 @@ export const typeStyles: Record<ToastType, string> = {
   success: 'bg-status-success text-text-inverse',
   error: 'bg-status-error text-text-inverse',
   warning: 'bg-status-warning text-text-inverse',
-  info: 'bg-brand-primary text-text-inverse',
+  info: 'bg-brand-primary text-on-brand',
 };
 
 // Icon size for toast notifications

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -551,6 +551,12 @@ body {
     z-index: 100; /* skip links, always-on-top affordances */
   }
 
+  /* Subtle top-edge highlight for active nav items (replaces a raw
+   * rgba(255,255,255,0.1) inline shadow — white at 10% via the knob token). */
+  .shadow-edge-highlight {
+    box-shadow: inset 0 1px 0 color-mix(in oklab, var(--color-knob) 10%, transparent);
+  }
+
   /* ========================================================================
      MARGIN UTILITIES
      ========================================================================

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -80,7 +80,7 @@ const NavItemButton: FC<NavItemButtonProps> = ({ item, active, collapsed, onNavi
     onMouseEnter={() => prefetchRoute(item.path)}
     className={`group flex items-center gap-default w-full px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 ${
       active
-        ? 'bg-gradient-to-r from-brand-primary/30 to-brand-primary/20 text-text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
+        ? 'bg-gradient-to-r from-brand-primary/30 to-brand-primary/20 text-text-primary shadow-edge-highlight'
         : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
     }`}
     title={collapsed ? item.label : undefined}
@@ -418,7 +418,7 @@ export const SidebarLayout: FC<SidebarLayoutProps> = ({
     <div className="min-h-screen text-text-primary bg-gradient-to-br from-surface-base via-surface-raised to-surface-deep">
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-row focus:rounded-lg focus:bg-brand-primary focus:text-text-inverse focus:outline-none"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-row focus:rounded-lg focus:bg-brand-primary focus:text-on-brand focus:outline-none"
       >
         Skip to main content
       </a>


### PR DESCRIPTION
Cross-repo re-audit polish (seed):

- **A11y (approved):** ~40 inline `bg-brand-primary text-text-inverse` rendered **white text on the green brand fill** → fails AA in light mode (~2.5:1). Migrated to `text-on-brand` (dark `#18181b`), matching the canonical 2026-05-22 brand decision and seed's token-buttons (already dark). Button solid tones: `violet`/`green` → `on-brand`, `red` → `on-danger`, `blue` → `on-info`. This makes seed's primary buttons/active-tabs uniformly dark-on-green.
- **Tokenize last non-domain raw color:** active-nav inset highlight `rgba(255,255,255,0.1)` → `.shadow-edge-highlight` (white@10% via `color-mix(var(--color-knob))`).
- **Guard:** add a blocking `rgb()/hsl()` rule; allowlist `HeatmapLegend` (signal-strength gradient) alongside the already-allowlisted `FloorPlanCanvas`.

Verified: guard **CLEAN** (incl rgb/hsl), biome clean, tsc passes, **117 tests pass**, build succeeds.

Deferred: status-badge `text-text-inverse` (toast/Vlan/ConfigBackups) — needs cross-brand `on-success`/`on-warning` tokens; separate a11y pass.