### PR TITLE
feat(ui): wrap SettingsDrawer in ReadOnlyView for viewer role (#1254 follow-up)

### DIFF
--- a/ui/src/components/settings/SettingsDrawer.tsx
+++ b/ui/src/components/settings/SettingsDrawer.tsx
@@ -49,6 +49,7 @@ import type {
   TestsSettings,
   WiFiSettings as WiFiSettingsType,
 } from '../../types/settings';
+import { ReadOnlyView } from '../ui/ReadOnlyView';
 import { SettingsDrawerFooter } from './SettingsDrawerFooter';
 import { SettingsDrawerNetworkSection } from './SettingsDrawerNetworkSection';
 import { ApiTokensSettings } from './sections/ApiTokensSettings';
@@ -556,148 +557,156 @@ export const SettingsDrawer: React.MemoExoticComponent<
           className={cn(spacing.drawerPad, 'section-gap body-small leading-relaxed')}
           ref={scrollRef}
         >
-          {/* Settings sections ordered to match dashboard card order */}
-          {/* Link Settings - always visible for ethernet interface config */}
-          <LinkSettings
-            linkSettings={linkSettings}
-            setLinkSettings={setLinkSettings}
-            linkStatus={linkStatus}
-            cardSettings={cardSettings}
-            updateCardSettings={updateCardSettings}
-          />
-
-          {/* Cable Test Settings - always visible for cable diagnostics */}
-          <CableTestSettings
-            cableTestSettings={cableTestSettings}
-            setCableTestSettings={setCableTestSettings}
-            cableTestStatus={cableTestStatus}
-          />
-
-          {/* Network Section - IP/DHCP config (third) */}
-          <SettingsDrawerNetworkSection
-            ipSettings={ipSettings}
-            setIpSettings={setIpSettings}
-            dnsInput={dnsInput}
-            setDnsInput={setDnsInput}
-            saveIpSettings={saveIpSettings}
-            savingIp={savingIp}
-            ipMessage={ipMessage}
-            displayOptions={displayOptions}
-            setDisplayOptions={setDisplayOptions}
-            displayStatus={displayStatus}
-            isValidIp={isValidIp}
-          />
-
-          {/* WiFi Settings - only shown in WiFi mode (#754) */}
-          {isWifi ? (
-            <WiFiSettings
-              wifiSettings={wifiSettings}
-              setWifiSettings={setWifiSettings}
-              wifiStatus={wifiStatus}
+          {/* #1254: viewers see every panel read-only via one wrap. The
+              fieldset inside ReadOnlyView propagates `disabled` to every
+              descendant input/button so each section needn't gate its own
+              controls. ApiTokensSettings still composes its license+role
+              tooltips per-control inside; ReadOnlyView's disabled is
+              idempotent with those, so no conflict. */}
+          <ReadOnlyView>
+            {/* Settings sections ordered to match dashboard card order */}
+            {/* Link Settings - always visible for ethernet interface config */}
+            <LinkSettings
+              linkSettings={linkSettings}
+              setLinkSettings={setLinkSettings}
+              linkStatus={linkStatus}
+              cardSettings={cardSettings}
+              updateCardSettings={updateCardSettings}
             />
-          ) : null}
 
-          {/* DNS Settings - matches DnsCard position */}
-          <DnsSettings
-            testsSettings={testsSettings}
-            setTestsSettings={setTestsSettings}
-            testsStatus={testsStatus}
-            cardSettings={cardSettings}
-            updateCardSettings={updateCardSettings}
-          />
+            {/* Cable Test Settings - always visible for cable diagnostics */}
+            <CableTestSettings
+              cableTestSettings={cableTestSettings}
+              setCableTestSettings={setCableTestSettings}
+              cableTestStatus={cableTestStatus}
+            />
 
-          <HealthChecksSettings
-            testsSettings={testsSettings}
-            setTestsSettings={setTestsSettings}
-            testsStatus={testsStatus}
-            cardSettings={cardSettings}
-            updateCardSettings={updateCardSettings}
-          />
+            {/* Network Section - IP/DHCP config (third) */}
+            <SettingsDrawerNetworkSection
+              ipSettings={ipSettings}
+              setIpSettings={setIpSettings}
+              dnsInput={dnsInput}
+              setDnsInput={setDnsInput}
+              saveIpSettings={saveIpSettings}
+              savingIp={savingIp}
+              ipMessage={ipMessage}
+              displayOptions={displayOptions}
+              setDisplayOptions={setDisplayOptions}
+              displayStatus={displayStatus}
+              isValidIp={isValidIp}
+            />
 
-          <PerformanceSettings
-            testsSettings={testsSettings}
-            setTestsSettings={setTestsSettings}
-            iperfSettings={iperfSettings}
-            setIperfSettings={setIperfSettings}
-            iperfStatus={iperfStatus}
-            iperfSuggestions={iperfSuggestions}
-            iperfSuggestionsStatus={iperfSuggestionsStatus}
-            iperfSuggestionsError={iperfSuggestionsError}
-            fetchIperfSuggestions={fetchIperfSuggestions}
-            cardSettings={cardSettings}
-            updateCardSettings={updateCardSettings}
-          />
+            {/* WiFi Settings - only shown in WiFi mode (#754) */}
+            {isWifi ? (
+              <WiFiSettings
+                wifiSettings={wifiSettings}
+                setWifiSettings={setWifiSettings}
+                wifiStatus={wifiStatus}
+              />
+            ) : null}
 
-          <DiscoverySettings
-            networkDiscoverySettings={networkDiscoverySettings}
-            setNetworkDiscoverySettings={setNetworkDiscoverySettings}
-            networkDiscoveryStatus={networkDiscoveryStatus}
-            subnets={subnets}
-            subnetsStatus={subnetsStatus}
-            newSubnetCidr={newSubnetCidr}
-            setNewSubnetCidr={setNewSubnetCidr}
-            newSubnetName={newSubnetName}
-            setNewSubnetName={setNewSubnetName}
-            subnetError={subnetError}
-            setSubnetError={setSubnetError}
-            addSubnet={addSubnet}
-            toggleSubnet={toggleSubnet}
-            deleteSubnet={deleteSubnet}
-            snmpSettings={snmpSettings}
-            setSnmpSettings={setSnmpSettings}
-            snmpStatus={snmpStatus}
-            cardSettings={cardSettings}
-            updateCardSettings={updateCardSettings}
-          />
+            {/* DNS Settings - matches DnsCard position */}
+            <DnsSettings
+              testsSettings={testsSettings}
+              setTestsSettings={setTestsSettings}
+              testsStatus={testsStatus}
+              cardSettings={cardSettings}
+              updateCardSettings={updateCardSettings}
+            />
 
-          <VulnerabilitySettings
-            settings={vulnSettings}
-            setSettings={setVulnSettings}
-            status={vulnStatus}
-          />
+            <HealthChecksSettings
+              testsSettings={testsSettings}
+              setTestsSettings={setTestsSettings}
+              testsStatus={testsStatus}
+              cardSettings={cardSettings}
+              updateCardSettings={updateCardSettings}
+            />
 
-          <ThresholdsSettings
-            thresholds={thresholds}
-            setThresholds={setThresholds}
-            thresholdsStatus={thresholdsStatus}
-          />
+            <PerformanceSettings
+              testsSettings={testsSettings}
+              setTestsSettings={setTestsSettings}
+              iperfSettings={iperfSettings}
+              setIperfSettings={setIperfSettings}
+              iperfStatus={iperfStatus}
+              iperfSuggestions={iperfSuggestions}
+              iperfSuggestionsStatus={iperfSuggestionsStatus}
+              iperfSuggestionsError={iperfSuggestionsError}
+              fetchIperfSuggestions={fetchIperfSuggestions}
+              cardSettings={cardSettings}
+              updateCardSettings={updateCardSettings}
+            />
 
-          {/* Appearance Section */}
-          <AppearanceSettings
-            theme={theme}
-            setTheme={setTheme}
-            isDark={isDark}
-            unitSystem={displayOptions.unitSystem || 'sae'}
-            setUnitSystem={(unit: 'sae' | 'metric'): void =>
-              setDisplayOptions((prev) => ({ ...prev, unitSystem: unit }))
-            }
-          />
+            <DiscoverySettings
+              networkDiscoverySettings={networkDiscoverySettings}
+              setNetworkDiscoverySettings={setNetworkDiscoverySettings}
+              networkDiscoveryStatus={networkDiscoveryStatus}
+              subnets={subnets}
+              subnetsStatus={subnetsStatus}
+              newSubnetCidr={newSubnetCidr}
+              setNewSubnetCidr={setNewSubnetCidr}
+              newSubnetName={newSubnetName}
+              setNewSubnetName={setNewSubnetName}
+              subnetError={subnetError}
+              setSubnetError={setSubnetError}
+              addSubnet={addSubnet}
+              toggleSubnet={toggleSubnet}
+              deleteSubnet={deleteSubnet}
+              snmpSettings={snmpSettings}
+              setSnmpSettings={setSnmpSettings}
+              snmpStatus={snmpStatus}
+              cardSettings={cardSettings}
+              updateCardSettings={updateCardSettings}
+            />
 
-          {/* API tokens (Phase D-2 LICENSE_STRATEGY) */}
-          <ApiTokensSettings />
+            <VulnerabilitySettings
+              settings={vulnSettings}
+              setSettings={setVulnSettings}
+              status={vulnStatus}
+            />
 
-          {/* Users CRUD (multi_user, seed#1191) */}
-          <UsersSettings />
+            <ThresholdsSettings
+              thresholds={thresholds}
+              setThresholds={setThresholds}
+              thresholdsStatus={thresholdsStatus}
+            />
 
-          {/* SSO admin panel (seed#1198) */}
-          <SsoSettings />
+            {/* Appearance Section */}
+            <AppearanceSettings
+              theme={theme}
+              setTheme={setTheme}
+              isDark={isDark}
+              unitSystem={displayOptions.unitSystem || 'sae'}
+              setUnitSystem={(unit: 'sae' | 'metric'): void =>
+                setDisplayOptions((prev) => ({ ...prev, unitSystem: unit }))
+              }
+            />
 
-          {/* Network Interfaces (multi_interface, seed#1192) */}
-          <InterfacesSettings />
+            {/* API tokens (Phase D-2 LICENSE_STRATEGY) */}
+            <ApiTokensSettings />
 
-          {/* Config Backups Section (implements #494) */}
-          <ConfigBackupsSection />
+            {/* Users CRUD (multi_user, seed#1191) */}
+            <UsersSettings />
 
-          {/* Updates Section (implements #862) */}
-          <UpdateSettings currentVersion={version} />
+            {/* SSO admin panel (seed#1198) */}
+            <SsoSettings />
 
-          <SettingsDrawerFooter
-            version={version}
-            fetchLogPreview={fetchLogPreview}
-            logLoading={logLoading}
-            logError={logError}
-            logPreview={logPreview}
-          />
+            {/* Network Interfaces (multi_interface, seed#1192) */}
+            <InterfacesSettings />
+
+            {/* Config Backups Section (implements #494) */}
+            <ConfigBackupsSection />
+
+            {/* Updates Section (implements #862) */}
+            <UpdateSettings currentVersion={version} />
+
+            <SettingsDrawerFooter
+              version={version}
+              fetchLogPreview={fetchLogPreview}
+              logLoading={logLoading}
+              logError={logError}
+              logPreview={logPreview}
+            />
+          </ReadOnlyView>
         </div>
       </div>
     </>

--- a/ui/src/components/ui/ReadOnlyView.test.tsx
+++ b/ui/src/components/ui/ReadOnlyView.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * ReadOnlyView tests — cover the operator-passes-through path, the
+ * viewer banner + fieldset path, and the native-disable propagation
+ * that's the whole reason the wrapper exists.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type CurrentUser, RoleProvider } from '../../contexts/RoleContext';
+import { ReadOnlyView } from './ReadOnlyView';
+
+const mockGet = vi.fn<(path: string) => Promise<unknown>>();
+vi.mock('../../api/client', () => ({
+  api: {
+    get: (path: string): Promise<unknown> => mockGet(path),
+  },
+}));
+
+const user = (role: CurrentUser['role']): CurrentUser => ({
+  username: 'u',
+  role,
+  isActive: true,
+});
+
+describe('<ReadOnlyView>', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('renders children unwrapped for an operator', async () => {
+    mockGet.mockResolvedValueOnce(user('operator'));
+    const { container, findByTestId, queryByRole } = render(
+      <RoleProvider>
+        <ReadOnlyView>
+          <input data-testid="probe" />
+        </ReadOnlyView>
+      </RoleProvider>,
+    );
+    const input = await findByTestId('probe');
+    expect((input as HTMLInputElement).disabled).toBe(false);
+    expect(queryByRole('status')).toBeNull();
+    expect(container.querySelector('fieldset')).toBeNull();
+  });
+
+  it('wraps children in a disabled fieldset and shows a banner for a viewer', async () => {
+    mockGet.mockResolvedValueOnce(user('viewer'));
+    const { findByTestId, findByRole, container } = render(
+      <RoleProvider>
+        <ReadOnlyView>
+          <input data-testid="probe-input" />
+          <button data-testid="probe-button" type="button">
+            Save
+          </button>
+        </ReadOnlyView>
+      </RoleProvider>,
+    );
+    // Banner renders with status role for assistive tech.
+    await findByRole('status');
+    // The fieldset is the HTML-spec lever that disables every nested
+    // form control without us having to gate each one. jsdom doesn't
+    // synthesize the disabled-propagation onto the input.disabled
+    // property, so the structural check (input nested under disabled
+    // fieldset) is what the test asserts; the actual disabled paint
+    // happens in real browsers per the HTML spec.
+    const fieldset = container.querySelector('fieldset');
+    expect(fieldset).not.toBeNull();
+    expect(fieldset?.hasAttribute('disabled')).toBe(true);
+    const input = await findByTestId('probe-input');
+    const button = await findByTestId('probe-button');
+    expect(fieldset?.contains(input)).toBe(true);
+    expect(fieldset?.contains(button)).toBe(true);
+  });
+
+  it('honors a custom notice', async () => {
+    mockGet.mockResolvedValueOnce(user('viewer'));
+    const { findByText } = render(
+      <RoleProvider>
+        <ReadOnlyView notice="Custom message for this panel.">
+          <span />
+        </ReadOnlyView>
+      </RoleProvider>,
+    );
+    await findByText('Custom message for this panel.');
+  });
+});

--- a/ui/src/components/ui/ReadOnlyView.tsx
+++ b/ui/src/components/ui/ReadOnlyView.tsx
@@ -1,0 +1,54 @@
+/**
+ * ReadOnlyView — wraps a settings panel so a viewer-role user sees the
+ * current configuration but cannot mutate it.
+ *
+ * Renders an explanatory banner when the current user lacks write
+ * access, and disables every descendant native form control via a
+ * `<fieldset disabled>`. The fieldset trick works because the HTML
+ * spec propagates `disabled` to every nested input, select, textarea,
+ * and button — one wrap on the form root locks down the whole surface
+ * regardless of how many sub-controls exist, sparing each settings
+ * section a per-control sweep.
+ *
+ * Operator and admin users see no chrome change: the wrapper renders
+ * children directly (no banner, no fieldset).
+ *
+ * Use this when a settings panel has many small inputs and one or more
+ * action buttons that all map to the same gated backend route. For
+ * surfaces with a single obvious write button, prefer the inline
+ * `useRole().canWrite` + `disabled` pattern so the tooltip can compose
+ * with other gates (e.g. license tier in <ApiTokensSettings>).
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+import { useRole } from '../../contexts/RoleContext';
+
+interface ReadOnlyViewProps {
+  children: ReactNode;
+  /**
+   * Optional override for the banner copy — useful when the surface's
+   * own terminology fits better than the default "settings on this
+   * panel are read-only" phrasing.
+   */
+  notice?: string;
+}
+
+export function ReadOnlyView({ children, notice }: ReadOnlyViewProps): ReactElement {
+  const { canWrite } = useRole();
+  if (canWrite) {
+    return <>{children}</>;
+  }
+  return (
+    <div className="stack-sm">
+      <div
+        role="status"
+        className="rounded-lg border border-status-info/30 bg-status-info/5 pad-sm text-sm text-status-info"
+      >
+        {notice ?? 'Read-only — your role does not allow changes on this panel.'}
+      </div>
+      <fieldset disabled className="contents">
+        {children}
+      </fieldset>
+    </div>
+  );
+}


### PR DESCRIPTION
Refs #1254 · Wave 4 follow-up · UI sweep for the role gate landed in #1267

## Why

#1267 added the role infrastructure and the first two pilot adoptions (API tokens + Profiles). This PR sweeps the remaining settings sections so a viewer-role user sees a consistent read-only view across the entire app, not just the two pilot surfaces.

## What

Adds \`<ReadOnlyView>\` — a single wrapper that uses HTML's \`<fieldset disabled>\` to propagate \`disabled\` to every nested input, select, textarea, and button. One wrap on \`SettingsDrawer\`'s container div covers the whole settings surface:

- LinkSettings, CableTestSettings, SettingsDrawerNetworkSection
- WiFiSettings (incl. connect/disconnect/forget)
- DnsSettings, HealthChecksSettings, PerformanceSettings, DiscoverySettings
- VulnerabilitySettings, ThresholdsSettings
- AppearanceSettings
- ApiTokensSettings (existing per-control composition still works — \`disabled\` is idempotent)
- UsersSettings (admin-only gates still apply on top)
- SsoSettings, InterfacesSettings, ConfigBackupsSection
- UpdateSettings (apply / rollback / config write)

Operator and admin: no chrome change — \`<ReadOnlyView>\` short-circuits to its children when \`canWrite\`.
Viewer: a single banner at the top of the drawer explains the read-only state; the whole form surface is HTML-spec disabled.

## Tests

- \`TestReadOnlyView_OperatorRendersUnwrapped\` — operator path is clean (no banner, no fieldset).
- \`TestReadOnlyView_ViewerWrapsAndBanners\` — children land inside a \`<fieldset disabled>\` and a status banner is rendered. jsdom doesn't synthesize \`disabled\` propagation onto descendant \`.disabled\` properties, so the test asserts the HTML spec lever (\`fieldset[disabled]\`) is in place; real browsers paint the cascade per spec.
- \`TestReadOnlyView_CustomNotice\` — caller-provided notice.

## Test plan
- [x] \`npx vitest run\` — 129/129 passed (11 files)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx biome check\` (changed files) — 0 issues

## Remaining

Canopy survey UI (mutation controls outside the SettingsDrawer) is the one remaining surface — a small canopy-side follow-up that will use the same \`useRole().canWrite\` + \`<WriteGate>\` pattern.