### PR TITLE
fix(e2e): drop top-level theme-toggle smoke test from seed

### DIFF
--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -31,14 +31,12 @@ test.describe('smoke @ authenticated', { tag: '@smoke' }, () => {
     await expect(page.getByTestId('card').first()).toBeVisible();
   });
 
-  test('theme toggle is interactive', async ({ page }) => {
-    await page.goto('/');
-    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 10000 });
-    const toggle = page.getByTestId('theme-toggle');
-    await expect(toggle).toBeVisible();
-    await toggle.click();
-    await expect(toggle).toBeVisible();
-  });
+  // No top-level theme-toggle smoke test: seed's data-testid="theme-toggle"
+  // lives on AppearanceSettings.tsx — only mounted when the settings
+  // drawer is open. Theme behaviour is covered by theme-and-help.spec.ts
+  // at the @smoke tier (reached through the drawer). Putting a deep-link
+  // assertion at the top-level smoke tier was a mis-port of stem's smoke
+  // shape (stem has header-theme-toggle at the chrome level).
 
   test('settings drawer opens from sidebar', async ({ page }) => {
     await page.goto('/');


### PR DESCRIPTION
The smoke.spec.ts rewrite in PR-AC4 (#1295) added a "theme toggle
is interactive" test that called page.getByTestId('theme-toggle')
at the dashboard route. That testid lives on AppearanceSettings.
tsx — only mounted when the settings drawer is open. The test
failed on both chromium and webkit smoke runs with element-not-found.

Root cause: mis-port of stem's smoke shape. Stem has data-testid=
"header-theme-toggle" on the page header (always mounted). Seed
doesn't — theme switching is reached via Settings → Appearance.

Two options:
  1. Open the settings drawer first, then toggle. Doubles the
     test's interaction surface and makes it deep-link into
     settings — redundant with the settings-drawer-opens smoke
     test already in the file.
  2. Drop the test from smoke. Theme behaviour is already covered
     by theme-and-help.spec.ts at the @smoke tier — it opens the
     drawer and toggles. No coverage gap.

Chose option 2: smoke should not deep-link past the chrome.

Net change: smoke.spec.ts drops from 7 tests to 6. Theme coverage
preserved via theme-and-help.spec.ts.
