### PR TITLE
test(e2e): open profile dropdown before clicking header-logout

### DIFF
--- a/ui/e2e/auth-complete.spec.ts
+++ b/ui/e2e/auth-complete.spec.ts
@@ -121,6 +121,9 @@ test.describe('Complete Authentication Lifecycle', () => {
 
     test('should logout successfully on desktop', async ({ page }) => {
       // Find and click logout button
+      // Open the profile dropdown — header-logout lives inside the
+      // dropdown panel (HeaderBar.tsx:382), not on the header rail.
+      await page.getByTestId('header-profile').click();
       const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
@@ -147,6 +150,9 @@ test.describe('Complete Authentication Lifecycle', () => {
       });
 
       // Click logout
+      // Open the profile dropdown — header-logout lives inside the
+      // dropdown panel (HeaderBar.tsx:382), not on the header rail.
+      await page.getByTestId('header-profile').click();
       const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
@@ -171,6 +177,9 @@ test.describe('Complete Authentication Lifecycle', () => {
       });
 
       // Logout
+      // Open the profile dropdown — header-logout lives inside the
+      // dropdown panel (HeaderBar.tsx:382), not on the header rail.
+      await page.getByTestId('header-profile').click();
       const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
@@ -192,6 +201,9 @@ test.describe('Complete Authentication Lifecycle', () => {
 
     test('should prevent access to protected routes after logout', async ({ page }) => {
       // Logout
+      // Open the profile dropdown — header-logout lives inside the
+      // dropdown panel (HeaderBar.tsx:382), not on the header rail.
+      await page.getByTestId('header-profile').click();
       const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
@@ -209,6 +221,9 @@ test.describe('Complete Authentication Lifecycle', () => {
 
     test('should display empty login form after logout', async ({ page }) => {
       // Logout
+      // Open the profile dropdown — header-logout lives inside the
+      // dropdown panel (HeaderBar.tsx:382), not on the header rail.
+      await page.getByTestId('header-profile').click();
       const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
@@ -274,6 +289,9 @@ test.describe('Complete Authentication Lifecycle', () => {
       });
 
       // Logout to simulate session expiry
+      // Open the profile dropdown — header-logout lives inside the
+      // dropdown panel (HeaderBar.tsx:382), not on the header rail.
+      await page.getByTestId('header-profile').click();
       const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();
@@ -365,17 +383,9 @@ test.describe('Complete Authentication Lifecycle', () => {
         timeout: 10000,
       });
 
-      // On mobile, logout might be in a menu - try hamburger menu first
-      const hamburgerMenu = page.locator(
-        'button[aria-label*="menu" i], button:has(svg[class*="menu"])',
-      );
-      const hasHamburger = await hamburgerMenu.isVisible();
-
-      if (hasHamburger) {
-        await hamburgerMenu.click();
-      }
-
-      // Find logout button
+      // Profile dropdown trigger lives in the icon toolbar, which is
+      // visible on mobile too — no separate hamburger step needed.
+      await page.getByTestId('header-profile').click();
       const logoutButton = page.getByTestId('header-logout');
 
       await logoutButton.click();

--- a/ui/src/components/app/HeaderBar.tsx
+++ b/ui/src/components/app/HeaderBar.tsx
@@ -244,6 +244,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = memo(function headerBar({
           <div ref={profileDropdownRef} className="relative">
             <button
               type="button"
+              data-testid="header-profile"
               className={iconButtonClass}
               onClick={(): void => setProfileDropdownOpen(!profileDropdownOpen)}
               aria-label={t('accessibility.selectProfile', 'Select profile')}


### PR DESCRIPTION
PR-1 fixed the rate-limit cascade in the Logout describe but the tests
were still red because `header-logout` lives INSIDE the profile
dropdown panel (HeaderBar.tsx:382-395), not on the header rail. The
tests called `getByTestId('header-logout').click()` directly and
timed out waiting for the testid because the dropdown was closed.

PR-1.1:

  - Add `data-testid="header-profile"` to the profile dropdown trigger
    button at HeaderBar.tsx:245. The button already has an aria-label
    of "Select profile" but using a testid keeps the E2E flow i18n-safe
    per the feedback_e2e_selectors_use_testid memory.

  - Insert `await page.getByTestId('header-profile').click()` before
    every `header-logout` lookup in auth-complete.spec.ts. Affects 7
    sites (5 in Logout Flow, 1 in Session Expiry re-login, 1 in Mobile
    Logout).

  - Drop the now-redundant hamburger-menu fallback in Mobile Logout
    (lines 365-371 of the pre-change file). The profile dropdown
    trigger sits in the icon toolbar which is visible on mobile
    viewports too, so the hamburger guess was never needed and made
    the test depend on an `aria-label*="menu"` substring match that
    other navigation buttons could also satisfy.

Verifies locally with biome + tsc; CI will run the full chromium +
webkit E2E pass on the PR.
