### PR TITLE
test(e2e): testid on Thresholds/Discovery/DNS/Performance settings sections

### DIFF
--- a/ui/e2e/settings.spec.ts
+++ b/ui/e2e/settings.spec.ts
@@ -39,23 +39,19 @@ test.describe('Settings', () => {
   });
 
   test('should display Thresholds settings section', async ({ page }) => {
-    const thresholdsSection = page.getByText(/threshold/i).first();
-    await expect(thresholdsSection).toBeVisible();
+    await expect(page.getByTestId('thresholds-settings-section')).toBeVisible();
   });
 
   test('should display Discovery settings section', async ({ page }) => {
-    const discoverySection = page.getByText(/discovery/i).first();
-    await expect(discoverySection).toBeVisible();
+    await expect(page.getByTestId('discovery-settings-section')).toBeVisible();
   });
 
   test('should display DNS settings section', async ({ page }) => {
-    const dnsSection = page.getByText(/dns/i).first();
-    await expect(dnsSection).toBeVisible();
+    await expect(page.getByTestId('dns-settings-section')).toBeVisible();
   });
 
   test('should display Performance settings section', async ({ page }) => {
-    const perfSection = page.getByText(/performance|speed|iperf/i).first();
-    await expect(perfSection).toBeVisible();
+    await expect(page.getByTestId('performance-settings-section')).toBeVisible();
   });
 
   test('should toggle theme between light and dark', async ({ page }) => {

--- a/ui/src/components/settings/sections/DiscoverySettings.tsx
+++ b/ui/src/components/settings/sections/DiscoverySettings.tsx
@@ -108,6 +108,7 @@ export const DiscoverySettings: React.NamedExoticComponent<DiscoverySettingsProp
 
     return (
       <CollapsibleSection
+        data-testid="discovery-settings-section"
         title={
           <div className={layout.inline.default}>
             <ScanSearch className={iconTokens.size.sm} />

--- a/ui/src/components/settings/sections/DnsSettings.tsx
+++ b/ui/src/components/settings/sections/DnsSettings.tsx
@@ -94,6 +94,7 @@ export const DnsSettings: React.NamedExoticComponent<DnsSettingsProps> = memo(
 
     return (
       <CollapsibleSection
+        data-testid="dns-settings-section"
         title={
           <div className={layout.inline.default}>
             <Globe className={iconTokens.size.sm} />

--- a/ui/src/components/settings/sections/PerformanceSettings.tsx
+++ b/ui/src/components/settings/sections/PerformanceSettings.tsx
@@ -110,6 +110,7 @@ export const PerformanceSettings: React.NamedExoticComponent<PerformanceSettings
 
     return (
       <CollapsibleSection
+        data-testid="performance-settings-section"
         title={
           <div className={layout.inline.default}>
             <Gauge className={iconTokens.size.sm} />

--- a/ui/src/components/settings/sections/ThresholdsSettings.tsx
+++ b/ui/src/components/settings/sections/ThresholdsSettings.tsx
@@ -107,6 +107,7 @@ export const ThresholdsSettings: React.NamedExoticComponent<ThresholdsSettingsPr
 
     return (
       <CollapsibleSection
+        data-testid="thresholds-settings-section"
         title={
           <div className={layout.inline.default}>
             <SlidersHorizontal className={iconTokens.size.sm} />

--- a/ui/src/components/ui/CollapsibleSection.tsx
+++ b/ui/src/components/ui/CollapsibleSection.tsx
@@ -52,6 +52,14 @@ interface CollapsibleSectionProps {
   status?: Status;
   /** Use compact styling for inside cards */
   variant?: 'default' | 'compact';
+  /**
+   * Stable test selector for E2E. Landed on the root `<section>` so the
+   * section is queryable whether collapsed or expanded — call sites that
+   * previously relied on `getByText(/title-substring/i)` were i18n-unsafe
+   * and matched the wrong node when a sibling tab or breadcrumb shared the
+   * substring (settings.spec.ts:41-58 was the canonical victim).
+   */
+  'data-testid'?: string;
 }
 
 /**
@@ -64,6 +72,7 @@ export function CollapsibleSection({
   count,
   status,
   variant = 'default',
+  'data-testid': dataTestId,
 }: CollapsibleSectionProps): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
@@ -71,6 +80,7 @@ export function CollapsibleSection({
 
   return (
     <section
+      data-testid={dataTestId}
       className={cn(
         !isCompact && border.card,
         !isCompact && radius.lg,


### PR DESCRIPTION
settings.spec.ts:41-58 used `page.getByText(/threshold|discovery|dns|
performance/i).first()` to find each settings section. That landed on
whatever node first matched the substring — under es the title text
shifts, under pluralised English ("thresholds" vs "threshold settings")
the regex slips, and other rendered elements (breadcrumbs, sidebar
labels) also share the substring.

PR-2 of the seed E2E plan:

  - Add an optional `data-testid` prop to the shared `CollapsibleSection`
    primitive (`components/ui/CollapsibleSection.tsx`) — landed on the
    root `<section>` so the section is queryable regardless of
    collapsed/open state. Existing call sites (SsoSettings et al.) are
    unaffected.

  - Pass `thresholds-settings-section`, `discovery-settings-section`,
    `dns-settings-section`, and `performance-settings-section` on the
    outer CollapsibleSection of the matching settings files
    (`components/settings/sections/{Thresholds,Discovery,Dns,
    Performance}Settings.tsx`). Mirrors the existing
    `sso-settings-section` testid pattern on SsoSettings.tsx:148.

  - Rewrite the four spec assertions to `getByTestId(...)`. i18n-safe
    and strict-mode-safe per the
    `feedback_e2e_selectors_use_testid` memory.

Verifies locally with biome + tsc; CI will run the full chromium +
webkit E2E pass on the PR.
