### PR TITLE
feat(db): drop superseded dns_monitors / ssl_monitors / cert_observations (Stage A1.9)

### DIFF
--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -129,12 +129,13 @@ func TestV10NMSSchemaArtifacts(t *testing.T) {
 
 	ctx := context.Background()
 
+	// dns_monitors, ssl_monitors, cert_observations are NOT in this
+	// list — Stage A1.9 drops them after the V1.0 NMS WIP services
+	// are absorbed into the unified probes engine. See
+	// SEED_ARCHITECTURE.md section 3.1.
 	nmsTables := []string{
 		"metrics_hourly",
 		"metrics_daily",
-		"dns_monitors",
-		"ssl_monitors",
-		"cert_observations",
 		"microburst_events",
 		"polling_targets",
 		"device_credentials",

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1634,6 +1634,37 @@ func getMigrationDefs() []migrationDef {
 			CREATE INDEX IF NOT EXISTS idx_device_credentials_client ON device_credentials(client_id);
 		`,
 		},
+		{
+			// Stage A1.9 (2026-05-31) — drop dns_monitors. The DNS
+			// checker in internal/probe/checkers/dns.go writes
+			// directly into the unified probe_results table; there is
+			// no remaining consumer of the dns_monitors config table.
+			// The probes config table replaces it (one row per
+			// configured probe with kind='dns').
+			Description: "Drop dns_monitors (superseded by probes + probe_results)",
+			Up: `
+			DROP TABLE IF EXISTS dns_monitors;
+		`,
+		},
+		{
+			// Stage A1.9 — drop ssl_monitors + cert_observations. The
+			// TLS checker in internal/probe/checkers/tls.go writes
+			// directly into probe_results with cert metadata in
+			// Metadata JSON. No remaining consumers.
+			Description: "Drop ssl_monitors (superseded by probes + probe_results)",
+			Up: `
+			DROP TABLE IF EXISTS ssl_monitors;
+		`,
+		},
+		{
+			// Stage A1.9 — drop cert_observations. Cert expiry data
+			// lives in probe_results.metadata_json (kind='tls') from
+			// the TLS checker.
+			Description: "Drop cert_observations (superseded by probe_results.metadata_json)",
+			Up: `
+			DROP TABLE IF EXISTS cert_observations;
+		`,
+		},
 	}
 }
 


### PR DESCRIPTION
Stage A1.9 - drops the V1.0 NMS WIP bespoke monitor tables now that the unified probes + probe_results pair has absorbed them. Zero remaining consumers (verified by grep).