### PR TITLE
feat(api): wire probe engine into server lifecycle (Stage A1.8)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -26,6 +26,9 @@ import (
 	"github.com/krisarmstrong/seed/internal/oauth"
 	"github.com/krisarmstrong/seed/internal/paths"
 	"github.com/krisarmstrong/seed/internal/pipeline/publicip"
+	"github.com/krisarmstrong/seed/internal/probe"
+	"github.com/krisarmstrong/seed/internal/probe/checkers"
+	"github.com/krisarmstrong/seed/internal/scheduler"
 	"github.com/krisarmstrong/seed/internal/services/cable"
 	"github.com/krisarmstrong/seed/internal/services/discovery"
 	"github.com/krisarmstrong/seed/internal/services/dns"
@@ -244,8 +247,14 @@ func NewServer(
 // is populated. Splits into per-concern helpers to keep each scope
 // focused and to keep NewServer under the funlen limit.
 func initDatabaseDependentServices(services *ServiceContainer, db *database.DB) {
+	if db == nil {
+		// Tests construct a Server without a DB; skip the
+		// database-dependent wiring entirely rather than crash.
+		return
+	}
 	initLicenseAndAPITokens(services, db)
 	initHealthServices(services, db)
+	initProbeEngine(services, db)
 }
 
 // initLicenseAndAPITokens wires the Phase D-2 license manager + API
@@ -262,6 +271,34 @@ func initLicenseAndAPITokens(services *ServiceContainer, db *database.DB) {
 	}
 	services.Auth.License = lm
 }
+
+// initProbeEngine constructs the unified probe.Engine, wires it to
+// the probes table and a fresh scheduler, registers V1.0 baseline
+// Checkers (DNS + TLS), and parks it in services.Probe for the
+// lifecycle to Start. The engine is *not* started here — that
+// happens in Server.Start so probes don't run during partial
+// service-container construction.
+//
+// V1.0 NMS expansion — Stage A1.8.
+func initProbeEngine(services *ServiceContainer, db *database.DB) {
+	sched := scheduler.New(probeSchedulerTick)
+
+	engine := probe.NewEngine(logging.GetLogger()).
+		WithStorage(db.Probes(), sched)
+
+	// Register V1.0 baseline checkers. Stage A1.7 will absorb the
+	// remaining 11 internal/api/health_checks_*.go kinds.
+	engine.RegisterChecker(checkers.NewDNSChecker())
+	engine.RegisterChecker(checkers.NewTLSChecker())
+
+	services.Probe.Engine = engine
+	services.Probe.Scheduler = sched
+}
+
+// probeSchedulerTick is the scheduler's tick interval — how often
+// it checks whether any registered Job is due. Production default
+// 5s; tests can run faster via direct scheduler.New construction.
+const probeSchedulerTick = 5 * time.Second
 
 // initHealthServices wires the previously-dead health subsystem
 // (Scorer, SLATracker, AnomalyDetector, DependencyMgr) into the

--- a/internal/api/server_lifecycle.go
+++ b/internal/api/server_lifecycle.go
@@ -126,6 +126,19 @@ func (s *Server) Start() error {
 		logging.GetLogger().Info("VLAN traffic monitor started")
 	}
 
+	// Start probe engine (Stage A1.8). The engine loads enabled
+	// probes from the DB on Start and dispatches them via the
+	// scheduler at their configured cadence. Failure here is
+	// non-fatal — the API surface stays up; only background
+	// dispatch is affected.
+	if engine := s.services.Probe.Engine; engine != nil {
+		if err := engine.Start(context.Background()); err != nil {
+			logging.GetLogger().Warn("probe engine failed to start", "error", err)
+		} else {
+			logging.GetLogger().Info("probe engine started")
+		}
+	}
+
 	if s.config.Server.HTTPS {
 		return s.startHTTPS()
 	}

--- a/internal/api/server_shutdown.go
+++ b/internal/api/server_shutdown.go
@@ -104,6 +104,15 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	logging.GetLogger().InfoContext(ctx, "Stopping VLAN traffic monitor...")
 	s.vlanTrafficMonitor().Stop()
 
+	// Stop probe engine (Stage A1.8) — drains in-flight probes via
+	// the scheduler's WaitGroup.
+	if engine := s.services.Probe.Engine; engine != nil {
+		logging.GetLogger().InfoContext(ctx, "Stopping probe engine...")
+		if stopErr := engine.Stop(ctx); stopErr != nil {
+			logging.GetLogger().WarnContext(ctx, "probe engine stop returned error", "error", stopErr)
+		}
+	}
+
 	logging.GetLogger().InfoContext(ctx, "Stopping rate limiters...")
 	s.loginRateLimiter().Stop()
 	s.endpointRateLimiter().Stop()

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -14,6 +14,8 @@ import (
 	"github.com/krisarmstrong/seed/internal/netif"
 	"github.com/krisarmstrong/seed/internal/oauth"
 	"github.com/krisarmstrong/seed/internal/pipeline/publicip"
+	"github.com/krisarmstrong/seed/internal/probe"
+	"github.com/krisarmstrong/seed/internal/scheduler"
 	"github.com/krisarmstrong/seed/internal/services/cable"
 	"github.com/krisarmstrong/seed/internal/services/discovery"
 	"github.com/krisarmstrong/seed/internal/services/dns"
@@ -33,6 +35,7 @@ type ServiceContainer struct {
 	Network   *NetworkServices
 	Discovery *DiscoveryServices
 	Sap       *SapServices
+	Probe     *ProbeServices
 	Canopy    *CanopyServices
 	Roots     *RootsServices
 	RealTime  *RealTimeServices
@@ -49,6 +52,7 @@ func NewServiceContainer() *ServiceContainer {
 		Network:   &NetworkServices{},
 		Discovery: &DiscoveryServices{},
 		Sap:       &SapServices{},
+		Probe:     &ProbeServices{},
 		Canopy:    &CanopyServices{},
 		Roots:     &RootsServices{},
 		RealTime:  &RealTimeServices{},
@@ -128,6 +132,22 @@ type SapServices struct {
 	Iperf         *iperf.Manager
 	Cable         *cable.Tester
 	PublicIP      *publicip.Checker
+}
+
+// ProbeServices groups the unified probe engine + its substrate.
+// The engine schedules and dispatches every probe-style observation
+// (DNS, TLS, PING, TCP, UDP, HTTP, HTTPS, RTSP, DICOM, HL7, FHIR,
+// LTI, LDAP, OPCUA, MODBUS, NTP, SIP, 802.1X, cable, transaction)
+// and emits ResultEvents to subscribers (alerts pipeline).
+//
+// V1.0 NMS expansion — Stage A1.8 wires the engine into the
+// production server lifecycle. Stage A1.7 will absorb the
+// remaining 11 internal/api/health_checks_*.go checkers; until
+// then the engine runs in parallel and handles only the kinds
+// registered (DNS, TLS in V1.0 baseline).
+type ProbeServices struct {
+	Engine    *probe.Engine
+	Scheduler *scheduler.Scheduler
 }
 
 // CanopyServices groups Canopy module services (Wi-Fi planning).

--- a/internal/probe/lifecycle.go
+++ b/internal/probe/lifecycle.go
@@ -30,7 +30,7 @@ type probeStorage interface {
 type probeScheduler interface {
 	Register(j scheduler.Job)
 	Unregister(id string) bool
-	Start(ctx context.Context) error
+	Start(ctx context.Context)
 	Stop()
 }
 
@@ -79,10 +79,7 @@ func (e *Engine) Start(ctx context.Context) error {
 		e.jobIDs = append(e.jobIDs, job.ID())
 	}
 
-	if startErr := sched.Start(ctx); startErr != nil {
-		return fmt.Errorf("scheduler start: %w", startErr)
-	}
-
+	sched.Start(ctx)
 	e.started = true
 	e.logger.InfoContext(ctx, "probe engine started",
 		"probes_scheduled", len(e.jobIDs),

--- a/internal/probe/lifecycle_test.go
+++ b/internal/probe/lifecycle_test.go
@@ -103,11 +103,10 @@ func (f *fakeScheduler) Unregister(id string) bool {
 	return present
 }
 
-func (f *fakeScheduler) Start(_ context.Context) error {
+func (f *fakeScheduler) Start(_ context.Context) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.started = true
-	return nil
 }
 
 func (f *fakeScheduler) Stop() {


### PR DESCRIPTION
## Summary

Lands the production wiring for probe.Engine. Configured probes now actually run in the production seed binary.

- New `ProbeServices` group with `Engine` + `Scheduler` instances
- `initProbeEngine` constructs engine, registers V1.0 baseline checkers (DNS + TLS), wires to db.Probes() + scheduler
- Start/Stop wired in server_lifecycle.go + server_shutdown.go (non-fatal failure)
- `nil` DB guard for test paths
- Scheduler interface signature alignment

End-to-end: insert a probe row with Enabled=true → restart server → engine picks it up → registered Checker fires at IntervalSeconds cadence → results persist to probe_results.

## What follows

- A1.7: absorb remaining 11 `internal/api/health_checks_*.go` checker kinds (PING/TCP/UDP/HTTP/HTTPS/RTSP/DICOM/HL7/FHIR/LTI/LDAP/OPCUA/MODBUS)
- A1.5: drop `dns_monitors` / `ssl_monitors` / `cert_observations` after the legacy services are fully retired
- A1.8b: alerts pipeline integration (Subscribe to engine ResultEvent channel)

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/probe/... ./internal/api/` all green
- [x] `golangci-lint run ./internal/api/... ./internal/probe/...` 0 issues
- [x] Pre-commit hook passed