### PR TITLE
test(e2e): collapse 3 OR-fallback empty-state regexes + drop auto-save junk

### DIFF
--- a/ui/e2e/error-scenarios.spec.ts
+++ b/ui/e2e/error-scenarios.spec.ts
@@ -467,15 +467,12 @@ test.describe('Resource Error Scenarios - Empty States', () => {
     // Reload to get fresh data
     await page.reload();
 
-    // Should show helpful empty state message
-    const emptyStateShown = await page
-      .getByText(/no devices|no hosts|0 devices|empty|start.*scan/i)
-      .isVisible({ timeout: 5000 });
-
-    // Should show either empty state or scan prompt
-    expect(
-      emptyStateShown || (await page.getByTestId('discovery-scan-button').isVisible()),
-    ).toBeTruthy();
+    // discovery-scan-button only renders in the empty-state branch
+    // of NetworkDiscoveryCard, so its presence is equivalent to "the
+    // SPA recognised the empty device list and offered a scan
+    // prompt." Previously OR'd with /no devices|no hosts|.../i regex
+    // which was i18n-fragile under es ("sin dispositivos" etc).
+    await expect(page.getByTestId('discovery-scan-button')).toBeVisible({ timeout: 5000 });
   });
 
   test('should show "No vulnerabilities found" success state', async ({ page }) => {
@@ -504,14 +501,12 @@ test.describe('Resource Error Scenarios - Empty States', () => {
       });
     });
 
-    // App should show this as a positive result
-
-    // Should either show success message or be functional
-    const successShown = await page
-      .getByText(/no vulnerabilities|secure|safe|clean/i)
-      .isVisible({ timeout: 5000 });
-
-    expect(successShown || (await page.getByTestId('page-header-title').isVisible())).toBeTruthy();
+    // The /no vulnerabilities|secure|safe|clean/i success-text regex
+    // was i18n-fragile and its OR-with-page-header-title meant the
+    // assertion never failed independently. Reduced to the survivor:
+    // the page renders. Real empty-state coverage needs a stable
+    // testid on the vulnerabilities EmptyState component.
+    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 5000 });
   });
 });
 
@@ -532,14 +527,14 @@ test.describe('Backend Service Unavailable', () => {
       });
     });
 
-    // Should show installation prompt
-
-    const promptShown = await page
-      .getByText(/install|not installed|iperf|unavailable/i)
-      .isVisible({ timeout: 5000 });
-
-    // Either shows prompt or app remains functional
-    expect(promptShown || (await page.getByTestId('page-header-title').isVisible())).toBeTruthy();
+    // The /install|not installed|iperf|unavailable/i regex was
+    // partially DNT-safe ("iperf" is a product name) but the rest
+    // of the alternation was i18n-fragile, and the OR-with-page-
+    // header-title meant the assertion never failed independently.
+    // Reduced to the survivor: the page renders. Real iperf3-missing
+    // coverage needs a stable testid on the iperf-availability
+    // banner / error component.
+    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 5000 });
   });
 
   test('should handle speedtest.net unavailable', async ({ page }) => {

--- a/ui/e2e/settings.spec.ts
+++ b/ui/e2e/settings.spec.ts
@@ -84,18 +84,14 @@ test.describe('Settings', () => {
     expect(inputCount).toBeGreaterThan(0);
   });
 
-  test('should show auto-save indicator', async ({ page }) => {
-    // Look for auto-save status
-    const autoSave = page
-      .getByText(/auto.?save|saved|saving/i)
-      .or(page.locator('[data-testid="auto-save"]'))
-      .first();
-
-    const _hasAutoSave = await autoSave.isVisible();
-
-    // Auto-save indicator may not always be visible, but settings should work
-    expect(true).toBeTruthy();
-  });
+  // Dropped: "should show auto-save indicator" — the assertion was
+  // literally `expect(true).toBeTruthy()` after a discarded
+  // `_hasAutoSave` lookup that combined an i18n-fragile getByText
+  // regex with a `[data-testid="auto-save"]` selector that has no
+  // matching element in the seed UI. Net signal: zero.
+  // Auto-save behaviour is exercised by the threshold-update CRUD
+  // test below ("should update threshold values and persist") which
+  // polls window.localStorage for the actual flushed state.
 
   test('should close settings drawer', async ({ page }) => {
     // settings-drawer-close testid is on SettingsDrawer.tsx.


### PR DESCRIPTION
See commit message for details.