### PR TITLE
fix(ui): undefined hover:bg-brand-primary-hover token

### DIFF
--- a/ui/src/components/profiles/ProfileEditor.tsx
+++ b/ui/src/components/profiles/ProfileEditor.tsx
@@ -210,7 +210,7 @@ export function ProfileEditor({
                 spacing.pad.sm,
                 'px-4',
                 radius.md,
-                'bg-brand-primary hover:bg-brand-primary-hover text-on-brand body-small font-medium disabled:opacity-50',
+                'bg-brand-primary hover:bg-brand-accent text-on-brand body-small font-medium disabled:opacity-50',
               )}
             >
               {getButtonLabel()}

--- a/ui/src/components/profiles/ProfileManagement.tsx
+++ b/ui/src/components/profiles/ProfileManagement.tsx
@@ -213,7 +213,7 @@ export function ProfileManagement({ onClose }: ProfileManagementProps): React.Re
                 spacing.pad.sm,
                 'px-4',
                 radius.md,
-                'bg-brand-primary hover:bg-brand-primary-hover text-on-brand body-small font-medium flex items-center gap-compact',
+                'bg-brand-primary hover:bg-brand-accent text-on-brand body-small font-medium flex items-center gap-compact',
               )}
             >
               <svg
@@ -353,7 +353,7 @@ export function ProfileManagement({ onClose }: ProfileManagementProps): React.Re
                       spacing.pad.sm,
                       'px-4',
                       radius.md,
-                      'bg-brand-primary hover:bg-brand-primary-hover text-on-brand body-small font-medium',
+                      'bg-brand-primary hover:bg-brand-accent text-on-brand body-small font-medium',
                     )}
                   >
                     {t('profile.createFirst', 'Create Your First Profile')}
@@ -562,7 +562,7 @@ function ProfileCard({
               className={cn(
                 spacing.chip.sm,
                 radius.md,
-                'bg-brand-primary hover:bg-brand-primary-hover text-on-brand caption font-medium flex items-center gap-1.5 ml-auto',
+                'bg-brand-primary hover:bg-brand-accent text-on-brand caption font-medium flex items-center gap-1.5 ml-auto',
               )}
               title={t('profile.activate', 'Activate')}
             >

--- a/ui/src/components/settings/sections/ConfigBackupsSection.tsx
+++ b/ui/src/components/settings/sections/ConfigBackupsSection.tsx
@@ -325,7 +325,7 @@ export const ConfigBackupsSection: React.NamedExoticComponent<Record<string, nev
               button.size.md,
               'bg-brand-primary text-on-brand',
               radius.md,
-              'font-medium hover:bg-brand-primary-hover transition-colors flex-center',
+              'font-medium hover:bg-brand-accent transition-colors flex-center',
               spacing.gap.compact,
               'touch-manipulation disabled:opacity-50',
             )}


### PR DESCRIPTION
Final-scan follow-up: `brand-primary-hover` is undefined → profile/config-backup buttons had no hover state. → `hover:bg-brand-accent` (defined hover sibling). guard CLEAN, lint/tsc clean, 117 tests pass.