### PR TITLE
test(e2e): fix error-scenarios stale mock prefixes + tighten cross-browser assertion

### DIFF
--- a/ui/e2e/error-scenarios.spec.ts
+++ b/ui/e2e/error-scenarios.spec.ts
@@ -351,8 +351,13 @@ test.describe('API Error Scenarios', () => {
     test('should redirect to login on session expiration', async ({ page }) => {
       await login(page);
 
-      // Mock API endpoints returning 401 after login
-      await page.route('**/api/link', async (route) => {
+      // Mock API endpoints returning 401 after login. The UI calls the
+      // v1-prefixed routes since the API namespace rollout; the previous
+      // `**/api/link` and `**/api/status` globs silently no-op'd because
+      // they didn't match `/api/v1/link` or `/api/v1/status`. Matching
+      // both legacy and v1 keeps the mock effective if any caller is
+      // still on the older path.
+      await page.route(/\/api(\/v1)?\/link$/, async (route) => {
         await route.fulfill({
           status: 401,
           contentType: 'application/json',
@@ -362,7 +367,7 @@ test.describe('API Error Scenarios', () => {
         });
       });
 
-      await page.route('**/api/status', async (route) => {
+      await page.route(/\/api(\/v1)?\/status$/, async (route) => {
         await route.fulfill({
           status: 401,
           contentType: 'application/json',
@@ -1156,8 +1161,14 @@ test.describe('Cross-Browser Error Handling', () => {
   test('should handle errors consistently across browsers', async ({ page }) => {
     await login(page);
 
-    // Mock error
-    await page.route('**/api/status', async (route) => {
+    // Mock error. The UI calls `/api/v1/status`; the previous
+    // `**/api/status` glob silently no-op'd against the v1 endpoint
+    // and the test was relying on the real backend response, not the
+    // mock. The dual `headerVisible || loginVisible` assertion was a
+    // tolerance band that masked the bug — collapsed to the single
+    // expected behaviour: a /api/v1/status 500 is non-fatal for the
+    // SPA, so the page header stays visible.
+    await page.route(/\/api(\/v1)?\/status$/, async (route) => {
       await route.fulfill({
         status: 500,
         contentType: 'application/json',
@@ -1167,17 +1178,8 @@ test.describe('Cross-Browser Error Handling', () => {
 
     await page.reload();
 
-    // Should handle error consistently regardless of browser — either
-    // the page-header (post-login) OR the login form is showing.
-    const headerVisible = await page
-      .getByTestId('page-header-title')
-      .isVisible({ timeout: 10000 })
-      .catch(() => false);
-    const loginVisible = await page
-      .getByTestId('login-title')
-      .isVisible({ timeout: 1000 })
-      .catch(() => false);
-
-    expect(headerVisible || loginVisible).toBeTruthy();
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
+      timeout: 10000,
+    });
   });
 });


### PR DESCRIPTION
Two route handlers in error-scenarios.spec.ts used the legacy
unprefixed paths `**/api/link` and `**/api/status`. The UI calls the
v1-prefixed routes (`/api/v1/link`, `/api/v1/status`) per the API
namespace rollout, so the globs silently no-op'd — every "401 session
expired" and "cross-browser error" test was hitting the real backend
response and the assertion either flaked or masked the bug.

PR-4 of the seed E2E plan:

  - `'**/api/link'` → `/\/api(\/v1)?\/link$/` so the mock matches both
    legacy and v1.
  - `'**/api/status'` → `/\/api(\/v1)?\/status$/` (two sites: the 401
    session-expiry test and the cross-browser error test).

  - The cross-browser test had a "tolerance band" assertion:
    `expect(headerVisible || loginVisible).toBeTruthy()`. That was the
    flake-disguising symptom of the mock not firing — the real
    /api/v1/status response sometimes left the page in the dashboard
    state and sometimes triggered an auth redirect. With the mock now
    actually intercepting, a 500 on /api/v1/status is non-fatal for
    the SPA and the header stays visible; collapsed the dual assertion
    to a single `await expect(...page-header-title).toBeVisible()`.

Verifies locally with biome + tsc.
