### PR TITLE
feat(a11y): axe-core test harness + DiscoveryModal clear-button label

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -47,6 +47,7 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.2",
         "@vitest/coverage-v8": "4.1.7",
+        "axe-core": "4.11.4",
         "jscodeshift": "^17.3.0",
         "jsdom": "29.1.1",
         "json-schema-to-typescript": "^15.0.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -64,6 +64,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
     "@vitest/coverage-v8": "4.1.7",
+    "axe-core": "4.11.4",
     "jscodeshift": "^17.3.0",
     "jsdom": "29.1.1",
     "json-schema-to-typescript": "^15.0.4",

--- a/ui/src/components/cards/DiscoveryModal.tsx
+++ b/ui/src/components/cards/DiscoveryModal.tsx
@@ -422,6 +422,8 @@ export function DiscoveryModal({
                 type="button"
                 onClick={(): void => setSearchQuery('')}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary"
+                aria-label={t('discovery.clearSearch', 'Clear search')}
+                title={t('discovery.clearSearch', 'Clear search')}
               >
                 <X className={iconTokens.size.sm} />
               </button>

--- a/ui/src/components/ui/Button.a11y.test.tsx
+++ b/ui/src/components/ui/Button.a11y.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Button.a11y.test.tsx — axe gate for the Button + IconButton primitives.
+ *
+ * These two components are the foundation of icon-button discipline: IconButton
+ * makes aria-label a required prop, and Button always renders text children.
+ * If anything in this file fails, the harness is broken or a regression has
+ * landed in the primitives — investigate before tweaking the test.
+ */
+import { render } from '@testing-library/react';
+import type React from 'react';
+import { describe, it } from 'vitest';
+import { expectNoAxeViolations } from '../../test/a11y';
+import { Button, IconButton } from './Button';
+
+// Minimal placeholder icon (axe needs no real svg here).
+function Dot(): React.JSX.Element {
+  return <span aria-hidden="true">·</span>;
+}
+
+describe('Button — a11y', () => {
+  it('solid+violet has no axe violations', async () => {
+    const { container } = render(<Button>Save</Button>);
+    await expectNoAxeViolations(container);
+  });
+
+  it('all tones+variants render without a11y violations', async () => {
+    const tones = ['violet', 'red', 'green', 'blue', 'gray'] as const;
+    const variants = ['solid', 'outline', 'ghost', 'secondary'] as const;
+    for (const variant of variants) {
+      for (const tone of tones) {
+        const { container } = render(
+          <Button variant={variant} tone={tone}>
+            Action
+          </Button>,
+        );
+        await expectNoAxeViolations(container);
+      }
+    }
+  });
+
+  it('disabled button has no a11y violations', async () => {
+    const { container } = render(<Button disabled>Save</Button>);
+    await expectNoAxeViolations(container);
+  });
+
+  it('button with leading icon + label has no a11y violations', async () => {
+    const { container } = render(<Button leftIcon={<Dot />}>Save</Button>);
+    await expectNoAxeViolations(container);
+  });
+});
+
+describe('IconButton — a11y', () => {
+  it('icon-only button with aria-label is accessible', async () => {
+    const { container } = render(<IconButton icon={<Dot />} aria-label="Refresh status" />);
+    await expectNoAxeViolations(container);
+  });
+
+  it('all tones+variants render without a11y violations', async () => {
+    const tones = ['violet', 'red', 'green', 'blue', 'gray'] as const;
+    const variants = ['solid', 'outline', 'ghost'] as const;
+    for (const variant of variants) {
+      for (const tone of tones) {
+        const { container } = render(
+          <IconButton icon={<Dot />} aria-label="Action" variant={variant} tone={tone} />,
+        );
+        await expectNoAxeViolations(container);
+      }
+    }
+  });
+});

--- a/ui/src/test/a11y.ts
+++ b/ui/src/test/a11y.ts
@@ -1,0 +1,56 @@
+/**
+ * a11y.ts — accessibility test helper.
+ *
+ * Runs axe-core against rendered output and fails the test on any violation.
+ * This is the "axe gate" referenced in the PR-A tooltip/a11y plan: pair every
+ * component or screen with an a11y test that calls expectNoAxeViolations() on
+ * the rendered container. Catches button-name, image-alt, link-name,
+ * aria-allowed-attr, label, and other WCAG rules that no static lint detects.
+ *
+ * Usage:
+ *   const { container } = render(<MyComponent />);
+ *   await expectNoAxeViolations(container);
+ *
+ * The harness is intentionally minimal (raw axe-core, no jest-axe/vitest-axe
+ * wrapper) so it ages well with axe-core upgrades and matches the seed/stem/
+ * niac "each repo owns its own copy" convention — the file shape is identical
+ * across repos.
+ */
+import axe, { type AxeResults, type Result, type RunOptions } from 'axe-core';
+
+/** Default rule set focused on the violations our app cares about. */
+const DEFAULT_RULES: RunOptions = {
+  rules: {
+    // 'region' fires on isolated component renders that lack a landmark. Off
+    // for component-scoped tests; re-enable in screen-level harness tests.
+    region: { enabled: false },
+  },
+};
+
+export async function runAxe(
+  container: Element,
+  options: RunOptions = DEFAULT_RULES,
+): Promise<AxeResults> {
+  return axe.run(container, options);
+}
+
+export async function expectNoAxeViolations(
+  container: Element,
+  options?: RunOptions,
+): Promise<void> {
+  const results = await runAxe(container, options);
+  if (results.violations.length === 0) return;
+  throw new Error(formatViolations(results.violations));
+}
+
+function formatViolations(violations: Result[]): string {
+  const lines = [`axe found ${violations.length} accessibility violation(s):`];
+  for (const v of violations) {
+    lines.push(`  [${v.id}] ${v.help}  (${v.nodes.length} node${v.nodes.length === 1 ? '' : 's'})`);
+    for (const node of v.nodes.slice(0, 3)) {
+      lines.push(`    ${node.html.slice(0, 200)}`);
+    }
+    lines.push(`    help: ${v.helpUrl}`);
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
Adds axe-core (4.11.4) and ui/src/test/a11y.ts (runAxe + expectNoAxeViolations)
so components can be paired with an a11y test that catches button-name,
image-alt, label, and other WCAG rules no static lint detects. This is the
shared harness pattern the stem and niac PR-A copies will reuse.

Smoke test: Button.a11y.test.tsx exercises every Button + IconButton variant
and tone (29 renders) and asserts zero axe violations.

Fix: DiscoveryModal.tsx search clear-button (the icon-only X) now carries
aria-label + title via the existing discovery.clearSearch i18n key (en/es
already present). Closes the one remaining seed tooltip gap identified in
the audit.
