### PR TITLE
test(e2e): mock /api/auth/logout in Logout describe (real root cause)

### DIFF
--- a/ui/e2e/auth-complete.spec.ts
+++ b/ui/e2e/auth-complete.spec.ts
@@ -110,6 +110,22 @@ test.describe('Complete Authentication Lifecycle', () => {
     test.use({ storageState: AUTH_STORAGE_STATE });
 
     test.beforeEach(async ({ page }) => {
+      // PR-1.3: mock /api/v1/auth/logout (and the legacy unprefixed
+      // route) so the request still fires (tests that assert the call
+      // happens still pass) but the backend doesn't actually invalidate
+      // the storageState token. Without this mock, the first Logout
+      // test invalidates the shared session on the real backend; every
+      // subsequent test loads the same now-stale token, the SPA's next
+      // /api/v1/status call gets 401, and the SPA's mid-test redirect
+      // to login detaches the dropdown panel before .click() can land.
+      // PR-1.2's explicit toBeVisible passed because the button WAS
+      // visible for a moment — then the SPA navigated and the button
+      // was DOM-detached. Mocking lets every Logout test keep the same
+      // valid token while still exercising the client-side flow.
+      await page.route(/\/api(\/v1)?\/auth\/logout$/, (route) => {
+        route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      });
+
       await disableAnimations(page);
       await page.goto('/');
       // Authenticated session lands on the dashboard; wait for it


### PR DESCRIPTION
After three iterations on the Logout describe (PR-1 storageState,
PR-1.1 open dropdown, PR-1.2 explicit toBeVisible wait), Playwright
still failed with `expect(locator).toBeVisible() failed` on the
logout click. Downloading the trace artifact made the real bug
obvious:

  - Call log:
      "element was detached from the DOM, retrying"
  - Page snapshot at failure time:
      alert: "Session expired. Please log in again."
      button: "Login"

The first Logout test calls the real /api/v1/auth/logout, which
invalidates the storageState session token on the backend. Every
subsequent Logout test loads the SAME storageState (per the describe-
level `test.use({ storageState: AUTH_STORAGE_STATE })`), so the cookie
carries the now-stale token. The SPA's next /api/v1/status poll gets
401, the SPA redirects to /login, the dropdown panel unmounts, and
the logout button is DOM-detached before .click() can fire. PR-1.2's
toBeVisible saw the brief window where the button was mounted before
the redirect — that's why "visibility passed, click failed."

PR-1.3 mocks /api/v1/auth/logout (and the legacy unprefixed form) in
the Logout describe's beforeEach. The request still fires (the
"verify POST /api/auth/logout is called" test still passes), but the
backend stays untouched, the storageState token remains valid for the
next test, and the client-side flow (clearing localStorage, SPA
redirect to login) is unaffected.

The PR-1.2 explicit toBeVisible wait stays — it's the right defensive
pattern for any dropdown-then-click test, and it doesn't hurt when
the underlying bug is fixed.
