### PR TITLE
feat(snmp): sys_info collector (stage a3.2)

### DIFF
--- a/internal/polling/snmp/client.go
+++ b/internal/polling/snmp/client.go
@@ -1,0 +1,35 @@
+package snmp
+
+import "context"
+
+// Varbind is one (OID, value) result from a Get or Walk. Value is the
+// raw decoded gosnmp value — Collectors that need typed bytes / ints
+// type-assert at the call site.
+type Varbind struct {
+	OID   string
+	Value any
+}
+
+// Client is the narrowed gosnmp surface the collector chain needs.
+// One Client per Target (or per chain run) — Collectors do not own
+// the connection lifecycle; the Poller does.
+//
+// Implementations live in internal/polling/snmp/snmpclient/. Tests
+// inject a fake to drive collector behavior without a live device.
+type Client interface {
+	// Get retrieves one or more scalar OIDs. Order of the returned
+	// slice matches order of the input. A non-existent OID yields a
+	// Varbind with a nil Value rather than an error.
+	Get(ctx context.Context, oids []string) ([]Varbind, error)
+
+	// Walk traverses a subtree rooted at prefix and returns every
+	// non-end-of-mib varbind. Callers MUST treat Walk as bounded by
+	// ctx — a misbehaving agent that never returns end-of-mib must
+	// not hang the collector chain forever.
+	Walk(ctx context.Context, prefix string) ([]Varbind, error)
+}
+
+// ClientFactory builds a Client for a Target + decoded credentials.
+// Stage A3.x's real factory dials gosnmp; tests inject a factory
+// that returns a fake Client.
+type ClientFactory func(target Target, creds ResolvedCredentials) (Client, error)

--- a/internal/polling/snmp/collectors/sysinfo/sysinfo.go
+++ b/internal/polling/snmp/collectors/sysinfo/sysinfo.go
@@ -1,0 +1,195 @@
+// Package sysinfo implements the sys_info SNMP Collector: one
+// per-target GET of the system MIB scalars (sysDescr, sysName,
+// sysObjectID, sysUpTime, sysLocation, sysContact). The observation
+// feeds Stage A4 topology identity merging and the operator-facing
+// device pane.
+package sysinfo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+)
+
+// Name is the collector key written into polling_targets.collector_chain.
+const Name = "sys_info"
+
+// MIB-II system OIDs (RFC 1213 §6.4). Scalar instances end in .0.
+const (
+	oidSysDescr    = "1.3.6.1.2.1.1.1.0"
+	oidSysObjectID = "1.3.6.1.2.1.1.2.0"
+	oidSysUpTime   = "1.3.6.1.2.1.1.3.0"
+	oidSysContact  = "1.3.6.1.2.1.1.4.0"
+	oidSysName     = "1.3.6.1.2.1.1.5.0"
+	oidSysLocation = "1.3.6.1.2.1.1.6.0"
+)
+
+// Observation carries one sys_info snapshot. ObservedAt is set by the
+// collector at the start of the GET. SysUpTimeTicks is the raw
+// TimeTicks value (hundredths of a second since reboot) — keep raw so
+// the Publisher can derive both uptime-duration and a boot-time
+// estimate.
+type Observation struct {
+	ClientID       string
+	TargetID       string
+	ObservedAt     time.Time
+	SysDescr       string
+	SysObjectID    string
+	SysUpTimeTicks uint32
+	SysContact     string
+	SysName        string
+	SysLocation    string
+}
+
+// Publisher is the consumer-defined seam the sysinfo collector calls
+// once per successful GET. Stage A3.5 orchestration wires this to the
+// topology reconciler + event log; tests inject a fake.
+type Publisher interface {
+	PublishSysInfo(ctx context.Context, obs Observation) error
+}
+
+// Collector runs the sys_info GET against each target. It is
+// stateless across runs — one Collector instance is registered with
+// the poller and reused for every target.
+type Collector struct {
+	newClient snmp.ClientFactory
+	publisher Publisher
+	now       func() time.Time
+}
+
+// New returns a Collector that dials Clients via factory and ships
+// observations to publisher. Pass nil for now to use [time.Now].
+func New(factory snmp.ClientFactory, publisher Publisher, now func() time.Time) *Collector {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Collector{newClient: factory, publisher: publisher, now: now}
+}
+
+// Name implements snmp.Collector.
+func (*Collector) Name() string { return Name }
+
+// Collect implements snmp.Collector. It performs one Get for the
+// six system MIB scalars and publishes the Observation.
+func (c *Collector) Collect(ctx context.Context, target snmp.Target, creds snmp.ResolvedCredentials) error {
+	if c.newClient == nil {
+		return errors.New("sysinfo: client factory not configured")
+	}
+	if c.publisher == nil {
+		return errors.New("sysinfo: publisher not configured")
+	}
+
+	client, err := c.newClient(target, creds)
+	if err != nil {
+		return fmt.Errorf("sysinfo: dial: %w", err)
+	}
+
+	observedAt := c.now()
+	vbs, err := client.Get(ctx, []string{
+		oidSysDescr, oidSysObjectID, oidSysUpTime,
+		oidSysContact, oidSysName, oidSysLocation,
+	})
+	if err != nil {
+		return fmt.Errorf("sysinfo: snmp get: %w", err)
+	}
+
+	obs := buildObservation(target, observedAt, vbs)
+	if pubErr := c.publisher.PublishSysInfo(ctx, obs); pubErr != nil {
+		return fmt.Errorf("sysinfo: publish: %w", pubErr)
+	}
+	return nil
+}
+
+// buildObservation reads the six varbinds returned by Get in the
+// order requested. Missing or wrong-typed values fall back to the
+// zero value of the corresponding field so a partial response still
+// produces a publishable Observation.
+func buildObservation(target snmp.Target, observedAt time.Time, vbs []snmp.Varbind) Observation {
+	obs := Observation{
+		ClientID:   target.ClientID,
+		TargetID:   target.ID,
+		ObservedAt: observedAt,
+	}
+	for _, vb := range vbs {
+		switch vb.OID {
+		case oidSysDescr:
+			obs.SysDescr = stringValue(vb.Value)
+		case oidSysObjectID:
+			obs.SysObjectID = stringValue(vb.Value)
+		case oidSysUpTime:
+			obs.SysUpTimeTicks = uint32Value(vb.Value)
+		case oidSysContact:
+			obs.SysContact = stringValue(vb.Value)
+		case oidSysName:
+			obs.SysName = stringValue(vb.Value)
+		case oidSysLocation:
+			obs.SysLocation = stringValue(vb.Value)
+		}
+	}
+	return obs
+}
+
+// stringValue extracts a string from a varbind. SNMP OCTET STRINGs
+// arrive as []byte; DisplayStrings arrive as string. Any other type
+// (or nil) yields "".
+func stringValue(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	default:
+		return ""
+	}
+}
+
+// uint32Value extracts a TimeTicks / Counter32 / Gauge32 / Uint32
+// scalar. Negative ints and out-of-range values clamp to the uint32
+// representable range so the caller never observes garbage.
+func uint32Value(v any) uint32 {
+	const maxUint32 uint64 = 1<<32 - 1
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case uint32:
+		return t
+	case uint:
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case uint64:
+		if t > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case int:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case int32:
+		if t < 0 {
+			return 0
+		}
+		return uint32(t)
+	case int64:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	default:
+		return 0
+	}
+}

--- a/internal/polling/snmp/collectors/sysinfo/sysinfo_test.go
+++ b/internal/polling/snmp/collectors/sysinfo/sysinfo_test.go
@@ -1,0 +1,278 @@
+package sysinfo_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/sysinfo"
+)
+
+// fakeClient records the OIDs requested and replays a fixed varbind
+// set. Wrong-OID tests can override the response per OID.
+type fakeClient struct {
+	requestedOIDs []string
+	getResponse   []snmp.Varbind
+	getErr        error
+}
+
+func (f *fakeClient) Get(_ context.Context, oids []string) ([]snmp.Varbind, error) {
+	f.requestedOIDs = append([]string{}, oids...)
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	// echo back only the responses we have, indexed by OID match
+	out := make([]snmp.Varbind, 0, len(f.getResponse))
+	for _, want := range oids {
+		for _, vb := range f.getResponse {
+			if vb.OID == want {
+				out = append(out, vb)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeClient) Walk(_ context.Context, _ string) ([]snmp.Varbind, error) {
+	return nil, errors.New("walk not used by sysinfo")
+}
+
+// fakePublisher records every PublishSysInfo invocation.
+type fakePublisher struct {
+	mu   sync.Mutex
+	got  []sysinfo.Observation
+	err  error
+	hits int
+}
+
+func (p *fakePublisher) PublishSysInfo(_ context.Context, obs sysinfo.Observation) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.hits++
+	if p.err != nil {
+		return p.err
+	}
+	p.got = append(p.got, obs)
+	return nil
+}
+
+func staticFactory(c *fakeClient) snmp.ClientFactory {
+	return func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+		return c, nil
+	}
+}
+
+func fixedClock() time.Time {
+	return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+}
+
+func TestCollector_Name(t *testing.T) {
+	t.Parallel()
+	c := sysinfo.New(nil, nil, fixedClock)
+	if got := c.Name(); got != sysinfo.Name {
+		t.Errorf("Name() = %q, want %q", got, sysinfo.Name)
+	}
+}
+
+func TestCollect_FetchesAllSixSystemOIDs(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		getResponse: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.1.1.0", Value: "Cisco IOS XE"},
+			{OID: "1.3.6.1.2.1.1.5.0", Value: "router-1"},
+		},
+	}
+	pub := &fakePublisher{}
+	c := sysinfo.New(staticFactory(fc), pub, fixedClock)
+
+	target := snmp.Target{ID: "t-1", ClientID: "client-a"}
+	if err := c.Collect(context.Background(), target, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	wantOIDs := []string{
+		"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.2.0", "1.3.6.1.2.1.1.3.0",
+		"1.3.6.1.2.1.1.4.0", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.6.0",
+	}
+	if len(fc.requestedOIDs) != len(wantOIDs) {
+		t.Fatalf("requested %d OIDs, want %d", len(fc.requestedOIDs), len(wantOIDs))
+	}
+	for i, oid := range wantOIDs {
+		if fc.requestedOIDs[i] != oid {
+			t.Errorf("OID[%d] = %q, want %q", i, fc.requestedOIDs[i], oid)
+		}
+	}
+}
+
+func TestCollect_PublishesObservationWithTargetMetadata(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		getResponse: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.1.1.0", Value: []byte("Linux 6.5")},
+			{OID: "1.3.6.1.2.1.1.2.0", Value: "1.3.6.1.4.1.8072.3.2.10"},
+			{OID: "1.3.6.1.2.1.1.3.0", Value: uint32(123456)},
+			{OID: "1.3.6.1.2.1.1.4.0", Value: "noc@example.com"},
+			{OID: "1.3.6.1.2.1.1.5.0", Value: "switch-1"},
+			{OID: "1.3.6.1.2.1.1.6.0", Value: "MDF-Rack-3"},
+		},
+	}
+	pub := &fakePublisher{}
+	c := sysinfo.New(staticFactory(fc), pub, fixedClock)
+
+	target := snmp.Target{ID: "t-99", ClientID: "client-x"}
+	if err := c.Collect(context.Background(), target, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	if len(pub.got) != 1 {
+		t.Fatalf("publisher hits = %d, want 1", len(pub.got))
+	}
+	obs := pub.got[0]
+	if obs.ClientID != "client-x" {
+		t.Errorf("ClientID = %q, want client-x", obs.ClientID)
+	}
+	if obs.TargetID != "t-99" {
+		t.Errorf("TargetID = %q, want t-99", obs.TargetID)
+	}
+	if !obs.ObservedAt.Equal(fixedClock()) {
+		t.Errorf("ObservedAt = %v, want %v", obs.ObservedAt, fixedClock())
+	}
+	if obs.SysDescr != "Linux 6.5" {
+		t.Errorf("SysDescr = %q, want Linux 6.5", obs.SysDescr)
+	}
+	if obs.SysObjectID != "1.3.6.1.4.1.8072.3.2.10" {
+		t.Errorf("SysObjectID = %q", obs.SysObjectID)
+	}
+	if obs.SysUpTimeTicks != 123456 {
+		t.Errorf("SysUpTimeTicks = %d, want 123456", obs.SysUpTimeTicks)
+	}
+	if obs.SysName != "switch-1" {
+		t.Errorf("SysName = %q", obs.SysName)
+	}
+	if obs.SysLocation != "MDF-Rack-3" {
+		t.Errorf("SysLocation = %q", obs.SysLocation)
+	}
+	if obs.SysContact != "noc@example.com" {
+		t.Errorf("SysContact = %q", obs.SysContact)
+	}
+}
+
+func TestCollect_PartialResponseStillPublishes(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		// Only 2 of 6 OIDs return a value (agent doesn't expose
+		// sysContact/sysLocation, etc.).
+		getResponse: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.1.1.0", Value: "Junos"},
+			{OID: "1.3.6.1.2.1.1.5.0", Value: "edge-1"},
+		},
+	}
+	pub := &fakePublisher{}
+	c := sysinfo.New(staticFactory(fc), pub, fixedClock)
+
+	if err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(pub.got) != 1 {
+		t.Fatalf("expected exactly one publish, got %d", len(pub.got))
+	}
+	obs := pub.got[0]
+	if obs.SysDescr != "Junos" {
+		t.Errorf("SysDescr = %q, want Junos", obs.SysDescr)
+	}
+	if obs.SysName != "edge-1" {
+		t.Errorf("SysName = %q, want edge-1", obs.SysName)
+	}
+	if obs.SysObjectID != "" || obs.SysContact != "" || obs.SysLocation != "" {
+		t.Errorf("missing OIDs should be empty strings, got %+v", obs)
+	}
+	if obs.SysUpTimeTicks != 0 {
+		t.Errorf("SysUpTimeTicks = %d, want 0 for missing", obs.SysUpTimeTicks)
+	}
+}
+
+func TestCollect_GetErrorPropagates(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{getErr: errors.New("snmp v2c timeout")}
+	pub := &fakePublisher{}
+	c := sysinfo.New(staticFactory(fc), pub, fixedClock)
+
+	err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{})
+	if err == nil {
+		t.Fatal("expected Collect to surface Get error")
+	}
+	if pub.hits != 0 {
+		t.Errorf("publisher called %d times, want 0 on Get error", pub.hits)
+	}
+}
+
+func TestCollect_PublishErrorPropagates(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		getResponse: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.1.5.0", Value: "host"},
+		},
+	}
+	pub := &fakePublisher{err: errors.New("event log full")}
+	c := sysinfo.New(staticFactory(fc), pub, fixedClock)
+
+	if err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected Collect to surface publisher error")
+	}
+}
+
+func TestCollect_FactoryNilReturnsError(t *testing.T) {
+	t.Parallel()
+	c := sysinfo.New(nil, &fakePublisher{}, fixedClock)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected error when client factory is nil")
+	}
+}
+
+func TestCollect_PublisherNilReturnsError(t *testing.T) {
+	t.Parallel()
+	c := sysinfo.New(staticFactory(&fakeClient{}), nil, fixedClock)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected error when publisher is nil")
+	}
+}
+
+func TestCollect_FactoryErrorPropagates(t *testing.T) {
+	t.Parallel()
+	pub := &fakePublisher{}
+	c := sysinfo.New(
+		func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+			return nil, errors.New("no creds resolved")
+		},
+		pub,
+		fixedClock,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected Collect to surface factory error")
+	}
+	if pub.hits != 0 {
+		t.Errorf("publisher called %d times on factory error, want 0", pub.hits)
+	}
+}
+
+func TestCollect_UnknownValueTypeClampsToZero(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		getResponse: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.1.3.0", Value: -42}, // negative int → 0
+		},
+	}
+	pub := &fakePublisher{}
+	c := sysinfo.New(staticFactory(fc), pub, fixedClock)
+
+	if err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if pub.got[0].SysUpTimeTicks != 0 {
+		t.Errorf("negative SysUpTime should clamp to 0, got %d", pub.got[0].SysUpTimeTicks)
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.2 — first real SNMP collector. Reads the six system MIB
scalars, publishes a structured `Observation` to a consumer-defined
sink. Stage A3.5 will wire the publisher to the topology reconciler
and event log.

## Changes
- `snmp.Client` + `snmp.Varbind` — narrowed gosnmp surface (Get + Walk) injected via `ClientFactory` so collectors are testable without a live device
- `collectors/sysinfo.Collector` — stateless implementation of `snmp.Collector`; one `Get` for `sysDescr`, `sysObjectID`, `sysUpTime`, `sysContact`, `sysName`, `sysLocation`
- `sysinfo.Publisher` — consumer-defined sink, one method (`PublishSysInfo`); orchestration wires this up next stage
- `uint32Value` / `stringValue` — tolerant decoders that clamp out-of-range numerics and accept both `string` and `[]byte` OCTET STRINGs

## Validation
- `go test ./internal/polling/...` → green (10 new tests)
- `golangci-lint run ./internal/polling/...` → 0 issues
- `go build ./...` → green

## Test plan
- [x] OID list matches RFC 1213 §6.4
- [x] Observation populated from full + partial agent responses
- [x] Negative SysUpTime clamps to 0
- [x] All error paths covered (factory, Get, Publish, nil deps)
- [ ] Stage A3.5 will wire real gosnmp factory + sink