### PR TITLE
feat(api): per-token role scope for personal-access tokens (#1255)

### DIFF
--- a/internal/api/handlers_api_tokens.go
+++ b/internal/api/handlers_api_tokens.go
@@ -47,9 +47,15 @@ const apiTokenDisplayPrefix = 12
 // limit keeps DB rows compact and prevents UI overflow.
 const apiTokenNameMaxLen = 64
 
-// MintTokenRequest is the body of POST /api/v1/tokens.
+// MintTokenRequest is the body of POST /api/v1/tokens. Scope is the
+// optional per-token role cap (#1255): omit / empty means the token
+// inherits the owner's role at auth time; "viewer"/"operator"/"admin"
+// caps the effective role at min(owner.role, scope). A scope above the
+// owner's role is rejected up front so the UI surfaces a clear error
+// rather than minting a token that silently downgrades.
 type MintTokenRequest struct {
-	Name string `json:"name"`
+	Name  string `json:"name"`
+	Scope string `json:"scope,omitempty"`
 }
 
 // MintTokenResponse is returned by POST /api/v1/tokens. The Token
@@ -61,6 +67,9 @@ type MintTokenResponse struct {
 	Token     string    `json:"token"`
 	Prefix    string    `json:"prefix"`
 	CreatedAt time.Time `json:"createdAt"`
+	// Scope echoes the requested per-token cap (#1255). Empty when the
+	// token inherits the owner's role.
+	Scope string `json:"scope,omitempty"`
 }
 
 // TokenListItem is a sanitized projection of APITokenRecord for the
@@ -72,6 +81,10 @@ type TokenListItem struct {
 	CreatedAt  time.Time `json:"createdAt"`
 	LastUsedAt time.Time `json:"lastUsedAt,omitzero"`
 	RevokedAt  time.Time `json:"revokedAt,omitzero"`
+	// Scope is the per-token role cap, empty when inheriting the owner's
+	// role (#1255). Surfaced so the UI can show "viewer" / "operator" /
+	// "admin" badges next to each token.
+	Scope string `json:"scope,omitempty"`
 }
 
 // LicenseStatusResponse is returned by GET /api/v1/license. It tells
@@ -193,6 +206,24 @@ func (s *Server) handleAPITokenMint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// #1255: optional per-token scope. Must be a legal role string and
+	// must not exceed the minter's own role — escalating via a PAT
+	// would defeat the role gate.
+	req.Scope = strings.TrimSpace(req.Scope)
+	if req.Scope != "" {
+		if !database.IsValidRole(req.Scope) {
+			writeAPITokenError(w, r, http.StatusBadRequest, ErrCodeValidation,
+				"`scope` must be one of viewer, operator, admin")
+			return
+		}
+		ownerRole, ok := s.callerRole(r)
+		if !ok || roleRank(req.Scope) > roleRank(ownerRole) {
+			writeAPITokenError(w, r, http.StatusForbidden, ErrCodeForbidden,
+				"`scope` may not exceed your own role")
+			return
+		}
+	}
+
 	id, secret, mintErr := mintTokenMaterial()
 	if mintErr != nil {
 		writeAPITokenError(w, r, http.StatusInternalServerError, ErrCodeInternal,
@@ -207,6 +238,7 @@ func (s *Server) handleAPITokenMint(w http.ResponseWriter, r *http.Request) {
 		TokenHash:     hashAPIToken(plaintext),
 		Prefix:        plaintext[:apiTokenDisplayPrefix],
 		CreatedAt:     time.Now().UTC(),
+		Scope:         req.Scope,
 	}
 	if insertErr := repo.Insert(r.Context(), rec); insertErr != nil {
 		logger := logging.FromContext(r.Context())
@@ -222,6 +254,7 @@ func (s *Server) handleAPITokenMint(w http.ResponseWriter, r *http.Request) {
 		Token:     plaintext,
 		Prefix:    rec.Prefix,
 		CreatedAt: rec.CreatedAt,
+		Scope:     rec.Scope,
 	})
 }
 
@@ -255,6 +288,7 @@ func (s *Server) handleAPITokenList(w http.ResponseWriter, r *http.Request) {
 			CreatedAt:  t.CreatedAt,
 			LastUsedAt: t.LastUsedAt,
 			RevokedAt:  t.RevokedAt,
+			Scope:      t.Scope,
 		})
 	}
 	sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusOK, out)
@@ -337,23 +371,25 @@ func hashAPIToken(plaintext string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// resolveAPIToken returns the owning username for the given plaintext
-// token, or "" if no active token matches. Token's last_used_at is
-// touched on a successful lookup (best-effort; failures are logged
-// but do not block the request).
-func resolveAPIToken(ctx context.Context, repo *database.APITokenRepository, plaintext string) string {
+// resolveAPIToken returns the matched record for the given plaintext
+// token, or a zero record if no active token matches. The token's
+// last_used_at is touched on a successful lookup (best-effort; failures
+// are logged but do not block the request). Callers check the returned
+// OwnerUsername == "" to detect no-match; #1255 callers also read Scope
+// to clamp the effective role.
+func resolveAPIToken(ctx context.Context, repo *database.APITokenRepository, plaintext string) database.APITokenRecord {
 	if repo == nil || !strings.HasPrefix(plaintext, APITokenPrefix) {
-		return ""
+		return database.APITokenRecord{}
 	}
 	rec, err := repo.FindActiveByHash(ctx, hashAPIToken(plaintext))
 	if err != nil {
-		return ""
+		return database.APITokenRecord{}
 	}
 	if touchErr := repo.TouchLastUsed(ctx, rec.ID); touchErr != nil {
 		logging.GetLogger().WarnContext(ctx, "failed to update api token last_used_at",
 			"token_id", rec.ID, "error", touchErr)
 	}
-	return rec.OwnerUsername
+	return rec
 }
 
 // apiTokenMiddleware sits in front of the existing JWT auth middleware.
@@ -385,14 +421,21 @@ func apiTokenMiddleware(repo *database.APITokenRepository, next http.Handler) ht
 			next.ServeHTTP(w, r)
 			return
 		}
-		owner := resolveAPIToken(r.Context(), repo, token)
-		if owner == "" {
+		rec := resolveAPIToken(r.Context(), repo, token)
+		if rec.OwnerUsername == "" {
 			writeAPITokenError(w, r, http.StatusUnauthorized, ErrCodeUnauthorized,
 				"Invalid or revoked API token")
 			return
 		}
-		ctx := logging.WithUserID(r.Context(), owner)
-		r.Header.Set("X-Username", owner)
+		ctx := logging.WithUserID(r.Context(), rec.OwnerUsername)
+		r.Header.Set("X-Username", rec.OwnerUsername)
+		// #1255: thread the per-token scope so callerRole can clamp the
+		// effective role at min(owner.role, token.scope). Empty scope
+		// (legacy tokens / no-cap mints) leaves the header unset and
+		// the owner's full role applies.
+		if rec.Scope != "" {
+			r.Header.Set("X-Token-Scope", rec.Scope)
+		}
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/api/handlers_api_tokens_scope_internal_test.go
+++ b/internal/api/handlers_api_tokens_scope_internal_test.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// TestCallerRole_ClampsOnTokenScope proves the #1255 auth-time clamp:
+// X-Token-Scope below the owner's role caps the effective role; at or
+// above the owner's role is a no-op (no escalation possible); invalid
+// scope values are ignored rather than locking the token out.
+func TestCallerRole_ClampsOnTokenScope(t *testing.T) {
+	t.Parallel()
+	s, _ := usersTestSetup(t) // seeds "admin"
+	seedRoledUser(t, s, "operator1", database.RoleOperator)
+
+	cases := []struct {
+		owner     string
+		scope     string
+		wantRole  string
+		wantOK    bool
+		wantClamp bool
+	}{
+		// Admin owner gets clamped down by viewer-scoped token.
+		{"admin", "viewer", database.RoleViewer, true, true},
+		{"admin", "operator", database.RoleOperator, true, true},
+		// No scope = inherit owner role; admin stays admin.
+		{"admin", "", database.RoleAdmin, true, false},
+		// Scope at owner's level is a no-op.
+		{"admin", "admin", database.RoleAdmin, true, false},
+		// Operator owner can be clamped down to viewer.
+		{"operator1", "viewer", database.RoleViewer, true, true},
+		// Scope above owner's role can't escalate — owner's role wins.
+		{"operator1", "admin", database.RoleOperator, true, false},
+		// Invalid scope is ignored, owner's role applies.
+		{"admin", "superuser", database.RoleAdmin, true, false},
+	}
+	for _, c := range cases {
+		req := newAuthedRequest(http.MethodGet, APIVersionPrefix+"/x", nil, c.owner)
+		if c.scope != "" {
+			req.Header.Set("X-Token-Scope", c.scope)
+		}
+		role, ok := s.callerRole(req)
+		if ok != c.wantOK || role != c.wantRole {
+			t.Errorf("callerRole(owner=%s,scope=%q) = (%q,%v), want (%q,%v)",
+				c.owner, c.scope, role, ok, c.wantRole, c.wantOK)
+		}
+	}
+}
+
+// TestWriteGate_ViewerScopedAdminTokenBlocksWrites proves end-to-end
+// that an admin-owned PAT with scope=viewer is rejected by the write
+// gate the same way a real viewer would be — the central #1226 gate
+// reads the clamped role from callerRole, no special case needed.
+func TestWriteGate_ViewerScopedAdminTokenBlocksWrites(t *testing.T) {
+	t.Parallel()
+	s, _ := usersTestSetup(t)
+
+	// As "admin", the write gate would let the request through.
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/probe", nil, "admin")
+	w := httptest.NewRecorder()
+	if !s.requireWriteAccess(w, req) {
+		t.Fatalf("admin without scope must clear gate, got %d", w.Code)
+	}
+
+	// Same admin caller, but the PAT clamped them to viewer.
+	req = newAuthedRequest(http.MethodPost, APIVersionPrefix+"/probe", nil, "admin")
+	req.Header.Set("X-Token-Scope", database.RoleViewer)
+	w = httptest.NewRecorder()
+	if s.requireWriteAccess(w, req) {
+		t.Errorf("admin-owned viewer-scoped token must be blocked by write gate, status=%d", w.Code)
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+// TestAPITokenRepo_ScopeRoundtrips proves the schema + Insert/Find/List
+// path persists and reads back the per-token scope.
+func TestAPITokenRepo_ScopeRoundtrips(t *testing.T) {
+	t.Parallel()
+	s, _ := usersTestSetup(t)
+	db := s.services.Database.DB
+	repo := database.NewAPITokenRepository(db)
+
+	// Seed two tokens for "admin": one viewer-scoped, one inherits.
+	rec1 := database.APITokenRecord{
+		ID: "t1", OwnerUsername: "admin", Name: "ci-readonly",
+		TokenHash: "hash1", Prefix: "sd_pat_abcde", Scope: database.RoleViewer,
+	}
+	rec2 := database.APITokenRecord{
+		ID: "t2", OwnerUsername: "admin", Name: "all-access",
+		TokenHash: "hash2", Prefix: "sd_pat_fghij", Scope: "",
+	}
+	if err := repo.Insert(t.Context(), rec1); err != nil {
+		t.Fatalf("insert t1: %v", err)
+	}
+	if err := repo.Insert(t.Context(), rec2); err != nil {
+		t.Fatalf("insert t2: %v", err)
+	}
+
+	got1, err := repo.FindActiveByHash(t.Context(), "hash1")
+	if err != nil {
+		t.Fatalf("find t1: %v", err)
+	}
+	if got1.Scope != database.RoleViewer {
+		t.Errorf("scope round-trip: got %q, want %q", got1.Scope, database.RoleViewer)
+	}
+
+	got2, err := repo.FindActiveByHash(t.Context(), "hash2")
+	if err != nil {
+		t.Fatalf("find t2: %v", err)
+	}
+	if got2.Scope != "" {
+		t.Errorf("empty-scope round-trip: got %q, want empty (NULL inherits)", got2.Scope)
+	}
+
+	// List preserves Scope on every row.
+	list, err := repo.ListByOwner(t.Context(), "admin")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	scopes := map[string]string{}
+	for _, r := range list {
+		scopes[r.ID] = r.Scope
+	}
+	if scopes["t1"] != database.RoleViewer || scopes["t2"] != "" {
+		t.Errorf("list scopes: got %v, want t1=viewer t2=''", scopes)
+	}
+}
+
+// attachAPITokenRepo wires an APITokenRepository onto the test server's
+// service container so the mint/list/revoke handlers can run.
+func attachAPITokenRepo(t *testing.T, s *Server) {
+	t.Helper()
+	s.services.Auth.APITokens = database.NewAPITokenRepository(s.services.Database.DB)
+}
+
+// TestMintAPIToken_RejectsScopeAboveOwner proves the mint handler
+// refuses to issue a token with a scope higher than the minter's role
+// — that would be a one-line escalation if accepted.
+func TestMintAPIToken_RejectsScopeAboveOwner(t *testing.T) {
+	t.Parallel()
+	s, mgr := usersTestSetup(t)
+	attachAPITokenRepo(t, s)
+	if r := mgr.StartTrial(); !r.Success { // mint requires Pro
+		t.Fatalf("StartTrial: %s", r.Message)
+	}
+	seedRoledUser(t, s, "operator1", database.RoleOperator)
+	// Operator tries to mint an admin-scoped token.
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/tokens",
+		[]byte(`{"name":"escalate","scope":"admin"}`), "operator1")
+	w := httptest.NewRecorder()
+	s.handleAPITokens(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestMintAPIToken_RejectsUnknownScope keeps the error from the schema
+// CHECK constraint from being the user's first signal — the handler
+// returns a clearer 400 up front.
+func TestMintAPIToken_RejectsUnknownScope(t *testing.T) {
+	t.Parallel()
+	s, mgr := usersTestSetup(t)
+	attachAPITokenRepo(t, s)
+	if r := mgr.StartTrial(); !r.Success {
+		t.Fatalf("StartTrial: %s", r.Message)
+	}
+	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/tokens",
+		[]byte(`{"name":"weird","scope":"superuser"}`), "admin")
+	w := httptest.NewRecorder()
+	s.handleAPITokens(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/handlers_users.go
+++ b/internal/api/handlers_users.go
@@ -434,6 +434,17 @@ func (s *Server) callerRole(r *http.Request) (string, bool) {
 	if err != nil || !u.IsActive {
 		return "", false
 	}
+	// #1255: PAT auth sets X-Token-Scope to a per-token role cap. The
+	// effective role becomes the lower of the owner's role and the
+	// token's scope so an automation token minted from an admin owner
+	// can't escalate. An invalid/unknown scope value is ignored (rank-0
+	// would lock the token out entirely, the wrong failure mode for a
+	// malformed header).
+	if scope := r.Header.Get("X-Token-Scope"); scope != "" && database.IsValidRole(scope) {
+		if roleRank(scope) < roleRank(u.Role) {
+			return scope, true
+		}
+	}
 	return u.Role, true
 }
 

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -979,6 +979,19 @@ func getMigrationDefs() []migrationDef {
 			PRAGMA foreign_keys = ON;
 		`,
 		},
+		{
+			// Wave 5 (#1255): per-token scope for personal-access tokens.
+			// NULL means the token inherits the owner's role (existing
+			// behavior); a non-NULL value caps the effective role at
+			// min(owner.role, token.scope). Validated by the CHECK
+			// constraint so writes through the application layer or via
+			// the SQLite shell both stay bounded to the legal set.
+			Description: "Add scope column to api_tokens for per-token role capping (#1255)",
+			Up: `
+			ALTER TABLE api_tokens ADD COLUMN scope TEXT
+			    CHECK (scope IS NULL OR scope IN ('admin','operator','viewer'));
+		`,
+		},
 	}
 }
 

--- a/internal/database/repository_api_tokens.go
+++ b/internal/database/repository_api_tokens.go
@@ -23,6 +23,12 @@ type APITokenRecord struct {
 	CreatedAt     time.Time
 	LastUsedAt    time.Time
 	RevokedAt     time.Time
+	// Scope caps the effective role of requests made with this token.
+	// Empty means inherit the owner's role (the default for tokens minted
+	// before #1255). When set, the effective role is min(owner.role,
+	// scope) at auth time so a less-privileged automation token can be
+	// minted from an admin owner.
+	Scope string
 }
 
 // IsActive reports whether the token is currently usable (not revoked).
@@ -42,12 +48,18 @@ func NewAPITokenRepository(db *DB) *APITokenRepository {
 	return &APITokenRepository{db: db}
 }
 
-// Insert persists a newly minted token record.
+// Insert persists a newly minted token record. An empty Scope is stored
+// as NULL so the column reads back as "" via the COALESCE in scan, which
+// the auth layer interprets as "inherit owner's role" (#1255).
 func (r *APITokenRepository) Insert(ctx context.Context, t APITokenRecord) error {
+	var scope any
+	if t.Scope != "" {
+		scope = t.Scope
+	}
 	_, err := r.db.conn.ExecContext(ctx, `
-		INSERT INTO api_tokens (id, owner_username, name, token_hash, prefix, created_at)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, t.ID, t.OwnerUsername, t.Name, t.TokenHash, t.Prefix, t.CreatedAt.UTC().Format(time.RFC3339Nano))
+		INSERT INTO api_tokens (id, owner_username, name, token_hash, prefix, created_at, scope)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, t.ID, t.OwnerUsername, t.Name, t.TokenHash, t.Prefix, t.CreatedAt.UTC().Format(time.RFC3339Nano), scope)
 	if err != nil {
 		return fmt.Errorf("insert api token: %w", err)
 	}
@@ -59,7 +71,8 @@ func (r *APITokenRepository) Insert(ctx context.Context, t APITokenRecord) error
 func (r *APITokenRepository) FindActiveByHash(ctx context.Context, hash string) (APITokenRecord, error) {
 	row := r.db.conn.QueryRowContext(ctx, `
 		SELECT id, owner_username, name, token_hash, prefix, created_at,
-		       COALESCE(last_used_at, ''), COALESCE(revoked_at, '')
+		       COALESCE(last_used_at, ''), COALESCE(revoked_at, ''),
+		       COALESCE(scope, '')
 		FROM api_tokens
 		WHERE token_hash = ? AND revoked_at IS NULL
 	`, hash)
@@ -73,7 +86,8 @@ func (r *APITokenRepository) FindActiveByHash(ctx context.Context, hash string) 
 func (r *APITokenRepository) ListByOwner(ctx context.Context, owner string) ([]APITokenRecord, error) {
 	rows, err := r.db.conn.QueryContext(ctx, `
 		SELECT id, owner_username, name, token_hash, prefix, created_at,
-		       COALESCE(last_used_at, ''), COALESCE(revoked_at, '')
+		       COALESCE(last_used_at, ''), COALESCE(revoked_at, ''),
+		       COALESCE(scope, '')
 		FROM api_tokens
 		WHERE owner_username = ?
 		ORDER BY created_at DESC
@@ -139,7 +153,7 @@ func scanAPIToken(r rowScanner) (APITokenRecord, error) {
 
 	scanErr := r.Scan(
 		&rec.ID, &rec.OwnerUsername, &rec.Name, &rec.TokenHash, &rec.Prefix,
-		&createdStr, &lastUsedStr, &revokedStr,
+		&createdStr, &lastUsedStr, &revokedStr, &rec.Scope,
 	)
 	if scanErr != nil {
 		if errors.Is(scanErr, sql.ErrNoRows) {


### PR DESCRIPTION
Closes #1255 · Wave 5

## Why

PATs previously inherited the full role of their owner — an admin's API token was an admin token, with no way to mint a reduced-privilege automation credential for CI/monitoring. This PR adds an optional per-token \`scope\`; the effective role at auth time becomes \`min(owner.role, token.scope)\`, so an admin can mint a viewer-scoped PAT that 403s on every gated write.

## Schema

- New migration: \`ALTER TABLE api_tokens ADD COLUMN scope TEXT\` with a CHECK constraint to (\`admin\`,\`operator\`,\`viewer\`). NULL is the existing-token / no-cap default and inherits the owner's role.
- \`APITokenRecord\` gains \`Scope\`. Insert stores NULL for empty Scope. Find/List COALESCE the column back to \`""\` so legacy rows surface as inherit.

## Mint flow

- \`MintTokenRequest\` accepts an optional \`scope\` string.
- Validated up front: must be a legal role; **must not exceed the caller's own role** — refusing the one-line escalation. The schema CHECK is the belt; this is the suspenders that gives the user a clearer 400 before the constraint fires.
- \`MintTokenResponse\` and \`TokenListItem\` surface the scope back to the UI so the panel can show "viewer" / "operator" / "admin" badges.

## Auth-time clamp

- \`apiTokenMiddleware\` sets \`X-Token-Scope\` on the request when a scoped token resolves. Empty/legacy scope leaves the header unset and the owner's full role applies — no behavior change for existing tokens.
- \`callerRole\` reads \`X-Token-Scope\` after the owner DB lookup and returns the lower of \`(owner.role, scope)\` so the central #1226 \`writeGated\` wrapper transparently blocks downscoped tokens on writes. Invalid scope is ignored (returns owner.role) — the wrong failure mode for a malformed header would be to lock the token out entirely.

## Tests

- \`TestCallerRole_ClampsOnTokenScope\` — clamp matrix (down clamps, same-rank no-op, escalation impossible, invalid ignored).
- \`TestWriteGate_ViewerScopedAdminTokenBlocksWrites\` — end-to-end against \`requireWriteAccess\` so the integration with #1226 can't silently regress.
- \`TestAPITokenRepo_ScopeRoundtrips\` — Insert/Find/List preserve scope including the NULL-as-empty inherit path.
- \`TestMintAPIToken_Rejects{ScopeAboveOwner,UnknownScope}\` — escalation + malformed input.

## Follow-up (not in this PR)

UI scope selector in the mint form. The backend contract is back-compat (omit scope = same behavior as today), so the selector lands separately.

## Test plan
- [x] \`go test ./internal/api/ -count=1\` — passes
- [x] \`go test ./internal/database/ -count=1\` — passes
- [x] \`golangci-lint run ./internal/...\` — 0 issues