### PR TITLE
feat: V1.0 NMS schema + scheduler + health services wiring (Stage A1.1b + A1.3b + A1.6)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/krisarmstrong/seed/internal/config"
 	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/dhcp"
+	"github.com/krisarmstrong/seed/internal/health"
 	"github.com/krisarmstrong/seed/internal/license"
 	"github.com/krisarmstrong/seed/internal/logging"
 	"github.com/krisarmstrong/seed/internal/mibdb"
@@ -190,7 +191,7 @@ func NewServer(
 	// Initialize database services
 	services.Database.DB = db
 
-	initLicenseAndAPITokens(services, db)
+	initDatabaseDependentServices(services, db)
 
 	s := &Server{
 		config:        cfg,
@@ -238,6 +239,15 @@ func NewServer(
 	return s
 }
 
+// initDatabaseDependentServices wires every service that needs a
+// live database connection. Called from NewServer after services.Database.DB
+// is populated. Splits into per-concern helpers to keep each scope
+// focused and to keep NewServer under the funlen limit.
+func initDatabaseDependentServices(services *ServiceContainer, db *database.DB) {
+	initLicenseAndAPITokens(services, db)
+	initHealthServices(services, db)
+}
+
 // initLicenseAndAPITokens wires the Phase D-2 license manager + API
 // token repository into the service container. The license manager is
 // best-effort: failure to load isn't fatal, the mint endpoint just
@@ -251,6 +261,30 @@ func initLicenseAndAPITokens(services *ServiceContainer, db *database.DB) {
 		return
 	}
 	services.Auth.License = lm
+}
+
+// initHealthServices wires the previously-dead health subsystem
+// (Scorer, SLATracker, AnomalyDetector, DependencyMgr) into the
+// service container. Stage A1.6 — these services existed in code
+// since prior phases but were declared-but-never-assigned in
+// services.HealthServices, so the health-check API endpoints
+// returned HTTP 503 on every request. This wires them up.
+//
+// AlertManager and Repository are wired elsewhere (existing code);
+// this function only handles the four previously-dead services.
+func initHealthServices(services *ServiceContainer, db *database.DB) {
+	services.Health.Repository = db.HealthChecks()
+
+	logger := logging.GetLogger()
+	services.Health.Scorer = health.NewScoringService(db, logger)
+
+	services.Health.SLATracker = health.NewSLATracker(health.SLATrackerConfig{
+		Repository: services.Health.Repository,
+	})
+
+	services.Health.AnomalyDetector = health.NewAnomalyDetector(health.AnomalyDetectorConfig{})
+
+	services.Health.DependencyMgr = health.NewDependencyManager(health.DependencyManagerConfig{})
 }
 
 // Service accessors - provide backwards-compatible access to services (#888)

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -115,6 +115,72 @@ func TestMigrations(t *testing.T) {
 	}
 }
 
+// TestV10NMSSchemaArtifacts asserts that every V1.0 NMS-expansion
+// table (Phase 0 schema landed in migrations 36-53) was actually
+// created after the standard migrate-on-open, plus the
+// wifi_access_points 802.11 management-frame columns. Catches typos
+// in CREATE TABLE / ALTER TABLE statements that compile but produce
+// no artifact.
+//
+// See msn-docs-internal/01-Strategy/SEED_NMS_EXPANSION.md.
+func TestV10NMSSchemaArtifacts(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	nmsTables := []string{
+		"metrics_hourly",
+		"metrics_daily",
+		"dns_monitors",
+		"ssl_monitors",
+		"cert_observations",
+		"microburst_events",
+		"polling_targets",
+		"device_credentials",
+		"topology_nodes",
+		"topology_links",
+		"wifi_clients",
+		"wifi_associations",
+		"wifi_roams",
+		"wifi_deauths",
+		"wifi_rogues",
+		"voip_calls",
+		"bgp_sessions",
+	}
+
+	for _, tbl := range nmsTables {
+		var name string
+		err := db.QueryRow(ctx,
+			"SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+			tbl).Scan(&name)
+		if errors.Is(err, sql.ErrNoRows) {
+			t.Errorf("V1.0 NMS table %q missing after migrate", tbl)
+			continue
+		}
+		if err != nil {
+			t.Errorf("query for table %q failed: %v", tbl, err)
+		}
+	}
+
+	// ALTER wifi_access_points — verify each added 802.11
+	// management-frame decode column landed.
+	addedColumns := []string{
+		"beacon_interval_tu",
+		"rsn_cipher",
+		"rsn_akm",
+		"phy_capabilities",
+		"supports_11k",
+		"supports_11v",
+		"supports_11r",
+		"bss_load_json",
+		"vendor_ies_json",
+	}
+	for _, col := range addedColumns {
+		assertHasColumn(t, db, "wifi_access_points", col)
+	}
+}
+
 // TestStageA12ProbeArtifacts asserts that the Stage A1.2 unified
 // probe schema landed correctly: probes and probe_results tables
 // exist with the expected columns.

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1133,6 +1133,507 @@ func getMigrationDefs() []migrationDef {
 			CREATE INDEX IF NOT EXISTS idx_probe_results_client_kind_ts ON probe_results(client_id, kind, timestamp);
 		`,
 		},
+		// ---------------------------------------------------------------
+		// V1.0 NMS expansion — Phase 0 schema (2026-05-30).
+		// See msn-docs-internal/01-Strategy/SEED_NMS_EXPANSION.md.
+		// Tables are added now (empty) so Phases 1–3 can write to them
+		// without further infrastructure work.
+		// ---------------------------------------------------------------
+		{
+			// Phase 2.5 (Wi-Fi Management Frame Analysis) extends the
+			// existing wifi_access_points table with the per-beacon
+			// Information Element decode fields. ALTER ADD COLUMN is
+			// the only safe SQLite ALTER; new columns nullable so
+			// existing rows remain valid.
+			Description: "Extend wifi_access_points with 802.11 management-frame decode columns",
+			Up: `
+			ALTER TABLE wifi_access_points ADD COLUMN beacon_interval_tu INTEGER;
+			ALTER TABLE wifi_access_points ADD COLUMN rsn_cipher TEXT;
+			ALTER TABLE wifi_access_points ADD COLUMN rsn_akm TEXT;
+			ALTER TABLE wifi_access_points ADD COLUMN phy_capabilities TEXT;
+			ALTER TABLE wifi_access_points ADD COLUMN supports_11k INTEGER DEFAULT 0;
+			ALTER TABLE wifi_access_points ADD COLUMN supports_11v INTEGER DEFAULT 0;
+			ALTER TABLE wifi_access_points ADD COLUMN supports_11r INTEGER DEFAULT 0;
+			ALTER TABLE wifi_access_points ADD COLUMN bss_load_json TEXT;
+			ALTER TABLE wifi_access_points ADD COLUMN vendor_ies_json TEXT;
+		`,
+		},
+		{
+			// Phase 1c — tiered retention. Mirrors health_check_rollups_hourly.
+			// hour_bucket is RFC3339 truncated to the hour. UNIQUE
+			// constraint enables UPSERT semantics during rollup runs.
+			Description: "Create metrics_hourly for tiered retention rollups",
+			Up: `
+			CREATE TABLE IF NOT EXISTS metrics_hourly (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				metric_type TEXT NOT NULL,
+				interface_name TEXT NOT NULL,
+				hour_bucket TEXT NOT NULL,
+				sample_count INTEGER NOT NULL,
+				avg_value REAL,
+				min_value REAL,
+				max_value REAL,
+				p95_value REAL,
+				UNIQUE(metric_type, interface_name, hour_bucket)
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_metrics_hourly_bucket ON metrics_hourly(hour_bucket);
+			CREATE INDEX IF NOT EXISTS idx_metrics_hourly_type ON metrics_hourly(metric_type, hour_bucket);
+		`,
+		},
+		{
+			// Phase 1c — daily aggregates roll up from metrics_hourly.
+			Description: "Create metrics_daily for long-term retention rollups",
+			Up: `
+			CREATE TABLE IF NOT EXISTS metrics_daily (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				metric_type TEXT NOT NULL,
+				interface_name TEXT NOT NULL,
+				day_bucket TEXT NOT NULL,
+				sample_count INTEGER NOT NULL,
+				avg_value REAL,
+				min_value REAL,
+				max_value REAL,
+				p95_value REAL,
+				UNIQUE(metric_type, interface_name, day_bucket)
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_metrics_daily_bucket ON metrics_daily(day_bucket);
+			CREATE INDEX IF NOT EXISTS idx_metrics_daily_type ON metrics_daily(metric_type, day_bucket);
+		`,
+		},
+		{
+			// Phase 1a — DNS endpoint monitoring. Starter capped at 5
+			// monitors via in-handler check; Pro unlimited via same flag.
+			Description: "Create dns_monitors for scheduled DNS endpoint monitoring",
+			Up: `
+			CREATE TABLE IF NOT EXISTS dns_monitors (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				hostname TEXT NOT NULL,
+				server TEXT,
+				record_type TEXT NOT NULL DEFAULT 'A',
+				interval_seconds INTEGER NOT NULL DEFAULT 60,
+				enabled INTEGER NOT NULL DEFAULT 1,
+				warning_ms INTEGER DEFAULT 100,
+				critical_ms INTEGER DEFAULT 500,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_dns_monitors_enabled ON dns_monitors(enabled);
+			CREATE INDEX IF NOT EXISTS idx_dns_monitors_hostname ON dns_monitors(hostname);
+		`,
+		},
+		{
+			// Phase 1b — SSL/TLS cert expiry monitoring. Starter capped
+			// at 5 monitors via in-handler check.
+			Description: "Create ssl_monitors for cert expiry tracking",
+			Up: `
+			CREATE TABLE IF NOT EXISTS ssl_monitors (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				host TEXT NOT NULL,
+				port INTEGER NOT NULL DEFAULT 443,
+				server_name TEXT,
+				check_interval_seconds INTEGER NOT NULL DEFAULT 86400,
+				enabled INTEGER NOT NULL DEFAULT 1,
+				warning_days INTEGER NOT NULL DEFAULT 30,
+				critical_days INTEGER NOT NULL DEFAULT 7,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_ssl_monitors_enabled ON ssl_monitors(enabled);
+			CREATE INDEX IF NOT EXISTS idx_ssl_monitors_host ON ssl_monitors(host);
+		`,
+		},
+		{
+			// Phase 1b — per-observation history for SSL cert sweeps.
+			// CASCADE delete: removing a monitor drops its history.
+			Description: "Create cert_observations for SSL/TLS cert sweep history",
+			Up: `
+			CREATE TABLE IF NOT EXISTS cert_observations (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				monitor_id TEXT NOT NULL,
+				timestamp TEXT NOT NULL,
+				subject TEXT,
+				issuer TEXT,
+				not_before TEXT,
+				not_after TEXT,
+				sha256_fingerprint TEXT,
+				days_remaining INTEGER,
+				status TEXT NOT NULL,
+				error_message TEXT,
+				FOREIGN KEY (monitor_id) REFERENCES ssl_monitors(id) ON DELETE CASCADE
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_cert_obs_monitor ON cert_observations(monitor_id);
+			CREATE INDEX IF NOT EXISTS idx_cert_obs_timestamp ON cert_observations(timestamp);
+			CREATE INDEX IF NOT EXISTS idx_cert_obs_status ON cert_observations(status);
+		`,
+		},
+		{
+			// Phase 1e — microburst events. INTEGER PK because high churn.
+			// sampling_mode records whether the event was caught at
+			// 100ms baseline or in 10ms burst mode (auto-throttle).
+			Description: "Create microburst_events for sub-poll-interval burst tracking",
+			Up: `
+			CREATE TABLE IF NOT EXISTS microburst_events (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				timestamp TEXT NOT NULL,
+				device_id TEXT,
+				interface_name TEXT NOT NULL,
+				direction TEXT NOT NULL,
+				peak_utilization_pct REAL NOT NULL,
+				duration_ms INTEGER NOT NULL,
+				sampling_mode TEXT NOT NULL,
+				link_speed_mbps INTEGER,
+				FOREIGN KEY (device_id) REFERENCES discovered_devices(id) ON DELETE SET NULL
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_microburst_timestamp ON microburst_events(timestamp);
+			CREATE INDEX IF NOT EXISTS idx_microburst_device ON microburst_events(device_id);
+			CREATE INDEX IF NOT EXISTS idx_microburst_interface ON microburst_events(interface_name);
+		`,
+		},
+		{
+			// Phase 2a — estate-wide SNMP poller target list. credentials_id
+			// is nullable so a target can be defined before its credentials.
+			Description: "Create polling_targets for estate-wide SNMP poller",
+			Up: `
+			CREATE TABLE IF NOT EXISTS polling_targets (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				ip_address TEXT NOT NULL,
+				snmp_version TEXT NOT NULL DEFAULT 'v2c',
+				credentials_id TEXT,
+				poll_interval_seconds INTEGER NOT NULL DEFAULT 300,
+				enabled INTEGER NOT NULL DEFAULT 1,
+				last_polled_at TEXT,
+				last_status TEXT,
+				last_error TEXT,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_polling_targets_enabled ON polling_targets(enabled);
+			CREATE INDEX IF NOT EXISTS idx_polling_targets_ip ON polling_targets(ip_address);
+		`,
+		},
+		{
+			// Phase 2a — encrypted SNMP credential vault. Secret fields
+			// are BLOBs holding ciphertext produced by the same key-derivation
+			// chain as internal/auth/ session state (coordinate with auth
+			// workstream before Phase 2 implementation).
+			Description: "Create device_credentials (encrypted vault) for SNMP auth",
+			Up: `
+			CREATE TABLE IF NOT EXISTS device_credentials (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				snmp_community_enc BLOB,
+				snmp_v3_user TEXT,
+				snmp_v3_auth_enc BLOB,
+				snmp_v3_priv_enc BLOB,
+				snmp_v3_auth_proto TEXT,
+				snmp_v3_priv_proto TEXT,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_device_credentials_name ON device_credentials(name);
+		`,
+		},
+		{
+			// Phase 2b — stable topology node graph after identity merge.
+			// identity_hash dedupes the same physical device seen via
+			// multiple sources (LLDP/CDP/SNMP/discovery). expires_at
+			// drives stale-node archival (default 24h after last_seen).
+			Description: "Create topology_nodes for stable identity-merged graph",
+			Up: `
+			CREATE TABLE IF NOT EXISTS topology_nodes (
+				id TEXT PRIMARY KEY,
+				identity_hash TEXT NOT NULL UNIQUE,
+				display_name TEXT NOT NULL,
+				device_type TEXT,
+				chassis_id TEXT,
+				sys_name TEXT,
+				primary_mac TEXT,
+				primary_ip TEXT,
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				expires_at TEXT,
+				metadata_json TEXT
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_topology_nodes_identity ON topology_nodes(identity_hash);
+			CREATE INDEX IF NOT EXISTS idx_topology_nodes_last_seen ON topology_nodes(last_seen);
+			CREATE INDEX IF NOT EXISTS idx_topology_nodes_type ON topology_nodes(device_type);
+		`,
+		},
+		{
+			// Phase 2b — stable topology edges. evidence_json records the
+			// sources backing the link (LLDP|CDP|FDB|SNMP); used by the
+			// reconciliation layer to compute confidence.
+			Description: "Create topology_links for stable identity-merged edges",
+			Up: `
+			CREATE TABLE IF NOT EXISTS topology_links (
+				id TEXT PRIMARY KEY,
+				source_node_id TEXT NOT NULL,
+				target_node_id TEXT NOT NULL,
+				source_interface TEXT,
+				target_interface TEXT,
+				link_type TEXT NOT NULL DEFAULT 'unknown',
+				status TEXT NOT NULL DEFAULT 'up',
+				speed_mbps INTEGER,
+				utilization_pct REAL,
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				evidence_json TEXT,
+				FOREIGN KEY (source_node_id) REFERENCES topology_nodes(id) ON DELETE CASCADE,
+				FOREIGN KEY (target_node_id) REFERENCES topology_nodes(id) ON DELETE CASCADE
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_topology_links_source ON topology_links(source_node_id);
+			CREATE INDEX IF NOT EXISTS idx_topology_links_target ON topology_links(target_node_id);
+			CREATE INDEX IF NOT EXISTS idx_topology_links_last_seen ON topology_links(last_seen);
+		`,
+		},
+		{
+			// Phase 2.5c — clients seen via probe-request frames.
+			// Full MAC retained by default per EtherScope-parity decision
+			// (2026-05-29). Anonymize toggle replaces mac_full with the
+			// OUI prefix only; pnl_json is hashed when anonymized.
+			Description: "Create wifi_clients for 802.11 client tracking",
+			Up: `
+			CREATE TABLE IF NOT EXISTS wifi_clients (
+				id TEXT PRIMARY KEY,
+				mac_full TEXT NOT NULL UNIQUE,
+				vendor_oui TEXT,
+				vendor_name TEXT,
+				capabilities_json TEXT,
+				pnl_json TEXT,
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				anonymized INTEGER NOT NULL DEFAULT 0
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_wifi_clients_mac ON wifi_clients(mac_full);
+			CREATE INDEX IF NOT EXISTS idx_wifi_clients_oui ON wifi_clients(vendor_oui);
+			CREATE INDEX IF NOT EXISTS idx_wifi_clients_last_seen ON wifi_clients(last_seen);
+		`,
+		},
+		{
+			// Phase 2.5d — full association handshake forensics. Each row
+			// is one observed assoc attempt with its terminal status code
+			// (802.11-2020 §9.4.1.9). client_mac/ap_bssid are NOT foreign
+			// keys — events are observational facts independent of
+			// wifi_clients / wifi_access_points lifecycle.
+			Description: "Create wifi_associations for association forensics",
+			Up: `
+			CREATE TABLE IF NOT EXISTS wifi_associations (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				timestamp TEXT NOT NULL,
+				client_mac TEXT NOT NULL,
+				ap_bssid TEXT NOT NULL,
+				ssid TEXT,
+				attempt_type TEXT NOT NULL,
+				status_code INTEGER,
+				status_text TEXT,
+				failure_stage TEXT,
+				duration_ms INTEGER,
+				rsn_negotiation_json TEXT
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_wifi_assoc_timestamp ON wifi_associations(timestamp);
+			CREATE INDEX IF NOT EXISTS idx_wifi_assoc_client ON wifi_associations(client_mac);
+			CREATE INDEX IF NOT EXISTS idx_wifi_assoc_ap ON wifi_associations(ap_bssid);
+			CREATE INDEX IF NOT EXISTS idx_wifi_assoc_status ON wifi_associations(status_code);
+		`,
+		},
+		{
+			// Phase 2.5e — roam events correlate disassoc on AP-A with
+			// (re)assoc on AP-B for same client. roam_type distinguishes
+			// 802.11r FT exchange from full reassoc.
+			Description: "Create wifi_roams for client roam tracking",
+			Up: `
+			CREATE TABLE IF NOT EXISTS wifi_roams (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				client_mac TEXT NOT NULL,
+				from_bssid TEXT NOT NULL,
+				to_bssid TEXT NOT NULL,
+				ssid TEXT,
+				started_at TEXT NOT NULL,
+				completed_at TEXT,
+				duration_ms INTEGER,
+				roam_type TEXT,
+				rssi_before INTEGER,
+				rssi_after INTEGER
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_wifi_roams_started ON wifi_roams(started_at);
+			CREATE INDEX IF NOT EXISTS idx_wifi_roams_client ON wifi_roams(client_mac);
+			CREATE INDEX IF NOT EXISTS idx_wifi_roams_from ON wifi_roams(from_bssid);
+			CREATE INDEX IF NOT EXISTS idx_wifi_roams_to ON wifi_roams(to_bssid);
+		`,
+		},
+		{
+			// Phase 2.5f — deauth/disassoc reason codes per 802.11-2020.
+			// originator: 'ap' if the AP sent the frame, 'client' if the
+			// STA sent it. reason_code covers std 1-66 + vendor-specific.
+			Description: "Create wifi_deauths for deauth/disassoc reason-code events",
+			Up: `
+			CREATE TABLE IF NOT EXISTS wifi_deauths (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				timestamp TEXT NOT NULL,
+				ap_bssid TEXT NOT NULL,
+				client_mac TEXT NOT NULL,
+				frame_type TEXT NOT NULL,
+				reason_code INTEGER NOT NULL,
+				reason_text TEXT,
+				originator TEXT NOT NULL
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_wifi_deauths_timestamp ON wifi_deauths(timestamp);
+			CREATE INDEX IF NOT EXISTS idx_wifi_deauths_ap ON wifi_deauths(ap_bssid);
+			CREATE INDEX IF NOT EXISTS idx_wifi_deauths_client ON wifi_deauths(client_mac);
+			CREATE INDEX IF NOT EXISTS idx_wifi_deauths_reason ON wifi_deauths(reason_code);
+		`,
+		},
+		{
+			// Phase 2.5g — rogue / evil-twin detection events.
+			// status moves active → acknowledged → resolved through the UI.
+			Description: "Create wifi_rogues for evil-twin and rogue-AP detection",
+			Up: `
+			CREATE TABLE IF NOT EXISTS wifi_rogues (
+				id TEXT PRIMARY KEY,
+				detected_at TEXT NOT NULL,
+				ap_bssid TEXT NOT NULL,
+				ssid TEXT,
+				rogue_type TEXT NOT NULL,
+				severity TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'active',
+				evidence_json TEXT,
+				acknowledged_at TEXT,
+				resolved_at TEXT
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_wifi_rogues_detected ON wifi_rogues(detected_at);
+			CREATE INDEX IF NOT EXISTS idx_wifi_rogues_bssid ON wifi_rogues(ap_bssid);
+			CREATE INDEX IF NOT EXISTS idx_wifi_rogues_status ON wifi_rogues(status);
+			CREATE INDEX IF NOT EXISTS idx_wifi_rogues_severity ON wifi_rogues(severity);
+		`,
+		},
+		{
+			// Phase 3a — VoIP call records with MOS scoring via E-model.
+			// call_id is the RTP-derived synthetic identifier (src+dst+ssrc).
+			Description: "Create voip_calls for RTP MOS scoring",
+			Up: `
+			CREATE TABLE IF NOT EXISTS voip_calls (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				call_id TEXT NOT NULL,
+				src_ip TEXT NOT NULL,
+				dst_ip TEXT NOT NULL,
+				src_port INTEGER,
+				dst_port INTEGER,
+				codec TEXT,
+				started_at TEXT NOT NULL,
+				ended_at TEXT,
+				duration_seconds INTEGER,
+				mos_score REAL,
+				avg_jitter_ms REAL,
+				packet_loss_pct REAL,
+				avg_latency_ms REAL,
+				direction TEXT
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_voip_calls_call_id ON voip_calls(call_id);
+			CREATE INDEX IF NOT EXISTS idx_voip_calls_started ON voip_calls(started_at);
+			CREATE INDEX IF NOT EXISTS idx_voip_calls_mos ON voip_calls(mos_score);
+		`,
+		},
+		{
+			// Phase 3b — BGP peer session monitoring via BGP4-MIB.
+			// device_id FK soft-references the polled router. state and
+			// last_state_change drive transition alerts.
+			Description: "Create bgp_sessions for BGP4-MIB neighbor monitoring",
+			Up: `
+			CREATE TABLE IF NOT EXISTS bgp_sessions (
+				id TEXT PRIMARY KEY,
+				device_id TEXT,
+				peer_address TEXT NOT NULL,
+				peer_as INTEGER,
+				local_as INTEGER,
+				state TEXT NOT NULL,
+				established_at TEXT,
+				last_state_change TEXT NOT NULL,
+				prefixes_received INTEGER DEFAULT 0,
+				prefixes_sent INTEGER DEFAULT 0,
+				last_error TEXT,
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				FOREIGN KEY (device_id) REFERENCES discovered_devices(id) ON DELETE SET NULL
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_bgp_sessions_device ON bgp_sessions(device_id);
+			CREATE INDEX IF NOT EXISTS idx_bgp_sessions_peer ON bgp_sessions(peer_address);
+			CREATE INDEX IF NOT EXISTS idx_bgp_sessions_state ON bgp_sessions(state);
+		`,
+		},
+		{
+			// Stage A1.1 — add client_id to V1.0 NMS observation tables
+			// (metrics rollups, microburst, voip, bgp).
+			Description: "Add client_id to V1.0 NMS observation tables",
+			Up: `
+			ALTER TABLE metrics_hourly ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+			ALTER TABLE metrics_daily ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+			ALTER TABLE microburst_events ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+			ALTER TABLE voip_calls ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+			ALTER TABLE bgp_sessions ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+
+			CREATE INDEX IF NOT EXISTS idx_metrics_hourly_client ON metrics_hourly(client_id);
+			CREATE INDEX IF NOT EXISTS idx_metrics_daily_client ON metrics_daily(client_id);
+			CREATE INDEX IF NOT EXISTS idx_microburst_events_client ON microburst_events(client_id);
+			CREATE INDEX IF NOT EXISTS idx_voip_calls_client ON voip_calls(client_id);
+			CREATE INDEX IF NOT EXISTS idx_bgp_sessions_client ON bgp_sessions(client_id);
+		`,
+		},
+		{
+			// Stage A1.1 — add client_id to V1.0 NMS event tables
+			// (wifi_*: clients, associations, roams, deauths, rogues).
+			Description: "Add client_id to V1.0 NMS wifi event tables",
+			Up: `
+			ALTER TABLE wifi_clients ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+			ALTER TABLE wifi_associations ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+			ALTER TABLE wifi_roams ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+			ALTER TABLE wifi_deauths ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+			ALTER TABLE wifi_rogues ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+
+			CREATE INDEX IF NOT EXISTS idx_wifi_clients_client ON wifi_clients(client_id);
+			CREATE INDEX IF NOT EXISTS idx_wifi_associations_client ON wifi_associations(client_id);
+			CREATE INDEX IF NOT EXISTS idx_wifi_roams_client ON wifi_roams(client_id);
+			CREATE INDEX IF NOT EXISTS idx_wifi_deauths_client ON wifi_deauths(client_id);
+			CREATE INDEX IF NOT EXISTS idx_wifi_rogues_client ON wifi_rogues(client_id);
+		`,
+		},
+		{
+			// Stage A1.1 — add client_id to V1.0 NMS topology and
+			// polling tables. dns_monitors/ssl_monitors/cert_observations
+			// are NOT migrated because Stage A1.2+ drops them as part
+			// of the probe-engine unification.
+			Description: "Add client_id to V1.0 NMS topology and polling tables",
+			Up: `
+			ALTER TABLE topology_nodes ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+			ALTER TABLE topology_links ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+			ALTER TABLE polling_targets ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+			ALTER TABLE device_credentials ADD COLUMN client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id);
+
+			CREATE INDEX IF NOT EXISTS idx_topology_nodes_client ON topology_nodes(client_id);
+			CREATE INDEX IF NOT EXISTS idx_topology_links_client ON topology_links(client_id);
+			CREATE INDEX IF NOT EXISTS idx_polling_targets_client ON polling_targets(client_id);
+			CREATE INDEX IF NOT EXISTS idx_device_credentials_client ON device_credentials(client_id);
+		`,
+		},
 	}
 }
 

--- a/internal/license/activation.go
+++ b/internal/license/activation.go
@@ -415,6 +415,29 @@ func (m *Manager) saveState() error {
 	return nil
 }
 
+// EncryptSecret encrypts arbitrary bytes for at-rest storage using
+// the same key-derivation chain as the license state file. Returns
+// base64-encoded AES-256-GCM ciphertext.
+//
+// Phase 2a (V1.0 NMS expansion) uses this to seal SNMPv3 auth/priv
+// passphrases in the device_credentials table. See
+// msn-docs-internal/01-Strategy/SEED_NMS_EXPANSION.md.
+//
+// Callers should treat encryption as best-effort tamper resistance
+// against on-disk snooping — the derivation depends on the device
+// fingerprint, so credentials are bound to this seed install. They
+// will not roundtrip after a fingerprint change.
+func (m *Manager) EncryptSecret(plaintext []byte) ([]byte, error) {
+	return m.encrypt(plaintext)
+}
+
+// DecryptSecret reverses EncryptSecret. Returns an error if the
+// fingerprint key no longer matches what the ciphertext was sealed
+// with.
+func (m *Manager) DecryptSecret(ciphertext []byte) ([]byte, error) {
+	return m.decrypt(ciphertext)
+}
+
 func (m *Manager) encrypt(plaintext []byte) ([]byte, error) {
 	key := m.deriveKey()
 

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -109,39 +109,58 @@ func TestFormatKey(t *testing.T) {
 // fix the cipher, or regenerate keygen + update all three products in
 // lockstep.
 //
-// Anchored to keygen v2.2.0 (2026-05-26) — multi_interface moved
-// Starter→Pro; multi_user added on Pro; multi_site renamed to
-// multi_client on Pro; sso added on Pro.
+// Anchored to keygen v2.3.0 (2026-05-30) — V1.0 NMS expansion:
+// Starter adds topology_local/dns_monitoring/ssl_cert_monitoring;
+// Pro adds 11 NMS flags (topology_estate, estate_polling,
+// microburst_detection, voip_mos_scoring, server_monitoring,
+// extended_retention, bgp_monitoring, wifi_management_capture,
+// wifi_rogue_detection, config_backup_diff, netflow_collection).
+// Pro also gets sso added at the keygen side to fix a latent
+// parity drift between this validator and keygen's productCatalog.
+// See msn-docs-internal/01-Strategy/SEED_NMS_EXPANSION.md.
 func TestKeygenContract(t *testing.T) {
 	t.Parallel()
 	vectors := []keygenVector{
 		{
-			name:    "seed-starter / serial SEEDSTR",
-			key:     "Q207-20AG-LLZR-C2C8",
+			name:    "seed-starter / serial TESTSTR (anchor v2.3.0)",
+			key:     "2Q07-20VG-PZZR-C28C",
 			tier:    license.TierStarter,
 			product: "4001",
-			serial:  "SEEDSTR",
+			serial:  "TESTSTR",
 			features: []string{
 				"monitoring_scheduled",
 				"wifi_visibility_basic",
 				"compliance_basic",
 				"export_csv_json",
+				"topology_local",
+				"dns_monitoring",
+				"ssl_cert_monitoring",
 			},
 		},
 		{
-			name:    "seed-pro / serial SEEDPRO",
-			key:     "MN07-25AG-LLVZ-P9GH",
+			name:    "seed-pro / serial TESTPRO (anchor v2.3.0)",
+			key:     "Z707-25VG-PZVZ-P9J5",
 			tier:    license.TierPro,
 			product: "4002",
-			serial:  "SEEDPRO",
+			serial:  "TESTPRO",
 			features: []string{
+				// Starter set.
 				"monitoring_scheduled", "wifi_visibility_basic",
 				"compliance_basic", "export_csv_json",
+				"topology_local", "dns_monitoring", "ssl_cert_monitoring",
+				// Pre-existing Pro set.
 				"wifi_roam_analysis", "wifi_association_forensics",
 				"airmapper_baseline_diff", "anomaly_detection", "path_analysis",
 				"live_telemetry", "compliance_advanced", "scheduled_reports",
 				"audit_pdf", "multi_interface", "multi_user", "multi_client",
 				"sso", "white_label", "rest_api",
+				// V1.0 NMS expansion additions.
+				"topology_estate", "estate_polling",
+				"microburst_detection", "voip_mos_scoring", "server_monitoring",
+				"extended_retention", "bgp_monitoring",
+				"wifi_management_capture", "wifi_rogue_detection",
+				// V1.1 flags (catalog-final now).
+				"config_backup_diff", "netflow_collection",
 			},
 		},
 	}

--- a/internal/license/validator.go
+++ b/internal/license/validator.go
@@ -250,18 +250,32 @@ func (li *Info) CanRunPro() bool {
 //
 // As of keygen v2.1.0 (2026-05-26) multi_interface moved Starter → Pro:
 // Free/Starter are capped at 1 ethernet + 1 wifi; Pro is unlimited.
+//
+// V1.0 NMS expansion (2026-05-30) added three Starter flags:
+// topology_local (local-jack LLDP/CDP view), dns_monitoring (5-target
+// cap), ssl_cert_monitoring (5-cert cap). See
+// msn-docs-internal/01-Strategy/SEED_NMS_EXPANSION.md.
 func starterFeatures() []string {
 	return []string{
 		"monitoring_scheduled",
 		"wifi_visibility_basic",
 		"compliance_basic",
 		"export_csv_json",
+		"topology_local",
+		"dns_monitoring",
+		"ssl_cert_monitoring",
 	}
 }
 
 // proFeatures returns the feature list granted to Seed Pro (product
 // code 4002). Includes every Starter feature plus the Pro additions.
-// Mirrors keygen's productCatalog (anchor: v2.2.0, 2026-05-26).
+// Mirrors keygen's productCatalog (anchor: v2.3.0, 2026-05-30).
+//
+// V1.0 NMS expansion (2026-05-30) added 11 Pro flags:
+// topology_estate, estate_polling, microburst_detection,
+// voip_mos_scoring, server_monitoring, extended_retention,
+// bgp_monitoring, wifi_management_capture, wifi_rogue_detection,
+// config_backup_diff (V1.1), netflow_collection (V1.1).
 func proFeatures() []string {
 	pro := []string{
 		"wifi_roam_analysis",
@@ -279,6 +293,21 @@ func proFeatures() []string {
 		"sso",
 		"white_label",
 		"rest_api",
+		// V1.0 NMS expansion (Phase 0 anchor, 2026-05-30).
+		"topology_estate",
+		"estate_polling",
+		"microburst_detection",
+		"voip_mos_scoring",
+		"server_monitoring",
+		"extended_retention",
+		"bgp_monitoring",
+		"wifi_management_capture",
+		"wifi_rogue_detection",
+		// V1.1 flags — present in catalog now; routes that gate on
+		// them return 402 until Phase 4 (NetFlow + config backup/diff)
+		// implements them.
+		"config_backup_diff",
+		"netflow_collection",
 	}
 	return append(starterFeatures(), pro...)
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,225 @@
+// Package scheduler provides a generic, persistence-agnostic job
+// scheduler. It is the chassis primitive for periodic work across
+// seed — harvest scheduled reports, DNS endpoint monitoring, SSL cert
+// expiry sweeps, microburst sampling, estate-wide SNMP polling,
+// management-frame capture, VoIP/BGP collection, and any future
+// collector that needs a "wake up periodically and check what's due"
+// behavior.
+//
+// Design properties:
+//
+//   - Persistence-agnostic: Scheduler holds no database handle. Each
+//     Job is responsible for its own state and persistence. The
+//     scheduler only knows "when does this job want to run next" and
+//     "run it."
+//
+//   - Time-source-injectable: tests pass a fake clock via NewWithClock.
+//     Production callers use New.
+//
+//   - Fire-and-forget: each Run is dispatched on its own goroutine.
+//     Stop() waits for in-flight Run calls to return via WaitGroup so
+//     shutdown is graceful.
+//
+//   - Configurable tick: callers choose the tick interval. Tick is the
+//     worst-case precision for NextRun. Harvest reports use 1 minute.
+//     Microburst sampling uses 100ms baseline. DNS monitors use 1
+//     minute. Each collector instantiates its own Scheduler with the
+//     cadence it needs.
+//
+// V1.0 NMS expansion — Phase 0 extraction from
+// internal/harvest/services_scheduler.go. See
+// msn-docs-internal/01-Strategy/SEED_NMS_EXPANSION.md.
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Job is something the scheduler can run. Implementations supply their
+// own identity, their own next-run calculation, and the action to
+// take when due. Jobs are responsible for their own persistence.
+type Job interface {
+	// ID returns the job's stable identity. Two jobs with the same
+	// ID cannot be registered at the same time.
+	ID() string
+
+	// NextRun returns the next absolute time at which Run should be
+	// invoked. The scheduler calls this on every tick and dispatches
+	// Run when now is at or past the returned time. Returning the
+	// zero time signals "do not run again until further notice" —
+	// the job stays registered but is skipped on subsequent ticks.
+	NextRun(now time.Time) time.Time
+
+	// Run performs the job's work. It executes on its own goroutine.
+	// Errors are logged and do not stop the scheduler. The context
+	// is the same one Start was called with — Run should respect
+	// cancellation.
+	Run(ctx context.Context) error
+}
+
+// clock abstracts [time.Now] and [time.Ticker] for tests.
+type clock interface {
+	Now() time.Time
+	NewTicker(d time.Duration) ticker
+}
+
+// ticker abstracts [time.Ticker] for tests.
+type ticker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+// Scheduler dispatches Job.Run calls when each registered job's
+// NextRun has elapsed. It is safe for concurrent use.
+type Scheduler struct {
+	interval time.Duration
+	logger   *slog.Logger
+	clk      clock
+
+	mu     sync.RWMutex
+	jobs   map[string]Job
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	// runMu serializes calls to dispatch so tests can observe a
+	// deterministic ordering. Production behavior is unaffected.
+	runMu sync.Mutex
+}
+
+// New returns a Scheduler that wakes up every interval to check for
+// due jobs. interval must be > 0.
+func New(interval time.Duration) *Scheduler {
+	return NewWithClock(interval, slog.Default(), realClock{})
+}
+
+// NewWithClock is the test seam — pass a fake clock to drive ticks
+// deterministically.
+func NewWithClock(interval time.Duration, logger *slog.Logger, clk clock) *Scheduler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Scheduler{
+		interval: interval,
+		logger:   logger,
+		clk:      clk,
+		jobs:     make(map[string]Job),
+	}
+}
+
+// Start begins the tick loop. The caller's ctx controls scheduler
+// lifetime; cancelling it (or calling Stop) ends the loop.
+// Start must be called exactly once per Scheduler instance.
+func (s *Scheduler) Start(ctx context.Context) {
+	ctx, s.cancel = context.WithCancel(ctx)
+	t := s.clk.NewTicker(s.interval)
+	s.wg.Add(1)
+	go s.loop(ctx, t)
+}
+
+func (s *Scheduler) loop(ctx context.Context, t ticker) {
+	defer s.wg.Done()
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C():
+			s.dispatch(ctx, now)
+		}
+	}
+}
+
+func (s *Scheduler) dispatch(ctx context.Context, now time.Time) {
+	s.runMu.Lock()
+	defer s.runMu.Unlock()
+
+	s.mu.RLock()
+	due := make([]Job, 0, len(s.jobs))
+	for _, j := range s.jobs {
+		next := j.NextRun(now)
+		if next.IsZero() {
+			continue
+		}
+		if !now.Before(next) {
+			due = append(due, j)
+		}
+	}
+	s.mu.RUnlock()
+
+	for _, j := range due {
+		s.wg.Add(1)
+		go func(job Job) {
+			defer s.wg.Done()
+			if err := job.Run(ctx); err != nil {
+				s.logger.ErrorContext(ctx, "scheduler job failed",
+					"job_id", job.ID(),
+					"error", err)
+			}
+		}(j)
+	}
+}
+
+// Stop cancels the tick loop and waits for in-flight Run calls to
+// return. Calling Stop more than once is a no-op.
+func (s *Scheduler) Stop() {
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+	s.wg.Wait()
+}
+
+// Register adds a job. If a job with the same ID is already
+// registered, Register replaces it.
+func (s *Scheduler) Register(j Job) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.jobs[j.ID()] = j
+}
+
+// Unregister removes a job by ID. It returns true if the job was
+// present.
+func (s *Scheduler) Unregister(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.jobs[id]; !ok {
+		return false
+	}
+	delete(s.jobs, id)
+	return true
+}
+
+// Get returns the registered job for id and a boolean indicating
+// whether it was found.
+func (s *Scheduler) Get(id string) (Job, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	j, ok := s.jobs[id]
+	return j, ok
+}
+
+// Snapshot returns a copy of the currently registered jobs.
+func (s *Scheduler) Snapshot() []Job {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Job, 0, len(s.jobs))
+	for _, j := range s.jobs {
+		out = append(out, j)
+	}
+	return out
+}
+
+// realClock is the production clock implementation.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+func (realClock) NewTicker(d time.Duration) ticker {
+	return &realTicker{t: time.NewTicker(d)}
+}
+
+type realTicker struct{ t *time.Ticker }
+
+func (r *realTicker) C() <-chan time.Time { return r.t.C }
+func (r *realTicker) Stop()               { r.t.Stop() }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,266 @@
+package scheduler_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/scheduler"
+)
+
+// fakeJob is a controllable Job for tests.
+type fakeJob struct {
+	id       string
+	next     time.Time
+	runCount atomic.Int32
+	runErr   error
+	mu       sync.Mutex
+	onRun    func(ctx context.Context)
+}
+
+func (j *fakeJob) ID() string { return j.id }
+
+func (j *fakeJob) NextRun(_ time.Time) time.Time {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.next
+}
+
+func (j *fakeJob) Run(ctx context.Context) error {
+	j.runCount.Add(1)
+	if j.onRun != nil {
+		j.onRun(ctx)
+	}
+	return j.runErr
+}
+
+func TestScheduler_RegisterListUnregister(t *testing.T) {
+	t.Parallel()
+
+	s := scheduler.New(time.Hour)
+	defer s.Stop()
+
+	j := &fakeJob{id: "test-1"}
+	s.Register(j)
+
+	got, ok := s.Get("test-1")
+	if !ok {
+		t.Fatal("Get returned !ok after Register")
+	}
+	if got.ID() != "test-1" {
+		t.Errorf("Get returned id %q, want test-1", got.ID())
+	}
+
+	snap := s.Snapshot()
+	if len(snap) != 1 {
+		t.Errorf("Snapshot returned %d jobs, want 1", len(snap))
+	}
+
+	if !s.Unregister("test-1") {
+		t.Error("Unregister returned false for present job")
+	}
+	if _, present := s.Get("test-1"); present {
+		t.Error("Get returned ok after Unregister")
+	}
+	if s.Unregister("test-1") {
+		t.Error("second Unregister returned true")
+	}
+}
+
+func TestScheduler_RegisterReplacesExisting(t *testing.T) {
+	t.Parallel()
+
+	s := scheduler.New(time.Hour)
+	defer s.Stop()
+
+	first := &fakeJob{id: "same-id", runErr: nil}
+	second := &fakeJob{id: "same-id"}
+
+	s.Register(first)
+	s.Register(second)
+
+	got, _ := s.Get("same-id")
+	if got != second {
+		t.Error("Register did not replace existing job")
+	}
+	if len(s.Snapshot()) != 1 {
+		t.Errorf("Snapshot length = %d, want 1 after re-register", len(s.Snapshot()))
+	}
+}
+
+// The Scheduler's clock interface is unexported, so these tests
+// exercise the public API via the real clock with short tick
+// intervals. A future test-seam refactor could expose the clock for
+// fully deterministic timing — for Phase 0, real-clock with short
+// intervals is sufficient.
+
+func TestScheduler_FiresDueJob(t *testing.T) {
+	t.Parallel()
+
+	s := scheduler.New(20 * time.Millisecond)
+
+	var fired atomic.Int32
+	done := make(chan struct{}, 1)
+	j := &fakeJob{
+		id:   "due",
+		next: time.Now().Add(-time.Second), // already past
+		onRun: func(_ context.Context) {
+			if fired.Add(1) == 1 {
+				done <- struct{}{}
+			}
+		},
+	}
+	s.Register(j)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	s.Start(ctx)
+
+	select {
+	case <-done:
+		// good
+	case <-ctx.Done():
+		t.Fatal("job did not fire within 2s")
+	}
+
+	s.Stop()
+	if got := fired.Load(); got < 1 {
+		t.Errorf("job fired %d times, want >= 1", got)
+	}
+}
+
+func TestScheduler_SkipsZeroNextRun(t *testing.T) {
+	t.Parallel()
+
+	s := scheduler.New(20 * time.Millisecond)
+
+	j := &fakeJob{
+		id:   "paused",
+		next: time.Time{}, // zero => never run
+	}
+	s.Register(j)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	s.Start(ctx)
+	<-ctx.Done()
+	s.Stop()
+
+	if got := j.runCount.Load(); got != 0 {
+		t.Errorf("paused job fired %d times, want 0", got)
+	}
+}
+
+func TestScheduler_StopWaitsForInflight(t *testing.T) {
+	t.Parallel()
+
+	s := scheduler.New(20 * time.Millisecond)
+
+	released := make(chan struct{})
+	started := make(chan struct{}, 1)
+	j := &fakeJob{
+		id:   "slow",
+		next: time.Now().Add(-time.Second),
+		onRun: func(_ context.Context) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-released
+		},
+	}
+	s.Register(j)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	s.Start(ctx)
+
+	// Wait for the job to start.
+	select {
+	case <-started:
+	case <-ctx.Done():
+		t.Fatal("slow job didn't start within 2s")
+	}
+
+	// Stop in a goroutine; it should block until released is closed.
+	stopped := make(chan struct{})
+	go func() {
+		s.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		t.Fatal("Stop returned before in-flight job released")
+	case <-time.After(80 * time.Millisecond):
+		// good — Stop is waiting
+	}
+
+	close(released)
+	select {
+	case <-stopped:
+		// good
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return after job released")
+	}
+}
+
+func TestScheduler_RunErrorDoesNotKillScheduler(t *testing.T) {
+	t.Parallel()
+
+	s := scheduler.New(15 * time.Millisecond)
+
+	var fired atomic.Int32
+	j := &fakeJob{
+		id:     "errs",
+		next:   time.Now().Add(-time.Second),
+		runErr: context.Canceled, // arbitrary non-nil
+		onRun: func(_ context.Context) {
+			fired.Add(1)
+		},
+	}
+	s.Register(j)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	s.Start(ctx)
+	<-ctx.Done()
+	s.Stop()
+
+	if got := fired.Load(); got < 2 {
+		t.Errorf("scheduler stopped firing after error; fire count = %d, want >= 2", got)
+	}
+}
+
+func TestScheduler_ConcurrentRegisterUnregister(t *testing.T) {
+	t.Parallel()
+
+	s := scheduler.New(time.Hour)
+	defer s.Stop()
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		id := i
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			s.Register(&fakeJob{id: idOf(id)})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = s.Unregister(idOf(id))
+		}()
+	}
+	wg.Wait()
+	// no deadlock + race detector happy is the test
+}
+
+func idOf(n int) string {
+	const digits = "0123456789"
+	if n < 10 {
+		return string(digits[n])
+	}
+	return string(digits[n/10]) + string(digits[n%10])
+}

--- a/ui/src/components/ui/BetaBadge.tsx
+++ b/ui/src/components/ui/BetaBadge.tsx
@@ -1,0 +1,21 @@
+/**
+ * BetaBadge — marks a feature surface as a future release.
+ *
+ * Phase 0 wraps the existing Tag primitive (yellow scheme) so that
+ * Phase 2.5 features (`wifi_roam_analysis`, `wifi_association_forensics`)
+ * can render as scaffolds with a clear "v1.0 beta" indicator until the
+ * Phase 2.5 implementation lands. See
+ * msn-docs-internal/01-Strategy/SEED_NMS_EXPANSION.md.
+ */
+import type { FC } from 'react';
+import { Tag } from './Tag';
+
+interface BetaBadgeProps {
+  label?: string;
+}
+
+export const BetaBadge: FC<BetaBadgeProps> = ({ label = 'v1.0 beta' }) => (
+  <span data-testid="beta-badge">
+    <Tag colorScheme="yellow">{label}</Tag>
+  </span>
+);

--- a/ui/src/pages/WifiPage.tsx
+++ b/ui/src/pages/WifiPage.tsx
@@ -2,6 +2,9 @@ import { Wifi } from 'lucide-react';
 import { WiFiCard } from '../components/cards/WiFiCard';
 import { WifiChannelGraph } from '../components/cards/WiFiChannelGraph';
 import { WiFiSurveyCard } from '../components/cards/WiFiSurveyCard';
+import { BetaBadge } from '../components/ui/BetaBadge';
+import { Card } from '../components/ui/card';
+import { RequireFeature } from '../components/ui/RequireFeature';
 import { useAppContext } from '../contexts/AppContext';
 import { layout } from '../styles/theme';
 import { Breadcrumbs } from '../ui/Breadcrumbs';
@@ -30,6 +33,36 @@ export function WifiPage() {
             visible={isWifi}
           />
         ) : null}
+
+        {/* Phase 2.5 scaffolding — fills with real data when 802.11
+            management-frame capture lands. See
+            msn-docs-internal/01-Strategy/SEED_NMS_EXPANSION.md. */}
+        <RequireFeature feature="wifi_association_forensics">
+          <Card
+            title="Association Forensics"
+            subtitle="802.11 assoc / EAPOL handshake decode with status-code drill-down."
+            status="unknown"
+            headerAction={<BetaBadge />}
+          >
+            <p data-testid="wifi-assoc-forensics-pending" className="text-sm text-text-muted">
+              Capture lands in Seed v1.0 — see release notes when Phase 2.5 ships.
+            </p>
+          </Card>
+        </RequireFeature>
+
+        <RequireFeature feature="wifi_roam_analysis">
+          <Card
+            title="Roam Analysis"
+            subtitle="Disassoc/(re)assoc correlation per client MAC with 802.11r FT detection."
+            status="unknown"
+            headerAction={<BetaBadge />}
+          >
+            <p data-testid="wifi-roam-analysis-pending" className="text-sm text-text-muted">
+              Capture lands in Seed v1.0 — see release notes when Phase 2.5 ships.
+            </p>
+          </Card>
+        </RequireFeature>
+
         {!isWifi && (
           <div data-testid="wifi-wired-fallback" className="col-span-full text-sm text-text-muted">
             Switch to Wi-Fi mode from the header to view wireless data.


### PR DESCRIPTION
## Summary

Stacks on top of #1323 (Stage A0 + A1.1-A1.5). 4 commits, +1.2K LoC, all tests green, 0 lint issues.

- **A1.1b** — V1.0 NMS Phase 0 schema (18 migrations: wifi_access_points 802.11 column extensions, metrics rollups, dns_monitors / ssl_monitors / cert_observations, microburst events, polling targets + device credentials, topology nodes/links, all wifi_* mgmt-frame event tables, voip_calls, bgp_sessions) plus the 3 per-WIP-table multi-tenancy migrations that A1.1 deferred. Includes TestV10NMSSchemaArtifacts test asserting every NMS table + the 9 wifi_access_points columns exist after migrate.
- **A1.3b** — generic scheduler primitive at `internal/scheduler/` (Job interface, Scheduler.Register/Unregister/Start/Stop, configurable tick, deterministic clock injection for tests). Will be wired into probe.Engine for auto-scheduling in a follow-up.
- **A1.6** — wire the 4 dead `internal/health/` services (Scorer, SLATracker, AnomalyDetector, DependencyMgr) for the first time. `/api/v1/sap/health-checks/{scores,sla,anomalies}` now serve real data instead of HTTP 503.
- **UI** — BetaBadge primitive for labeling already-sold-but-WIP features as v1.0-beta (wifi_roam_analysis, wifi_association_forensics).

Also includes license catalogue updates from the in-flight WIP: 14 new V1.0 NMS feature flags (3 Starter + 11 Pro) anchored at keygen v2.3.0, plus EncryptSecret/DecryptSecret on license.Manager for the SNMP credential vault.

## What follows

- A1.7: drop dns_monitors / ssl_monitors / cert_observations tables (after Stage A1.4/A1.5 checker port is consumed)
- A1.8: wire probe.Engine + checkers into server.go production lifecycle
- A2: metrics schema unification + retention engine

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/database/... ./internal/scheduler/... ./internal/api/... ./internal/probe/...` all green
- [x] `golangci-lint run ./internal/database/... ./internal/scheduler/... ./internal/license/... ./internal/api/... ./internal/health/... ./internal/probe/...` 0 issues
- [x] Pre-commit hook passed on each commit