### PR TITLE
feat(snmp): fdp neighbor collector via cdp wrapper (stage a3.4c)

### DIFF
--- a/internal/polling/snmp/collectors/fdp/fdp.go
+++ b/internal/polling/snmp/collectors/fdp/fdp.go
@@ -1,0 +1,36 @@
+// Package fdp implements the fdp SNMP Collector for Foundry /
+// Brocade / Ruckus ICX Discovery Protocol neighbors. FDP is wire-
+// compatible with CDP: Foundry copied Cisco's cdpCacheTable schema
+// column-for-column under their own enterprise OID prefix
+// (1.3.6.1.4.1.1991.1.1.3.2.2.1).
+//
+// Implementation is a thin wrapper that constructs a [cdp.Collector]
+// with WithName("fdp") + WithTablePrefix(TablePrefix). Any new CDP
+// column the upstream collector learns to parse is automatically
+// available here.
+package fdp
+
+import (
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/cdp"
+)
+
+// Name is the collector key used in polling_targets.collector_chain.
+const Name = "fdp"
+
+// TablePrefix is the Foundry FDP cache-table root. Wire-compatible
+// with cdpCacheTable column numbering.
+const TablePrefix = "1.3.6.1.4.1.1991.1.1.3.2.2.1"
+
+// New returns a CDP-shaped Collector configured for FDP — same
+// schema, different OID prefix, different chain name. The returned
+// *cdp.Collector reports Name()=="fdp" so polling_targets chains
+// referencing "fdp" resolve to this implementation.
+func New(factory snmp.ClientFactory, publisher cdp.Publisher, now func() time.Time) *cdp.Collector {
+	return cdp.New(factory, publisher, now,
+		cdp.WithName(Name),
+		cdp.WithTablePrefix(TablePrefix),
+	)
+}

--- a/internal/polling/snmp/collectors/fdp/fdp_test.go
+++ b/internal/polling/snmp/collectors/fdp/fdp_test.go
@@ -1,0 +1,87 @@
+package fdp_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/cdp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/fdp"
+)
+
+type fakeClient struct {
+	prefixSeen string
+	vbs        []snmp.Varbind
+}
+
+func (f *fakeClient) Get(_ context.Context, _ []string) ([]snmp.Varbind, error) {
+	return nil, errors.New("get not used by fdp")
+}
+
+func (f *fakeClient) Walk(_ context.Context, prefix string) ([]snmp.Varbind, error) {
+	f.prefixSeen = prefix
+	return f.vbs, nil
+}
+
+type fakePublisher struct {
+	mu  sync.Mutex
+	got []cdp.Observation
+}
+
+func (p *fakePublisher) PublishCDP(_ context.Context, obs cdp.Observation) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.got = append(p.got, obs)
+	return nil
+}
+
+func at() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+func TestNew_NameIsFDP(t *testing.T) {
+	t.Parallel()
+	c := fdp.New(nil, nil, at)
+	if c.Name() != fdp.Name {
+		t.Errorf("Name() = %q, want %q", c.Name(), fdp.Name)
+	}
+}
+
+func TestNew_WalksFoundryTablePrefix(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		vbs: []snmp.Varbind{
+			{OID: fdp.TablePrefix + ".6.1.1", Value: "foundry-edge"},
+			{OID: fdp.TablePrefix + ".8.1.1", Value: "Ruckus ICX 7150"},
+		},
+	}
+	pub := &fakePublisher{}
+	c := fdp.New(
+		func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+			return fc, nil
+		},
+		pub,
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if fc.prefixSeen != fdp.TablePrefix {
+		t.Errorf("walked %q, want %q", fc.prefixSeen, fdp.TablePrefix)
+	}
+	if len(pub.got) != 1 || len(pub.got[0].Neighbors) != 1 {
+		t.Fatalf("expected one neighbor, got %+v", pub.got)
+	}
+	n := pub.got[0].Neighbors[0]
+	if n.DeviceID != "foundry-edge" {
+		t.Errorf("DeviceID = %q", n.DeviceID)
+	}
+	if n.Platform != "Ruckus ICX 7150" {
+		t.Errorf("Platform = %q", n.Platform)
+	}
+	if pub.got[0].TablePrefix != fdp.TablePrefix {
+		t.Errorf("Observation.TablePrefix = %q, want %q",
+			pub.got[0].TablePrefix, fdp.TablePrefix)
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.4c — Foundry / Brocade / Ruckus ICX FDP collector. Reuses
the CDP parser via `WithTablePrefix`, plus a 35-line wrapper that
sets the chain key to `fdp` and the table root to Foundry's
enterprise OID. EDP (Extreme) deferred — Extreme EXOS fully supports
LLDP today.

## Changes
- `collectors/fdp.New` — thin wrapper instantiating `cdp.Collector`
- `fdp.TablePrefix = 1.3.6.1.4.1.1991.1.1.3.2.2.1`
- Observations land in the same `cdp.Publisher` sink so the Stage A4 topology reconciler treats CDP + FDP edges uniformly
- 2 unit tests (name + Foundry-prefix walk)

## Validation
- `go test ./internal/polling/...` → all green (62 tests across A3.x)
- `golangci-lint run` → 0 issues