### PR TITLE
test(e2e): drop tautological scroll test + finish responsive [class*=card] migration

### DIFF
--- a/ui/e2e/responsive.spec.ts
+++ b/ui/e2e/responsive.spec.ts
@@ -180,19 +180,11 @@ test.describe('Responsive Layout Tests', () => {
       }
     });
 
-    test('should scroll cards vertically on mobile', async ({ page }) => {
-      // Get initial scroll position
-      const initialScroll = await page.evaluate(() => window.scrollY);
-
-      // Scroll down
-      await page.evaluate(() => window.scrollBy(0, 300));
-
-      // Get new scroll position
-      const newScroll = await page.evaluate(() => window.scrollY);
-
-      // Scroll position should have changed
-      expect(newScroll).toBeGreaterThan(initialScroll);
-    });
+    // PR-C1 cleanup: dropped "should scroll cards vertically on mobile" —
+    // it asserted `window.scrollBy(0, 300)` actually moved scrollY, which
+    // tests the BROWSER (or jsdom), not the app. Any future regression to
+    // mobile scroll would never surface here; the test added a CI run-cost
+    // for zero defensive signal.
 
     test('should open help modal properly on mobile', async ({ page }) => {
       // Help lives in the sidebar drawer behind the hamburger on mobile.
@@ -214,8 +206,11 @@ test.describe('Responsive Layout Tests', () => {
     });
 
     test('should display all essential features on mobile', async ({ page }) => {
-      // Verify essential UI elements are present
-      const cards = page.locator('[class*="card"]');
+      // Verify essential UI elements are present. PR-3 / PR-C1 swap:
+      // `[class*="card"]` was substring-matching against Tailwind's
+      // hashed class names and grabbing arbitrary unrelated nodes;
+      // BaseCard emits `data-testid="card"` on every wrapper.
+      const cards = page.locator('[data-testid="card"]');
       const cardCount = await cards.count();
 
       expect(cardCount).toBeGreaterThan(0);
@@ -343,15 +338,17 @@ test.describe('Responsive Layout Tests', () => {
     });
 
     test('should display all cards on tablet', async ({ page }) => {
-      // Count visible cards
-      const cards = page.locator('[class*="card"]');
+      // PR-C1: same fix as the two other shard sites in this file —
+      // [class*="card"] was non-deterministic, and the `text=/link/i`
+      // fallback would match the sidebar nav item before reaching the
+      // dashboard card. Use the stable BaseCard `data-testid="card"`
+      // and the `#card-title-link` ID also emitted by BaseCard.
+      const cards = page.locator('[data-testid="card"]');
       const cardCount = await cards.count();
 
       expect(cardCount).toBeGreaterThan(0);
 
-      // Verify common cards are visible
-      const linkCard = page.locator('text=/link/i').first();
-      await expect(linkCard).toBeVisible();
+      await expect(page.locator('#card-title-link')).toBeVisible();
     });
   });
 


### PR DESCRIPTION
Cleanup PR-C1 of the seed E2E cleanup phase (see
project_e2e_cleanup_directive memory).

  - DROPPED: "should scroll cards vertically on mobile" (lines 183-195
    of the pre-change file). It asserted `window.scrollBy(0, 300)`
    actually moved scrollY, which tests the browser's built-in
    scrolling, not the app. Any regression to mobile scroll behavior
    in the app would never surface here; the test added CI run-cost
    for zero defensive signal — the textbook definition of junk in the
    cleanup directive's Stage 1.

  - FINISHED: PR-3 / PR-2.5 left two `[class*="card"]` sites in this
    file untouched (the replace_all in PR-3 matched only sites with
    a preceding "// Get all cards" comment; lines 218 and 347 had
    different surrounding comments and slipped through). Swapped both
    to `[data-testid="card"]` to complete the migration.

  - FIXED: the "should display all cards on tablet" test additionally
    queried `page.locator('text=/link/i').first()` which under strict
    mode would match the sidebar Link nav entry before reaching the
    dashboard Link card. Replaced with `#card-title-link` (the stable
    BaseCard-emitted ID we already use in dashboard.spec.ts).

No new tests added — this is intentionally subtractive.
