### PR TITLE
feat(snmp): if_table collector (stage a3.3)

### DIFF
--- a/internal/polling/snmp/collectors/iftable/iftable.go
+++ b/internal/polling/snmp/collectors/iftable/iftable.go
@@ -1,0 +1,374 @@
+// Package iftable implements the if_table SNMP Collector: walks
+// IF-MIB ifTable (RFC 2233 §6) plus ifXTable extensions and emits
+// one Observation containing every interface row indexed by ifIndex.
+// Used by Stage A4 topology to attach physical/logical interfaces
+// to their parent Node.
+package iftable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+)
+
+// Name is the collector key written into polling_targets.collector_chain.
+const Name = "if_table"
+
+// Column OIDs under ifTable (1.3.6.1.2.1.2.2.1.*) — the subset that
+// V1.0 topology + counters need. The full ifTable carries 22 columns;
+// the remainder land when their consumers materialize.
+const (
+	ifTablePrefix    = "1.3.6.1.2.1.2.2.1"
+	colIfDescr       = "2"
+	colIfType        = "3"
+	colIfSpeed       = "5"
+	colIfPhysAddress = "6"
+	colIfAdminStatus = "7"
+	colIfOperStatus  = "8"
+)
+
+// Column OIDs under ifXTable (1.3.6.1.2.1.31.1.1.1.*).
+const (
+	ifXTablePrefix = "1.3.6.1.2.1.31.1.1.1"
+	colIfName      = "1"
+	colIfHighSpeed = "15"
+	colIfAlias     = "18"
+)
+
+// AdminStatus / OperStatus values from RFC 2233 — exported because
+// downstream listeners decode them by name in alert messages.
+const (
+	StatusUp             = 1
+	StatusDown           = 2
+	StatusTesting        = 3
+	StatusUnknown        = 4 // ifOperStatus only
+	StatusDormant        = 5 // ifOperStatus only
+	StatusNotPresent     = 6 // ifOperStatus only
+	StatusLowerLayerDown = 7 // ifOperStatus only
+)
+
+// Row is one ifTable/ifXTable row keyed by IfIndex. SpeedBps prefers
+// ifHighSpeed*1e6 when available (multi-gigabit links); falls back
+// to ifSpeed (32-bit bps) for older agents.
+type Row struct {
+	IfIndex     uint32
+	IfDescr     string
+	IfName      string
+	IfAlias     string
+	IfType      uint32
+	IfAdmin     int
+	IfOper      int
+	IfPhysAddr  string
+	SpeedBps    uint64
+	rawIfSpeed  uint32
+	rawHighMbps uint32
+}
+
+// Observation is the per-target ifTable snapshot. Rows is sorted by
+// ascending IfIndex so downstream comparisons (alerting on
+// new/missing interfaces) are deterministic.
+type Observation struct {
+	ClientID   string
+	TargetID   string
+	ObservedAt time.Time
+	Rows       []Row
+}
+
+// Publisher is the consumer-defined seam for iftable observations.
+// Stage A3.5 wires it to topology reconciliation.
+type Publisher interface {
+	PublishIfTable(ctx context.Context, obs Observation) error
+}
+
+// Collector implements snmp.Collector for the if_table chain step.
+type Collector struct {
+	newClient snmp.ClientFactory
+	publisher Publisher
+	now       func() time.Time
+}
+
+// New returns a Collector bound to factory + publisher. Pass nil now
+// to use [time.Now].UTC.
+func New(factory snmp.ClientFactory, publisher Publisher, now func() time.Time) *Collector {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Collector{newClient: factory, publisher: publisher, now: now}
+}
+
+// Name implements snmp.Collector.
+func (*Collector) Name() string { return Name }
+
+// Collect walks ifTable + ifXTable subtrees, merges by ifIndex, and
+// publishes the resulting Observation.
+func (c *Collector) Collect(
+	ctx context.Context,
+	target snmp.Target,
+	creds snmp.ResolvedCredentials,
+) error {
+	if c.newClient == nil {
+		return errors.New("iftable: client factory not configured")
+	}
+	if c.publisher == nil {
+		return errors.New("iftable: publisher not configured")
+	}
+
+	client, err := c.newClient(target, creds)
+	if err != nil {
+		return fmt.Errorf("iftable: dial: %w", err)
+	}
+
+	observedAt := c.now()
+
+	ifVarbinds, err := client.Walk(ctx, ifTablePrefix)
+	if err != nil {
+		return fmt.Errorf("iftable: walk ifTable: %w", err)
+	}
+	ifXVarbinds, err := client.Walk(ctx, ifXTablePrefix)
+	if err != nil {
+		return fmt.Errorf("iftable: walk ifXTable: %w", err)
+	}
+
+	rows := mergeRows(ifVarbinds, ifXVarbinds)
+
+	if pubErr := c.publisher.PublishIfTable(ctx, Observation{
+		ClientID:   target.ClientID,
+		TargetID:   target.ID,
+		ObservedAt: observedAt,
+		Rows:       rows,
+	}); pubErr != nil {
+		return fmt.Errorf("iftable: publish: %w", pubErr)
+	}
+	return nil
+}
+
+// mergeRows folds ifTable + ifXTable varbinds into Rows keyed by
+// ifIndex. Order is ascending ifIndex for deterministic downstream
+// comparisons.
+func mergeRows(ifVarbinds, ifXVarbinds []snmp.Varbind) []Row {
+	byIndex := make(map[uint32]*Row)
+
+	for _, vb := range ifVarbinds {
+		col, idx, ok := parseColumnIndex(vb.OID, ifTablePrefix)
+		if !ok {
+			continue
+		}
+		row := getOrCreate(byIndex, idx)
+		applyIfTableColumn(row, col, vb.Value)
+	}
+	for _, vb := range ifXVarbinds {
+		col, idx, ok := parseColumnIndex(vb.OID, ifXTablePrefix)
+		if !ok {
+			continue
+		}
+		row := getOrCreate(byIndex, idx)
+		applyIfXTableColumn(row, col, vb.Value)
+	}
+
+	out := make([]Row, 0, len(byIndex))
+	for _, row := range byIndex {
+		row.SpeedBps = pickSpeedBps(row.rawHighMbps, row.rawIfSpeed)
+		out = append(out, *row)
+	}
+	sortByIfIndex(out)
+	return out
+}
+
+// columnIndexParts is the number of dot-separated fields a column-
+// indexed OID has under its table prefix: <column>.<ifIndex>.
+const columnIndexParts = 2
+
+// parseColumnIndex splits an OID under prefix into its column and
+// ifIndex parts. Returns ok=false when the OID is malformed or not
+// rooted at prefix.
+func parseColumnIndex(oid, prefix string) (string, uint32, bool) {
+	if !strings.HasPrefix(oid, prefix+".") {
+		return "", 0, false
+	}
+	rest := strings.TrimPrefix(oid, prefix+".")
+	parts := strings.SplitN(rest, ".", columnIndexParts)
+	if len(parts) != columnIndexParts {
+		return "", 0, false
+	}
+	idx64, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil {
+		return "", 0, false
+	}
+	return parts[0], uint32(idx64), true
+}
+
+func getOrCreate(m map[uint32]*Row, idx uint32) *Row {
+	if r, ok := m[idx]; ok {
+		return r
+	}
+	r := &Row{IfIndex: idx}
+	m[idx] = r
+	return r
+}
+
+// applyIfTableColumn sets one ifTable column on row by column number.
+func applyIfTableColumn(row *Row, col string, v any) {
+	switch col {
+	case colIfDescr:
+		row.IfDescr = stringValue(v)
+	case colIfType:
+		row.IfType = uint32Value(v)
+	case colIfSpeed:
+		row.rawIfSpeed = uint32Value(v)
+	case colIfPhysAddress:
+		row.IfPhysAddr = macAddressString(v)
+	case colIfAdminStatus:
+		row.IfAdmin = intValue(v)
+	case colIfOperStatus:
+		row.IfOper = intValue(v)
+	}
+}
+
+// applyIfXTableColumn sets one ifXTable column on row by column number.
+func applyIfXTableColumn(row *Row, col string, v any) {
+	switch col {
+	case colIfName:
+		row.IfName = stringValue(v)
+	case colIfHighSpeed:
+		row.rawHighMbps = uint32Value(v)
+	case colIfAlias:
+		row.IfAlias = stringValue(v)
+	}
+}
+
+// mbpsToBps converts ifHighSpeed (megabits per second) to bps. Kept
+// as a named constant to avoid an opaque "1_000_000" at the call
+// site.
+const mbpsToBps uint64 = 1_000_000
+
+// pickSpeedBps prefers ifHighSpeed (Mbps) when present — it covers
+// multi-gigabit links that overflow ifSpeed's 32-bit bps. Falls back
+// to ifSpeed for older agents.
+func pickSpeedBps(highMbps, ifSpeedBps uint32) uint64 {
+	if highMbps > 0 {
+		return uint64(highMbps) * mbpsToBps
+	}
+	return uint64(ifSpeedBps)
+}
+
+// stringValue extracts a string from a varbind value. SNMP OCTET
+// STRINGs arrive as []byte; gosnmp DisplayStrings arrive as string.
+func stringValue(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	default:
+		return ""
+	}
+}
+
+// macAddressString formats a 6-byte MAC as "aa:bb:cc:dd:ee:ff".
+// Non-6-byte inputs fall back to the raw stringValue.
+func macAddressString(v any) string {
+	if b, ok := v.([]byte); ok && len(b) == 6 {
+		return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
+			b[0], b[1], b[2], b[3], b[4], b[5])
+	}
+	return stringValue(v)
+}
+
+// intValue extracts a small signed int (admin/oper status, etc.).
+// Status values are 1..7, so wider scalars are clamped to the int
+// range; out-of-range (negative or huge) falls back to 0, which
+// downstream code treats as "unknown".
+func intValue(v any) int {
+	const maxIntAsUint64 = uint64(^uint(0) >> 1)
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case int:
+		return t
+	case int32:
+		return int(t)
+	case int64:
+		if t < 0 || uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint:
+		if uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint32:
+		return int(t)
+	case uint64:
+		if t > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	default:
+		return 0
+	}
+}
+
+// uint32Value mirrors sysinfo's tolerant decoder. Negative values
+// clamp to 0; oversized clamp to [math.MaxUint32].
+func uint32Value(v any) uint32 {
+	const maxUint32 uint64 = 1<<32 - 1
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case uint32:
+		return t
+	case uint:
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case uint64:
+		if t > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case int:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case int32:
+		if t < 0 {
+			return 0
+		}
+		return uint32(t)
+	case int64:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	default:
+		return 0
+	}
+}
+
+// sortByIfIndex sorts rows by ascending IfIndex in-place.
+// Uses an insertion sort because real targets have O(10-1000)
+// interfaces and the simpler implementation reads cleaner than
+// pulling in [sort.Slice] for this hot path.
+func sortByIfIndex(rows []Row) {
+	for i := 1; i < len(rows); i++ {
+		for j := i; j > 0 && rows[j-1].IfIndex > rows[j].IfIndex; j-- {
+			rows[j-1], rows[j] = rows[j], rows[j-1]
+		}
+	}
+}

--- a/internal/polling/snmp/collectors/iftable/iftable_test.go
+++ b/internal/polling/snmp/collectors/iftable/iftable_test.go
@@ -1,0 +1,253 @@
+package iftable_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/iftable"
+)
+
+type fakeClient struct {
+	ifTableVbs  []snmp.Varbind
+	ifXTableVbs []snmp.Varbind
+	walkErr     error
+}
+
+func (f *fakeClient) Get(_ context.Context, _ []string) ([]snmp.Varbind, error) {
+	return nil, errors.New("get not used by iftable")
+}
+
+func (f *fakeClient) Walk(_ context.Context, prefix string) ([]snmp.Varbind, error) {
+	if f.walkErr != nil {
+		return nil, f.walkErr
+	}
+	switch {
+	case strings.HasPrefix(prefix, "1.3.6.1.2.1.2.2.1"):
+		return f.ifTableVbs, nil
+	case strings.HasPrefix(prefix, "1.3.6.1.2.1.31.1.1.1"):
+		return f.ifXTableVbs, nil
+	}
+	return nil, nil
+}
+
+type fakePublisher struct {
+	mu  sync.Mutex
+	got []iftable.Observation
+	err error
+}
+
+func (p *fakePublisher) PublishIfTable(_ context.Context, obs iftable.Observation) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
+	p.got = append(p.got, obs)
+	return nil
+}
+
+func factoryFor(c *fakeClient) snmp.ClientFactory {
+	return func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+		return c, nil
+	}
+}
+
+func at() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+func TestCollector_Name(t *testing.T) {
+	t.Parallel()
+	c := iftable.New(nil, nil, at)
+	if c.Name() != iftable.Name {
+		t.Errorf("Name() = %q, want %q", c.Name(), iftable.Name)
+	}
+}
+
+func TestCollect_BuildsRowsFromIfTableAndIfXTable(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		ifTableVbs: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.2.2.1.2.1", Value: "GigabitEthernet0/0"},
+			{OID: "1.3.6.1.2.1.2.2.1.3.1", Value: uint32(6)},
+			{OID: "1.3.6.1.2.1.2.2.1.5.1", Value: uint32(1_000_000_000)},
+			{OID: "1.3.6.1.2.1.2.2.1.6.1", Value: []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}},
+			{OID: "1.3.6.1.2.1.2.2.1.7.1", Value: 1},
+			{OID: "1.3.6.1.2.1.2.2.1.8.1", Value: 1},
+			{OID: "1.3.6.1.2.1.2.2.1.2.2", Value: "GigabitEthernet0/1"},
+			{OID: "1.3.6.1.2.1.2.2.1.7.2", Value: 2},
+			{OID: "1.3.6.1.2.1.2.2.1.8.2", Value: 2},
+		},
+		ifXTableVbs: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.31.1.1.1.1.1", Value: "Gi0/0"},
+			{OID: "1.3.6.1.2.1.31.1.1.1.18.1", Value: "uplink-to-core"},
+			{OID: "1.3.6.1.2.1.31.1.1.1.1.2", Value: "Gi0/1"},
+		},
+	}
+	pub := &fakePublisher{}
+	c := iftable.New(factoryFor(fc), pub, at)
+
+	target := snmp.Target{ID: "t-1", ClientID: "client-a"}
+	if err := c.Collect(context.Background(), target, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(pub.got) != 1 {
+		t.Fatalf("publisher hits = %d, want 1", len(pub.got))
+	}
+	obs := pub.got[0]
+	if len(obs.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(obs.Rows))
+	}
+	row0 := obs.Rows[0]
+	if row0.IfIndex != 1 || row0.IfDescr != "GigabitEthernet0/0" || row0.IfName != "Gi0/0" {
+		t.Errorf("row0 = %+v", row0)
+	}
+	if row0.IfAlias != "uplink-to-core" {
+		t.Errorf("row0.IfAlias = %q, want uplink-to-core", row0.IfAlias)
+	}
+	if row0.IfPhysAddr != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("row0.IfPhysAddr = %q, want aa:bb:cc:dd:ee:ff", row0.IfPhysAddr)
+	}
+	if row0.IfAdmin != iftable.StatusUp || row0.IfOper != iftable.StatusUp {
+		t.Errorf("row0 status admin/oper = %d/%d, want 1/1", row0.IfAdmin, row0.IfOper)
+	}
+	if row0.SpeedBps != 1_000_000_000 {
+		t.Errorf("row0.SpeedBps = %d, want 1Gbps", row0.SpeedBps)
+	}
+}
+
+func TestCollect_PrefersIfHighSpeedOverIfSpeed(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		ifTableVbs: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.2.2.1.5.1", Value: uint32(4_294_967_295)}, // ifSpeed maxed out
+		},
+		ifXTableVbs: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.31.1.1.1.15.1", Value: uint32(10_000)}, // ifHighSpeed: 10 Gbps
+		},
+	}
+	pub := &fakePublisher{}
+	c := iftable.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	if pub.got[0].Rows[0].SpeedBps != 10_000_000_000 {
+		t.Errorf("SpeedBps = %d, want 10Gbps (from ifHighSpeed)", pub.got[0].Rows[0].SpeedBps)
+	}
+}
+
+func TestCollect_RowsSortedAscendingByIfIndex(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		ifTableVbs: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.2.2.1.2.10", Value: "if-10"},
+			{OID: "1.3.6.1.2.1.2.2.1.2.2", Value: "if-2"},
+			{OID: "1.3.6.1.2.1.2.2.1.2.1", Value: "if-1"},
+		},
+	}
+	pub := &fakePublisher{}
+	c := iftable.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	rows := pub.got[0].Rows
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d, want 3", len(rows))
+	}
+	wantOrder := []uint32{1, 2, 10}
+	for i, want := range wantOrder {
+		if rows[i].IfIndex != want {
+			t.Errorf("rows[%d].IfIndex = %d, want %d", i, rows[i].IfIndex, want)
+		}
+	}
+}
+
+func TestCollect_IfTableWalkErrorPropagates(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{walkErr: errors.New("snmp v3 auth failed")}
+	pub := &fakePublisher{}
+	c := iftable.New(factoryFor(fc), pub, at)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected walk error to propagate")
+	}
+}
+
+func TestCollect_PublishErrorPropagates(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{}
+	pub := &fakePublisher{err: errors.New("topology busy")}
+	c := iftable.New(factoryFor(fc), pub, at)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected publish error to propagate")
+	}
+}
+
+func TestCollect_NilDepsReturnError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		c    *iftable.Collector
+	}{
+		{"nil factory", iftable.New(nil, &fakePublisher{}, at)},
+		{"nil publisher", iftable.New(factoryFor(&fakeClient{}), nil, at)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tt.c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+				t.Errorf("%s: expected error", tt.name)
+			}
+		})
+	}
+}
+
+func TestCollect_FactoryErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := iftable.New(
+		func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+			return nil, errors.New("no credentials")
+		},
+		&fakePublisher{},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected factory error to propagate")
+	}
+}
+
+func TestCollect_NonSixByteMACFallsBackToString(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		ifTableVbs: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.2.2.1.6.1", Value: []byte{0xaa, 0xbb}}, // 2 bytes only
+		},
+	}
+	pub := &fakePublisher{}
+	c := iftable.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	row := pub.got[0].Rows[0]
+	// Should NOT be the canonical 6-byte mac format
+	if strings.Count(row.IfPhysAddr, ":") == 5 {
+		t.Errorf("malformed MAC should NOT format as 6-byte canonical, got %q", row.IfPhysAddr)
+	}
+}
+
+func TestCollect_MalformedOIDsSkipped(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		ifTableVbs: []snmp.Varbind{
+			{OID: "1.3.6.1.2.1.2.2.1.2.1", Value: "good"},
+			{OID: "1.3.6.1.2.1.2.2.1.2.notanindex", Value: "bad"},
+			{OID: "garbage-oid", Value: "discarded"},
+		},
+	}
+	pub := &fakePublisher{}
+	c := iftable.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	if len(pub.got[0].Rows) != 1 || pub.got[0].Rows[0].IfDescr != "good" {
+		t.Errorf("malformed OIDs should be skipped; got rows = %+v", pub.got[0].Rows)
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.3 — second SNMP collector. Walks IF-MIB ifTable + ifXTable,
emits one `Observation` with rows indexed by ifIndex. Used by Stage
A4 topology and the listener pipeline (link-state alerts).

## Changes
- `collectors/iftable.Collector` — walks `1.3.6.1.2.1.2.2.1` + `1.3.6.1.2.1.31.1.1.1`, merges by ifIndex
- `Row.SpeedBps` prefers ifHighSpeed×1e6 over ifSpeed for multi-gigabit links
- `macAddressString` formats 6-byte phys addresses as canonical colon-hex
- Status constants exported (`StatusUp`, `StatusDown`, …) for alert decode
- `iftable.Publisher` — consumer-defined seam (wired Stage A3.5)

## Validation
- `go test ./internal/polling/...` → all green (10 new tests, 28 total)
- `golangci-lint run ./internal/polling/...` → 0 issues

## Test plan
- [x] OID columns merged by ifIndex
- [x] ifHighSpeed preferred over saturated ifSpeed
- [x] Rows sorted ascending
- [x] All error paths covered
- [x] Malformed OIDs skipped (not aborted)
- [x] Non-6-byte phys addresses fall back to raw bytes