### PR TITLE
feat(config): refuse CORS `*` origin at startup (#1256)

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -490,6 +490,36 @@ func TestValidateSamePortAndRedirectPort(t *testing.T) {
 	}
 }
 
+// TestValidateCORSWildcardOrigin asserts the #1256 guard: a literal `*`
+// in security.allowed_origins refuses startup because Allow-Credentials
+// is unconditionally true, making the pair invalid per the CORS spec.
+func TestValidateCORSWildcardOrigin(t *testing.T) {
+	cases := []struct {
+		name    string
+		origins []string
+		wantErr bool
+	}{
+		{"explicit origin is fine", []string{"https://seed.example.com"}, false},
+		{"explicit list mixed is fine", []string{"https://a.example.com", "https://b.example.com"}, false},
+		{"empty list defaults to RFC1918 and is fine", []string{}, false},
+		{"bare wildcard is rejected", []string{"*"}, true},
+		{"wildcard with surrounding whitespace is rejected", []string{" * "}, true},
+		{"wildcard mixed with explicit is rejected", []string{"https://seed.example.com", "*"}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.Auth.DefaultPasswordHash = "hash"
+			cfg.Security.AllowedOrigins = c.origins
+
+			err := cfg.Validate()
+			if (err != nil) != c.wantErr {
+				t.Errorf("Validate() err = %v, wantErr = %v", err, c.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateEmptyInterface(t *testing.T) {
 	// Empty interface is now valid - triggers auto-detection (#572)
 	cfg := config.DefaultConfig()

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -24,9 +24,32 @@ func (c *Config) Validate() error {
 	errs = append(errs, c.validateAuthConfig()...)
 	errs = append(errs, c.validateSNMPConfig()...)
 	errs = append(errs, c.validateLoggingConfig()...)
+	errs = append(errs, c.validateCORSConfig()...)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("configuration validation failed:\n  - %s", strings.Join(errs, "\n  - "))
+	}
+	return nil
+}
+
+// validateCORSConfig refuses `*` in Security.AllowedOrigins (#1256). Seed's
+// corsMiddleware always responds with `Access-Control-Allow-Credentials:
+// true`, and per the CORS spec wildcard origin with credentials is an
+// invalid pair: browsers reject it. Honoring `*` here is at best
+// non-functional and at worst the kind of subtle config footgun where
+// credentialed responses leak across origins if a UA ever does honor it.
+// Operators must list explicit origins; the WARN-only behavior of the
+// pre-#1256 path silently allowed insecure setups.
+func (c *Config) validateCORSConfig() []string {
+	for _, origin := range c.Security.AllowedOrigins {
+		if strings.TrimSpace(origin) == "*" {
+			return []string{
+				"security.allowed_origins: `*` is not allowed because " +
+					"credentialed CORS (Access-Control-Allow-Credentials: true) " +
+					"is invalid with a wildcard origin per the CORS spec; " +
+					"list explicit origins (e.g. https://seed.example.com)",
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #1256 · Wave 5

## Why

\`corsMiddleware\` unconditionally responds with \`Access-Control-Allow-Credentials: true\`. Per the CORS spec, pairing that with \`Access-Control-Allow-Origin: *\` is invalid — browsers reject it. Pre-#1256 the wildcard was honored with a WARN log only, so a misconfigured production seed could silently ship the invalid pair and depend on UA-side rejection for safety (the wrong place to enforce a credentials boundary).

## What

Adds \`validateCORSConfig()\` to \`Config.Validate()\`. A literal \`*\` in \`security.allowed_origins\` (or \`SEED_SECURITY_ALLOWED_ORIGINS=*\` after env-merge) now **fails startup** with a clear, actionable message naming the spec issue and pointing the operator at explicit origins.

Both \`cmd serve\` and \`cmd validate\` invoke \`Config.Validate()\`, so the guard runs before the listener binds.

- Whitespace-only \`*\` is also rejected (a hand-edited \"  *  \" entry would otherwise sneak past).
- Mixed lists where \`*\` appears alongside explicit origins are rejected so an audited explicit list can't be silently neutered by a stray catch-all.

The pre-existing \`logWildcardOriginWarning\` in \`server_init.go\` is now unreachable but left in place as defense-in-depth — if any future code path constructs a server bypassing \`Validate()\`, the warning still fires.

## Tests

- \`TestValidateCORSWildcardOrigin\` — explicit origin, mixed-explicit, empty (RFC1918 default), bare \`*\`, whitespace-padded \`*\`, and wildcard-mixed-with-explicit cases.

## Test plan
- [x] \`go test ./internal/config/ -count=1\` — passes
- [x] \`golangci-lint run ./internal/config/...\` — 0 issues

## Operator note

If you're currently running with \`SEED_SECURITY_ALLOWED_ORIGINS=*\`, you must list explicit origins before upgrading. The error message at startup names the spec issue and the field.