### PR TITLE
fix(ui): replace more undefined color tokens

### DIFF
--- a/ui/src/app/LoginForm.tsx
+++ b/ui/src/app/LoginForm.tsx
@@ -337,7 +337,7 @@ export function LoginForm({ onLogin, isLoading, error }: LoginFormProps): JSX.El
                     button.size.md,
                     'bg-status-info text-text-inverse',
                     radius.md,
-                    'font-medium hover:bg-status-info-dark focus:outline-none focus:ring-2 focus:ring-status-info focus:ring-offset-2 focus:ring-offset-surface-base disabled:opacity-50',
+                    'font-medium hover:bg-status-info/85 focus:outline-none focus:ring-2 focus:ring-status-info focus:ring-offset-2 focus:ring-offset-surface-base disabled:opacity-50',
                   )}
                 >
                   {t('buttons.signInWithGoogle')}

--- a/ui/src/components/cards/HealthCheckCard.tsx
+++ b/ui/src/components/cards/HealthCheckCard.tsx
@@ -324,7 +324,7 @@ export const HealthCheckCard: React.MemoExoticComponent<
     return (
       <div className={spacing.micro.mtCompactMd}>
         {/* Stacked bar */}
-        <div className={cn('h-2', radius.full, 'overflow-hidden flex bg-bg-tertiary')}>
+        <div className={cn('h-2', radius.full, 'overflow-hidden flex bg-surface-sunken')}>
           {segments.map((seg, i) => {
             const widthPercent = Math.min(100, Math.max(0, (seg.value / total) * 100));
             return (

--- a/ui/src/components/settings/sections/discovery/DiscoveryCustomOptions.tsx
+++ b/ui/src/components/settings/sections/discovery/DiscoveryCustomOptions.tsx
@@ -333,7 +333,7 @@ export const DiscoveryCustomOptions: React.NamedExoticComponent<DiscoveryCustomO
                     spacing.margin.top.tight,
                     inputTokens.base,
                     (settings.options?.portScan?.preset ?? 'common') !== 'custom'
-                      ? 'bg-surface-muted cursor-not-allowed opacity-60'
+                      ? 'bg-surface-hover cursor-not-allowed opacity-60'
                       : inputTokens.state.default,
                     inputTokens.size.sm,
                     'body-small',
@@ -377,7 +377,7 @@ export const DiscoveryCustomOptions: React.NamedExoticComponent<DiscoveryCustomO
                     spacing.margin.top.tight,
                     inputTokens.base,
                     (settings.options?.portScan?.preset ?? 'common') !== 'custom'
-                      ? 'bg-surface-muted cursor-not-allowed opacity-60'
+                      ? 'bg-surface-hover cursor-not-allowed opacity-60'
                       : inputTokens.state.default,
                     inputTokens.size.sm,
                     'body-small',

--- a/ui/src/components/setup/SetupWizard.tsx
+++ b/ui/src/components/setup/SetupWizard.tsx
@@ -523,7 +523,7 @@ export function SetupWizard({
                       button.size.md,
                       'bg-status-info text-text-inverse',
                       radius.md,
-                      'font-medium hover:bg-status-info-dark focus:outline-none focus:ring-2 focus:ring-status-info focus:ring-offset-2 focus:ring-offset-surface-base disabled:opacity-50',
+                      'font-medium hover:bg-status-info/85 focus:outline-none focus:ring-2 focus:ring-status-info focus:ring-offset-2 focus:ring-offset-surface-base disabled:opacity-50',
                     )}
                   >
                     {tCommon('buttons.signInWithGoogle')}


### PR DESCRIPTION
Convergence-scan findings: bg-bg-tertiary→bg-surface-sunken, hover:bg-status-info-dark→hover:bg-status-info/85, bg-surface-muted→bg-surface-hover (all undefined → rendered no color). guard CLEAN, lint/tsc clean, 117 tests pass.