### PR TITLE
test(e2e): 4 coverage-gaps testids - profile/logs/discovery modals

### DIFF
--- a/ui/e2e/coverage-gaps.spec.ts
+++ b/ui/e2e/coverage-gaps.spec.ts
@@ -11,30 +11,37 @@ test.describe('Coverage gaps', () => {
   });
 
   test('opens profile management modal', async ({ page }) => {
+    // profile-manage-open testid is on ProfileSelector.tsx (the
+    // "Manage Profiles" link inside the profile dropdown).
+    // profile-modal-close is on ProfileManagement.tsx.
+    // Previously matched /manage profiles/i and /close/i — both
+    // translated under es ("Administrar perfiles", "Cerrar").
     await page.getByLabel(/select profile/i).click();
-    await page.getByRole('button', { name: /manage profiles/i }).click();
+    await page.getByTestId('profile-manage-open').click();
 
     // ProfileManagement.tsx already gives the H2 id="profile-modal-title"
-    // (aria-labelledby target on the dialog); using it avoids i18n drift
-    // on the /profile management/i regex.
+    // (aria-labelledby target on the dialog); using it avoids i18n drift.
     await expect(page.locator('#profile-modal-title')).toBeVisible();
 
-    await page.getByRole('button', { name: /close/i }).click();
+    await page.getByTestId('profile-modal-close').click();
   });
 
   test('opens log viewer modal', async ({ page }) => {
-    // Card.tsx generates id="card-title-<slug>" — see comment in
-    // dashboard.spec.ts. "System Logs" → "system-logs".
+    // Card.tsx generates id="card-title-<slug>"; logs-card-maximize is
+    // on LogViewerCard.tsx. Previously matched /full screen/i which
+    // would miss under es ("Pantalla completa").
     const logsCardTitle = page.locator('#card-title-system-logs');
     await expect(logsCardTitle).toBeVisible();
 
     const logsCard = logsCardTitle.locator('..').first();
-    await logsCard.getByRole('button', { name: /full screen/i }).click();
+    await logsCard.getByTestId('logs-card-maximize').click();
     await expect(page.getByText(/system logs/i)).toBeVisible();
   });
 
   test('opens discovery modal', async ({ page }) => {
-    await page.getByRole('button', { name: /open full screen view/i }).click();
+    // discovery-card-maximize is on NetworkDiscoveryCard.tsx (the
+    // expand-to-modal button). Previously /open full screen view/i.
+    await page.getByTestId('discovery-card-maximize').click();
     await expect(page.getByText(/network discovery/i)).toBeVisible();
   });
 });

--- a/ui/src/components/cards/LogViewerCard.tsx
+++ b/ui/src/components/cards/LogViewerCard.tsx
@@ -113,6 +113,7 @@ export function LogViewerCard({ className = '' }: LogViewerCardProps): JSX.Eleme
           <button
             type="button"
             onClick={() => setIsModalOpen(true)}
+            data-testid="logs-card-maximize"
             className={cn(
               'p-1.5',
               'bg-surface-hover text-text-secondary',

--- a/ui/src/components/cards/NetworkDiscoveryCard.tsx
+++ b/ui/src/components/cards/NetworkDiscoveryCard.tsx
@@ -159,6 +159,7 @@ export const NetworkDiscoveryCard: React.NamedExoticComponent<NetworkDiscoveryCa
             <button
               type="button"
               onClick={(): void => setIsModalOpen(true)}
+              data-testid="discovery-card-maximize"
               className={cn(
                 'p-1.5',
                 'bg-surface-hover text-text-secondary',

--- a/ui/src/components/profiles/ProfileManagement.tsx
+++ b/ui/src/components/profiles/ProfileManagement.tsx
@@ -176,6 +176,7 @@ export function ProfileManagement({ onClose }: ProfileManagementProps): React.Re
               type="button"
               ref={closeButtonRef}
               onClick={onClose}
+              data-testid="profile-modal-close"
               className={cn(
                 'pad-xs',
                 radius.md,

--- a/ui/src/components/ui/ProfileSelector.tsx
+++ b/ui/src/components/ui/ProfileSelector.tsx
@@ -302,6 +302,7 @@ function ProfileSelectorComponent({
             <button
               type="button"
               onClick={goToManagement}
+              data-testid="profile-manage-open"
               className={cn(
                 'w-full flex-center',
                 spacing.gap.tight,


### PR DESCRIPTION
See commit message for details.