### PR TITLE
feat(api): gate wifi_roam_analysis on survey response — close revenue leak

### DIFF
--- a/internal/api/handlers_survey.go
+++ b/internal/api/handlers_survey.go
@@ -244,7 +244,14 @@ func (s *Server) createSurvey(w http.ResponseWriter, r *http.Request) {
 func (s *Server) listSurveys(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	surveys := s.surveyManager().ListSurveys()
-	sendJSONResponse(w, logger, http.StatusOK, surveys)
+	// #1226 / wifi_roam_analysis: filter the roam fields per-tier.
+	// Returns the slice as-is for Pro / dev builds; deep-copies + zeroes
+	// for Free / Starter.
+	filtered := make([]*survey.Survey, len(surveys))
+	for i, sv := range surveys {
+		filtered[i] = s.applyRoamFilterIfGated(sv)
+	}
+	sendJSONResponse(w, logger, http.StatusOK, filtered)
 }
 
 func (s *Server) getSurvey(w http.ResponseWriter, r *http.Request) {
@@ -278,7 +285,8 @@ func (s *Server) getSurvey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sendJSONResponse(w, logger, http.StatusOK, surveyData)
+	// #1226 / wifi_roam_analysis: filter the roam fields per-tier.
+	sendJSONResponse(w, logger, http.StatusOK, s.applyRoamFilterIfGated(surveyData))
 }
 
 func (s *Server) deleteSurvey(w http.ResponseWriter, r *http.Request) {
@@ -392,4 +400,76 @@ func (s *Server) pauseSurvey(w http.ResponseWriter, r *http.Request) {
 func (s *Server) completeSurvey(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	s.handleSurveyStateChange(w, r, logger, "complete", s.surveyManager().CompleteSurvey)
+}
+
+// filterSurveyRoamFields strips the wifi_roam_analysis fields
+// (RoamingEvent, PreviousBSSID, RoamCount) from every ActiveSample in
+// the survey when the active license does not include the
+// `wifi_roam_analysis` feature. Returns a deep-copied survey so the
+// in-memory cache held by surveyManager is not mutated. Free / Starter
+// tiers see the basic survey data (SSID, BSSID, RSSI, DataRate) and
+// receive zero/empty for the roam-analytics fields; Pro receives the
+// untouched record.
+//
+// wifi_association_forensics is also a Pro-tier flag in the matrix
+// but maps to no distinct data fields in the current Sample structs —
+// association-event modeling is part of the broader Wi-Fi build-out
+// that's still in progress. When those fields land, extend this
+// helper or add a sibling filter for that flag.
+func filterSurveyRoamFields(in *survey.Survey) *survey.Survey {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if len(out.Samples) > 0 {
+		out.Samples = filterSamplePointsRoam(out.Samples)
+	}
+	if len(out.Floors) > 0 {
+		floors := make([]*survey.Floor, len(out.Floors))
+		for i, f := range out.Floors {
+			if f == nil {
+				continue
+			}
+			fCopy := *f
+			fCopy.Samples = filterSamplePointsRoam(f.Samples)
+			floors[i] = &fCopy
+		}
+		out.Floors = floors
+	}
+	return &out
+}
+
+func filterSamplePointsRoam(in []*survey.SamplePoint) []*survey.SamplePoint {
+	if len(in) == 0 {
+		return in
+	}
+	out := make([]*survey.SamplePoint, len(in))
+	for i, sp := range in {
+		if sp == nil {
+			continue
+		}
+		cp := *sp
+		if active, ok := sp.SampleData.(*survey.ActiveSample); ok && active != nil {
+			ac := *active
+			ac.RoamingEvent = false
+			ac.PreviousBSSID = ""
+			ac.RoamCount = 0
+			cp.SampleData = &ac
+		}
+		out[i] = &cp
+	}
+	return out
+}
+
+// applyRoamFilterIfGated returns the survey unchanged when the active
+// license includes wifi_roam_analysis (or no license manager is wired
+// — dev/test builds); otherwise returns a copy with the roam fields
+// stripped. Centralizes the gate so getSurvey + listSurveys share the
+// same policy.
+func (s *Server) applyRoamFilterIfGated(in *survey.Survey) *survey.Survey {
+	mgr := s.services.Auth.License
+	if mgr == nil || mgr.HasFeature("wifi_roam_analysis") {
+		return in
+	}
+	return filterSurveyRoamFields(in)
 }

--- a/internal/api/handlers_survey_license_internal_test.go
+++ b/internal/api/handlers_survey_license_internal_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/canopy/survey"
+)
+
+// newRoamFixture returns a survey with one Active + one Passive sample
+// at the top level and one per-floor Active sample, with the roam
+// fields populated so the filter has something to strip.
+func newRoamFixture() *survey.Survey {
+	return &survey.Survey{
+		ID: "s1",
+		Samples: []*survey.SamplePoint{
+			{
+				X: 1, Y: 1,
+				SampleData: &survey.ActiveSample{
+					SSID:          "office",
+					BSSID:         "aa:bb:cc:dd:ee:ff",
+					RSSI:          -55,
+					DataRate:      300,
+					RoamingEvent:  true,
+					PreviousBSSID: "11:22:33:44:55:66",
+					RoamCount:     5,
+				},
+			},
+			{
+				X: 2, Y: 2,
+				SampleData: &survey.PassiveSample{UniqueSSIDs: 7},
+			},
+		},
+		Floors: []*survey.Floor{
+			{
+				ID: "f1",
+				Samples: []*survey.SamplePoint{
+					{
+						X: 3, Y: 3,
+						SampleData: &survey.ActiveSample{
+							SSID:          "lab",
+							RSSI:          -60,
+							DataRate:      150,
+							RoamingEvent:  true,
+							PreviousBSSID: "deadbeefcafe",
+							RoamCount:     2,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestFilterSurveyRoamFields_StripsTopLevelSamples — roam fields on
+// the top-level Samples slice are zeroed while non-roam fields and
+// non-Active samples (Passive) are preserved.
+func TestFilterSurveyRoamFields_StripsTopLevelSamples(t *testing.T) {
+	t.Parallel()
+	in := newRoamFixture()
+	got := filterSurveyRoamFields(in)
+
+	if got == in {
+		t.Fatal("filter must deep-copy; got the input pointer back")
+	}
+	active0, ok := got.Samples[0].SampleData.(*survey.ActiveSample)
+	if !ok || active0 == nil {
+		t.Fatalf("samples[0] sample data = %T, want *ActiveSample", got.Samples[0].SampleData)
+	}
+	if active0.RoamingEvent || active0.PreviousBSSID != "" || active0.RoamCount != 0 {
+		t.Errorf("samples[0] roam fields not stripped: %+v", active0)
+	}
+	if active0.SSID != "office" || active0.BSSID != "aa:bb:cc:dd:ee:ff" ||
+		active0.RSSI != -55 || active0.DataRate != 300 {
+		t.Errorf("samples[0] non-roam fields disturbed: %+v", active0)
+	}
+	passive, isPassive := got.Samples[1].SampleData.(*survey.PassiveSample)
+	if !isPassive || passive.UniqueSSIDs != 7 {
+		t.Errorf("samples[1] passive sample disturbed: %+v", got.Samples[1].SampleData)
+	}
+}
+
+// TestFilterSurveyRoamFields_StripsPerFloorSamples — same treatment
+// applies to samples nested under Floors (the modern multi-floor path).
+func TestFilterSurveyRoamFields_StripsPerFloorSamples(t *testing.T) {
+	t.Parallel()
+	got := filterSurveyRoamFields(newRoamFixture())
+
+	sample, ok := got.Floors[0].Samples[0].SampleData.(*survey.ActiveSample)
+	if !ok || sample == nil {
+		t.Fatalf("floors[0].samples[0] sample data wrong type")
+	}
+	if sample.RoamingEvent || sample.PreviousBSSID != "" || sample.RoamCount != 0 {
+		t.Errorf("floors[0].samples[0] roam fields not stripped: %+v", sample)
+	}
+}
+
+// TestFilterSurveyRoamFields_DoesNotMutateInput — the filter must
+// deep-copy so the surveyManager cache stays untouched.
+func TestFilterSurveyRoamFields_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+	in := newRoamFixture()
+	_ = filterSurveyRoamFields(in)
+
+	origActive, ok := in.Samples[0].SampleData.(*survey.ActiveSample)
+	if !ok {
+		t.Fatal("fixture sample type changed")
+	}
+	if !origActive.RoamingEvent || origActive.PreviousBSSID != "11:22:33:44:55:66" ||
+		origActive.RoamCount != 5 {
+		t.Errorf("filter mutated the input survey: %+v", origActive)
+	}
+}
+
+// TestApplyRoamFilterIfGated_AppliesGateBasedOnLicense proves the
+// dispatcher: with a Pro-trial license the survey passes through
+// unmodified; without one, the filter is applied.
+func TestApplyRoamFilterIfGated_AppliesGateBasedOnLicense(t *testing.T) {
+	t.Parallel()
+	s, mgr := apiTokenTestSetup(t)
+
+	in := &survey.Survey{
+		ID: "s1",
+		Samples: []*survey.SamplePoint{
+			{
+				X: 1, Y: 1,
+				SampleData: &survey.ActiveSample{
+					SSID:          "x",
+					RoamingEvent:  true,
+					PreviousBSSID: "old",
+					RoamCount:     3,
+				},
+			},
+		},
+	}
+
+	// 1. No license → roam fields stripped.
+	got := s.applyRoamFilterIfGated(in)
+	if got == in {
+		t.Fatal("free tier: dispatcher should return a filtered copy, got input pointer back")
+	}
+	freeActive := got.Samples[0].SampleData.(*survey.ActiveSample)
+	if freeActive.RoamCount != 0 || freeActive.PreviousBSSID != "" {
+		t.Errorf("free tier: roam fields not stripped: %+v", freeActive)
+	}
+
+	// 2. Start trial → roam fields preserved (dispatcher returns input
+	//    as-is).
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+	got2 := s.applyRoamFilterIfGated(in)
+	if got2 != in {
+		t.Error("pro trial: dispatcher should return the input pointer unchanged")
+	}
+}


### PR DESCRIPTION
## Why

Pre-2026-05-29 the matrix claimed `wifi_roam_analysis` was gated at `server_routes.go`'s Canopy roam routes. The 2026-05-29 cross-repo audit found 0 code references to the flag key outside the catalog: the roam fields (`RoamingEvent`, `PreviousBSSID`, `RoamCount`) on every `ActiveSample` in `internal/canopy/survey/survey.go:173-175` rode along in every tier's survey response. Free / Starter users were receiving Pro-tier Wi-Fi-troubleshooting telemetry for free.

This PR closes the leak at the response layer — field-level filtering rather than route gating, because roam analytics aren't a separate route, they're data fields inside the existing survey response.

## What

`internal/api/handlers_survey.go`:
- `filterSurveyRoamFields(in)` returns a deep-copied `*survey.Survey` with `RoamingEvent` / `PreviousBSSID` / `RoamCount` zeroed on every `ActiveSample` (top-level Samples and per-floor Samples). Non-Active samples (Passive, Throughput) and non-roam fields on Active samples are preserved.
- `(s *Server).applyRoamFilterIfGated(in)` dispatches: returns the input unchanged when `mgr == nil` (dev / test) or `mgr.HasFeature("wifi_roam_analysis")` (Pro / trial); otherwise returns the filtered copy.
- `getSurvey` + `listSurveys` both call `applyRoamFilterIfGated` on the outbound payload.

Deep copy is essential: the surveyManager cache holds the canonical `*Survey` and must not be mutated by a per-request filter.

## wifi_association_forensics scope note

The matrix lists this as a Pro-tier flag but it maps to no distinct fields in the current Sample structs — association-event modeling is part of the broader Wi-Fi build-out that's still in progress. When those fields land, extend `filterSurveyRoamFields` (or add a sibling) to gate them on the `wifi_association_forensics` flag.

## Tests

- `TestFilterSurveyRoamFields_StripsTopLevelSamples`
- `TestFilterSurveyRoamFields_StripsPerFloorSamples`
- `TestFilterSurveyRoamFields_DoesNotMutateInput`
- `TestApplyRoamFilterIfGated_AppliesGateBasedOnLicense`

## Test plan
- [x] `go build ./internal/api/` — clean
- [x] `go test ./internal/api/ -count=1` — passes (22s full suite)
- [x] `golangci-lint run ./internal/api/...` — 0 issues

## Operator note

Customers on Free / Starter who were silently receiving the Pro-tier roam analytics will now see zero/empty roam fields in their survey JSON. Pro / trial behavior is unchanged.

## Cross-repo

Part of the Phase 3 revenue-protection effort. Pairs with seed#1278 (live_telemetry gate).