### PR TITLE
feat(snmp): collector-chain poller scaffold (stage a3.1)

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -64,16 +64,17 @@ type DB struct {
 	closed bool
 
 	// Repositories - lazily initialized
-	profiles     *ProfileRepository
-	metrics      *MetricsRepository
-	devices      *DeviceRepository
-	alerts       *AlertRepository
-	settings     *SettingsRepository
-	logs         *LogRepository
-	healthChecks *HealthCheckRepository
-	discovery    *DiscoveryRepository
-	clients      *ClientRepository
-	probes       *ProbeRepository
+	profiles       *ProfileRepository
+	metrics        *MetricsRepository
+	devices        *DeviceRepository
+	alerts         *AlertRepository
+	settings       *SettingsRepository
+	logs           *LogRepository
+	healthChecks   *HealthCheckRepository
+	discovery      *DiscoveryRepository
+	clients        *ClientRepository
+	probes         *ProbeRepository
+	pollingTargets *PollingTargetRepository
 }
 
 // Config holds database configuration options.
@@ -472,6 +473,19 @@ func (db *DB) Probes() *ProbeRepository {
 		db.probes = &ProbeRepository{db: db}
 	}
 	return db.probes
+}
+
+// PollingTargets returns the polling-target repository (Stage A3.1).
+// Targets carry the per-target SNMP credentials + collector chain
+// that the Poller walks on each tick.
+func (db *DB) PollingTargets() *PollingTargetRepository {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.pollingTargets == nil {
+		db.pollingTargets = &PollingTargetRepository{db: db}
+	}
+	return db.pollingTargets
 }
 
 // Exec executes a query without returning any rows.

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1735,6 +1735,18 @@ func getMigrationDefs() []migrationDef {
 			CREATE INDEX IF NOT EXISTS idx_probe_rollups_daily_probe ON probe_rollups_daily(probe_id, day_bucket);
 		`,
 		},
+		{
+			// Stage A3.1 — collector_chain on polling_targets.
+			// The estate-wide SNMP poller dispatches a target's chain
+			// in order; each chain entry names a Collector registered
+			// at startup (sys_info, if_table, lldp, arp, fdb, ...).
+			// Default chain covers the topology-relevant collectors so
+			// brand-new targets immediately feed Stage A4 topology.
+			Description: "Add collector_chain to polling_targets",
+			Up: `
+			ALTER TABLE polling_targets ADD COLUMN collector_chain TEXT NOT NULL DEFAULT '["sys_info","if_table","lldp","arp","fdb"]';
+		`,
+		},
 	}
 }
 

--- a/internal/database/repository_polling_targets.go
+++ b/internal/database/repository_polling_targets.go
@@ -1,0 +1,165 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrPollingTargetNotFound is returned when a polling target lookup
+// misses.
+var ErrPollingTargetNotFound = errors.New("polling target not found")
+
+// PollingTarget mirrors a polling_targets row. CollectorChain is
+// decoded from the JSON column. Last* fields record the most
+// recent poll's outcome and feed the operator-facing target status.
+type PollingTarget struct {
+	ID              string    `json:"id"`
+	ClientID        string    `json:"clientId"`
+	Name            string    `json:"name"`
+	IPAddress       string    `json:"ipAddress"`
+	SNMPVersion     string    `json:"snmpVersion"`
+	CredentialsID   string    `json:"credentialsId,omitempty"`
+	PollIntervalSec int       `json:"pollIntervalSeconds"`
+	Enabled         bool      `json:"enabled"`
+	CollectorChain  []string  `json:"collectorChain"`
+	LastPolledAt    time.Time `json:"lastPolledAt,omitzero"`
+	LastStatus      string    `json:"lastStatus,omitempty"`
+	LastError       string    `json:"lastError,omitempty"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+}
+
+// PollingTargetRepository owns CRUD + status-update access to
+// polling_targets.
+type PollingTargetRepository struct {
+	db *DB
+}
+
+// List returns all enabled polling targets for a client. Empty
+// clientID returns enabled targets across every client (useful for
+// the system-wide poller loop).
+func (r *PollingTargetRepository) List(ctx context.Context, clientID string) ([]*PollingTarget, error) {
+	query := `
+		SELECT id, client_id, name, ip_address, snmp_version,
+			credentials_id, poll_interval_seconds, enabled, collector_chain,
+			last_polled_at, last_status, last_error, created_at, updated_at
+		FROM polling_targets
+		WHERE enabled = 1
+	`
+	args := []any{}
+	if clientID != "" {
+		query += " AND client_id = ?"
+		args = append(args, clientID)
+	}
+	query += " ORDER BY name ASC"
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list polling_targets: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*PollingTarget
+	for rows.Next() {
+		t, scanErr := scanPollingTarget(rows.Scan)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, t)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("list polling_targets iter: %w", rowsErr)
+	}
+	return out, nil
+}
+
+// Get returns one polling target by id.
+func (r *PollingTargetRepository) Get(ctx context.Context, id string) (*PollingTarget, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, client_id, name, ip_address, snmp_version,
+			credentials_id, poll_interval_seconds, enabled, collector_chain,
+			last_polled_at, last_status, last_error, created_at, updated_at
+		FROM polling_targets WHERE id = ?
+	`, id)
+	return scanPollingTarget(row.Scan)
+}
+
+// UpdateLastPoll records the outcome of the most recent poll attempt.
+// errMsg may be empty on success.
+func (r *PollingTargetRepository) UpdateLastPoll(ctx context.Context, id, status, errMsg string) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE polling_targets
+		SET last_polled_at = ?, last_status = ?, last_error = ?, updated_at = ?
+		WHERE id = ?
+	`,
+		time.Now().UTC().Format(time.RFC3339Nano),
+		status,
+		toNullString(errMsg),
+		time.Now().UTC().Format(time.RFC3339Nano),
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("update polling_target last poll: %w", err)
+	}
+	return nil
+}
+
+// scanPollingTarget reads a PollingTarget row via a [sql.Row.Scan]
+// or [sql.Rows.Scan] signature.
+func scanPollingTarget(scan func(...any) error) (*PollingTarget, error) {
+	var (
+		t             PollingTarget
+		credentialsID sql.NullString
+		chainJSON     sql.NullString
+		lastPolledAt  sql.NullString
+		lastStatus    sql.NullString
+		lastError     sql.NullString
+		enabledInt    int
+		createdAtStr  string
+		updatedAtStr  string
+	)
+	err := scan(
+		&t.ID, &t.ClientID, &t.Name, &t.IPAddress, &t.SNMPVersion,
+		&credentialsID, &t.PollIntervalSec, &enabledInt, &chainJSON,
+		&lastPolledAt, &lastStatus, &lastError, &createdAtStr, &updatedAtStr,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrPollingTargetNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan polling_target: %w", err)
+	}
+
+	t.Enabled = enabledInt != 0
+	if credentialsID.Valid {
+		t.CredentialsID = credentialsID.String
+	}
+	if chainJSON.Valid && chainJSON.String != "" {
+		var chain []string
+		if jsonErr := json.Unmarshal([]byte(chainJSON.String), &chain); jsonErr == nil {
+			t.CollectorChain = chain
+		}
+	}
+	if lastPolledAt.Valid {
+		if parsed, parseErr := time.Parse(time.RFC3339Nano, lastPolledAt.String); parseErr == nil {
+			t.LastPolledAt = parsed
+		}
+	}
+	if lastStatus.Valid {
+		t.LastStatus = lastStatus.String
+	}
+	if lastError.Valid {
+		t.LastError = lastError.String
+	}
+	if parsed, parseErr := time.Parse(time.RFC3339Nano, createdAtStr); parseErr == nil {
+		t.CreatedAt = parsed
+	}
+	if parsed, parseErr := time.Parse(time.RFC3339Nano, updatedAtStr); parseErr == nil {
+		t.UpdatedAt = parsed
+	}
+	return &t, nil
+}

--- a/internal/polling/snmp/poller.go
+++ b/internal/polling/snmp/poller.go
@@ -1,29 +1,231 @@
 package snmp
 
-import "context"
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
 
-// Poller schedules SNMP polling across all enabled Targets. One
-// instance per Seed instance. Implementation lands in Stage A3.
-//
-// Per-target lifecycle on each tick:
-//  1. Resolve the Target's credentials from device_credentials
-//     (decrypted via license.Manager.DecryptSecret)
-//  2. Walk the configured CollectorChain in order, invoking each
-//     registered Collector
-//  3. Persist results via the collectors' chosen surfaces (metrics,
-//     events, topology)
-//  4. Update the Target's last_polled_at / last_status / last_error
-type Poller interface {
-	// RegisterCollector adds a Collector. Re-registering the same
-	// Name replaces the previous Collector. Must be called before
-	// Start.
-	RegisterCollector(c Collector)
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/scheduler"
+)
 
-	// Start begins the per-target scheduling loop. Honors ctx
-	// cancellation for clean shutdown.
-	Start(ctx context.Context) error
+// pollStatusOK / pollStatusError are the values written into
+// polling_targets.last_status by the poll job.
+const (
+	pollStatusOK    = "ok"
+	pollStatusError = "error"
+)
 
-	// Stop signals the loop to exit and waits up to ctx deadline for
-	// in-flight collector chains to complete.
-	Stop(ctx context.Context) error
+// ErrCollectorNotRegistered is returned when a target's collector
+// chain references a collector that no implementation has registered
+// for. The chain entry is skipped (logged warn) but the rest of the
+// chain runs.
+var ErrCollectorNotRegistered = errors.New("collector not registered")
+
+// pollerStorage is the narrowed surface the Poller needs from the
+// database layer. Tests inject a fake.
+type pollerStorage interface {
+	List(ctx context.Context, clientID string) ([]*database.PollingTarget, error)
+	UpdateLastPoll(ctx context.Context, id, status, errMsg string) error
+}
+
+// pollerScheduler is the narrowed scheduler surface for tests.
+type pollerScheduler interface {
+	Register(j scheduler.Job)
+	Unregister(id string) bool
+	Start(ctx context.Context)
+	Stop()
+}
+
+// Poller orchestrates per-target SNMP polling. On Start it loads
+// every enabled target, registers one scheduler.Job per target,
+// and the scheduler dispatches the per-target collector chain at
+// each target's configured cadence.
+type Poller struct {
+	logger    *slog.Logger
+	storage   pollerStorage
+	scheduler pollerScheduler
+
+	mu         sync.RWMutex
+	collectors map[string]Collector
+
+	runMu   sync.Mutex
+	started bool
+	jobIDs  []string
+}
+
+// NewPoller returns an unstarted Poller. Pass nil logger to use
+// [slog.Default].
+func NewPoller(storage pollerStorage, sched pollerScheduler, logger *slog.Logger) *Poller {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Poller{
+		logger:     logger,
+		storage:    storage,
+		scheduler:  sched,
+		collectors: make(map[string]Collector),
+	}
+}
+
+// RegisterCollector adds a Collector. Replaces any prior collector
+// registered with the same Name.
+func (p *Poller) RegisterCollector(c Collector) {
+	if c == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.collectors[c.Name()] = c
+}
+
+// Start loads all enabled polling_targets and registers one job
+// per target with the scheduler. Idempotent.
+func (p *Poller) Start(ctx context.Context) error {
+	p.runMu.Lock()
+	defer p.runMu.Unlock()
+
+	if p.started {
+		return nil
+	}
+
+	targets, err := p.storage.List(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	for _, t := range targets {
+		job := &targetJob{poller: p, target: t}
+		p.scheduler.Register(job)
+		p.jobIDs = append(p.jobIDs, job.ID())
+	}
+
+	p.scheduler.Start(ctx)
+	p.started = true
+	p.logger.InfoContext(ctx, "snmp poller started",
+		"targets", len(p.jobIDs),
+		"collectors", len(p.collectors),
+	)
+	return nil
+}
+
+// Stop unregisters all jobs and stops the scheduler.
+func (p *Poller) Stop(ctx context.Context) error {
+	p.runMu.Lock()
+	defer p.runMu.Unlock()
+
+	if !p.started {
+		return nil
+	}
+
+	for _, id := range p.jobIDs {
+		p.scheduler.Unregister(id)
+	}
+	p.jobIDs = nil
+	p.scheduler.Stop()
+	p.started = false
+	p.logger.InfoContext(ctx, "snmp poller stopped")
+	return nil
+}
+
+// runChain walks the target's collector chain. Each collector is
+// invoked sequentially; failures are logged and the chain
+// continues. After the chain runs, last_status / last_error /
+// last_polled_at are recorded.
+func (p *Poller) runChain(ctx context.Context, target *database.PollingTarget) {
+	creds := credentialsForTarget(target)
+
+	wireTarget := wireTarget(target)
+	var firstErr error
+	for _, name := range target.CollectorChain {
+		p.mu.RLock()
+		c, ok := p.collectors[name]
+		p.mu.RUnlock()
+
+		if !ok {
+			p.logger.WarnContext(ctx, "snmp poller: collector not registered, skipping",
+				"target_id", target.ID, "collector", name)
+			if firstErr == nil {
+				firstErr = ErrCollectorNotRegistered
+			}
+			continue
+		}
+
+		if err := c.Collect(ctx, wireTarget, creds); err != nil {
+			p.logger.WarnContext(ctx, "snmp poller: collector failed",
+				"target_id", target.ID, "collector", name, "error", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+
+	status := pollStatusOK
+	errMsg := ""
+	if firstErr != nil {
+		status = pollStatusError
+		errMsg = firstErr.Error()
+	}
+	if updErr := p.storage.UpdateLastPoll(ctx, target.ID, status, errMsg); updErr != nil {
+		p.logger.WarnContext(ctx, "snmp poller: update last_poll failed",
+			"target_id", target.ID, "error", updErr)
+	}
+}
+
+// credentialsForTarget resolves the decrypted credentials for a
+// polling target. V1.0 ships with a no-credentials stub — Stage
+// A3.x adds the device_credentials decryption via
+// license.Manager.DecryptSecret.
+func credentialsForTarget(_ *database.PollingTarget) ResolvedCredentials {
+	return ResolvedCredentials{}
+}
+
+// wireTarget converts a database.PollingTarget into the
+// internal/polling/snmp Target shape that Collectors consume.
+func wireTarget(t *database.PollingTarget) Target {
+	return Target{
+		ID:              t.ID,
+		ClientID:        t.ClientID,
+		Name:            t.Name,
+		IPAddress:       t.IPAddress,
+		SNMPVersion:     t.SNMPVersion,
+		CredentialsID:   t.CredentialsID,
+		PollIntervalSec: t.PollIntervalSec,
+		CollectorChain:  t.CollectorChain,
+		Enabled:         t.Enabled,
+		LastPolledAt:    t.LastPolledAt,
+		LastStatus:      t.LastStatus,
+		LastError:       t.LastError,
+	}
+}
+
+// targetJob is the scheduler.Job adapter for a single polling
+// target. Implements scheduler.Job by reaching into the poller for
+// dispatch.
+type targetJob struct {
+	poller  *Poller
+	target  *database.PollingTarget
+	lastRun time.Time
+}
+
+// ID is the scheduler key for this target.
+func (j *targetJob) ID() string {
+	return "snmp:" + j.target.ID
+}
+
+// NextRun returns now on first call, then lastRun + interval.
+func (j *targetJob) NextRun(now time.Time) time.Time {
+	if j.lastRun.IsZero() {
+		return now
+	}
+	return j.lastRun.Add(time.Duration(j.target.PollIntervalSec) * time.Second)
+}
+
+// Run dispatches the target's collector chain.
+func (j *targetJob) Run(ctx context.Context) error {
+	j.lastRun = time.Now().UTC()
+	j.poller.runChain(ctx, j.target)
+	return nil
 }

--- a/internal/polling/snmp/poller_test.go
+++ b/internal/polling/snmp/poller_test.go
@@ -1,0 +1,355 @@
+package snmp_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/scheduler"
+)
+
+func silentLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+// fakeStorage mirrors a tiny subset of database.PollingTargetRepository.
+type fakeStorage struct {
+	mu      sync.Mutex
+	targets []*database.PollingTarget
+	listErr error
+
+	updates []updateRecord
+	updErr  error
+}
+
+type updateRecord struct {
+	id     string
+	status string
+	errMsg string
+}
+
+func (f *fakeStorage) List(_ context.Context, _ string) ([]*database.PollingTarget, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.targets, nil
+}
+
+func (f *fakeStorage) UpdateLastPoll(_ context.Context, id, status, errMsg string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updates = append(f.updates, updateRecord{id: id, status: status, errMsg: errMsg})
+	return f.updErr
+}
+
+// fakeScheduler captures registered jobs without ticking.
+type fakeScheduler struct {
+	mu      sync.Mutex
+	jobs    map[string]scheduler.Job
+	started bool
+	stopped bool
+}
+
+func newFakeScheduler() *fakeScheduler {
+	return &fakeScheduler{jobs: make(map[string]scheduler.Job)}
+}
+
+func (f *fakeScheduler) Register(j scheduler.Job) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.jobs[j.ID()] = j
+}
+
+func (f *fakeScheduler) Unregister(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.jobs[id]
+	delete(f.jobs, id)
+	return ok
+}
+
+func (f *fakeScheduler) Start(_ context.Context) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.started = true
+}
+
+func (f *fakeScheduler) Stop() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopped = true
+}
+
+func (f *fakeScheduler) jobCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.jobs)
+}
+
+// firstJob returns any one job in the scheduler — useful when the
+// test created a single target and just wants to drive its Run().
+func (f *fakeScheduler) firstJob() scheduler.Job {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, j := range f.jobs {
+		return j
+	}
+	return nil
+}
+
+// stubCollector records every Collect invocation; returns the
+// configured err on call.
+type stubCollector struct {
+	mu    sync.Mutex
+	name  string
+	err   error
+	calls []snmp.Target
+}
+
+func (s *stubCollector) Name() string { return s.name }
+
+func (s *stubCollector) Collect(
+	_ context.Context,
+	t snmp.Target,
+	_ snmp.ResolvedCredentials,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, t)
+	return s.err
+}
+
+func (s *stubCollector) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+func TestPoller_Start_RegistersJobsForEachEnabledTarget(t *testing.T) {
+	t.Parallel()
+	storage := &fakeStorage{
+		targets: []*database.PollingTarget{
+			{
+				ID:              "t-1",
+				Name:            "router-1",
+				IPAddress:       "10.0.0.1",
+				Enabled:         true,
+				PollIntervalSec: 60,
+				CollectorChain:  []string{"sys_info"},
+			},
+			{
+				ID:              "t-2",
+				Name:            "router-2",
+				IPAddress:       "10.0.0.2",
+				Enabled:         true,
+				PollIntervalSec: 300,
+				CollectorChain:  []string{"sys_info"},
+			},
+		},
+	}
+	sched := newFakeScheduler()
+	p := snmp.NewPoller(storage, sched, silentLogger())
+
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if sched.jobCount() != 2 {
+		t.Errorf("scheduler.jobCount = %d, want 2", sched.jobCount())
+	}
+	if !sched.started {
+		t.Error("scheduler.Start was not called")
+	}
+}
+
+func TestPoller_Start_Idempotent(t *testing.T) {
+	t.Parallel()
+	storage := &fakeStorage{
+		targets: []*database.PollingTarget{
+			{ID: "t-1", Enabled: true, PollIntervalSec: 60},
+		},
+	}
+	sched := newFakeScheduler()
+	p := snmp.NewPoller(storage, sched, silentLogger())
+
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Errorf("second Start = %v, want nil", err)
+	}
+	if sched.jobCount() != 1 {
+		t.Errorf("scheduler.jobCount = %d, want 1 after 2 Starts", sched.jobCount())
+	}
+}
+
+func TestPoller_Start_PropagatesListError(t *testing.T) {
+	t.Parallel()
+	storage := &fakeStorage{listErr: errors.New("DB down")}
+	sched := newFakeScheduler()
+	p := snmp.NewPoller(storage, sched, silentLogger())
+	if err := p.Start(context.Background()); err == nil {
+		t.Error("Start should propagate List error")
+	}
+}
+
+func TestPoller_Stop_UnregistersJobsAndStopsScheduler(t *testing.T) {
+	t.Parallel()
+	storage := &fakeStorage{
+		targets: []*database.PollingTarget{
+			{ID: "t-1", Enabled: true, PollIntervalSec: 60},
+		},
+	}
+	sched := newFakeScheduler()
+	p := snmp.NewPoller(storage, sched, silentLogger())
+
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := p.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if sched.jobCount() != 0 {
+		t.Errorf("scheduler.jobCount = %d, want 0", sched.jobCount())
+	}
+	if !sched.stopped {
+		t.Error("scheduler.Stop was not called")
+	}
+}
+
+func TestPoller_Stop_NotStartedReturnsNil(t *testing.T) {
+	t.Parallel()
+	p := snmp.NewPoller(&fakeStorage{}, newFakeScheduler(), silentLogger())
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop without Start = %v, want nil", err)
+	}
+}
+
+func TestPoller_RunChain_InvokesEveryCollectorInOrder(t *testing.T) {
+	t.Parallel()
+	target := &database.PollingTarget{
+		ID: "t-1", Name: "router-1", IPAddress: "10.0.0.1",
+		Enabled: true, PollIntervalSec: 60,
+		CollectorChain: []string{"sys_info", "if_table"},
+	}
+	storage := &fakeStorage{targets: []*database.PollingTarget{target}}
+	sched := newFakeScheduler()
+	p := snmp.NewPoller(storage, sched, silentLogger())
+
+	sys := &stubCollector{name: "sys_info"}
+	ift := &stubCollector{name: "if_table"}
+	p.RegisterCollector(sys)
+	p.RegisterCollector(ift)
+
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	job := sched.firstJob()
+	if job == nil {
+		t.Fatal("expected job snmp:t-1")
+	}
+	_ = job.Run(context.Background())
+
+	if sys.callCount() != 1 {
+		t.Errorf("sys_info called %d times, want 1", sys.callCount())
+	}
+	if ift.callCount() != 1 {
+		t.Errorf("if_table called %d times, want 1", ift.callCount())
+	}
+	if len(storage.updates) != 1 {
+		t.Fatalf("UpdateLastPoll called %d times, want 1", len(storage.updates))
+	}
+	if storage.updates[0].status != "ok" {
+		t.Errorf("status = %q, want ok", storage.updates[0].status)
+	}
+}
+
+func TestPoller_RunChain_UnknownCollectorIsSkipped(t *testing.T) {
+	t.Parallel()
+	target := &database.PollingTarget{
+		ID: "t-1", IPAddress: "10.0.0.1", Enabled: true,
+		PollIntervalSec: 60,
+		CollectorChain:  []string{"unknown_kind", "sys_info"},
+	}
+	storage := &fakeStorage{targets: []*database.PollingTarget{target}}
+	sched := newFakeScheduler()
+	p := snmp.NewPoller(storage, sched, silentLogger())
+
+	sys := &stubCollector{name: "sys_info"}
+	p.RegisterCollector(sys)
+
+	_ = p.Start(context.Background())
+	job := sched.firstJob()
+	_ = job.Run(context.Background())
+
+	// sys_info should still run even though unknown_kind was first.
+	if sys.callCount() != 1 {
+		t.Errorf("sys_info called %d times, want 1", sys.callCount())
+	}
+	if len(storage.updates) != 1 || storage.updates[0].status != "error" {
+		t.Errorf("expected one update with status=error; got %+v", storage.updates)
+	}
+}
+
+func TestPoller_RunChain_CollectorErrorCapturedInLastError(t *testing.T) {
+	t.Parallel()
+	target := &database.PollingTarget{
+		ID: "t-1", IPAddress: "10.0.0.1", Enabled: true,
+		PollIntervalSec: 60,
+		CollectorChain:  []string{"sys_info"},
+	}
+	storage := &fakeStorage{targets: []*database.PollingTarget{target}}
+	sched := newFakeScheduler()
+	p := snmp.NewPoller(storage, sched, silentLogger())
+
+	sys := &stubCollector{name: "sys_info", err: errors.New("snmp timeout")}
+	p.RegisterCollector(sys)
+
+	_ = p.Start(context.Background())
+	job := sched.firstJob()
+	_ = job.Run(context.Background())
+
+	if len(storage.updates) != 1 {
+		t.Fatalf("UpdateLastPoll called %d times, want 1", len(storage.updates))
+	}
+	if storage.updates[0].status != "error" {
+		t.Errorf("status = %q, want error", storage.updates[0].status)
+	}
+	if storage.updates[0].errMsg != "snmp timeout" {
+		t.Errorf("errMsg = %q, want %q", storage.updates[0].errMsg, "snmp timeout")
+	}
+}
+
+func TestPoller_TargetJob_NextRunCadence(t *testing.T) {
+	t.Parallel()
+	target := &database.PollingTarget{
+		ID: "t-1", IPAddress: "10.0.0.1", Enabled: true,
+		PollIntervalSec: 300,
+		CollectorChain:  []string{"sys_info"},
+	}
+	storage := &fakeStorage{targets: []*database.PollingTarget{target}}
+	sched := newFakeScheduler()
+	p := snmp.NewPoller(storage, sched, silentLogger())
+	p.RegisterCollector(&stubCollector{name: "sys_info"})
+
+	_ = p.Start(context.Background())
+	job := sched.firstJob()
+	if job == nil {
+		t.Fatal("no job registered")
+	}
+
+	now := time.Now().UTC()
+	first := job.NextRun(now)
+	if !first.Equal(now) {
+		t.Errorf("first NextRun = %v, want now (immediate first run)", first)
+	}
+	_ = job.Run(context.Background())
+	second := job.NextRun(now)
+	if !second.After(first) {
+		t.Errorf("second NextRun = %v, want after first %v", second, first)
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.1 — estate-wide SNMP poller skeleton. Targets are loaded
from `polling_targets`, each gets a `scheduler.Job` that walks its
`collector_chain` at the configured cadence. Collectors register by
name; the chain is data-driven so future kinds (lldp, arp, fdb, bgp4,
etc.) land without touching the dispatch loop.

## Changes
- **migration**: `ALTER TABLE polling_targets ADD COLUMN collector_chain TEXT NOT NULL DEFAULT '["sys_info","if_table","lldp","arp","fdb"]'`
- **repository**: `PollingTargetRepository` with `List(ctx, clientID)`, `Get`, `UpdateLastPoll` — JSON-decodes the chain, surfaces last-poll status
- **poller**: idempotent `Start`/`Stop`, registers one job per enabled target, `runChain` walks collectors sequentially, captures first error into `last_error`, records `last_status` after every run
- **targetJob**: `scheduler.Job` adapter — fires immediately then at `poll_interval_seconds`
- **tests**: 8 unit tests via `fakeStorage` + `fakeScheduler` + `stubCollector`

## Validation
- `go test ./internal/database/... ./internal/polling/...` → green
- `golangci-lint run ./internal/polling/... ./internal/database/...` → 0 issues
- `go build ./...` → green

## Test plan
- [x] poller_test.go covers start/stop/runchain/cadence
- [x] migration applies on fresh + existing DBs
- [ ] follow-up: real `Collector` implementations (Stage A3.2+)