### PR TITLE
test(e2e): rewrite smoke.spec.ts as a golden-path required-status gate

### DIFF
--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -1,81 +1,68 @@
 import { expect, test } from '@playwright/test';
+import { AUTH_STORAGE_STATE, sidebarHelpButton, sidebarSettingsButton } from './helpers/auth';
 
-/**
- * Smoke Tests
- *
- * Quick sanity checks to verify the app is running:
- * - Page loads without errors
- * - No console errors
- * - Basic UI elements render
- */
+const VERSION_KEYS = ['version', 'commit', 'buildTime', 'uiBuildHash'] as const;
 
-test.describe('Smoke Tests', { tag: '@smoke' }, () => {
-  test('should load the application without errors', async ({ page }) => {
-    const errors: string[] = [];
+test.describe('smoke @ unauthenticated', { tag: '@smoke' }, () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
 
-    // Capture console errors
-    page.on('console', (msg) => {
-      if (msg.type() === 'error') {
-        errors.push(msg.text());
-      }
-    });
-
-    await page.goto('/');
-
-    // Page should have loaded something
-    await expect(page.locator('body')).not.toBeEmpty();
-
-    // Filter out expected errors. Smoke is for CATASTROPHIC errors only
-    // (page fails to render, bundle fails to load, JS exception bubbles up).
-    // The following are expected on a freshly-started backend:
-    //   - 401 / Unauthorized: pre-login probes against authenticated endpoints
-    //   - "Failed to fetch": transient network during initial app boot
-    //   - 404 / "Failed to load resource": endpoints not wired up yet
-    //     (notably /api/v1/profiles and /api/events — tracked separately
-    //     in the backend backlog; they don't break the UI render)
-    const criticalErrors = errors.filter(
-      (e) =>
-        !(
-          e.includes('401') ||
-          e.includes('404') ||
-          e.includes('Unauthorized') ||
-          e.includes('Failed to fetch') ||
-          e.includes('Failed to load resource')
-        ),
-    );
-
-    // No critical console errors
-    expect(criticalErrors).toHaveLength(0);
+  test('GET /__version returns canonical build metadata', async ({ request }) => {
+    const res = await request.get('/__version');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    for (const k of VERSION_KEYS) {
+      expect(body[k], `missing ${k} in /__version`).toBeTruthy();
+      expect(typeof body[k]).toBe('string');
+    }
   });
 
-  test('should have proper page title', async ({ page }) => {
+  test('login surface renders for unauthenticated visitors', async ({ page }) => {
     await page.goto('/');
+    await expect(page.getByTestId('login-title')).toBeVisible({ timeout: 10000 });
+  });
+});
 
-    // Title should contain app name
-    await expect(page).toHaveTitle(/seed|The Seed|network/i);
+test.describe('smoke @ authenticated', { tag: '@smoke' }, () => {
+  test.use({ storageState: AUTH_STORAGE_STATE });
+
+  test('dashboard renders with page header and at least one card', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('card').first()).toBeVisible();
   });
 
-  test('should have proper viewport and be responsive', async ({ page }) => {
+  test('theme toggle is interactive', async ({ page }) => {
     await page.goto('/');
-
-    // Set mobile viewport
-    await page.setViewportSize({ width: 375, height: 667 });
-
-    // Content should still be visible
-    await expect(page.locator('body')).toBeVisible();
-
-    // Set desktop viewport
-    await page.setViewportSize({ width: 1920, height: 1080 });
-
-    // Content should still be visible
-    await expect(page.locator('body')).toBeVisible();
+    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 10000 });
+    const toggle = page.getByTestId('theme-toggle');
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+    await expect(toggle).toBeVisible();
   });
 
-  test('should handle 404 routes gracefully', async ({ page }) => {
-    await page.goto('/nonexistent-route-12345');
+  test('settings drawer opens from sidebar', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 10000 });
+    await sidebarSettingsButton(page).click();
+    await expect(page.getByTestId('settings-drawer')).toBeVisible();
+    await page.getByTestId('settings-drawer-close').click();
+    await expect(page.getByTestId('settings-drawer')).toBeHidden();
+  });
 
-    // Should either redirect to login or show 404 page
-    const hasContent = await page.locator('body').textContent();
-    expect(hasContent).toBeTruthy();
+  test('help drawer opens from sidebar', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 10000 });
+    await sidebarHelpButton(page).click();
+    await expect(page.getByTestId('help-drawer')).toBeVisible();
+    await expect(page.getByTestId('help-drawer-content')).toBeVisible();
+    await page.getByTestId('help-drawer-close').click();
+    await expect(page.getByTestId('help-drawer')).toBeHidden();
+  });
+
+  test('profile dropdown reveals logout control', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('header-profile').click();
+    await expect(page.getByTestId('header-logout')).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
Cleanup PR-AC4 of the seed E2E aggressive cleanup phase.

The previous 4 tests in smoke.spec.ts asserted next-to-nothing:

  - "should load the application without errors" parsed console
    log strings and filtered out 401/404/"Failed to fetch" — making
    the assertion "no critical errors" pass even when the SPA
    didn't render. Console-log scraping doesn't belong in smoke.
  - "should have proper page title" regex'd `/seed|The Seed|network/i`
    against `<title>`. The title is always present; that's an HTML
    requirement, not an app contract.
  - "should have proper viewport and be responsive" set mobile then
    desktop viewport and asserted `body` was visible — `body` is
    always visible. Tested the browser, not the app.
  - "should handle 404 routes gracefully" asserted the body had
    *some* text content. Tautological.

Replaced with 7 golden-path tests that each assert a real merge-gate
contract:

  Unauthenticated (storageState forced empty):
    1. GET /__version returns { version, commit, buildTime,
       uiBuildHash } as strings (the canonical Universal Build
       Contract surface in CLAUDE.md).
    2. login-title testid is visible at `/` — proves the auth
       gate kicks in for anonymous visitors.

  Authenticated (default storageState):
    3. Dashboard: page-header-title + first card testid visible.
    4. theme-toggle clickable (proves the global UI surface mounts
       and is interactive).
    5. settings-drawer opens via the existing sidebar helper, then
       closes via settings-drawer-close.
    6. help-drawer opens, help-drawer-content visible, then closes.
    7. header-profile dropdown reveals header-logout — covers the
       PR-1.1 regression where the logout button was tested before
       the dropdown was opened.

All selectors are getByTestId — zero regex, zero `[class*=...]`,
zero `if (await x.isVisible())` gating. No console-log scraping.
No viewport-shake tests.

The smoke tier remains required-status; full E2E stays advisory
(see upcoming PR-AC5). The reduced surface area + tightened
selectors should bring smoke wall-clock under 30s per browser.
