### PR TITLE
refactor(api): use HasFeature("rest_api") for PAT minting gate

### DIFF
--- a/internal/api/handlers_api_tokens.go
+++ b/internal/api/handlers_api_tokens.go
@@ -140,7 +140,10 @@ func (s *Server) handleLicenseStatus(w http.ResponseWriter, r *http.Request) {
 		resp.CanMintTokens = true
 	} else {
 		resp.Tier = st.Tier.String()
-		resp.CanMintTokens = st.Tier >= license.TierPro
+		// Route the UI signal through the same catalog lookup the
+		// backend gate uses (licenseAllowsAPITokens). Keeps the two
+		// in lock-step if rest_api ever moves between tiers.
+		resp.CanMintTokens = mgr.HasFeature("rest_api")
 	}
 	sendJSONResponse(w, logging.FromContext(r.Context()), http.StatusOK, resp)
 }
@@ -328,23 +331,27 @@ func (s *Server) handleAPITokenRevoke(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// licenseAllowsAPITokens reports whether the active license tier is
-// allowed to mint API tokens. Pro grants it; trial mode (which grants
-// Pro-equivalent features) grants it. Free / Starter do not.
+// licenseAllowsAPITokens reports whether the active license includes
+// the rest_api feature (PAT minting + scoped automation tokens). Pro
+// grants it; trial mode grants it via the same catalog. Free / Starter
+// do not.
 //
 // A nil license manager is treated as "license disabled" (developer
 // builds, tests) and permits minting so the feature stays usable
-// without forcing a license setup.
+// without forcing a license setup. The HasFeature call handles the
+// state==nil / not-activated / expired-trial cases internally and
+// returns false, matching the previous explicit guards.
+//
+// Mirrors the pattern used by licenseAllowsMultiUser. The feature
+// catalog (internal/license/validator.go) is the single source of
+// truth for which features belong to which tier — moving rest_api to
+// a different tier would not need a code change here.
 func (s *Server) licenseAllowsAPITokens() bool {
 	mgr := s.services.Auth.License
 	if mgr == nil {
 		return true
 	}
-	st := mgr.GetState()
-	if st == nil {
-		return false
-	}
-	return st.IsTrialMode || st.Tier >= license.TierPro
+	return mgr.HasFeature("rest_api")
 }
 
 // mintTokenMaterial returns (id, secret, err). The ID is a hex string


### PR DESCRIPTION
## Why

Switches `licenseAllowsAPITokens` and the matching `CanMintTokens` UI signal in `handleLicenseStatus` from a hand-rolled tier comparison to the canonical feature-catalog lookup. Routes both through the same single source of truth as every other Pro-tier gate (`multi_user`, `multi_client`, `multi_interface`, `sso`, `live_telemetry`, `wifi_roam_analysis`).

Zero behavior change for any license that currently exists — Free / Starter still 402, Pro still mints, trial still mints. The point is **future-proofing**: if `rest_api` ever moves between tiers, only the catalog needs editing; the gate updates automatically.

## What

Two callsites updated to match the canonical `licenseAllowsMultiUser` pattern at `handlers_users.go:550`:

```diff
- st := mgr.GetState()
- if st == nil { return false }
- return st.IsTrialMode || st.Tier >= license.TierPro
+ return mgr.HasFeature("rest_api")
```

And in `handleLicenseStatus` the UI signal previously inlined as `st.Tier >= license.TierPro` now flows through `HasFeature("rest_api")` so the UI's "can mint tokens" badge can never drift from what the mint endpoint actually accepts.

`HasFeature` handles `state==nil` / not-activated / expired-trial internally (returns false), matching the previous explicit guards. The nil-manager "license disabled" dev/test path is preserved.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/api/ -count=1` — passes (20s full suite; all `TestMintAPIToken_*` + scope-clamp + PAT tests green)
- [x] `golangci-lint run ./internal/api/...` — 0 issues

## Operator note

Nothing visible — the boolean is identical for every license that currently exists.

## Cross-repo

Phase 3 PR8 from the session plan. Originally deferred as "skip if uncertain"; done now to consolidate every Pro-tier gate around the catalog-lookup pattern so future tier changes only need a catalog edit.