### PR TITLE
test(e2e): wifi-wired-fallback testid + replace fragile wifi-page selectors

### DIFF
--- a/ui/e2e/wifi-page.spec.ts
+++ b/ui/e2e/wifi-page.spec.ts
@@ -24,9 +24,8 @@ test.describe('Wi-Fi Page', () => {
     });
   });
 
-  test('should render the page header with the Wi-Fi title', async ({ page }) => {
+  test('should render the page header', async ({ page }) => {
     await expect(page.getByTestId('page-header-title')).toBeVisible();
-    await expect(page.getByText(/wireless link, channel survey/i)).toBeVisible();
   });
 
   test('should land on the /wifi route after navigation', async ({ page }) => {
@@ -35,12 +34,14 @@ test.describe('Wi-Fi Page', () => {
 
   test('should render either WiFi cards or the wired-mode fallback', async ({ page }) => {
     // One branch must be visible:
-    //   - isWifi=true  → WiFiCard / WiFiSurveyCard / WifiChannelGraph
-    //   - isWifi=false → "Switch to Wi-Fi mode from the header to view wireless data."
-    const wifiContent = page
-      .locator('text=/channel|ssid|signal|survey/i')
-      .or(page.getByText(/switch to wi-fi mode from the header/i));
-    await expect(wifiContent.first()).toBeVisible({ timeout: 5000 });
+    //   - isWifi=true  → at least one WiFi card (`#card-title-wifi`,
+    //     `#card-title-wifi-survey`, or `#card-title-channels`).
+    //   - isWifi=false → `data-testid="wifi-wired-fallback"` div on WifiPage.
+    const wifiCards = page.locator(
+      '#card-title-wifi, #card-title-wifi-survey, #card-title-channels',
+    );
+    const wiredFallback = page.getByTestId('wifi-wired-fallback');
+    await expect(wifiCards.first().or(wiredFallback)).toBeVisible({ timeout: 5000 });
   });
 
   test('should show the wired-mode message when WiFi card data unavailable', async ({ page }) => {
@@ -54,11 +55,12 @@ test.describe('Wi-Fi Page', () => {
     });
     await page.reload();
     await expect(page.getByTestId('page-header-title')).toBeVisible();
-    // Either the wired-mode message OR the cards must be the one rendered;
-    // both branches are valid given different test environments.
-    const content = page
-      .getByText(/switch to wi-fi mode from the header/i)
-      .or(page.locator('text=/channel|ssid|survey/i'));
-    await expect(content.first()).toBeVisible({ timeout: 5000 });
+    // Either the wired-mode message OR the cards must be rendered; both
+    // branches are valid given different test environments.
+    const wifiCards = page.locator(
+      '#card-title-wifi, #card-title-wifi-survey, #card-title-channels',
+    );
+    const wiredFallback = page.getByTestId('wifi-wired-fallback');
+    await expect(wiredFallback.or(wifiCards.first())).toBeVisible({ timeout: 5000 });
   });
 });

--- a/ui/src/pages/WifiPage.tsx
+++ b/ui/src/pages/WifiPage.tsx
@@ -31,7 +31,7 @@ export function WifiPage() {
           />
         ) : null}
         {!isWifi && (
-          <div className="col-span-full text-sm text-text-muted">
+          <div data-testid="wifi-wired-fallback" className="col-span-full text-sm text-text-muted">
             Switch to Wi-Fi mode from the header to view wireless data.
           </div>
         )}


### PR DESCRIPTION
PR-5 of the seed E2E plan — narrowed scope:

  - WifiPage.tsx: add `data-testid="wifi-wired-fallback"` to the
    `!isWifi` branch's `<div>`. The fallback used to be queried by
    `getByText(/switch to wi-fi mode from the header/i)`, which broke
    under es and would also slip if the copy ever shifted.

  - wifi-page.spec.ts: dropped the page-subtitle regex assertion
    (the header testid check above it is the durable smoke signal);
    replaced the dual `text=/channel|ssid|signal|survey/i` OR
    `getByText(/switch to wi-fi mode/i)` locator in two tests with a
    stable `.or()` between the BaseCard `#card-title-{wifi,wifi-survey,
    channels}` IDs and the new `wifi-wired-fallback` testid.

Scope note: PR-5 in the plan also called for tightening
gateway.spec.ts (12 getByText regexes) and setup-wizard.spec.ts (7
getByRole + 4 getByText). Both target dynamic card content / Setup
Wizard step components and need multiple UI testid additions —
deferring to PR-5b after the primary green-state is verified.
