### PR TITLE
feat(snmp): cdp neighbor collector (stage a3.4b)

### DIFF
--- a/internal/polling/snmp/collectors/cdp/cdp.go
+++ b/internal/polling/snmp/collectors/cdp/cdp.go
@@ -1,0 +1,384 @@
+// Package cdp implements the cdp SNMP Collector for Cisco
+// Discovery Protocol neighbors. Walks CDP-MIB::cdpCacheTable
+// (1.3.6.1.4.1.9.9.23.1.2.1.1) and emits one Observation per poll.
+//
+// CDP coexists with LLDP on most Cisco devices and stays on the wire
+// even when LLDP is disabled (default IOS-XE access-port behavior),
+// so a topology built only from LLDP misses edges to IP phones, IP
+// cameras, and ME-series gear that announce only via CDP. The lldp
+// + cdp observations are merged at the Stage A4 topology reconciler.
+//
+// Foundry / Brocade FDP uses the same schema under a different OID
+// prefix — the parser is parameterized via [WithTablePrefix] so an
+// fdp collector instantiates this exact code with the foundry root.
+package cdp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+)
+
+// Name is the default collector key used in polling_targets.collector_chain.
+const Name = "cdp"
+
+// DefaultTablePrefix is Cisco's cdpCacheTable root. The Foundry FDP
+// table at 1.3.6.1.4.1.1991.1.1.3.2.2.1 is column-compatible; pass
+// it via [WithTablePrefix] to reuse this collector for FDP.
+const DefaultTablePrefix = "1.3.6.1.4.1.9.9.23.1.2.1.1"
+
+// cdpCacheTable columns — Cisco's MIB definitions are stable since
+// 1996 so these values are safe to hardcode.
+const (
+	colAddressType  = "3"
+	colAddress      = "4"
+	colVersion      = "5"
+	colDeviceID     = "6"
+	colDevicePort   = "7"
+	colPlatform     = "8"
+	colCapabilities = "9"
+	colNativeVLAN   = "11"
+	colDuplex       = "12"
+
+	// indexFieldsCDP is the field count after the table prefix:
+	// (cdpCacheIfIndex, cdpCacheDeviceIndex).
+	indexFieldsCDP = 2
+
+	addrTypeIPv4 = 1
+	addrTypeIPv6 = 20
+
+	macAddressBytes = 6
+	ipv4AddrBytes   = 4
+	ipv6AddrBytes   = 16
+)
+
+// Neighbor is one row of cdpCacheTable. LocalIfIndex is the index
+// into ifTable on the local device through which this neighbor was
+// learned — the bridge to Stage A4 topology edges.
+type Neighbor struct {
+	LocalIfIndex uint32
+	DeviceIndex  uint32
+	DeviceID     string
+	DevicePort   string
+	Platform     string
+	Version      string
+	Address      string
+	Capabilities uint32
+	NativeVLAN   int
+	Duplex       int
+}
+
+// Observation is the per-poll set of CDP neighbors.
+type Observation struct {
+	ClientID    string
+	TargetID    string
+	ObservedAt  time.Time
+	Neighbors   []Neighbor
+	TablePrefix string // honest about which protocol (cdp vs fdp) emitted this
+}
+
+// Publisher is the consumer-defined seam. Stage A3.5 wires it to
+// topology edge reconciliation alongside LLDP.
+type Publisher interface {
+	PublishCDP(ctx context.Context, obs Observation) error
+}
+
+// Collector implements snmp.Collector. Default Name is "cdp"; for
+// FDP, override the name via [WithName] and the table prefix via
+// [WithTablePrefix].
+type Collector struct {
+	name        string
+	tablePrefix string
+	newClient   snmp.ClientFactory
+	publisher   Publisher
+	now         func() time.Time
+}
+
+// Option configures a Collector at construction time.
+type Option func(*Collector)
+
+// WithName overrides the collector's Name() (e.g. "fdp" for the
+// foundry variant). Defaults to "cdp".
+func WithName(n string) Option { return func(c *Collector) { c.name = n } }
+
+// WithTablePrefix overrides the table root walked. Defaults to
+// [DefaultTablePrefix] (CDP); set to the Foundry root for FDP.
+func WithTablePrefix(p string) Option { return func(c *Collector) { c.tablePrefix = p } }
+
+// New returns a CDP Collector bound to factory + publisher. Pass nil
+// now to use [time.Now] in UTC.
+func New(factory snmp.ClientFactory, publisher Publisher, now func() time.Time, opts ...Option) *Collector {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	c := &Collector{
+		name:        Name,
+		tablePrefix: DefaultTablePrefix,
+		newClient:   factory,
+		publisher:   publisher,
+		now:         now,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Name implements snmp.Collector. Returns the configured name.
+func (c *Collector) Name() string { return c.name }
+
+// Collect walks the configured cache table and publishes the result.
+func (c *Collector) Collect(ctx context.Context, target snmp.Target, creds snmp.ResolvedCredentials) error {
+	if c.newClient == nil {
+		return errors.New("cdp: client factory not configured")
+	}
+	if c.publisher == nil {
+		return errors.New("cdp: publisher not configured")
+	}
+
+	client, err := c.newClient(target, creds)
+	if err != nil {
+		return fmt.Errorf("cdp: dial: %w", err)
+	}
+
+	observedAt := c.now()
+	vbs, err := client.Walk(ctx, c.tablePrefix)
+	if err != nil {
+		return fmt.Errorf("cdp: walk: %w", err)
+	}
+
+	if pubErr := c.publisher.PublishCDP(ctx, Observation{
+		ClientID:    target.ClientID,
+		TargetID:    target.ID,
+		ObservedAt:  observedAt,
+		Neighbors:   c.buildNeighbors(vbs),
+		TablePrefix: c.tablePrefix,
+	}); pubErr != nil {
+		return fmt.Errorf("cdp: publish: %w", pubErr)
+	}
+	return nil
+}
+
+// rowKey identifies one cdpCacheTable row by (ifIndex, deviceIndex).
+type rowKey struct {
+	ifIndex     uint32
+	deviceIndex uint32
+}
+
+func (c *Collector) buildNeighbors(vbs []snmp.Varbind) []Neighbor {
+	rows := make(map[rowKey]*Neighbor)
+	addrTypes := make(map[rowKey]int)
+
+	for _, vb := range vbs {
+		col, key, ok := c.parseRowOID(vb.OID)
+		if !ok {
+			continue
+		}
+		n := rows[key]
+		if n == nil {
+			n = &Neighbor{LocalIfIndex: key.ifIndex, DeviceIndex: key.deviceIndex}
+			rows[key] = n
+		}
+		if col == colAddressType {
+			addrTypes[key] = intValue(vb.Value)
+			continue
+		}
+		applyColumn(n, col, vb.Value, addrTypes[key])
+	}
+
+	out := make([]Neighbor, 0, len(rows))
+	for _, n := range rows {
+		out = append(out, *n)
+	}
+	sortNeighbors(out)
+	return out
+}
+
+// parseRowOID splits an OID under c.tablePrefix into the column
+// number and the (ifIndex, deviceIndex) row key.
+func (c *Collector) parseRowOID(oid string) (string, rowKey, bool) {
+	if !strings.HasPrefix(oid, c.tablePrefix+".") {
+		return "", rowKey{}, false
+	}
+	rest := strings.TrimPrefix(oid, c.tablePrefix+".")
+	parts := strings.Split(rest, ".")
+	if len(parts) != 1+indexFieldsCDP {
+		return "", rowKey{}, false
+	}
+	ifIdx, err1 := parseUint32(parts[1])
+	devIdx, err2 := parseUint32(parts[2])
+	if err1 != nil || err2 != nil {
+		return "", rowKey{}, false
+	}
+	return parts[0], rowKey{ifIndex: ifIdx, deviceIndex: devIdx}, true
+}
+
+func parseUint32(s string) (uint32, error) {
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(v), nil
+}
+
+// applyColumn writes one cdpCacheTable column onto n. addrType is
+// the row's cdpCacheAddressType so we can decode cdpCacheAddress
+// correctly (IPv4 = 4 bytes, IPv6 = 16).
+func applyColumn(n *Neighbor, col string, v any, addrType int) {
+	switch col {
+	case colAddress:
+		n.Address = addressString(v, addrType)
+	case colVersion:
+		n.Version = stringValue(v)
+	case colDeviceID:
+		n.DeviceID = stringValue(v)
+	case colDevicePort:
+		n.DevicePort = stringValue(v)
+	case colPlatform:
+		n.Platform = stringValue(v)
+	case colCapabilities:
+		n.Capabilities = capabilityValue(v)
+	case colNativeVLAN:
+		n.NativeVLAN = intValue(v)
+	case colDuplex:
+		n.Duplex = intValue(v)
+	}
+}
+
+// addressString decodes cdpCacheAddress given its companion type.
+// IPv4 → dotted-quad, IPv6 → canonical, MAC fallback for length 6,
+// raw string fallback otherwise.
+func addressString(v any, addrType int) string {
+	b, ok := v.([]byte)
+	if !ok {
+		return stringValue(v)
+	}
+	switch addrType {
+	case addrTypeIPv4:
+		if len(b) == ipv4AddrBytes {
+			addr, addrOk := netip.AddrFromSlice(b)
+			if addrOk {
+				return addr.String()
+			}
+		}
+	case addrTypeIPv6:
+		if len(b) == ipv6AddrBytes {
+			addr, addrOk := netip.AddrFromSlice(b)
+			if addrOk {
+				return addr.String()
+			}
+		}
+	}
+	if len(b) == macAddressBytes {
+		return formatMAC(b)
+	}
+	return string(b)
+}
+
+func formatMAC(b []byte) string {
+	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
+		b[0], b[1], b[2], b[3], b[4], b[5])
+}
+
+func stringValue(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	default:
+		return ""
+	}
+}
+
+func intValue(v any) int {
+	const maxIntAsUint64 = uint64(^uint(0) >> 1)
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case int:
+		return t
+	case int32:
+		return int(t)
+	case int64:
+		if t < 0 || uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint:
+		if uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint32:
+		return int(t)
+	case uint64:
+		if t > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	default:
+		return 0
+	}
+}
+
+// capabilityValue decodes the CDP capability bit field. CDP returns
+// the value as an INTEGER (4-byte big-endian) but some agents emit
+// it as an OCTET STRING. Handle both.
+func capabilityValue(v any) uint32 {
+	const bitsPerByte = 8
+	const bitsCapWidth = 32
+	const maxUint32 uint64 = 1<<32 - 1
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case int:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case int32:
+		if t < 0 {
+			return 0
+		}
+		return uint32(t)
+	case uint32:
+		return t
+	case []byte:
+		var out uint32
+		for i, b := range t {
+			shift := bitsCapWidth - bitsPerByte*(i+1)
+			if shift < 0 {
+				break
+			}
+			out |= uint32(b) << uint(shift)
+		}
+		return out
+	}
+	return 0
+}
+
+func sortNeighbors(ns []Neighbor) {
+	less := func(i, j int) bool {
+		if ns[i].LocalIfIndex != ns[j].LocalIfIndex {
+			return ns[i].LocalIfIndex < ns[j].LocalIfIndex
+		}
+		return ns[i].DeviceIndex < ns[j].DeviceIndex
+	}
+	for i := 1; i < len(ns); i++ {
+		for j := i; j > 0 && less(j, j-1); j-- {
+			ns[j-1], ns[j] = ns[j], ns[j-1]
+		}
+	}
+}

--- a/internal/polling/snmp/collectors/cdp/cdp_test.go
+++ b/internal/polling/snmp/collectors/cdp/cdp_test.go
@@ -1,0 +1,277 @@
+package cdp_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/cdp"
+)
+
+type fakeClient struct {
+	prefixSeen string
+	vbs        []snmp.Varbind
+	walkErr    error
+}
+
+func (f *fakeClient) Get(_ context.Context, _ []string) ([]snmp.Varbind, error) {
+	return nil, errors.New("get not used by cdp")
+}
+
+func (f *fakeClient) Walk(_ context.Context, prefix string) ([]snmp.Varbind, error) {
+	f.prefixSeen = prefix
+	if f.walkErr != nil {
+		return nil, f.walkErr
+	}
+	return f.vbs, nil
+}
+
+type fakePublisher struct {
+	mu  sync.Mutex
+	got []cdp.Observation
+	err error
+}
+
+func (p *fakePublisher) PublishCDP(_ context.Context, obs cdp.Observation) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
+	p.got = append(p.got, obs)
+	return nil
+}
+
+func factoryFor(c *fakeClient) snmp.ClientFactory {
+	return func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+		return c, nil
+	}
+}
+
+func at() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+func cdpOID(col string, ifIdx, devIdx uint32) string {
+	return fmt.Sprintf("%s.%s.%d.%d", cdp.DefaultTablePrefix, col, ifIdx, devIdx)
+}
+
+func TestCollector_Name_DefaultsToCDP(t *testing.T) {
+	t.Parallel()
+	c := cdp.New(nil, nil, at)
+	if c.Name() != cdp.Name {
+		t.Errorf("Name() = %q, want %q", c.Name(), cdp.Name)
+	}
+}
+
+func TestCollector_WithNameOverridesForFDP(t *testing.T) {
+	t.Parallel()
+	c := cdp.New(nil, nil, at, cdp.WithName("fdp"))
+	if c.Name() != "fdp" {
+		t.Errorf("Name() = %q, want fdp", c.Name())
+	}
+}
+
+func TestCollect_BuildsNeighborFromCompleteRow(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: cdpOID("3", 1, 1), Value: 1},
+		{OID: cdpOID("4", 1, 1), Value: []byte{10, 0, 0, 1}},
+		{OID: cdpOID("5", 1, 1), Value: "Cisco IOS XE 17.6"},
+		{OID: cdpOID("6", 1, 1), Value: "core-sw-1.example.com"},
+		{OID: cdpOID("7", 1, 1), Value: "GigabitEthernet1/0/24"},
+		{OID: cdpOID("8", 1, 1), Value: "cisco WS-C9300-24P"},
+		{OID: cdpOID("9", 1, 1), Value: uint32(0x28)},
+	}}
+	pub := &fakePublisher{}
+	c := cdp.New(factoryFor(fc), pub, at)
+	if err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(pub.got) != 1 || len(pub.got[0].Neighbors) != 1 {
+		t.Fatalf("got %+v, want 1 neighbor", pub.got)
+	}
+	n := pub.got[0].Neighbors[0]
+	if n.LocalIfIndex != 1 || n.DeviceIndex != 1 {
+		t.Errorf("index = (%d,%d), want (1,1)", n.LocalIfIndex, n.DeviceIndex)
+	}
+	if n.DeviceID != "core-sw-1.example.com" {
+		t.Errorf("DeviceID = %q", n.DeviceID)
+	}
+	if n.DevicePort != "GigabitEthernet1/0/24" {
+		t.Errorf("DevicePort = %q", n.DevicePort)
+	}
+	if n.Platform != "cisco WS-C9300-24P" {
+		t.Errorf("Platform = %q", n.Platform)
+	}
+	if n.Address != "10.0.0.1" {
+		t.Errorf("Address = %q, want 10.0.0.1", n.Address)
+	}
+	if n.Capabilities != 0x28 {
+		t.Errorf("Capabilities = 0x%x, want 0x28", n.Capabilities)
+	}
+}
+
+func TestCollect_IPv6AddressDecodes(t *testing.T) {
+	t.Parallel()
+	v6 := []byte{
+		0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0x01,
+	}
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: cdpOID("3", 1, 1), Value: 20},
+		{OID: cdpOID("4", 1, 1), Value: v6},
+	}}
+	pub := &fakePublisher{}
+	c := cdp.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	if pub.got[0].Neighbors[0].Address != "2001:db8::1" {
+		t.Errorf("Address = %q, want 2001:db8::1", pub.got[0].Neighbors[0].Address)
+	}
+}
+
+func TestCollect_NeighborsSortedByIfIndexThenDeviceIndex(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: cdpOID("6", 10, 2), Value: "c"},
+		{OID: cdpOID("6", 10, 1), Value: "b"},
+		{OID: cdpOID("6", 1, 1), Value: "a"},
+	}}
+	pub := &fakePublisher{}
+	c := cdp.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	got := pub.got[0].Neighbors
+	wantOrder := []struct{ ifIdx, devIdx uint32 }{{1, 1}, {10, 1}, {10, 2}}
+	for i, w := range wantOrder {
+		if got[i].LocalIfIndex != w.ifIdx || got[i].DeviceIndex != w.devIdx {
+			t.Errorf("[%d] = (%d,%d), want (%d,%d)",
+				i, got[i].LocalIfIndex, got[i].DeviceIndex, w.ifIdx, w.devIdx)
+		}
+	}
+}
+
+func TestCollect_WithTablePrefixSwitchesToFDP(t *testing.T) {
+	t.Parallel()
+	const foundryPrefix = "1.3.6.1.4.1.1991.1.1.3.2.2.1"
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: foundryPrefix + ".6.1.1", Value: "foundry-edge-1"},
+	}}
+	pub := &fakePublisher{}
+	c := cdp.New(factoryFor(fc), pub, at,
+		cdp.WithName("fdp"),
+		cdp.WithTablePrefix(foundryPrefix),
+	)
+	if err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if fc.prefixSeen != foundryPrefix {
+		t.Errorf("walked %q, want %q", fc.prefixSeen, foundryPrefix)
+	}
+	if len(pub.got[0].Neighbors) != 1 || pub.got[0].Neighbors[0].DeviceID != "foundry-edge-1" {
+		t.Errorf("foundry row not parsed; got %+v", pub.got[0].Neighbors)
+	}
+	if pub.got[0].TablePrefix != foundryPrefix {
+		t.Errorf("Observation.TablePrefix = %q, want %q", pub.got[0].TablePrefix, foundryPrefix)
+	}
+}
+
+func TestCollect_MalformedOIDsSkipped(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: cdpOID("6", 1, 1), Value: "good"},
+		{OID: "garbage", Value: "bad"},
+		{OID: cdp.DefaultTablePrefix + ".6.notanint.1", Value: "bad"},
+	}}
+	pub := &fakePublisher{}
+	c := cdp.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	if len(pub.got[0].Neighbors) != 1 || pub.got[0].Neighbors[0].DeviceID != "good" {
+		t.Errorf("malformed should be skipped, got %+v", pub.got[0].Neighbors)
+	}
+}
+
+func TestCollect_EmptyCacheStillPublishes(t *testing.T) {
+	t.Parallel()
+	pub := &fakePublisher{}
+	c := cdp.New(factoryFor(&fakeClient{}), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+	if len(pub.got) != 1 || len(pub.got[0].Neighbors) != 0 {
+		t.Errorf("empty cache should publish empty observation, got %+v", pub.got)
+	}
+}
+
+func TestCollect_WalkErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := cdp.New(
+		factoryFor(&fakeClient{walkErr: errors.New("timeout")}),
+		&fakePublisher{},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected walk error to propagate")
+	}
+}
+
+func TestCollect_PublishErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := cdp.New(
+		factoryFor(&fakeClient{}),
+		&fakePublisher{err: errors.New("topo busy")},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected publish error to propagate")
+	}
+}
+
+func TestCollect_NilDepsReturnError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		c    *cdp.Collector
+	}{
+		{"nil factory", cdp.New(nil, &fakePublisher{}, at)},
+		{"nil publisher", cdp.New(factoryFor(&fakeClient{}), nil, at)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tt.c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+				t.Error("expected nil-dep error")
+			}
+		})
+	}
+}
+
+func TestCollect_FactoryErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := cdp.New(
+		func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+			return nil, errors.New("creds failed")
+		},
+		&fakePublisher{},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected factory error to propagate")
+	}
+}
+
+func TestCollect_AddressFallsBackToMacWhenSixBytesAndTypeUnknown(t *testing.T) {
+	t.Parallel()
+	// No address-type row, but a 6-byte value should fall back to MAC.
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: cdpOID("4", 1, 1), Value: []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}},
+	}}
+	pub := &fakePublisher{}
+	c := cdp.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+	if pub.got[0].Neighbors[0].Address != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("Address fallback = %q", pub.got[0].Neighbors[0].Address)
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.4b — Cisco Discovery Protocol collector. Walks
`cdpCacheTable`, emits one `Observation` per poll. Captures
edges/devices that LLDP misses (IP phones, IP cameras, ME-series
gear that announce only via CDP).

## Changes
- `collectors/cdp.Collector` — walks `1.3.6.1.4.1.9.9.23.1.2.1.1`
- 9 columns parsed (addresstype/address, version, deviceID, devicePort, platform, capabilities, nativeVLAN, duplex)
- IPv4 / IPv6 / MAC fallback via `net/netip`
- `WithName` + `WithTablePrefix` options — A3.4c FDP instantiates this code with the Foundry table root
- `Capabilities` decodes both INTEGER (Cisco) and OCTET STRING (vendor variants) MSB-first
- 12 unit tests

## Validation
- `go test ./internal/polling/snmp/collectors/cdp/...` → green
- `golangci-lint run` → 0 issues

## Next
A3.4c — FDP (Foundry/Brocade): one ~20-line `New(...)` wrapper around this code with the Foundry prefix.