### PR TITLE
test(e2e): tighten help-drawer backdrop test with stable testid

### DIFF
--- a/ui/e2e/theme-and-help.spec.ts
+++ b/ui/e2e/theme-and-help.spec.ts
@@ -210,12 +210,16 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const drawer = page.getByTestId('help-drawer');
       await expect(drawer).toBeVisible();
 
-      // Click the backdrop (dark overlay behind the drawer).
-      const backdrop = page.locator('[class*="backdrop"]').first();
-      if (await backdrop.isVisible()) {
-        await backdrop.click({ position: { x: 10, y: 10 } });
-        await expect(drawer).not.toBeVisible({ timeout: 3000 });
-      }
+      // Click the backdrop (dark overlay behind the drawer). The
+      // previous `[class*="backdrop"]` substring-match against
+      // Tailwind utilities was unreliable AND was wrapped in an
+      // `if (await backdrop.isVisible())` gate that silently passed
+      // when the locator missed — flagged by the cleanup audit as
+      // the last hidden-failure test in seed E2E.
+      const backdrop = page.getByTestId('help-drawer-backdrop');
+      await expect(backdrop).toBeVisible();
+      await backdrop.click({ position: { x: 10, y: 10 } });
+      await expect(drawer).not.toBeVisible({ timeout: 3000 });
     });
 
     test('should switch sections when clicking a table-of-contents entry', async ({ page }) => {

--- a/ui/src/components/help/HelpDrawer.tsx
+++ b/ui/src/components/help/HelpDrawer.tsx
@@ -78,6 +78,7 @@ export function HelpDrawer({ isOpen, onClose, version }: HelpDrawerProps): React
         className="fixed inset-0 bg-scrim/50 backdrop-blur-sm z-40"
         onClick={onClose}
         aria-hidden="true"
+        data-testid="help-drawer-backdrop"
       />
 
       {/* Drawer */}


### PR DESCRIPTION
Last hidden-failure test in seed E2E per the cleanup audit. The
"should close help drawer when clicking outside" test in
theme-and-help.spec.ts located the backdrop via:

    page.locator('[class*="backdrop"]').first()

Two problems:
  1. `[class*="backdrop"]` is a substring match against Tailwind
     utility classes. Same pitfall as the deleted `[class*="card"]`
     selectors in responsive.spec.ts (PR-AC1) — matches anything
     containing the substring, including unrelated utilities like
     `backdrop-blur-sm` (which the drawer itself uses) and any
     other element with a backdrop-* utility.
  2. The match was wrapped in `if (await backdrop.isVisible())
     { ... }`. When the locator hit zero or wrong elements, the
     test passed silently — never verifying that clicking the
     backdrop actually dismisses the drawer.

Fix:
  - Add data-testid="help-drawer-backdrop" to the HelpDrawer
    backdrop div (same shape as the drawer itself which already
    carries help-drawer / help-drawer-content / help-drawer-close).
  - Replace the locator + if-visible gate with a hard
    `expect(backdrop).toBeVisible()` assertion, then click and
    assert dismissal.

Net: -1 hidden-failure test across the seed E2E suite. The 78
i18n-fragile selector sites identified by the same audit are
deferred to a separate PR (it's a much bigger sweep — 56 sites in
seed alone, concentrated in error-scenarios.spec.ts and gateway.
spec.ts).
