### PR TITLE
test(e2e): discovery-scan-button testid, migrate 5 sites

### DIFF
--- a/ui/e2e/error-scenarios.spec.ts
+++ b/ui/e2e/error-scenarios.spec.ts
@@ -92,7 +92,7 @@ test.describe('API Error Scenarios', () => {
       });
 
       // Try to trigger a scan
-      const scanButton = page.getByRole('button', { name: /scan|discover|refresh/i }).first();
+      const scanButton = page.getByTestId('discovery-scan-button');
 
       if (await scanButton.isVisible({ timeout: 5000 })) {
         await scanButton.click();
@@ -234,7 +234,7 @@ test.describe('API Error Scenarios', () => {
         await route.abort('timedout');
       });
 
-      const scanButton = page.getByRole('button', { name: /scan|discover|refresh/i }).first();
+      const scanButton = page.getByTestId('discovery-scan-button');
 
       if (await scanButton.isVisible({ timeout: 5000 })) {
         await scanButton.click();
@@ -405,7 +405,7 @@ test.describe('API Error Scenarios', () => {
         });
       });
 
-      const scanButton = page.getByRole('button', { name: /scan|discover|refresh/i }).first();
+      const scanButton = page.getByTestId('discovery-scan-button');
 
       if (await scanButton.isVisible({ timeout: 5000 })) {
         await scanButton.click();
@@ -726,7 +726,7 @@ test.describe('Resource Error Scenarios - Empty States', () => {
 
     // Should show either empty state or scan prompt
     expect(
-      emptyStateShown || (await page.getByRole('button', { name: /scan/i }).isVisible()),
+      emptyStateShown || (await page.getByTestId('discovery-scan-button').isVisible()),
     ).toBeTruthy();
   });
 
@@ -906,7 +906,7 @@ test.describe('Error Recovery Mechanisms', () => {
       });
     });
 
-    const scanButton = page.getByRole('button', { name: /scan/i }).first();
+    const scanButton = page.getByTestId('discovery-scan-button');
 
     if (await scanButton.isVisible({ timeout: 5000 })) {
       await scanButton.click();

--- a/ui/src/components/cards/NetworkDiscoveryCard.tsx
+++ b/ui/src/components/cards/NetworkDiscoveryCard.tsx
@@ -122,6 +122,7 @@ export const NetworkDiscoveryCard: React.NamedExoticComponent<NetworkDiscoveryCa
                 'hover:bg-brand-primary/90 transition-colors font-medium body-small',
               )}
               aria-label="Start network discovery scan"
+              data-testid="discovery-scan-button"
             >
               {t('discovery.startScan')}
             </button>
@@ -206,6 +207,7 @@ export const NetworkDiscoveryCard: React.NamedExoticComponent<NetworkDiscoveryCa
                 aria-label={
                   status.scanning || isPipelineRunning ? 'Scanning network' : 'Start network scan'
                 }
+                data-testid="discovery-scan-button"
               >
                 {status.scanning || isPipelineRunning ? (
                   <>


### PR DESCRIPTION
Brittleness fix #11 of the i18n-fragile-selector sweep.

The NetworkDiscoveryCard renders two scan-triggering buttons,
one in each branch of its data-state conditional render:

  - Empty state (line 113): "Start network discovery scan" with
    aria-label "Start network discovery scan"
  - Populated header (line 175): "Scan" button driving the
    pipeline-start logic with aria-label that toggles between
    "Start network scan" and "Scanning network"

Both have been tagged data-testid="discovery-scan-button". Only
one is in the DOM at any given time (mutually exclusive render
branches), so the testid resolves to exactly one element under
strict-mode.

Five sites in error-scenarios.spec.ts that matched
getByRole('button', { name: /scan(|discover|refresh)?/i }).first()
migrated to getByTestId('discovery-scan-button'):

  - line 95   /scan|discover|refresh/i  500 on device scan
  - line 237  /scan|discover|refresh/i  device scan timeout
  - line 408  /scan|discover|refresh/i  401 during device scan
  - line 729  /scan/i                   empty-state OR-fallback
  - line 909  /scan/i                   error-recovery scan retry

All five were locale-fragile under es ("escanear" / "descubrir")
and copy-fragile to any English label change.

Net: -5 i18n-fragile button selector sites in seed error-scenarios.
spec.ts. seed button-regex count drops from ~40 to ~35.
