### PR TITLE
test(e2e): appearance-settings-section testid, migrate 3 sites

### DIFF
--- a/ui/e2e/dashboard.spec.ts
+++ b/ui/e2e/dashboard.spec.ts
@@ -57,9 +57,10 @@ test.describe('Dashboard', () => {
     const settingsButton = sidebarSettingsButton(page);
     await settingsButton.click();
 
-    // Find and click theme toggle
-    const themeSection = page.getByText(/appearance|theme/i).first();
-    await expect(themeSection).toBeVisible();
+    // Find appearance section by stable testid (was /appearance|theme/i —
+    // both translated under es). AppearanceSettings carries
+    // data-testid="appearance-settings-section" on its CollapsibleSection.
+    await expect(page.getByTestId('appearance-settings-section')).toBeVisible();
   });
 
   test('should show help modal', async ({ page }) => {

--- a/ui/e2e/settings.spec.ts
+++ b/ui/e2e/settings.spec.ts
@@ -34,8 +34,7 @@ test.describe('Settings', () => {
   });
 
   test('should display Appearance settings section', async ({ page }) => {
-    const appearanceSection = page.getByText(/appearance|theme/i).first();
-    await expect(appearanceSection).toBeVisible();
+    await expect(page.getByTestId('appearance-settings-section')).toBeVisible();
   });
 
   test('should display Thresholds settings section', async ({ page }) => {
@@ -112,8 +111,10 @@ test.describe('Settings', () => {
 
     await closeButton.click();
 
-    // Drawer should close - settings text no longer visible
-    await expect(page.getByText(/thresholds|appearance/i).first()).toBeHidden({
+    // Drawer should close. Assert the drawer itself is hidden via its
+    // stable testid (settings-drawer) rather than per-section text —
+    // /thresholds|appearance/i was i18n-fragile.
+    await expect(page.getByTestId('settings-drawer')).toBeHidden({
       timeout: 3000,
     });
   });

--- a/ui/src/components/settings/sections/AppearanceSettings.tsx
+++ b/ui/src/components/settings/sections/AppearanceSettings.tsx
@@ -69,6 +69,7 @@ export const AppearanceSettings: React.NamedExoticComponent<AppearanceSettingsPr
 
     return (
       <CollapsibleSection
+        data-testid="appearance-settings-section"
         title={
           <div className={layout.inline.default}>
             <Palette className={iconTokens.size.sm} />


### PR DESCRIPTION
Brittleness fix #6 of the i18n-fragile-selector sweep.

AppearanceSettings.tsx was the only settings section without a
matching *-settings-section testid (Thresholds, Discovery, DNS,
Performance, Interfaces, SSO, Users all already have theirs).
Added data-testid="appearance-settings-section" on its
CollapsibleSection root.

Migrated three specs that were matching the section by language-
specific text regex:

  - dashboard.spec.ts:61  /appearance|theme/i
  - settings.spec.ts:37   /appearance|theme/i
  - settings.spec.ts:115  /thresholds|appearance/i (drawer-close
    assertion; collapsed to a stable settings-drawer toBeHidden
    instead of per-section text)

Net: -3 i18n-fragile assertion sites in seed.
