### PR TITLE
feat(api): gate /events SSE on live_telemetry — close Pro revenue leak

### DIFF
--- a/internal/api/handlers_sse_license_internal_test.go
+++ b/internal/api/handlers_sse_license_internal_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/license"
+)
+
+// TestSSEEventsRequiresLiveTelemetry asserts the `/events` SSE route
+// returns 402 Payment Required for unlicensed callers and routes
+// through to handleSSE for Pro-trial callers. Mirrors the canonical
+// requireFeature test pattern from TestRootsPathRequiresPro.
+//
+// Pre-2026-05-29 this route was ungated: Free / Starter callers
+// received the Pro-tier real-time stream. This test guards against
+// that regression.
+func TestSSEEventsRequiresLiveTelemetry(t *testing.T) {
+	t.Parallel()
+	s, mgr := apiTokenTestSetup(t)
+	s.setupRoutes()
+
+	// 1. No license → 402, requiredFeature reports the right key.
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/events", http.NoBody)
+	req.Header.Set("X-Username", "alice")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("free tier: status = %d, want 402; body=%s", w.Code, w.Body.String())
+	}
+	var body FeatureGateResponse
+	if decErr := json.NewDecoder(w.Body).Decode(&body); decErr != nil {
+		t.Fatalf("decode 402 body: %v", decErr)
+	}
+	if body.RequiredFeature != "live_telemetry" {
+		t.Errorf("requiredFeature = %q, want %q", body.RequiredFeature, "live_telemetry")
+	}
+	if body.CurrentTier != license.TierFree.String() {
+		t.Errorf("currentTier = %q, want %q", body.CurrentTier, license.TierFree.String())
+	}
+
+	// 2. Start trial → Pro features → no longer 402. The handler may
+	//    fail downstream (no auth cookie set, no flusher in the test
+	//    recorder, etc.), but it must NOT 402 — that's the regression
+	//    guard.
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+	req2 := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/events", http.NoBody)
+	req2.Header.Set("X-Username", "alice")
+	w2 := httptest.NewRecorder()
+	s.mux.ServeHTTP(w2, req2)
+	if w2.Code == http.StatusPaymentRequired {
+		t.Errorf("trial license: status = 402 (should pass the gate); body=%s", w2.Body.String())
+	}
+}
+
+// TestDiscoveryEngineEventsStaysOpen guards the explicit policy
+// decision in setupSSEAndStatic: `/discovery/engine/events` is a
+// discovery-lifecycle stream, available on every tier. If a future
+// refactor accidentally extends the `live_telemetry` gate to this
+// route, this test fails.
+func TestDiscoveryEngineEventsStaysOpen(t *testing.T) {
+	t.Parallel()
+	s, _ := apiTokenTestSetup(t)
+	s.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/discovery/engine/events", http.NoBody)
+	req.Header.Set("X-Username", "alice")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code == http.StatusPaymentRequired {
+		t.Errorf("discovery events should NOT be license-gated; got 402: body=%s", w.Body.String())
+	}
+}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -316,8 +316,14 @@ func (s *Server) setupHarvestRoutes() {
 
 // setupSSEAndStatic registers SSE and static file handlers.
 func (s *Server) setupSSEAndStatic() {
-	// SSE endpoint for real-time updates
-	s.mux.HandleFunc(APIVersionPrefix+"/events", s.handleSSE)
+	// SSE endpoint for real-time updates. Gated on `live_telemetry`
+	// (Pro tier) per FEATURE_TIER_MATRIX — the live stream of card
+	// data (RSSI, link state, gateway latency, etc.) is the Pro-tier
+	// real-time surface. Free / Starter get card data via the
+	// per-endpoint REST handlers without the WebSocket-like stream.
+	// `/discovery/engine/events` (the discovery-lifecycle SSE) is
+	// intentionally NOT gated here — discovery is a Free-tier surface.
+	s.mux.HandleFunc(APIVersionPrefix+"/events", s.requireFeature("live_telemetry", s.handleSSE))
 	frontendFS, err := getUIFS()
 	if err != nil {
 		logging.GetLogger().


### PR DESCRIPTION
## Why

Pre-2026-05-29 the `/events` SSE route in `handlers_sse.go:260` was auth-gated only — every authenticated user (Free, Starter, Pro) received the Pro-tier real-time card stream. `FEATURE_TIER_MATRIX.md` had this flagged as \"not yet wired\"; this PR closes the gap.

## What

1-line wrap at registration time, same pattern as the already-wired `path_analysis` / `anomaly_detection` / `compliance_advanced` / `airmapper_baseline_diff` / `sso` gates:

```diff
- s.mux.HandleFunc(prefix+\"/events\", s.handleSSE)
+ s.mux.HandleFunc(prefix+\"/events\", s.requireFeature(\"live_telemetry\", s.handleSSE))
```

**Explicitly NOT gated:** `/discovery/engine/events` stays open to every tier. Discovery is a Free-tier surface; the engine-events stream is a side-channel for discovery lifecycle (scan started, device added), not the product-feature real-time stream described by the `live_telemetry` matrix entry.

## Tests

`handlers_sse_license_internal_test.go`:
- `TestSSEEventsRequiresLiveTelemetry`: Free tier → 402 with `requiredFeature=live_telemetry` + `currentTier=free`; Pro-trial → any status except 402.
- `TestDiscoveryEngineEventsStaysOpen`: regression guard so a future refactor doesn't accidentally extend the gate to engine events.

Pattern mirrors the canonical `TestRootsPathRequiresPro` from `handlers_path_gate_internal_test.go`.

## Test plan

- [x] `go build ./internal/api/` — clean
- [x] `go test ./internal/api/ -count=1` — passes (28s full suite)
- [x] `golangci-lint run ./internal/api/...` — 0 issues

## Operator note

Customers on Free / Starter who were silently receiving Pro-tier live telemetry will now get 402 from `/events`. The existing per-endpoint REST card data (link, dns, gateway, etc.) remains available to all tiers.

## Cross-repo

Part of the Phase 3 revenue-protection effort following the HTTPS-only Phase 1 (seed#1277 / stem#376 / niac#778 / mustardseednetworks-com#2). Companion PR for `wifi_roam_analysis` / `wifi_association_forensics` field-level filtering ships next.