### PR TITLE
test(e2e): explicit toBeVisible wait between profile and logout click

### DIFF
--- a/ui/e2e/auth-complete.spec.ts
+++ b/ui/e2e/auth-complete.spec.ts
@@ -124,7 +124,14 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Open the profile dropdown — header-logout lives inside the
       // dropdown panel (HeaderBar.tsx:382), not on the header rail.
       await page.getByTestId('header-profile').click();
+      // PR-1.2: explicit visibility settle. Playwright's .click()
+      // auto-wait races React's re-render that mounts the dropdown —
+      // the locator resolves but its retried actionability check
+      // times out on stability before the action fires. Awaiting
+      // toBeVisible() forces the auto-wait to land on the same
+      // settled render pass that mounted the button.
       const logoutButton = page.getByTestId('header-logout');
+      await expect(logoutButton).toBeVisible({ timeout: 5000 });
 
       await logoutButton.click();
 
@@ -153,7 +160,14 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Open the profile dropdown — header-logout lives inside the
       // dropdown panel (HeaderBar.tsx:382), not on the header rail.
       await page.getByTestId('header-profile').click();
+      // PR-1.2: explicit visibility settle. Playwright's .click()
+      // auto-wait races React's re-render that mounts the dropdown —
+      // the locator resolves but its retried actionability check
+      // times out on stability before the action fires. Awaiting
+      // toBeVisible() forces the auto-wait to land on the same
+      // settled render pass that mounted the button.
       const logoutButton = page.getByTestId('header-logout');
+      await expect(logoutButton).toBeVisible({ timeout: 5000 });
 
       await logoutButton.click();
 
@@ -180,7 +194,14 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Open the profile dropdown — header-logout lives inside the
       // dropdown panel (HeaderBar.tsx:382), not on the header rail.
       await page.getByTestId('header-profile').click();
+      // PR-1.2: explicit visibility settle. Playwright's .click()
+      // auto-wait races React's re-render that mounts the dropdown —
+      // the locator resolves but its retried actionability check
+      // times out on stability before the action fires. Awaiting
+      // toBeVisible() forces the auto-wait to land on the same
+      // settled render pass that mounted the button.
       const logoutButton = page.getByTestId('header-logout');
+      await expect(logoutButton).toBeVisible({ timeout: 5000 });
 
       await logoutButton.click();
       await expect(page.getByTestId('login-title')).toBeVisible({
@@ -204,7 +225,14 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Open the profile dropdown — header-logout lives inside the
       // dropdown panel (HeaderBar.tsx:382), not on the header rail.
       await page.getByTestId('header-profile').click();
+      // PR-1.2: explicit visibility settle. Playwright's .click()
+      // auto-wait races React's re-render that mounts the dropdown —
+      // the locator resolves but its retried actionability check
+      // times out on stability before the action fires. Awaiting
+      // toBeVisible() forces the auto-wait to land on the same
+      // settled render pass that mounted the button.
       const logoutButton = page.getByTestId('header-logout');
+      await expect(logoutButton).toBeVisible({ timeout: 5000 });
 
       await logoutButton.click();
       await expect(page.getByTestId('login-title')).toBeVisible({
@@ -224,7 +252,14 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Open the profile dropdown — header-logout lives inside the
       // dropdown panel (HeaderBar.tsx:382), not on the header rail.
       await page.getByTestId('header-profile').click();
+      // PR-1.2: explicit visibility settle. Playwright's .click()
+      // auto-wait races React's re-render that mounts the dropdown —
+      // the locator resolves but its retried actionability check
+      // times out on stability before the action fires. Awaiting
+      // toBeVisible() forces the auto-wait to land on the same
+      // settled render pass that mounted the button.
       const logoutButton = page.getByTestId('header-logout');
+      await expect(logoutButton).toBeVisible({ timeout: 5000 });
 
       await logoutButton.click();
       await expect(page.getByTestId('login-title')).toBeVisible({
@@ -292,7 +327,14 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Open the profile dropdown — header-logout lives inside the
       // dropdown panel (HeaderBar.tsx:382), not on the header rail.
       await page.getByTestId('header-profile').click();
+      // PR-1.2: explicit visibility settle. Playwright's .click()
+      // auto-wait races React's re-render that mounts the dropdown —
+      // the locator resolves but its retried actionability check
+      // times out on stability before the action fires. Awaiting
+      // toBeVisible() forces the auto-wait to land on the same
+      // settled render pass that mounted the button.
       const logoutButton = page.getByTestId('header-logout');
+      await expect(logoutButton).toBeVisible({ timeout: 5000 });
 
       await logoutButton.click();
       await expect(page.getByTestId('login-title')).toBeVisible({

--- a/ui/e2e/auth-complete.spec.ts
+++ b/ui/e2e/auth-complete.spec.ts
@@ -428,7 +428,9 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Profile dropdown trigger lives in the icon toolbar, which is
       // visible on mobile too — no separate hamburger step needed.
       await page.getByTestId('header-profile').click();
+      // PR-1.2: explicit visibility settle (see Logout Flow describe).
       const logoutButton = page.getByTestId('header-logout');
+      await expect(logoutButton).toBeVisible({ timeout: 5000 });
 
       await logoutButton.click();
 


### PR DESCRIPTION
PR-1.1 opened the dropdown but Playwright's .click() auto-wait on the
logout button kept failing actionability — the locator resolved (the
button mounted inside the dropdown panel) but its retried visibility
check timed out before the action fired. The failure log showed the
classic "locator resolved to <button data-testid='header-logout'>"
with `expect(locator).toBeVisible() failed` immediately after — i.e.
the click action could not settle the render-stability window between
profile click and logout click.

Adding an explicit `await expect(logoutButton).toBeVisible({ timeout:
5000 })` between the two clicks forces Playwright's auto-wait onto the
settled render pass that mounted the dropdown panel, instead of
racing it. Applied to all 7 sites (5 Logout Flow tests + Session
Expiry re-login + Mobile Logout).

Verifies locally with biome + tsc; this is the third increment of the
auth-complete logout fix (PR-1 = storageState, PR-1.1 = open
dropdown, PR-1.2 = wait for it to actually be visible).
