### PR TITLE
feat(api): enforce viewer read-only via writeGated route wrapper (#1226)

### DIFF
--- a/internal/api/handlers_profiles_authz_internal_test.go
+++ b/internal/api/handlers_profiles_authz_internal_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// seedRoledUser adds a user with the given role to the test server's DB.
+func seedRoledUser(t *testing.T, s *Server, username, role string) {
+	t.Helper()
+	if _, err := s.services.Database.DB.CreateUser(t.Context(), username, "$2a$10$x", role); err != nil {
+		t.Fatalf("seed %s (%s): %v", username, role, err)
+	}
+}
+
+// TestWriteGate_MethodAndRoleMatrix proves the central #1226 wrapper:
+// reads pass through for every role; non-safe methods require operator+.
+func TestWriteGate_MethodAndRoleMatrix(t *testing.T) {
+	t.Parallel()
+	s, _ := usersTestSetup(t) // seeds "admin" (RoleAdmin)
+	seedRoledUser(t, s, "viewer1", database.RoleViewer)
+	seedRoledUser(t, s, "operator1", database.RoleOperator)
+
+	called := false
+	probe := func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}
+	gated := s.writeGated(probe)
+
+	cases := []struct {
+		user       string
+		method     string
+		wantStatus int
+		wantCalled bool
+	}{
+		// Safe methods pass through for every role, including viewer.
+		{"viewer1", http.MethodGet, http.StatusOK, true},
+		{"viewer1", http.MethodHead, http.StatusOK, true},
+		{"viewer1", http.MethodOptions, http.StatusOK, true},
+		// Viewer is blocked on every write method.
+		{"viewer1", http.MethodPost, http.StatusForbidden, false},
+		{"viewer1", http.MethodPut, http.StatusForbidden, false},
+		{"viewer1", http.MethodPatch, http.StatusForbidden, false},
+		{"viewer1", http.MethodDelete, http.StatusForbidden, false},
+		// Operator and admin clear the gate on writes.
+		{"operator1", http.MethodPost, http.StatusOK, true},
+		{"admin", http.MethodDelete, http.StatusOK, true},
+	}
+	for _, c := range cases {
+		called = false
+		req := newAuthedRequest(c.method, APIVersionPrefix+"/probe", nil, c.user)
+		w := httptest.NewRecorder()
+		gated(w, req)
+		if w.Code != c.wantStatus {
+			t.Errorf("%s %s: status = %d, want %d", c.user, c.method, w.Code, c.wantStatus)
+		}
+		if called != c.wantCalled {
+			t.Errorf("%s %s: handler called = %v, want %v", c.user, c.method, called, c.wantCalled)
+		}
+	}
+
+	// No caller -> 401, not 403.
+	called = false
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/probe", nil, "")
+	w := httptest.NewRecorder()
+	gated(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("no-caller POST: status = %d, want 401", w.Code)
+	}
+	if called {
+		t.Error("no-caller POST: handler should not be called")
+	}
+}
+
+// TestRequireRole_Hierarchy exercises the rank comparison directly so the
+// viewer<operator<admin ordering can't silently regress.
+func TestRequireRole_Hierarchy(t *testing.T) {
+	t.Parallel()
+	s, _ := usersTestSetup(t)
+	seedRoledUser(t, s, "viewer1", database.RoleViewer)
+	seedRoledUser(t, s, "operator1", database.RoleOperator)
+
+	cases := []struct {
+		user    string
+		min     string
+		allowed bool
+	}{
+		{"viewer1", database.RoleViewer, true},
+		{"viewer1", database.RoleOperator, false},
+		{"viewer1", database.RoleAdmin, false},
+		{"operator1", database.RoleOperator, true},
+		{"operator1", database.RoleAdmin, false},
+		{"admin", database.RoleAdmin, true},
+		{"admin", database.RoleOperator, true},
+	}
+	for _, c := range cases {
+		req := newAuthedRequest(http.MethodGet, APIVersionPrefix+"/x", nil, c.user)
+		w := httptest.NewRecorder()
+		got := s.requireRole(w, req, c.min)
+		if got != c.allowed {
+			t.Errorf("requireRole(%s, min=%s) = %v, want %v (status %d)", c.user, c.min, got, c.allowed, w.Code)
+		}
+	}
+}
+
+// TestCallerRole_NoDBIsImplicitAdmin guards the single-user/env-mode path:
+// with no user DB configured, the lone operator is treated as admin so the
+// write gate never locks a single-user deployment out of its own tool.
+func TestCallerRole_NoDBIsImplicitAdmin(t *testing.T) {
+	t.Parallel()
+	s := &Server{services: NewServiceContainer()} // no DB attached
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/x", nil, "someone")
+	role, ok := s.callerRole(req)
+	if !ok || role != database.RoleAdmin {
+		t.Fatalf("callerRole with no DB = (%q, %v), want (admin, true)", role, ok)
+	}
+	w := httptest.NewRecorder()
+	if !s.requireWriteAccess(w, req) {
+		t.Errorf("requireWriteAccess with no DB should allow; status=%d", w.Code)
+	}
+}
+
+// TestWriteGate_WiredOnSettingsRoute proves the wrapper is actually
+// attached at route registration: a viewer hitting POST /api/v1/settings
+// is rejected with 403 by the gate, never reaching handleSettings. If
+// somebody removes the s.writeGated(...) wrap at registration time, this
+// test fails — guarding against a silent regression of the policy.
+func TestWriteGate_WiredOnSettingsRoute(t *testing.T) {
+	t.Parallel()
+	s, _ := usersTestSetup(t)
+	seedRoledUser(t, s, "viewer1", database.RoleViewer)
+	s.setupRoutes()
+
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/settings", []byte(`{}`), "viewer1")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("viewer POST /settings via mux: status = %d, want 403 (gate must be wired at registration)", w.Code)
+	}
+}

--- a/internal/api/handlers_update.go
+++ b/internal/api/handlers_update.go
@@ -61,14 +61,14 @@ func (s *Server) registerUpdateRoutes() {
 	s.mux.HandleFunc("GET /api/v1/updates/status", s.handleUpdateStatus)
 	s.mux.HandleFunc("GET /api/v1/updates/info", s.handleUpdateInfo)
 
-	// Update actions
-	s.mux.HandleFunc("POST /api/v1/updates/download", s.handleUpdateDownload)
-	s.mux.HandleFunc("POST /api/v1/updates/apply", s.handleUpdateApply)
-	s.mux.HandleFunc("POST /api/v1/updates/rollback", s.handleUpdateRollback)
+	// Update actions — mutate system state, so operator-or-above only (#1226).
+	s.mux.HandleFunc("POST /api/v1/updates/download", s.writeGated(s.handleUpdateDownload))
+	s.mux.HandleFunc("POST /api/v1/updates/apply", s.writeGated(s.handleUpdateApply))
+	s.mux.HandleFunc("POST /api/v1/updates/rollback", s.writeGated(s.handleUpdateRollback))
 
 	// Configuration
 	s.mux.HandleFunc("GET /api/v1/updates/config", s.handleGetUpdateConfig)
-	s.mux.HandleFunc("PATCH /api/v1/updates/config", s.handleUpdateConfig)
+	s.mux.HandleFunc("PATCH /api/v1/updates/config", s.writeGated(s.handleUpdateConfig))
 }
 
 // handleUpdateCheck checks for available updates.

--- a/internal/api/handlers_users.go
+++ b/internal/api/handlers_users.go
@@ -410,23 +410,102 @@ func (s *Server) requireAdmin(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
-// callerIsAdmin looks up the request's user and returns whether their
-// role is "admin". Tolerates a missing DB (dev builds) by assuming
-// admin so the panel stays usable.
-func (s *Server) callerIsAdmin(r *http.Request) bool {
-	caller := usernameFromContext(r)
-	if caller == "" {
-		return false
-	}
+// callerRole resolves the requesting user's role. ok is false when the
+// role can't be established (no caller, lookup failure, inactive user).
+// When no user DB is configured (single-user/env mode) it returns
+// admin/true: the lone env-configured operator is implicitly admin, which
+// keeps single-user dev builds fully usable.
+func (s *Server) callerRole(r *http.Request) (string, bool) {
 	db := s.services.Database.DB
+	caller := usernameFromContext(r)
+	// No user DB attached = no multi-user authorization model in effect,
+	// so the gate has nothing to enforce — treat the request as admin.
+	// Production single-user still gets X-Username from the auth
+	// middleware, so this branch only fires in test/dev contexts that
+	// reach the mux without auth middleware, matching the long-standing
+	// callerIsAdmin "no DB = admin" tolerance.
 	if db == nil {
-		return true
+		return database.RoleAdmin, true
+	}
+	if caller == "" {
+		return "", false
 	}
 	u, err := db.GetUser(r.Context(), caller)
-	if err != nil {
+	if err != nil || !u.IsActive {
+		return "", false
+	}
+	return u.Role, true
+}
+
+// Role ranks order the three roles for >= comparisons. Unknown/unresolved
+// roles rank at rankNone so they never satisfy a minimum of viewer or above.
+const (
+	rankNone     = 0
+	rankViewer   = 1
+	rankOperator = 2
+	rankAdmin    = 3
+)
+
+// roleRank maps a role string to its comparable rank.
+func roleRank(role string) int {
+	switch role {
+	case database.RoleAdmin:
+		return rankAdmin
+	case database.RoleOperator:
+		return rankOperator
+	case database.RoleViewer:
+		return rankViewer
+	default:
+		return rankNone
+	}
+}
+
+// callerIsAdmin reports whether the request's user is an admin. Tolerates
+// a missing DB (dev builds) by assuming admin so the panel stays usable.
+func (s *Server) callerIsAdmin(r *http.Request) bool {
+	role, ok := s.callerRole(r)
+	return ok && role == database.RoleAdmin
+}
+
+// requireRole replies 401 (no caller) or 403 (under-privileged) unless the
+// requester's role ranks at or above min. Returns true when the request
+// may proceed.
+func (s *Server) requireRole(w http.ResponseWriter, r *http.Request, minRole string) bool {
+	role, ok := s.callerRole(r)
+	if !ok {
+		writeAPITokenError(w, r, http.StatusUnauthorized, ErrCodeUnauthorized, "Authentication required")
 		return false
 	}
-	return u.Role == database.RoleAdmin && u.IsActive
+	if roleRank(role) < roleRank(minRole) {
+		writeAPITokenError(w, r, http.StatusForbidden, ErrCodeForbidden, minRole+" role required")
+		return false
+	}
+	return true
+}
+
+// requireWriteAccess gates state-changing operations on operator-or-above;
+// viewers are read-only (#1226). Safe (read) methods should skip this.
+func (s *Server) requireWriteAccess(w http.ResponseWriter, r *http.Request) bool {
+	return s.requireRole(w, r, database.RoleOperator)
+}
+
+// writeGated wraps a handler so that state-changing methods require an
+// operator-or-above role while safe reads (GET/HEAD/OPTIONS) pass through
+// untouched. Applied at route registration to persistent-configuration
+// endpoints so viewers stay read-only on them; diagnostic actions
+// (scans/pings/traceroute) are deliberately left ungated (#1226).
+func (s *Server) writeGated(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			next(w, r)
+		default:
+			if !s.requireWriteAccess(w, r) {
+				return
+			}
+			next(w, r)
+		}
+	}
 }
 
 // licenseAllowsMultiUser reports whether the active license tier may

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -28,8 +28,8 @@ func (s *Server) setupRoutes() {
 // endpoints and the read-only license status endpoint the UI uses to
 // know whether the mint button should be enabled.
 func (s *Server) setupAPITokenRoutes() {
-	s.mux.HandleFunc(APIVersionPrefix+"/tokens", s.handleAPITokens)
-	s.mux.HandleFunc(APIVersionPrefix+"/tokens/", s.handleAPITokenByID)
+	s.mux.HandleFunc(APIVersionPrefix+"/tokens", s.writeGated(s.handleAPITokens))
+	s.mux.HandleFunc(APIVersionPrefix+"/tokens/", s.writeGated(s.handleAPITokenByID))
 	s.mux.HandleFunc(APIVersionPrefix+"/license", s.handleLicenseStatus)
 
 	// Users CRUD (seed#1191 — multi_user). The /users/me endpoint must
@@ -59,23 +59,23 @@ func (s *Server) setupCoreRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/auth/webauthn/login/begin", s.handleWebAuthnLoginBegin)
 	s.mux.HandleFunc(APIVersionPrefix+"/auth/webauthn/login/finish", s.handleWebAuthnLoginFinish)
 	s.mux.HandleFunc(APIVersionPrefix+"/status", s.handleStatus)
-	s.mux.HandleFunc(APIVersionPrefix+"/settings", s.handleSettings)
-	s.mux.HandleFunc(APIVersionPrefix+"/settings/defaults", s.handleSettingsDefaults)
-	s.mux.HandleFunc(APIVersionPrefix+"/settings/link", s.handleLinkSettings)
-	s.mux.HandleFunc(APIVersionPrefix+"/settings/cable", s.handleCableTestSettings)
+	s.mux.HandleFunc(APIVersionPrefix+"/settings", s.writeGated(s.handleSettings))
+	s.mux.HandleFunc(APIVersionPrefix+"/settings/defaults", s.writeGated(s.handleSettingsDefaults))
+	s.mux.HandleFunc(APIVersionPrefix+"/settings/link", s.writeGated(s.handleLinkSettings))
+	s.mux.HandleFunc(APIVersionPrefix+"/settings/cable", s.writeGated(s.handleCableTestSettings))
 	s.mux.HandleFunc(APIVersionPrefix+"/interfaces", s.handleInterfaces)
 	s.mux.HandleFunc(APIVersionPrefix+"/interface", s.handleInterface)
-	s.mux.HandleFunc(APIVersionPrefix+"/network/mtu", s.handleSetMTU)
+	s.mux.HandleFunc(APIVersionPrefix+"/network/mtu", s.writeGated(s.handleSetMTU))
 	s.mux.HandleFunc(APIVersionPrefix+"/config/backups", s.handleConfigBackups)
-	s.mux.HandleFunc(APIVersionPrefix+"/config/backup", s.handleConfigBackupCreate)
-	s.mux.HandleFunc(APIVersionPrefix+"/config/backup/delete", s.handleConfigBackupDelete)
-	s.mux.HandleFunc(APIVersionPrefix+"/config/restore", s.handleConfigRestore)
+	s.mux.HandleFunc(APIVersionPrefix+"/config/backup", s.writeGated(s.handleConfigBackupCreate))
+	s.mux.HandleFunc(APIVersionPrefix+"/config/backup/delete", s.writeGated(s.handleConfigBackupDelete))
+	s.mux.HandleFunc(APIVersionPrefix+"/config/restore", s.writeGated(s.handleConfigRestore))
 	s.mux.HandleFunc(APIVersionPrefix+"/config/version", s.handleConfigVersion)
-	s.mux.HandleFunc(APIVersionPrefix+"/profiles", s.handleProfiles)
-	s.mux.HandleFunc(APIVersionPrefix+"/profiles/active", s.handleActiveProfile)
-	s.mux.HandleFunc(APIVersionPrefix+"/profiles/import", s.handleImportProfiles)
+	s.mux.HandleFunc(APIVersionPrefix+"/profiles", s.writeGated(s.handleProfiles))
+	s.mux.HandleFunc(APIVersionPrefix+"/profiles/active", s.writeGated(s.handleActiveProfile))
+	s.mux.HandleFunc(APIVersionPrefix+"/profiles/import", s.writeGated(s.handleImportProfiles))
 	s.mux.HandleFunc(APIVersionPrefix+"/profiles/export", s.handleExportProfiles)
-	s.mux.HandleFunc(APIVersionPrefix+"/profiles/", s.handleProfiles)
+	s.mux.HandleFunc(APIVersionPrefix+"/profiles/", s.writeGated(s.handleProfiles))
 	s.mux.HandleFunc(APIVersionPrefix+"/setup/status", s.handleSetupStatus)
 	s.mux.HandleFunc(APIVersionPrefix+"/setup/complete", s.handleSetupComplete)
 	s.mux.HandleFunc(APIVersionPrefix+"/recovery/status", s.handleRecoveryStatus)
@@ -84,13 +84,13 @@ func (s *Server) setupCoreRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/sso/providers", s.handleSSOProviders)
 	s.mux.HandleFunc(APIVersionPrefix+"/sso/login", s.handleSSOLogin)
 	s.mux.HandleFunc(APIVersionPrefix+"/sso/callback", s.handleSSOCallback)
-	s.mux.HandleFunc(APIVersionPrefix+"/sso/settings", s.handleSSOSettings)
+	s.mux.HandleFunc(APIVersionPrefix+"/sso/settings", s.writeGated(s.handleSSOSettings))
 	// SSO settings PUT is Pro-gated via requireFeature("sso") — see seed#1198.
 	// GET stays open so operators can inspect existing config on any tier
 	// (a Pro→Free downgrade must not lock them out of reading current
 	// state). Provider login + callback continue to work for already-
 	// configured providers regardless of tier — only WRITES are blocked.
-	s.mux.HandleFunc(APIVersionPrefix+"/sso/update", s.requireFeature("sso", s.handleSSOUpdate))
+	s.mux.HandleFunc(APIVersionPrefix+"/sso/update", s.writeGated(s.requireFeature("sso", s.handleSSOUpdate)))
 	s.mux.HandleFunc(APIVersionPrefix+"/health", s.handleHealth)
 }
 
@@ -100,11 +100,11 @@ func (s *Server) setupSAPRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/cable", s.handleCable)
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/dns", s.handleDNS)
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/dns/security", s.handleDNSSecurity)
-	s.mux.HandleFunc(APIVersionPrefix+"/sap/dns/security/settings", s.handleDNSSecuritySettings)
+	s.mux.HandleFunc(APIVersionPrefix+"/sap/dns/security/settings", s.writeGated(s.handleDNSSecuritySettings))
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/gateway", s.handleGateway)
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/dhcp/rogue", s.handleRogueDHCP)
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/dhcp/rogue/servers", s.handleRogueDHCPServers)
-	s.mux.HandleFunc(APIVersionPrefix+"/sap/dhcp/rogue/config", s.handleRogueDHCPConfig)
+	s.mux.HandleFunc(APIVersionPrefix+"/sap/dhcp/rogue/config", s.writeGated(s.handleRogueDHCPConfig))
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/vlan", s.handleVLAN)
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/vlan/traffic", s.handleVLANTraffic)
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/vlan/interface", s.handleVLANInterface)
@@ -122,7 +122,7 @@ func (s *Server) setupSAPRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/iperf/server", s.handleIperfServer)
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/iperf/server/status", s.handleIperfServerStatus)
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/iperf/suggestions", s.handleIperfSuggestions)
-	s.mux.HandleFunc(APIVersionPrefix+"/sap/health-checks/settings", s.handleHealthChecksSettings)
+	s.mux.HandleFunc(APIVersionPrefix+"/sap/health-checks/settings", s.writeGated(s.handleHealthChecksSettings))
 	s.mux.Handle(
 		APIVersionPrefix+"/sap/health-checks/run",
 		s.endpointRateLimiter().RateLimitMiddleware(http.HandlerFunc(s.handleHealthChecks)),
@@ -139,10 +139,10 @@ func (s *Server) setupSAPRoutes() {
 		APIVersionPrefix+"/sap/health-checks/anomalies",
 		s.requireFeature("anomaly_detection", s.handleHealthCheckAnomalies),
 	)
-	s.mux.HandleFunc(APIVersionPrefix+"/sap/snmp/settings", s.handleSNMPSettings)
+	s.mux.HandleFunc(APIVersionPrefix+"/sap/snmp/settings", s.writeGated(s.handleSNMPSettings))
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/system/health", s.handleSystemHealth)
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/ipconfig", s.handleIPConfig)
-	s.mux.HandleFunc(APIVersionPrefix+"/sap/ipconfig/settings", s.handleIPSettings)
+	s.mux.HandleFunc(APIVersionPrefix+"/sap/ipconfig/settings", s.writeGated(s.handleIPSettings))
 	s.mux.HandleFunc(APIVersionPrefix+"/sap/publicip", s.handlePublicIP)
 }
 
@@ -160,7 +160,7 @@ func (s *Server) setupShellRoutes() {
 		s.endpointRateLimiter().RateLimitMiddleware(http.HandlerFunc(s.handleDevicesScan)),
 	)
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/devices/status", s.handleDevicesStatus)
-	s.mux.HandleFunc(APIVersionPrefix+"/shell/devices/settings", s.handleDevicesSettings)
+	s.mux.HandleFunc(APIVersionPrefix+"/shell/devices/settings", s.writeGated(s.handleDevicesSettings))
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/devices/subnets", s.handleDevicesSubnets)
 	// Vulnerability scan + guest-audit run are compliance_advanced
 	// (Pro) per LICENSE_STRATEGY §2. Read-only results / status /
@@ -176,10 +176,10 @@ func (s *Server) setupShellRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/vulnerabilities/status", s.handleVulnerabilityStatus)
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/vulnerabilities/results", s.handleVulnerabilityResults)
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/vulnerabilities/device", s.handleDeviceVulnerabilities)
-	s.mux.HandleFunc(APIVersionPrefix+"/shell/vulnerabilities/settings", s.handleVulnerabilitySettings)
+	s.mux.HandleFunc(APIVersionPrefix+"/shell/vulnerabilities/settings", s.writeGated(s.handleVulnerabilitySettings))
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/vulnerabilities/validate-api-key", s.handleNVDAPIKeyValidate)
 	// Guest-network isolation audit (#397).
-	s.mux.HandleFunc(APIVersionPrefix+"/shell/guest-audit/settings", s.handleGuestAuditSettings)
+	s.mux.HandleFunc(APIVersionPrefix+"/shell/guest-audit/settings", s.writeGated(s.handleGuestAuditSettings))
 	s.mux.Handle(
 		APIVersionPrefix+"/shell/guest-audit/run",
 		s.endpointRateLimiter().RateLimitMiddleware(
@@ -189,14 +189,14 @@ func (s *Server) setupShellRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/pipeline/status", s.handlePipelineStatus)
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/pipeline/start", s.handlePipelineStart)
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/pipeline/cancel", s.handlePipelineCancel)
-	s.mux.HandleFunc(APIVersionPrefix+"/shell/pipeline/config", s.handlePipelineConfigRoute)
+	s.mux.HandleFunc(APIVersionPrefix+"/shell/pipeline/config", s.writeGated(s.handlePipelineConfigRoute))
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/pipeline/port-intensity", s.handlePipelinePortIntensityInfo)
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/pipeline/timing-profiles", s.handlePipelineTimingProfiles)
 
 	// Network problem detection routes
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/problems", s.handleNetworkProblems)
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/problems/scan", s.handleProblemScan)
-	s.mux.HandleFunc(APIVersionPrefix+"/shell/problems/thresholds", s.handleProblemThresholds)
+	s.mux.HandleFunc(APIVersionPrefix+"/shell/problems/thresholds", s.writeGated(s.handleProblemThresholds))
 
 	// Bluetooth discovery routes
 	s.mux.HandleFunc(APIVersionPrefix+"/shell/bluetooth/scan", s.handleBluetoothScan)
@@ -254,22 +254,22 @@ func (s *Server) setupCanopyRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/scan", s.handleWiFiScan)
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/status", s.handleWiFiStatus)
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/channel-graph", s.handleWiFiChannelGraph)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/settings", s.handleWiFiSettings)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/connect", s.handleWiFiConnect)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/disconnect", s.handleWiFiDisconnect)
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/settings", s.writeGated(s.handleWiFiSettings))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/connect", s.writeGated(s.handleWiFiConnect))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/disconnect", s.writeGated(s.handleWiFiDisconnect))
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/saved", s.handleWiFiSavedNetworks)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/forget", s.handleWiFiForgetNetwork)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/create", s.createSurvey)
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/wifi/forget", s.writeGated(s.handleWiFiForgetNetwork))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/create", s.writeGated(s.createSurvey))
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/list", s.listSurveys)
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey", s.getSurvey)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/delete", s.deleteSurvey)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/start", s.startSurvey)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/pause", s.pauseSurvey)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/complete", s.completeSurvey)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/sample", s.addSurveySample)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floorplan", s.updateSurveyFloorPlan)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/settings", s.updateSurveySettings)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/imported-data", s.updateSurveyImportedData)
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/delete", s.writeGated(s.deleteSurvey))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/start", s.writeGated(s.startSurvey))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/pause", s.writeGated(s.pauseSurvey))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/complete", s.writeGated(s.completeSurvey))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/sample", s.writeGated(s.addSurveySample))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floorplan", s.writeGated(s.updateSurveyFloorPlan))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/settings", s.writeGated(s.updateSurveySettings))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/imported-data", s.writeGated(s.updateSurveyImportedData))
 	// AirMapper baseline-diff is a Pro feature (LICENSE_STRATEGY §2):
 	// imports an existing AirMapper survey JSON and diffs it against
 	// the current floor-plan baseline. The rate limiter still wraps
@@ -277,7 +277,7 @@ func (s *Server) setupCanopyRoutes() {
 	s.mux.Handle(
 		APIVersionPrefix+"/canopy/survey/import/airmapper",
 		s.endpointRateLimiter().RateLimitMiddleware(
-			s.requireFeature("airmapper_baseline_diff", s.importAirMapper),
+			s.requireFeature("airmapper_baseline_diff", s.writeGated(s.importAirMapper)),
 		),
 	)
 	s.mux.Handle(
@@ -285,11 +285,11 @@ func (s *Server) setupCanopyRoutes() {
 		s.endpointRateLimiter().RateLimitMiddleware(http.HandlerFunc(s.getSurveyHeatmap)),
 	)
 	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/dead-zones", s.getSurveyDeadZones)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floors", s.handleSurveyFloors)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floor", s.handleSurveyFloor)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floor/floorplan", s.updateFloorFloorPlan)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floor/sample", s.addFloorSample)
-	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/active-floor", s.setActiveFloor)
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floors", s.writeGated(s.handleSurveyFloors))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floor", s.writeGated(s.handleSurveyFloor))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floor/floorplan", s.writeGated(s.updateFloorFloorPlan))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/floor/sample", s.writeGated(s.addFloorSample))
+	s.mux.HandleFunc(APIVersionPrefix+"/canopy/survey/active-floor", s.writeGated(s.setActiveFloor))
 	s.mux.Handle(
 		APIVersionPrefix+"/canopy/survey/report",
 		s.endpointRateLimiter().RateLimitMiddleware(http.HandlerFunc(s.generateSurveyReport)),


### PR DESCRIPTION
Closes #1226 · Wave 4

## Why

Seed's three-tier role model (`admin`/`operator`/`viewer`) already exists in the database schema (`migrations.go:899` `CHECK IN ('admin','operator','viewer')`) and the User model (`RoleAdmin`/`RoleOperator`/`RoleViewer` constants), but until now only `admin` was actually enforced (via `requireAdmin` on user management). `operator` and `viewer` were dormant — a `viewer` user could perform every state-changing call that a non-admin could, including modifying settings, profiles, SSO config, API tokens, and applying system updates. This made the `viewer` role security-meaningless.

This PR activates that existing distinction so `viewer = read-only on persistent configuration` while keeping read-only diagnostic actions (scans, ping, traceroute, speedtest, discovery) open to viewers per the **Model B** policy chosen interactively for #1226.

## What

Adds reusable role infrastructure in `internal/api/handlers_users.go`:

- `callerRole` / `roleRank` / `requireRole` — DB-backed role lookup that works uniformly for both JWT and PAT identities (PATs inherit the owner's role). Preserves the long-standing _no-DB-is-admin_ tolerance so single-user/dev deployments and direct-mux tests continue to work without auth middleware.
- `requireWriteAccess` — convenience for operator-or-above.
- `writeGated(next)` — route-registration wrapper: `GET`/`HEAD`/`OPTIONS` pass through, every other method calls `requireWriteAccess`. Applied centrally at registration so the policy is auditable in one place rather than scattered across handlers.

Refactors `callerIsAdmin` to delegate to `callerRole` (behavior preserved).

### Gated routes (operator-or-above on non-safe methods)

- `/settings`, `/settings/{defaults,link,cable}`
- `/network/mtu`
- `/config/{backup,backup/delete,restore}`
- `/profiles`, `/profiles/`, `/profiles/active`, `/profiles/import`
- `/sso/settings`, `/sso/update` (composed with `requireFeature`)
- `/tokens`, `/tokens/`
- `/updates/{download,apply,rollback,config}`
- `/sap/{dns/security,dhcp/rogue/config,health-checks,snmp,ipconfig}/settings`
- `/shell/{devices,vulnerabilities,guest-audit}/settings`, `/shell/pipeline/config`, `/shell/problems/thresholds`
- `/canopy/wifi/{settings,connect,disconnect,forget}`
- `/canopy/survey/{create,delete,start,pause,complete,sample,floorplan,settings,imported-data,floors,floor,floor/floorplan,floor/sample,active-floor}`, `/canopy/survey/import/airmapper`

### Deliberately NOT gated (viewer-allowed diagnostic actions per Model B)

`/sap/speedtest`, `/sap/iperf*`, `/sap/health-checks/run`, `/shell/**/scan`, `/shell/discovery/*`, `/roots/{traceroute,path}`, `/canopy/wifi/scan`, `/discovery/engine/*`, `/harvest/*`, `/interface(s)`.

## Tests

New internal tests in `handlers_profiles_authz_internal_test.go`:

- `TestWriteGate_MethodAndRoleMatrix` — full safe-method × role matrix on the wrapper, plus no-caller → 401.
- `TestRequireRole_Hierarchy` — locks in `viewer<operator<admin` ordering so a future refactor can't silently reorder them.
- `TestCallerRole_NoDBIsImplicitAdmin` — guards the no-DB single-user fallback.
- `TestWriteGate_WiredOnSettingsRoute` — wiring proof: a viewer `POST /api/v1/settings` through `s.mux` must return 403. If somebody removes the `s.writeGated(...)` wrap at registration, this test fails.

Full `internal/api` test package: 16.4s, ok. `golangci-lint`: 0 issues.

## E2E impact

None. The bootstrap E2E user is `admin`, which clears the write gate, so existing profile/settings/SSO/update Playwright flows behave identically. Viewer/operator E2E coverage is the UI-gating companion (#1254).

## Test plan
- [x] `go test ./internal/api/ -count=1` — passes
- [x] `golangci-lint run ./internal/api/...` — 0 issues
- [x] `go build ./...` — clean
- [ ] CI gates (full `make verify` on push)