### PR TITLE
feat(api): structured audit log for authz denials (#1257)

### DIFF
--- a/internal/api/handlers_users.go
+++ b/internal/api/handlers_users.go
@@ -481,13 +481,37 @@ func (s *Server) callerIsAdmin(r *http.Request) bool {
 // requireRole replies 401 (no caller) or 403 (under-privileged) unless the
 // requester's role ranks at or above min. Returns true when the request
 // may proceed.
+//
+// Denials emit structured `event=auth.unauthorized` / `event=auth.forbidden`
+// records (#1257) so SIEM pipelines across seed/stem/niac can filter
+// authorization failures uniformly. The fields mirror what niac emits on
+// scope mismatch: required role/scope, actual role (if resolved), client
+// IP, request path + method, and the caller username.
 func (s *Server) requireRole(w http.ResponseWriter, r *http.Request, minRole string) bool {
 	role, ok := s.callerRole(r)
 	if !ok {
+		logging.FromContext(r.Context()).WarnContext(r.Context(),
+			"Authentication required for protected endpoint",
+			"event", "auth.unauthorized",
+			"required_role", minRole,
+			"client_ip", GetClientIP(r),
+			"path", r.URL.Path,
+			"method", r.Method,
+		)
 		writeAPITokenError(w, r, http.StatusUnauthorized, ErrCodeUnauthorized, "Authentication required")
 		return false
 	}
 	if roleRank(role) < roleRank(minRole) {
+		logging.FromContext(r.Context()).WarnContext(r.Context(),
+			"Forbidden: insufficient role",
+			"event", "auth.forbidden",
+			"required_role", minRole,
+			"actual_role", role,
+			"username", usernameFromContext(r),
+			"client_ip", GetClientIP(r),
+			"path", r.URL.Path,
+			"method", r.Method,
+		)
 		writeAPITokenError(w, r, http.StatusForbidden, ErrCodeForbidden, minRole+" role required")
 		return false
 	}

--- a/internal/api/handlers_users_audit_internal_test.go
+++ b/internal/api/handlers_users_audit_internal_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/logging"
+)
+
+// captureLogs swaps the global logger to a buffer-backed JSON sink for
+// the duration of fn so assertions can read the structured records that
+// requireRole emits on a denial. The audit tests don't run in parallel
+// because the swap is process-global.
+func captureLogs(t *testing.T, fn func()) []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := logging.InitLogger(&logging.LoggingConfig{
+		Format: "json",
+		Level:  "debug",
+		Writer: &buf,
+	}); err != nil {
+		t.Fatalf("init test logger: %v", err)
+	}
+	fn()
+
+	var out []map[string]any
+	for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("unparseable log line %q: %v", line, err)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// TestRequireRole_EmitsForbiddenEvent covers the #1257 structured audit
+// log for the 403 path: a viewer denied operator+ access produces a
+// record with event=auth.forbidden plus the SIEM-essential fields
+// (required_role, actual_role, username, path, method, client_ip).
+func TestRequireRole_EmitsForbiddenEvent(t *testing.T) {
+	s, _ := usersTestSetup(t)
+	seedRoledUser(t, s, "viewer1", database.RoleViewer)
+
+	records := captureLogs(t, func() {
+		req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/profiles", []byte(`{}`), "viewer1")
+		w := httptest.NewRecorder()
+		if got := s.requireRole(w, req, database.RoleOperator); got {
+			t.Fatal("requireRole should reject viewer asking for operator+")
+		}
+	})
+
+	var forbidden map[string]any
+	for _, r := range records {
+		if r["event"] == "auth.forbidden" {
+			forbidden = r
+			break
+		}
+	}
+	if forbidden == nil {
+		t.Fatalf("expected an event=auth.forbidden record, got %v", records)
+	}
+	for _, field := range []string{"required_role", "actual_role", "username", "path", "method", "client_ip"} {
+		if _, ok := forbidden[field]; !ok {
+			t.Errorf("event=auth.forbidden missing field %q: %v", field, forbidden)
+		}
+	}
+	if forbidden["required_role"] != database.RoleOperator {
+		t.Errorf("required_role = %v, want operator", forbidden["required_role"])
+	}
+	if forbidden["actual_role"] != database.RoleViewer {
+		t.Errorf("actual_role = %v, want viewer", forbidden["actual_role"])
+	}
+	if forbidden["username"] != "viewer1" {
+		t.Errorf("username = %v, want viewer1", forbidden["username"])
+	}
+	if forbidden["method"] != http.MethodPost {
+		t.Errorf("method = %v, want POST", forbidden["method"])
+	}
+}
+
+// TestRequireRole_EmitsUnauthorizedEvent covers the 401 (no caller)
+// path so SIEM can also alarm on unauthenticated probes of protected
+// endpoints — distinct event name so the two failure modes are
+// filterable independently.
+func TestRequireRole_EmitsUnauthorizedEvent(t *testing.T) {
+	s, _ := usersTestSetup(t)
+
+	records := captureLogs(t, func() {
+		req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/profiles", []byte(`{}`), "")
+		w := httptest.NewRecorder()
+		if got := s.requireRole(w, req, database.RoleOperator); got {
+			t.Fatal("requireRole should reject empty caller")
+		}
+	})
+
+	var unauthz map[string]any
+	for _, r := range records {
+		if r["event"] == "auth.unauthorized" {
+			unauthz = r
+			break
+		}
+	}
+	if unauthz == nil {
+		t.Fatalf("expected an event=auth.unauthorized record, got %v", records)
+	}
+	if unauthz["required_role"] != database.RoleOperator {
+		t.Errorf("required_role = %v, want operator", unauthz["required_role"])
+	}
+	if unauthz["path"] != APIVersionPrefix+"/profiles" {
+		t.Errorf("path = %v, want %s/profiles", unauthz["path"], APIVersionPrefix)
+	}
+}


### PR DESCRIPTION
Refs #1257 · Wave 5 sub-item 1 (seed half)

## Why

niac already emits a structured \`auth.forbidden_scope\` event on scope denials; seed logged some denials ad-hoc with no consistent shape. SIEM rules across the three repos couldn't share a filter. This PR makes seed emit the same structured shape so a single SIEM rule covers authorization failures across the fleet.

## What

\`requireRole\` now emits one of two structured records on its existing 401/403 paths:

\`\`\`
event=auth.forbidden    required_role=... actual_role=...
                        username=... path=... method=... client_ip=...
event=auth.unauthorized required_role=... path=... method=... client_ip=...
\`\`\`

Distinct event names so detections can alarm on unauthenticated probes (\`auth.unauthorized\`) separately from authenticated-but-under-privileged attempts (\`auth.forbidden\`) — they have different operational meaning.

Records ride on the existing \`logging.FromContext(r.Context())\` sink, which already augments every record with \`request_id\` + \`user_id\`, so no observability context is lost relative to the prior ad-hoc denial logs.

## Tests

\`TestRequireRole_Emits{Forbidden,Unauthorized}Event\` capture the global logger to a buffer via \`logging.InitLogger\` with a \`Writer\` override and assert the SIEM-essential fields are present plus that \`required_role\` and \`actual_role\` read back correctly. Audit tests don't \`t.Parallel()\` because the InitLogger swap is process-global.

## Test plan
- [x] \`go test ./internal/api/ -count=1\` — passes
- [x] \`golangci-lint run ./internal/api/...\` — 0 issues

## Operator note

Existing 403 / 401 HTTP responses are unchanged. The new WARN-level records appear in JSON log streams; adjust SIEM filters to expect \`event=auth.forbidden\` / \`event=auth.unauthorized\`.

## Follow-up

niac side ships separately so each repo lands independently.