### PR TITLE
refactor(api,config): remove HTTP→HTTPS redirector — HTTPS-only

### DIFF
--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -438,11 +438,6 @@ func ExportIsAddrInUse(err error) bool {
 	return isAddrInUse(err)
 }
 
-// HTTPToHTTPSRedirectHandler exposes the HTTP→HTTPS redirect handler for testing.
-func (s *Server) HTTPToHTTPSRedirectHandler() http.Handler {
-	return s.httpToHTTPSRedirectHandler()
-}
-
 // EnsureSelfSignedCert exposes ensureSelfSignedCert for testing.
 func (s *Server) EnsureSelfSignedCert() (string, string, error) {
 	return s.ensureSelfSignedCert()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -42,9 +42,6 @@ const (
 	// logBroadcasterBufferSize is the buffer size for log broadcaster entries.
 	logBroadcasterBufferSize = 1000
 
-	// httpsDefaultPort is the standard HTTPS port number.
-	httpsDefaultPort = 443
-
 	// portScannerTimeout is the timeout for the port scanner.
 	portScannerTimeout = 5 * time.Second
 
@@ -59,9 +56,6 @@ const (
 
 	// serverIdleTimeoutSec is the HTTP server idle connection timeout in seconds.
 	serverIdleTimeoutSec = 60
-
-	// redirectReadWriteTimeoutSec is the timeout for HTTP redirect server operations.
-	redirectReadWriteTimeoutSec = 5
 
 	// acmeReadHeaderTimeoutSec is the timeout for reading ACME challenge request headers.
 	acmeReadHeaderTimeoutSec = 10
@@ -101,8 +95,6 @@ type Server struct {
 	// HTTP server components
 	httpServer          *http.Server
 	mux                 *http.ServeMux
-	redirectServer      *http.Server // HTTP→HTTPS redirect server (fixes #515)
-	redirectServerErr   chan error   // Error channel for redirect server
 	acmeChallengeServer *http.Server // HTTP-01 challenge server for ACME (fixes #837)
 
 	// Service container - holds all domain services (#888)

--- a/internal/api/server_lifecycle.go
+++ b/internal/api/server_lifecycle.go
@@ -1,8 +1,7 @@
 package api
 
-// server_lifecycle.go contains the HTTP/HTTPS server lifecycle: Start, the
-// HTTP→HTTPS redirect server, ACME-managed HTTPS, and the self-signed
-// fallback certificate generator.
+// server_lifecycle.go contains the HTTP/HTTPS server lifecycle: Start,
+// ACME-managed HTTPS, and the self-signed fallback certificate generator.
 
 import (
 	"context"
@@ -15,12 +14,9 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 
 	"golang.org/x/crypto/acme"
@@ -131,10 +127,6 @@ func (s *Server) Start() error {
 	}
 
 	if s.config.Server.HTTPS {
-		// Start HTTP→HTTPS redirect server if configured
-		if s.config.Server.HTTPRedirectPort > 0 {
-			go s.startHTTPRedirect(s.config.Server.HTTPRedirectPort)
-		}
 		return s.startHTTPS()
 	}
 	return s.startHTTP()
@@ -157,79 +149,6 @@ func (s *Server) startHTTP() error {
 		return fmt.Errorf("http server: %w", serveErr)
 	}
 	return nil
-}
-
-// httpToHTTPSRedirectHandler returns an [http.Handler] that permanently
-// redirects every request to the equivalent HTTPS URL. Extracted from
-// startHTTPRedirect so it can be exercised in tests without bringing up
-// a real listener.
-func (s *Server) httpToHTTPSRedirectHandler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Build HTTPS URL preserving the host and path
-		host := r.Host
-		// Remove port from host if present (to avoid localhost:80 → https://localhost:80:8443)
-		if colonPos := strings.LastIndex(host, ":"); colonPos != -1 {
-			host = host[:colonPos]
-		}
-
-		// If HTTPS is on standard port 443, don't include it in URL
-		httpsPort := s.config.Server.Port
-		var httpsURL string
-		if httpsPort == httpsDefaultPort {
-			httpsURL = fmt.Sprintf("https://%s%s", host, r.RequestURI)
-		} else {
-			httpsURL = "https://" + net.JoinHostPort(host, strconv.Itoa(httpsPort)) + r.RequestURI
-		}
-
-		// #nosec G710 -- httpsURL is server-controlled: scheme/port from our config, host stripped to its
-		// bare form before re-joining; user-supplied r.RequestURI is appended as the path/query only.
-		//
-		// Use 308 Permanent Redirect (RFC 7538) rather than 301 so the HTTP
-		// method and body are preserved across the redirect. 301 allows
-		// clients to downgrade POST to GET, which would silently break
-		// state-changing API calls that arrive on the HTTP listener.
-		http.Redirect(w, r, httpsURL, http.StatusPermanentRedirect)
-	})
-}
-
-// startHTTPRedirect starts an HTTP server that redirects all requests to HTTPS (fixes #515).
-// Properly tracks the server and allows shutdown.
-func (s *Server) startHTTPRedirect(port int) {
-	redirectHandler := s.httpToHTTPSRedirectHandler()
-
-	// Bind via the port-fallback helper so a busy :80 (or whatever is
-	// configured) walks up to +9 instead of killing the redirect goroutine.
-	ln, actualPort, bindErr := bindWithFallback(context.Background(), "", port)
-	if bindErr != nil {
-		logging.GetLogger().Error("HTTP redirect server bind failed", "error", bindErr)
-		if s.redirectServerErr == nil {
-			s.redirectServerErr = make(chan error, 1)
-		}
-		s.redirectServerErr <- bindErr
-		return
-	}
-	addr := fmt.Sprintf(":%d", actualPort)
-	logging.GetLogger().Info("Starting HTTP→HTTPS redirect server", "addr", addr)
-
-	// Store redirect server for proper shutdown (fixes #515)
-	s.redirectServer = &http.Server{
-		Addr:         addr,
-		Handler:      redirectHandler,
-		ReadTimeout:  redirectReadWriteTimeoutSec * time.Second,
-		WriteTimeout: redirectReadWriteTimeoutSec * time.Second,
-	}
-
-	// Create error channel if not already created
-	if s.redirectServerErr == nil {
-		s.redirectServerErr = make(chan error, 1)
-	}
-
-	// Run server and report errors
-	err := s.redirectServer.Serve(ln)
-	if err != nil && err != http.ErrServerClosed {
-		logging.GetLogger().Error("HTTP redirect server error", "error", err)
-		s.redirectServerErr <- err
-	}
 }
 
 // startHTTPS starts the server in HTTPS mode.

--- a/internal/api/server_lifecycle_test.go
+++ b/internal/api/server_lifecycle_test.go
@@ -3,85 +3,12 @@ package api_test
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/krisarmstrong/seed/internal/api"
 )
-
-// TestHTTPRedirectUsesStatus308 verifies that the HTTP→HTTPS redirect
-// returns 308 Permanent Redirect (not 301 Moved Permanently) so the HTTP
-// method is preserved across the redirect.
-func TestHTTPRedirectUsesStatus308(t *testing.T) {
-	server := api.NewTestServer()
-	defer server.Close()
-
-	// HTTPS listening port from the test config informs the Location header.
-	cfg := server.Config()
-	cfg.Server.Port = 8443
-	server.SetConfig(cfg)
-
-	handler := server.HTTPToHTTPSRedirectHandler()
-
-	cases := []struct {
-		method string
-	}{
-		{http.MethodGet},
-		{http.MethodPost},
-		{http.MethodPut},
-		{http.MethodDelete},
-		{http.MethodPatch},
-	}
-	for _, tc := range cases {
-		t.Run(tc.method, func(t *testing.T) {
-			req := httptest.NewRequest(tc.method, "http://localhost/api/anything?x=1", http.NoBody)
-			req.Host = "localhost"
-			req.RequestURI = "/api/anything?x=1"
-			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
-
-			if rec.Code != http.StatusPermanentRedirect {
-				t.Errorf("method=%s: status = %d, want %d (308)",
-					tc.method, rec.Code, http.StatusPermanentRedirect)
-			}
-			loc := rec.Header().Get("Location")
-			want := "https://localhost:8443/api/anything?x=1"
-			if loc != want {
-				t.Errorf("method=%s: Location = %q, want %q", tc.method, loc, want)
-			}
-		})
-	}
-}
-
-// TestHTTPRedirectStripsPortForStandardHTTPS verifies the Location header
-// drops the port when HTTPS listens on the standard 443.
-func TestHTTPRedirectStripsPortForStandardHTTPS(t *testing.T) {
-	server := api.NewTestServer()
-	defer server.Close()
-
-	cfg := server.Config()
-	cfg.Server.Port = 443
-	server.SetConfig(cfg)
-
-	handler := server.HTTPToHTTPSRedirectHandler()
-
-	req := httptest.NewRequest(http.MethodGet, "http://example.com:80/path", http.NoBody)
-	req.Host = "example.com:80"
-	req.RequestURI = "/path"
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusPermanentRedirect {
-		t.Errorf("status = %d, want 308", rec.Code)
-	}
-	const want = "https://example.com/path"
-	if got := rec.Header().Get("Location"); got != want {
-		t.Errorf("Location = %q, want %q", got, want)
-	}
-}
 
 // TestEnsureSelfSignedCertIsCAEligible verifies the generated self-signed
 // cert carries IsCA=true and KeyUsageCertSign so it can be installed into

--- a/internal/api/server_shutdown.go
+++ b/internal/api/server_shutdown.go
@@ -82,15 +82,6 @@ func (s *Server) onLinkStateChange(event netif.LinkEvent) {
 func (s *Server) Shutdown(ctx context.Context) error {
 	logging.GetLogger().InfoContext(ctx, "Shutting down server...")
 
-	// Shutdown HTTP redirect server if running (fixes #515)
-	if s.redirectServer != nil {
-		logging.GetLogger().InfoContext(ctx, "Shutting down HTTP redirect server...")
-		if err := s.redirectServer.Shutdown(ctx); err != nil {
-			logging.GetLogger().
-				ErrorContext(ctx, "Error shutting down redirect server", "error", err)
-		}
-	}
-
 	// Shutdown ACME HTTP-01 challenge server if running (fixes #837)
 	if s.acmeChallengeServer != nil {
 		logging.GetLogger().InfoContext(ctx, "Shutting down ACME challenge server...")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -467,29 +467,6 @@ func TestValidateInvalidPort(t *testing.T) {
 	}
 }
 
-func TestValidateInvalidHTTPRedirectPort(t *testing.T) {
-	cfg := config.DefaultConfig()
-	cfg.Auth.DefaultPasswordHash = "hash"
-	cfg.Server.HTTPRedirectPort = -1
-
-	err := cfg.Validate()
-	if err == nil {
-		t.Error("expected validation error for negative HTTP redirect port")
-	}
-}
-
-func TestValidateSamePortAndRedirectPort(t *testing.T) {
-	cfg := config.DefaultConfig()
-	cfg.Auth.DefaultPasswordHash = "hash"
-	cfg.Server.Port = 8080
-	cfg.Server.HTTPRedirectPort = 8080 // Same as main port
-
-	err := cfg.Validate()
-	if err == nil {
-		t.Error("expected validation error when port equals HTTP redirect port")
-	}
-}
-
 // TestValidateCORSWildcardOrigin asserts the #1256 guard: a literal `*`
 // in security.allowed_origins refuses startup because Allow-Credentials
 // is unconditionally true, making the pair invalid per the CORS spec.

--- a/internal/config/config_types_network.go
+++ b/internal/config/config_types_network.go
@@ -8,11 +8,10 @@ import "time"
 
 // ServerConfig contains HTTP server settings.
 type ServerConfig struct {
-	Port             int    `json:"port"`
-	HTTPS            bool   `json:"https"`
-	HTTPRedirectPort int    `json:"http_redirect_port,omitempty"` // Port for HTTP→HTTPS redirect (0 = disabled, typically 80)
-	CertFile         string `json:"cert_file"`
-	KeyFile          string `json:"key_file"`
+	Port     int    `json:"port"`
+	HTTPS    bool   `json:"https"`
+	CertFile string `json:"cert_file"`
+	KeyFile  string `json:"key_file"`
 	// Security fix #301: Removed LogAccessToken/LogAccessHeader - JWT authentication is sufficient
 
 	// ACME/Let's Encrypt automatic certificate management

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -63,18 +63,6 @@ func (c *Config) validateServerConfig() []string {
 			fmt.Sprintf("server.port must be between 1-65535, got %d", c.Server.Port),
 		)
 	}
-	if c.Server.HTTPRedirectPort < 0 || c.Server.HTTPRedirectPort > 65535 {
-		errs = append(
-			errs,
-			fmt.Sprintf(
-				"server.http_redirect_port must be between 0-65535, got %d",
-				c.Server.HTTPRedirectPort,
-			),
-		)
-	}
-	if c.Server.HTTPRedirectPort > 0 && c.Server.Port == c.Server.HTTPRedirectPort {
-		errs = append(errs, "server.port and server.http_redirect_port cannot be the same")
-	}
 	return errs
 }
 

--- a/internal/config/system_config.go
+++ b/internal/config/system_config.go
@@ -64,10 +64,6 @@ type SystemServerConfig struct {
 	// Env: SEED_HTTPS_ENABLED
 	HTTPS bool `json:"https"`
 
-	// HTTPRedirectPort is the port for HTTP->HTTPS redirect (0 = disabled).
-	// Env: SEED_HTTP_REDIRECT_PORT
-	HTTPRedirectPort int `json:"http_redirect_port,omitempty"`
-
 	// CertFile is the path to the TLS certificate.
 	// Env: SEED_TLS_CERT_FILE
 	CertFile string `json:"cert_file"`
@@ -295,11 +291,6 @@ func applyServerEnv(cfg *SystemConfig) {
 	if v := os.Getenv("SEED_HTTPS_ENABLED"); v != "" {
 		cfg.Server.HTTPS = parseBool(v)
 	}
-	if v := os.Getenv("SEED_HTTP_REDIRECT_PORT"); v != "" {
-		if i, err := strconv.Atoi(v); err == nil {
-			cfg.Server.HTTPRedirectPort = i
-		}
-	}
 	if v := os.Getenv("SEED_TLS_CERT_FILE"); v != "" {
 		cfg.Server.CertFile = v
 	}
@@ -501,7 +492,6 @@ func (c *SystemConfig) ToLegacyConfig() *Config {
 
 	cfg.Server.Port = c.Server.Port
 	cfg.Server.HTTPS = c.Server.HTTPS
-	cfg.Server.HTTPRedirectPort = c.Server.HTTPRedirectPort
 	cfg.Server.CertFile = c.Server.CertFile
 	cfg.Server.KeyFile = c.Server.KeyFile
 	cfg.Server.ACME.Enabled = c.Server.ACME.Enabled


### PR DESCRIPTION
## Why

Strategy decision: seed binds only its HTTPS port. The plain-HTTP listener that 308-redirected to the HTTPS port is removed.

An operator who types `seed.example.com` into a browser without a scheme will get connection refused; HTTPS is the only API path.

## What

Removed across config + API + tests:

- `ServerConfig.HTTPRedirectPort` (json `http_redirect_port`) — gone from both `config_types_network.go` and `system_config.go`. Env-merge for `SEED_HTTP_REDIRECT_PORT` is gone, `toConfig()` field copy is gone, range/same-port validation in `config_validate.go` is gone.
- `redirectServer` + `redirectServerErr` fields on `Server`; the unused `httpsDefaultPort` and `redirectReadWriteTimeoutSec` constants.
- `httpToHTTPSRedirectHandler`, `startHTTPRedirect`, and the `if HTTPRedirectPort > 0` startup branch in `server_lifecycle.go`. File-level doc updated.
- `Server.Shutdown`'s redirect-server cleanup branch.
- `HTTPToHTTPSRedirectHandler` test-only accessor from `export_test.go`.
- 4 tests in 2 files: `TestHTTPRedirectUsesStatus308`, `TestHTTPRedirectStripsPortForStandardHTTPS`, `TestValidateInvalidHTTPRedirectPort`, `TestValidateSamePortAndRedirectPort`.

## Operator note

- `SEED_HTTP_REDIRECT_PORT` env var is a no-op now.
- If you previously relied on typing `seed.example.com` without a scheme to redirect, update bookmarks / monitoring to `https://`.
- Default HTTPS port (8443) is unchanged.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/config/ ./internal/api/ -count=1` — passes
- [x] `golangci-lint run ./internal/config/... ./internal/api/...` — 0 issues
- [ ] CI gates (full `make verify` on push)

## Part of the cross-repo HTTPS-only effort

Stem and niac get matching PRs that drop their respective redirectors (stem's mandatory 8043 / niac's optional 8044) in the same Phase.