### PR TITLE
test(e2e): page-header-description testid, migrate 7 per-page specs

### DIFF
--- a/ui/e2e/link-page.spec.ts
+++ b/ui/e2e/link-page.spec.ts
@@ -23,7 +23,7 @@ test.describe('Link Page', () => {
 
   test('should render the page header with Link title', async ({ page }) => {
     await expect(page.getByTestId('page-header-title')).toBeVisible();
-    await expect(page.getByText(/physical link state.*cable diagnostics/i)).toBeVisible();
+    await expect(page.getByTestId('page-header-description')).toBeVisible();
   });
 
   test('should land on the /link route', async ({ page }) => {

--- a/ui/e2e/logs-page.spec.ts
+++ b/ui/e2e/logs-page.spec.ts
@@ -20,7 +20,7 @@ test.describe('Logs Page', () => {
 
   test('should render the page header with Logs title', async ({ page }) => {
     await expect(page.getByTestId('page-header-title')).toBeVisible();
-    await expect(page.getByText(/live log stream and system health/i)).toBeVisible();
+    await expect(page.getByTestId('page-header-description')).toBeVisible();
   });
 
   test('should land on the /logs route', async ({ page }) => {

--- a/ui/e2e/network-page.spec.ts
+++ b/ui/e2e/network-page.spec.ts
@@ -23,7 +23,7 @@ test.describe('Network Page', () => {
 
   test('should render the page header with Network title', async ({ page }) => {
     await expect(page.getByTestId('page-header-title')).toBeVisible();
-    await expect(page.getByText(/dhcp.*gateway.*dns/i)).toBeVisible();
+    await expect(page.getByTestId('page-header-description')).toBeVisible();
   });
 
   test('should land on the /network route', async ({ page }) => {

--- a/ui/e2e/path-analysis-page.spec.ts
+++ b/ui/e2e/path-analysis-page.spec.ts
@@ -21,7 +21,7 @@ test.describe('Path Analysis Page', () => {
 
   test('should render the page header with Path Analysis title', async ({ page }) => {
     await expect(page.getByTestId('page-header-title')).toBeVisible();
-    await expect(page.getByText(/path discovery|traceroute|device discovery/i)).toBeVisible();
+    await expect(page.getByTestId('page-header-description')).toBeVisible();
   });
 
   test('should land on the /path route', async ({ page }) => {

--- a/ui/e2e/performance-page.spec.ts
+++ b/ui/e2e/performance-page.spec.ts
@@ -21,7 +21,7 @@ test.describe('Performance Page', () => {
 
   test('should render the page header with Performance title', async ({ page }) => {
     await expect(page.getByTestId('page-header-title')).toBeVisible();
-    await expect(page.getByText(/active throughput tests/i)).toBeVisible();
+    await expect(page.getByTestId('page-header-description')).toBeVisible();
   });
 
   test('should land on the /performance route', async ({ page }) => {

--- a/ui/e2e/reports-page.spec.ts
+++ b/ui/e2e/reports-page.spec.ts
@@ -19,9 +19,7 @@ test.describe('Reports Page', () => {
 
   test('should render the page header with Reports title', async ({ page }) => {
     await expect(page.getByTestId('page-header-title')).toBeVisible();
-    await expect(
-      page.getByText(/aggregated sla dashboard|compliance|historical reporting/i),
-    ).toBeVisible();
+    await expect(page.getByTestId('page-header-description')).toBeVisible();
   });
 
   test('should land on the /reports route', async ({ page }) => {

--- a/ui/e2e/security-page.spec.ts
+++ b/ui/e2e/security-page.spec.ts
@@ -20,7 +20,7 @@ test.describe('Security Page', () => {
 
   test('should render the page header with Security title', async ({ page }) => {
     await expect(page.getByTestId('page-header-title')).toBeVisible();
-    await expect(page.getByText(/guest network isolation audit/i)).toBeVisible();
+    await expect(page.getByTestId('page-header-description')).toBeVisible();
   });
 
   test('should land on the /security route', async ({ page }) => {

--- a/ui/src/ui/PageHeader.tsx
+++ b/ui/src/ui/PageHeader.tsx
@@ -142,7 +142,11 @@ export const PageHeader: FC<PageHeaderProps> = ({
             <h1 className="heading-1 font-display" data-testid="page-header-title">
               {title}
             </h1>
-            {description ? <p className="body-small mt-tight max-w-2xl">{description}</p> : null}
+            {description ? (
+              <p className="body-small mt-tight max-w-2xl" data-testid="page-header-description">
+                {description}
+              </p>
+            ) : null}
           </div>
         </div>
         <div className="flex items-center gap-default">


### PR DESCRIPTION
Brittleness fix #3 of the i18n-fragile-selector sweep.

Seven per-page route specs (performance, security, path-analysis,
logs, link, reports, network) each asserted the page header
description by language-specific text regex:

  await expect(page.getByText(/active throughput tests/i))
    .toBeVisible();

The description copy is i18n-translated through t() — Spanish,
future locales, and any product-copy churn all break the regex.
The assertion intent ("page header description rendered") is
locale-independent.

UI change (PageHeader.tsx:145): added data-testid="page-header-
description" to the description <p> tag.

Spec migrations:
  - performance-page.spec.ts:24 /active throughput tests/i
  - security-page.spec.ts:23    /guest network isolation audit/i
  - path-analysis-page.spec.ts:24 /path discovery|traceroute|device discovery/i
  - logs-page.spec.ts:23        /live log stream and system health/i
  - link-page.spec.ts:26        /physical link state.*cable diagnostics/i
  - reports-page.spec.ts:23     /aggregated sla dashboard|compliance|historical reporting/i
  - network-page.spec.ts:26     /dhcp.*gateway.*dns/i

Net: -7 i18n-fragile sites + 1 new stable testid surface shared
across every page-header rendering in seed. Mirrors the page-
header-title testid pattern already established on the same <h1>.
