### PR TITLE
feat(ui): role-based write gating with RoleContext + WriteGate (#1254)

### DIFF
--- a/ui/src/components/profiles/ProfileManagement.tsx
+++ b/ui/src/components/profiles/ProfileManagement.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { useProfileContext } from '../../contexts/profileContext';
 import { cn, icon as iconTokens, layout, modal, radius, spacing } from '../../styles/theme';
 import type { Profile, ProfileRequest } from '../../types/profile';
+import { WriteGate } from '../ui/WriteGate';
 import { ProfileEditor } from './ProfileEditor';
 
 interface ProfileManagementProps {
@@ -206,32 +207,34 @@ export function ProfileManagement({ onClose }: ProfileManagementProps): React.Re
               'border-b border-surface-border bg-surface-base flex items-center gap-compact shrink-0',
             )}
           >
-            <button
-              type="button"
-              onClick={handleCreate}
-              className={cn(
-                spacing.pad.sm,
-                'px-4',
-                radius.md,
-                'bg-brand-primary hover:bg-brand-accent text-on-brand body-small font-medium flex items-center gap-compact',
-              )}
-            >
-              <svg
-                className="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
+            <WriteGate>
+              <button
+                type="button"
+                onClick={handleCreate}
+                className={cn(
+                  spacing.pad.sm,
+                  'px-4',
+                  radius.md,
+                  'bg-brand-primary hover:bg-brand-accent text-on-brand body-small font-medium flex items-center gap-compact',
+                )}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 4v16m8-8H4"
-                />
-              </svg>
-              {t('profile.create', 'Create Profile')}
-            </button>
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 4v16m8-8H4"
+                  />
+                </svg>
+                {t('profile.create', 'Create Profile')}
+              </button>
+            </WriteGate>
             <button
               type="button"
               onClick={handleExport}
@@ -346,18 +349,20 @@ export function ProfileManagement({ onClose }: ProfileManagementProps): React.Re
                     : t('profile.noProfilesDesc', 'Create your first profile to get started')}
                 </p>
                 {searchQuery ? null : (
-                  <button
-                    type="button"
-                    onClick={handleCreate}
-                    className={cn(
-                      spacing.pad.sm,
-                      'px-4',
-                      radius.md,
-                      'bg-brand-primary hover:bg-brand-accent text-on-brand body-small font-medium',
-                    )}
-                  >
-                    {t('profile.createFirst', 'Create Your First Profile')}
-                  </button>
+                  <WriteGate>
+                    <button
+                      type="button"
+                      onClick={handleCreate}
+                      className={cn(
+                        spacing.pad.sm,
+                        'px-4',
+                        radius.md,
+                        'bg-brand-primary hover:bg-brand-accent text-on-brand body-small font-medium',
+                      )}
+                    >
+                      {t('profile.createFirst', 'Create Your First Profile')}
+                    </button>
+                  </WriteGate>
                 )}
               </div>
             ) : (
@@ -466,75 +471,19 @@ function ProfileCard({
           {t('profile.updated', 'Updated')} {new Date(profile.updatedAt).toLocaleDateString()}
         </p>
 
-        {/* Action buttons - always visible */}
-        <div className="flex items-center gap-compact flex-wrap">
-          {/* Edit button */}
-          <button
-            type="button"
-            onClick={onEdit}
-            className={cn(
-              spacing.chip.sm,
-              radius.md,
-              'border border-surface-border bg-surface-base hover:bg-surface-hover text-text-primary caption font-medium flex items-center gap-1.5',
-            )}
-            title={t('common.edit', 'Edit')}
-          >
-            <svg
-              className="w-3.5 h-3.5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-              />
-            </svg>
-            {t('common.edit', 'Edit')}
-          </button>
-
-          {/* Clone/Duplicate button */}
-          <button
-            type="button"
-            onClick={onDuplicate}
-            className={cn(
-              spacing.chip.sm,
-              radius.md,
-              'border border-surface-border bg-surface-base hover:bg-surface-hover text-text-primary caption font-medium flex items-center gap-1.5',
-            )}
-            title={t('common.clone', 'Clone')}
-          >
-            <svg
-              className="w-3.5 h-3.5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-              />
-            </svg>
-            {t('common.clone', 'Clone')}
-          </button>
-
-          {/* Delete button - only if not default and not active */}
-          {profile.isDefault || isActive ? null : (
+        {/* Action buttons - hidden for viewers (#1226). */}
+        <WriteGate>
+          <div className="flex items-center gap-compact flex-wrap">
+            {/* Edit button */}
             <button
               type="button"
-              onClick={onDelete}
+              onClick={onEdit}
               className={cn(
                 spacing.chip.sm,
                 radius.md,
-                'border border-status-error/30 bg-status-error/5 hover:bg-status-error/10 text-status-error caption font-medium flex items-center gap-1.5',
+                'border border-surface-border bg-surface-base hover:bg-surface-hover text-text-primary caption font-medium flex items-center gap-1.5',
               )}
-              title={t('common.delete', 'Delete')}
+              title={t('common.edit', 'Edit')}
             >
               <svg
                 className="w-3.5 h-3.5"
@@ -547,24 +496,22 @@ function ProfileCard({
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   strokeWidth={2}
-                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
                 />
               </svg>
-              {t('common.delete', 'Delete')}
+              {t('common.edit', 'Edit')}
             </button>
-          )}
 
-          {/* Activate button - only if not active */}
-          {isActive ? null : (
+            {/* Clone/Duplicate button */}
             <button
               type="button"
-              onClick={onSetActive}
+              onClick={onDuplicate}
               className={cn(
                 spacing.chip.sm,
                 radius.md,
-                'bg-brand-primary hover:bg-brand-accent text-on-brand caption font-medium flex items-center gap-1.5 ml-auto',
+                'border border-surface-border bg-surface-base hover:bg-surface-hover text-text-primary caption font-medium flex items-center gap-1.5',
               )}
-              title={t('profile.activate', 'Activate')}
+              title={t('common.clone', 'Clone')}
             >
               <svg
                 className="w-3.5 h-3.5"
@@ -577,13 +524,73 @@ function ProfileCard({
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   strokeWidth={2}
-                  d="M5 13l4 4L19 7"
+                  d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
                 />
               </svg>
-              {t('profile.activate', 'Activate')}
+              {t('common.clone', 'Clone')}
             </button>
-          )}
-        </div>
+
+            {/* Delete button - only if not default and not active */}
+            {profile.isDefault || isActive ? null : (
+              <button
+                type="button"
+                onClick={onDelete}
+                className={cn(
+                  spacing.chip.sm,
+                  radius.md,
+                  'border border-status-error/30 bg-status-error/5 hover:bg-status-error/10 text-status-error caption font-medium flex items-center gap-1.5',
+                )}
+                title={t('common.delete', 'Delete')}
+              >
+                <svg
+                  className="w-3.5 h-3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
+                </svg>
+                {t('common.delete', 'Delete')}
+              </button>
+            )}
+
+            {/* Activate button - only if not active */}
+            {isActive ? null : (
+              <button
+                type="button"
+                onClick={onSetActive}
+                className={cn(
+                  spacing.chip.sm,
+                  radius.md,
+                  'bg-brand-primary hover:bg-brand-accent text-on-brand caption font-medium flex items-center gap-1.5 ml-auto',
+                )}
+                title={t('profile.activate', 'Activate')}
+              >
+                <svg
+                  className="w-3.5 h-3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+                {t('profile.activate', 'Activate')}
+              </button>
+            )}
+          </div>
+        </WriteGate>
       </div>
     </div>
   );

--- a/ui/src/components/settings/sections/ApiTokensSettings.tsx
+++ b/ui/src/components/settings/sections/ApiTokensSettings.tsx
@@ -15,6 +15,7 @@ import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { api } from '../../../api/client';
 import { useLicense } from '../../../contexts/LicenseContext';
+import { useRole } from '../../../contexts/RoleContext';
 import { Button } from '../../ui/Button';
 import { CollapsibleSection } from '../../ui/CollapsibleSection';
 import { Input } from '../../ui/Input';
@@ -57,6 +58,8 @@ export function ApiTokensSettings(): React.ReactElement {
   // tier-aware UI surface stays in sync; this panel used to fetch it
   // inline (pre-PR-A4).
   const { status: licenseStatus, refresh: refreshLicense } = useLicense();
+  // #1226: viewers are read-only — block the mint flow regardless of tier.
+  const { canWrite } = useRole();
   const [tokens, setTokens] = useState<ApiToken[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -185,7 +188,7 @@ export function ApiTokensSettings(): React.ReactElement {
               onChange={(e) => setNewTokenName(e.target.value)}
               placeholder="e.g. monitoring-prod"
               maxLength={64}
-              disabled={!canMint || minting}
+              disabled={!canMint || !canWrite || minting}
             />
           </div>
           <Button
@@ -193,9 +196,15 @@ export function ApiTokensSettings(): React.ReactElement {
             tone="violet"
             size="md"
             leftIcon={<Plus className="w-4 h-4" />}
-            disabled={!canMint || minting || newTokenName.trim().length === 0}
+            disabled={!canMint || !canWrite || minting || newTokenName.trim().length === 0}
             loading={minting}
-            title={canMint ? undefined : 'API token minting requires the Pro tier'}
+            title={
+              !canWrite
+                ? 'Read-only — operator role required to mint API tokens'
+                : !canMint
+                  ? 'API token minting requires the Pro tier'
+                  : undefined
+            }
             onClick={() => void handleMint()}
           >
             Create token
@@ -241,6 +250,12 @@ export function ApiTokensSettings(): React.ReactElement {
                           tone="red"
                           size="xs"
                           leftIcon={<Trash2 className="w-3 h-3" />}
+                          disabled={!canWrite}
+                          title={
+                            canWrite
+                              ? undefined
+                              : 'Read-only — operator role required to revoke tokens'
+                          }
                           onClick={() => void handleRevoke(t)}
                         >
                           Revoke

--- a/ui/src/components/ui/WriteGate.tsx
+++ b/ui/src/components/ui/WriteGate.tsx
@@ -1,0 +1,49 @@
+/**
+ * WriteGate — render children only if the current user has write access.
+ *
+ * Hide-variant role gating, parallel to <RequireFeature> for license
+ * tier. Use it to wrap entire forms, save buttons, "Create" toolbars,
+ * or any UI surface that mutates persistent state on the backend (per
+ * the seed#1226 viewer-is-read-only policy).
+ *
+ * A `viewer` user (or any unauthenticated / fetch-failed state) sees
+ * `fallback` instead of children — default `null`, so a "Save" button
+ * simply disappears. For controls that should remain visible but
+ * disabled with an explanatory tooltip, read `useRole().canWrite`
+ * directly and apply `disabled` + a title attribute.
+ *
+ * Example — hide:
+ * ```tsx
+ * <WriteGate>
+ *   <Button onClick={save}>Save</Button>
+ * </WriteGate>
+ * ```
+ *
+ * Example — disable instead of hide:
+ * ```tsx
+ * const { canWrite } = useRole();
+ * <Button disabled={!canWrite} title={canWrite ? '' : 'Read-only — operator role required'}>
+ *   Save
+ * </Button>
+ * ```
+ *
+ * While the initial /users/me fetch is in flight, `canWrite` is false,
+ * so children render `fallback` — fail-closed, matching RequireFeature.
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+import { useRole } from '../../contexts/RoleContext';
+
+interface WriteGateProps {
+  children: ReactNode;
+  /** Rendered when the user lacks write access (viewer/loading/error). */
+  fallback?: ReactNode;
+}
+
+export function WriteGate({ children, fallback = null }: WriteGateProps): ReactElement {
+  const { canWrite } = useRole();
+  if (!canWrite) {
+    return <>{fallback}</>;
+  }
+  return <>{children}</>;
+}

--- a/ui/src/contexts/RoleContext.test.tsx
+++ b/ui/src/contexts/RoleContext.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * RoleContext tests — cover the canWrite/isAdmin matrix, the loading
+ * fail-closed default, and the fetch-error fallback, so the #1226 UI
+ * gate can't silently regress.
+ */
+
+import { act, render, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WriteGate } from '../components/ui/WriteGate';
+import { type CurrentUser, RoleProvider, useRole } from './RoleContext';
+
+const mockGet = vi.fn<(path: string) => Promise<unknown>>();
+vi.mock('../api/client', () => ({
+  api: {
+    get: (path: string): Promise<unknown> => mockGet(path),
+  },
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }): React.ReactElement => (
+  <RoleProvider>{children}</RoleProvider>
+);
+
+const user = (role: CurrentUser['role'], isActive = true): CurrentUser => ({
+  username: 'u',
+  role,
+  isActive,
+});
+
+describe('RoleContext / useRole', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches /users/me on mount and exposes role + helpers', async () => {
+    mockGet.mockResolvedValueOnce(user('operator'));
+    const { result } = renderHook(() => useRole(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/users/me');
+    expect(result.current.user?.role).toBe('operator');
+    expect(result.current.canWrite).toBe(true);
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it('viewer cannot write and is not admin', async () => {
+    mockGet.mockResolvedValueOnce(user('viewer'));
+    const { result } = renderHook(() => useRole(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canWrite).toBe(false);
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it('admin can write and is admin', async () => {
+    mockGet.mockResolvedValueOnce(user('admin'));
+    const { result } = renderHook(() => useRole(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canWrite).toBe(true);
+    expect(result.current.isAdmin).toBe(true);
+  });
+
+  it('inactive user cannot write even with operator role', async () => {
+    mockGet.mockResolvedValueOnce(user('operator', false));
+    const { result } = renderHook(() => useRole(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canWrite).toBe(false);
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it('fails closed on fetch error: canWrite=false, error surfaced', async () => {
+    mockGet.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useRole(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.user).toBeNull();
+    expect(result.current.canWrite).toBe(false);
+    expect(result.current.isAdmin).toBe(false);
+    expect(result.current.error).toBe('boom');
+  });
+
+  it('refresh() re-fetches /users/me and updates state', async () => {
+    mockGet.mockResolvedValueOnce(user('viewer'));
+    const { result } = renderHook(() => useRole(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canWrite).toBe(false);
+
+    mockGet.mockResolvedValueOnce(user('operator'));
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.canWrite).toBe(true);
+  });
+
+  it('throws if useRole is called outside RoleProvider', () => {
+    const orig = console.error;
+    console.error = (): void => {}; // silence React's expected error boundary log
+    try {
+      expect(() => renderHook(() => useRole())).toThrow(/inside <RoleProvider>/);
+    } finally {
+      console.error = orig;
+    }
+  });
+});
+
+describe('<WriteGate>', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('renders children for operator', async () => {
+    mockGet.mockResolvedValueOnce(user('operator'));
+    const { findByText } = render(
+      <RoleProvider>
+        <WriteGate fallback={<span>blocked</span>}>
+          <span>writable</span>
+        </WriteGate>
+      </RoleProvider>,
+    );
+    await findByText('writable');
+  });
+
+  it('renders fallback for viewer', async () => {
+    mockGet.mockResolvedValueOnce(user('viewer'));
+    const { findByText } = render(
+      <RoleProvider>
+        <WriteGate fallback={<span>blocked</span>}>
+          <span>writable</span>
+        </WriteGate>
+      </RoleProvider>,
+    );
+    await findByText('blocked');
+  });
+});

--- a/ui/src/contexts/RoleContext.tsx
+++ b/ui/src/contexts/RoleContext.tsx
@@ -1,0 +1,112 @@
+/**
+ * RoleContext — current user's role and write-permission helpers.
+ *
+ * Fetches GET /api/v1/users/me once at app boot, caches the result, and
+ * exposes it via `useRole()`. UI components use this to render or hide
+ * write controls so a `viewer` user sees a consistent read-only view
+ * rather than clicking buttons that 403 against the seed#1226 write
+ * gate.
+ *
+ * Production seed always returns a 200 from /users/me for an
+ * authenticated session (the bootstrap admin is seeded at first run),
+ * so the loading state is brief. On fetch error the role falls back to
+ * `null` and the helpers report "no write access" — fail-closed so a
+ * broken /users/me never accidentally enables writes for a viewer.
+ *
+ * Single-user / no-DB seed deployments are admin implicitly (the
+ * backend's callerRole tolerates a missing user DB); the /users/me
+ * response will be the env-configured username with admin role, so
+ * `canWrite` resolves true and no UI changes.
+ */
+
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
+import { api } from '../api/client';
+
+/** Allowed role values, mirroring the seed DB CHECK constraint. */
+export type Role = 'admin' | 'operator' | 'viewer';
+
+/**
+ * Shape of GET /api/v1/users/me — a subset of the backend UserResponse
+ * sufficient for role gating. Extend in lockstep with the server type
+ * if more fields are needed for UI decisions.
+ */
+export interface CurrentUser {
+  username: string;
+  role: Role;
+  isActive: boolean;
+}
+
+interface RoleContextValue {
+  /** Latest /users/me fetch, or null while loading / on fetch error. */
+  user: CurrentUser | null;
+  /** True while the initial fetch is in flight. */
+  loading: boolean;
+  /** Last fetch error message, or null if none. */
+  error: string | null;
+  /** Force a re-fetch (e.g. after role change in another tab). */
+  refresh: () => Promise<void>;
+  /**
+   * True iff the current user may perform write operations against the
+   * seed#1226 write gate (operator or admin). Fail-closed: `false`
+   * during loading and on fetch error, so write controls hide rather
+   * than flash visible.
+   */
+  canWrite: boolean;
+  /**
+   * True iff the current user is admin. Use for admin-only UI sections
+   * such as user management.
+   */
+  isAdmin: boolean;
+}
+
+const RoleContext = createContext<RoleContextValue | null>(null);
+
+interface RoleProviderProps {
+  children: ReactNode;
+}
+
+const ROLE_RANK: Record<Role, number> = { viewer: 1, operator: 2, admin: 3 };
+
+export function RoleProvider({ children }: RoleProviderProps): React.ReactElement {
+  const [user, setUser] = useState<CurrentUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setError(null);
+    try {
+      const fresh = await api.get<CurrentUser>('/api/v1/users/me');
+      setUser(fresh);
+    } catch (err) {
+      setUser(null);
+      setError(err instanceof Error ? err.message : 'Failed to load current user');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const canWrite = user?.isActive === true && ROLE_RANK[user.role] >= ROLE_RANK.operator;
+  const isAdmin = user?.isActive === true && user.role === 'admin';
+
+  return (
+    <RoleContext.Provider value={{ user, loading, error, refresh, canWrite, isAdmin }}>
+      {children}
+    </RoleContext.Provider>
+  );
+}
+
+/**
+ * useRole returns the current user's role state. Throws if called
+ * outside a `<RoleProvider>` — that always indicates a wiring bug.
+ */
+export function useRole(): RoleContextValue {
+  const ctx = useContext(RoleContext);
+  if (!ctx) {
+    throw new Error('useRole() must be called inside <RoleProvider>');
+  }
+  return ctx;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -21,6 +21,7 @@ import App from './app';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { LicenseProvider } from './contexts/LicenseContext';
 import { ProfileProvider } from './contexts/profileContext';
+import { RoleProvider } from './contexts/RoleContext';
 import { getQueryClient } from './lib/queryClient';
 import './index.css';
 
@@ -36,9 +37,11 @@ createRoot(rootElement).render(
     <ErrorBoundary>
       <QueryClientProvider client={getQueryClient()}>
         <LicenseProvider>
-          <ProfileProvider>
-            <App />
-          </ProfileProvider>
+          <RoleProvider>
+            <ProfileProvider>
+              <App />
+            </ProfileProvider>
+          </RoleProvider>
         </LicenseProvider>
       </QueryClientProvider>
     </ErrorBoundary>


### PR DESCRIPTION
Refs #1254 · Wave 4 · UI companion to #1226

## Why

The backend write gate (#1265, in flight) returns 403 to `viewer` users on state-changing requests against the gated routes. Without UI gating, viewers still see writable buttons and forms — they click, hit 403, get a generic error. This PR makes the UI honor the same policy: viewers see a consistent read-only experience.

## What

Mirrors the existing `LicenseContext` / `RequireFeature` pattern so the codebase stays coherent:

- **`RoleContext`** (`ui/src/contexts/RoleContext.tsx`) — provider that fetches `GET /api/v1/users/me` once at boot, exposes `user`, `canWrite`, `isAdmin`, `loading`, `error`, and `refresh()`. Fail-closed on loading/fetch-error so write controls hide rather than flash visible.
- **`useRole()`** hook with the same throw-outside-provider invariant as `useLicense`.
- **`<WriteGate>`** (`ui/src/components/ui/WriteGate.tsx`) — render children only when `canWrite` is true. Hide-variant for whole controls; for visible-but-disabled-with-hint composition, read `useRole().canWrite` directly (as the API tokens flow does).
- Mounted in `main.tsx` between `LicenseProvider` and `ProfileProvider` so profile/license consumers can also read role.

### Pilot adoptions in this PR

- **ApiTokensSettings** — mint button + token-name input now disabled for `!canWrite` with a "Read-only — operator role required" tooltip (composes with the existing Pro-tier `canMint` gate). Revoke button disabled likewise.
- **ProfileManagement** — "Create Profile" toolbar button, the empty-state "Create Your First Profile" button, and the per-card Edit / Delete / Duplicate / Activate action bar all wrap in `<WriteGate>`. Viewers see profiles read-only.

### Follow-up (intentionally not in this PR)

Sweep the remaining gated-surface UIs against the established pattern:

- `SettingsSettings` save flows, `SsoSettings` save, `UpdateSettings` apply/rollback
- `*Settings` panels for DNS-security, SNMP, health-checks, devices, vulnerabilities, guest-audit, thresholds, pipeline
- Canopy survey mutation controls (create / delete / start / pause / floor / sample / settings)

Each is a mechanical wrap — no new infrastructure required. Will be tracked in a #1254 follow-up so each surface gets reviewed for the right hide-vs-disable choice rather than a blind blast.

## Tests

`RoleContext.test.tsx` (9 cases): canWrite/isAdmin matrix, inactive-user, fetch-error fail-closed, refresh(), throw-outside-provider invariant, `<WriteGate>` render path for both operator and viewer.

## Test plan
- [x] `npx vitest run` — 126/126 passed (10 files)
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` (changed files) — 0 issues, 0 warnings
- [ ] Manual smoke as viewer once #1265 merges (the backend gate is what makes this visible — locally still admin so the buttons render today)