### PR TITLE
test(e2e): migrate seed auth specs from text-regex to role=alert

### DIFF
--- a/ui/e2e/auth-complete.spec.ts
+++ b/ui/e2e/auth-complete.spec.ts
@@ -52,7 +52,7 @@ test.describe('Complete Authentication Lifecycle', () => {
       await page.getByRole('button', { name: /sign in|login/i }).click();
 
       // Verify error message displays
-      await expect(page.getByText(/invalid|incorrect|failed/i)).toBeVisible({
+      await expect(page.getByRole('alert')).toBeVisible({
         timeout: 5000,
       });
 
@@ -86,7 +86,7 @@ test.describe('Complete Authentication Lifecycle', () => {
       await page.getByRole('button', { name: /sign in|login/i }).click();
 
       // Wait for error
-      await expect(page.getByText(/invalid|incorrect|failed/i)).toBeVisible({
+      await expect(page.getByRole('alert')).toBeVisible({
         timeout: 5000,
       });
 
@@ -323,10 +323,12 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Trigger an API call (reload page or wait for WebSocket/polling)
       await page.reload();
 
-      // Should redirect to login or show session expired message
-      await expect(
-        page.getByText(/session expired|logged out|please login/i).or(page.getByLabel(/username/i)),
-      ).toBeVisible({ timeout: 10000 });
+      // Should redirect to login or show session expired message.
+      // login-title testid is the stable surface; previously this
+      // fell back to language-specific regex which would miss in es.
+      await expect(page.getByTestId('login-title').or(page.getByRole('alert'))).toBeVisible({
+        timeout: 10000,
+      });
     });
 
     test('should allow re-login after session expiry', async ({ page }) => {

--- a/ui/e2e/auth.spec.ts
+++ b/ui/e2e/auth.spec.ts
@@ -44,8 +44,9 @@ test.describe('Authentication', () => {
     await page.getByLabel(/password/i).fill('wrongpassword');
     await page.getByRole('button', { name: /sign in|login/i }).click();
 
-    // Should show error message
-    await expect(page.getByText(/invalid|incorrect|failed/i)).toBeVisible({
+    // Should show error message. role=alert is i18n-stable; the
+    // LoginForm error alert (LoginForm.tsx:298) carries it natively.
+    await expect(page.getByRole('alert')).toBeVisible({
       timeout: 5000,
     });
   });


### PR DESCRIPTION
Brittleness fix #2 of the i18n-fragile-selector sweep.

Four sites in seed auth specs were matching login-error message
text by regex: `getByText(/invalid|incorrect|failed/i)`. Same
fragility class as the error-scenarios.spec.ts batch (PR #1300):
breaks under es locale (invalid -> invalido, incorrect ->
incorrecto, failed -> fallido), breaks under copy churn.

Migrated to getByRole alert which matches by ARIA role on the
LoginForm error surface (LoginForm.tsx:298 — role=alert already
present).

Sites migrated:
  - auth.spec.ts:48          /invalid|incorrect|failed/i
  - auth-complete.spec.ts:55 /invalid|incorrect|failed/i
  - auth-complete.spec.ts:89 /invalid|incorrect|failed/i
  - auth-complete.spec.ts:328 session-expired or login-form
    visible — collapsed to login-title testid OR role=alert
    (the test only needs to verify the user was bounced).

Net: -4 i18n-fragile assertion sites across seed auth specs.
