### PR TITLE
feat(probe): ping checker via TCP fallback (Stage A1.7 - 1 of N)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -290,6 +290,7 @@ func initProbeEngine(services *ServiceContainer, db *database.DB) {
 	// remaining 11 internal/api/health_checks_*.go kinds.
 	engine.RegisterChecker(checkers.NewDNSChecker())
 	engine.RegisterChecker(checkers.NewTLSChecker())
+	engine.RegisterChecker(checkers.NewPingChecker())
 
 	services.Probe.Engine = engine
 	services.Probe.Scheduler = sched

--- a/internal/probe/checkers/ping.go
+++ b/internal/probe/checkers/ping.go
@@ -1,0 +1,153 @@
+package checkers
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/probe"
+)
+
+// defaultPingDialTimeout is the per-attempt dial timeout. Probes
+// that need a tighter or looser bound override via Params.
+const defaultPingDialTimeout = 3 * time.Second
+
+// pingPrimaryPort is tried first; on failure pingFallbackPort
+// is tried before declaring the host unreachable. This mirrors
+// the existing internal/api/health_checks_ping.go behavior of
+// using TCP reachability (port 80 → 443) as the ICMP substitute
+// because seed deployments often lack CAP_NET_RAW.
+const (
+	pingPrimaryPort  = "80"
+	pingFallbackPort = "443"
+)
+
+// PingParams is the kind-specific params shape. Empty values fall
+// back to defaults.
+type PingParams struct {
+	// Port overrides the primary TCP port to dial. When non-empty,
+	// the fallback port is NOT tried — the operator chose this
+	// port deliberately.
+	Port string `json:"port,omitempty"`
+
+	// TimeoutMs overrides the per-attempt dial timeout. Default
+	// 3000.
+	TimeoutMs int `json:"timeout_ms,omitempty"`
+}
+
+// PingDialer is the test seam for PingChecker — production wires
+// it to [net.Dialer].
+type PingDialer interface {
+	Dial(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+// PingChecker implements probe.Checker for Kind="ping". Reports
+// reachability + dial latency via TCP fallback (the same ICMP
+// substitute the legacy internal/api/health_checks_ping.go uses).
+type PingChecker struct {
+	dialer PingDialer
+}
+
+// NewPingChecker returns a PingChecker wired to a real [net.Dialer]
+// via a small adapter that surfaces DialContext as the Dial method.
+func NewPingChecker() *PingChecker {
+	return &PingChecker{dialer: realPingDialer{}}
+}
+
+// realPingDialer wraps [net.Dialer] to expose DialContext as a Dial
+// method matching the PingDialer interface.
+type realPingDialer struct{}
+
+// Dial honors ctx-based deadlines via [net.Dialer.DialContext].
+func (realPingDialer) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	d := &net.Dialer{}
+	return d.DialContext(ctx, network, addr)
+}
+
+// WithPingDialer swaps the dialer (for tests).
+func (c *PingChecker) WithPingDialer(d PingDialer) *PingChecker {
+	c.dialer = d
+	return c
+}
+
+// Kind returns probe.KindPing.
+func (c *PingChecker) Kind() string { return probe.KindPing }
+
+// RequiredCapabilities returns nil — TCP fallback needs no special
+// capability. A future ICMP-only variant would require "raw_sockets".
+func (c *PingChecker) RequiredCapabilities() []string { return nil }
+
+// Run dials Probe.Target on the configured (or default) TCP port,
+// times the dial, and returns a Result. Falls back to port 443
+// only when the operator did NOT pin a port via Params.Port.
+func (c *PingChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
+	params := parsePingParams(p.Params)
+
+	timeout := defaultPingDialTimeout
+	if params.TimeoutMs > 0 {
+		timeout = time.Duration(params.TimeoutMs) * time.Millisecond
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	primaryPort := params.Port
+	if primaryPort == "" {
+		primaryPort = pingPrimaryPort
+	}
+
+	addr := net.JoinHostPort(p.Target, primaryPort)
+	start := time.Now()
+	conn, err := c.dialer.Dial(dialCtx, "tcp", addr)
+	latencyMs := float64(time.Since(start).Milliseconds())
+
+	fellBack := false
+	// Only attempt fallback when the operator did NOT pin a port.
+	if err != nil && params.Port == "" {
+		fellBack = true
+		addr = net.JoinHostPort(p.Target, pingFallbackPort)
+		start = time.Now()
+		conn, err = c.dialer.Dial(dialCtx, "tcp", addr)
+		latencyMs = float64(time.Since(start).Milliseconds())
+	}
+
+	if err != nil {
+		return probe.Result{
+			ProbeID:   p.ID,
+			ClientID:  p.ClientID,
+			Kind:      p.Kind,
+			Timestamp: time.Now().UTC(),
+			Success:   false,
+			LatencyMs: latencyMs,
+			Error:     err.Error(),
+		}
+	}
+	_ = conn.Close()
+
+	meta, _ := json.Marshal(map[string]any{
+		"dialed_addr": addr,
+		"fell_back":   fellBack,
+	})
+
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   true,
+		LatencyMs: latencyMs,
+		Metadata:  meta,
+	}
+}
+
+// parsePingParams decodes the params JSON; returns zero on empty
+// or unparseable input.
+func parsePingParams(raw json.RawMessage) PingParams {
+	if len(raw) == 0 {
+		return PingParams{}
+	}
+	var p PingParams
+	_ = json.Unmarshal(raw, &p)
+	return p
+}

--- a/internal/probe/checkers/ping_test.go
+++ b/internal/probe/checkers/ping_test.go
@@ -1,0 +1,200 @@
+package checkers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/probe"
+	"github.com/krisarmstrong/seed/internal/probe/checkers"
+)
+
+// fakePingDialer is a programmable dialer for tests. attempts[i] is
+// the (conn, err) tuple returned by the i-th Dial call.
+type fakePingDialer struct {
+	attempts []dialOutcome
+	called   int
+	gotAddrs []string
+}
+
+type dialOutcome struct {
+	conn net.Conn
+	err  error
+}
+
+// fakeConn is a no-op [net.Conn] used to satisfy the interface in
+// tests.
+type fakeConn struct{ net.Conn }
+
+func (fakeConn) Close() error                     { return nil }
+func (fakeConn) Read([]byte) (int, error)         { return 0, nil }
+func (fakeConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (fakeConn) LocalAddr() net.Addr              { return nil }
+func (fakeConn) RemoteAddr() net.Addr             { return nil }
+func (fakeConn) SetDeadline(time.Time) error      { return nil }
+func (fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (fakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+func (f *fakePingDialer) Dial(_ context.Context, _, addr string) (net.Conn, error) {
+	f.gotAddrs = append(f.gotAddrs, addr)
+	idx := f.called
+	f.called++
+	if idx >= len(f.attempts) {
+		return nil, errors.New("no more outcomes configured")
+	}
+	o := f.attempts[idx]
+	return o.conn, o.err
+}
+
+func TestPingChecker_Kind(t *testing.T) {
+	t.Parallel()
+	c := checkers.NewPingChecker()
+	if c.Kind() != "ping" {
+		t.Errorf("Kind() = %q, want %q", c.Kind(), "ping")
+	}
+}
+
+func TestPingChecker_RequiredCapabilities(t *testing.T) {
+	t.Parallel()
+	c := checkers.NewPingChecker()
+	if caps := c.RequiredCapabilities(); len(caps) != 0 {
+		t.Errorf("RequiredCapabilities() = %v, want empty", caps)
+	}
+}
+
+func TestPingChecker_Run_PrimaryPortSucceeds(t *testing.T) {
+	t.Parallel()
+	dialer := &fakePingDialer{attempts: []dialOutcome{{conn: fakeConn{}}}}
+	c := checkers.NewPingChecker().WithPingDialer(dialer)
+
+	r := c.Run(context.Background(), probe.Probe{Kind: "ping", Target: "google.com"})
+
+	if !r.Success {
+		t.Errorf("Result.Success = false, want true; error=%q", r.Error)
+	}
+	if dialer.called != 1 {
+		t.Errorf("dialer.called = %d, want 1 (no fallback needed)", dialer.called)
+	}
+	if dialer.gotAddrs[0] != "google.com:80" {
+		t.Errorf("dialer addr = %q, want google.com:80", dialer.gotAddrs[0])
+	}
+
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta["fell_back"] != false {
+		t.Errorf("metadata.fell_back = %v, want false", meta["fell_back"])
+	}
+}
+
+func TestPingChecker_Run_FallsBackToHTTPS(t *testing.T) {
+	t.Parallel()
+	dialer := &fakePingDialer{attempts: []dialOutcome{
+		{err: errors.New("connection refused")},
+		{conn: fakeConn{}},
+	}}
+	c := checkers.NewPingChecker().WithPingDialer(dialer)
+
+	r := c.Run(context.Background(), probe.Probe{Kind: "ping", Target: "secure-only.example.com"})
+
+	if !r.Success {
+		t.Errorf("Result.Success = false, want true after fallback")
+	}
+	if dialer.called != 2 {
+		t.Errorf("dialer.called = %d, want 2 (primary + fallback)", dialer.called)
+	}
+	if dialer.gotAddrs[1] != "secure-only.example.com:443" {
+		t.Errorf("fallback addr = %q, want secure-only.example.com:443", dialer.gotAddrs[1])
+	}
+
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta["fell_back"] != true {
+		t.Errorf("metadata.fell_back = %v, want true", meta["fell_back"])
+	}
+}
+
+func TestPingChecker_Run_BothPortsFail(t *testing.T) {
+	t.Parallel()
+	dialer := &fakePingDialer{attempts: []dialOutcome{
+		{err: errors.New("primary refused")},
+		{err: errors.New("fallback refused")},
+	}}
+	c := checkers.NewPingChecker().WithPingDialer(dialer)
+
+	r := c.Run(context.Background(), probe.Probe{Kind: "ping", Target: "down.example.com"})
+
+	if r.Success {
+		t.Error("Result.Success = true, want false")
+	}
+	if r.Error == "" {
+		t.Error("Result.Error should describe failure")
+	}
+	if dialer.called != 2 {
+		t.Errorf("dialer.called = %d, want 2", dialer.called)
+	}
+}
+
+func TestPingChecker_Run_CustomPort_NoFallback(t *testing.T) {
+	t.Parallel()
+	dialer := &fakePingDialer{attempts: []dialOutcome{{err: errors.New("refused")}}}
+	c := checkers.NewPingChecker().WithPingDialer(dialer)
+
+	p := probe.Probe{
+		Kind:   "ping",
+		Target: "mqtt.example.com",
+		Params: json.RawMessage(`{"port":"1883"}`),
+	}
+	r := c.Run(context.Background(), p)
+
+	if r.Success {
+		t.Error("Result.Success = true, want false")
+	}
+	if dialer.called != 1 {
+		t.Errorf("dialer.called = %d, want 1 (operator-pinned port, no fallback)", dialer.called)
+	}
+	if dialer.gotAddrs[0] != "mqtt.example.com:1883" {
+		t.Errorf("dialed addr = %q, want mqtt.example.com:1883", dialer.gotAddrs[0])
+	}
+}
+
+func TestPingChecker_Run_CustomTimeout(t *testing.T) {
+	t.Parallel()
+	// Verify Params.TimeoutMs is honored by the context deadline.
+	// We can't easily assert on the deadline value through the
+	// dialer interface, but a 1ms timeout against a slow dialer
+	// proves the context cancellation reaches the dial.
+	dialer := &slowDialer{delay: 50 * time.Millisecond}
+	c := checkers.NewPingChecker().WithPingDialer(dialer)
+
+	p := probe.Probe{
+		Kind:   "ping",
+		Target: "slow.example.com",
+		Params: json.RawMessage(`{"timeout_ms":1}`),
+	}
+	r := c.Run(context.Background(), p)
+
+	if r.Success {
+		t.Error("Result.Success = true, want false (timeout)")
+	}
+}
+
+// slowDialer sleeps for delay before checking ctx and returning.
+type slowDialer struct {
+	delay time.Duration
+}
+
+func (s *slowDialer) Dial(ctx context.Context, _, _ string) (net.Conn, error) {
+	select {
+	case <-time.After(s.delay):
+		return fakeConn{}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}


### PR DESCRIPTION
Adds PingChecker - third probe.Checker after DNS + TLS. Wired into production via initProbeEngine.

Ports the existing TCP-port reachability pattern (80 -> 443 fallback) from internal/api/health_checks_ping.go. Same operational semantics now flowing through the unified probes + probe_results pipeline.

6 tests cover Kind, capabilities, primary success, fallback, both-ports-fail, operator-pinned-port no-fallback, custom timeout deadlines.