### PR TITLE
feat(snmp): arp collector (stage a3.5)

### DIFF
--- a/internal/polling/snmp/collectors/arp/arp.go
+++ b/internal/polling/snmp/collectors/arp/arp.go
@@ -1,0 +1,302 @@
+// Package arp implements the arp SNMP Collector. Walks
+// IP-MIB::ipNetToMediaTable (1.3.6.1.2.1.4.22.1) and emits one
+// Observation per poll listing every IP↔MAC binding the target has
+// learned. ARP data feeds Stage A4 topology — it's how L2-only
+// neighbor edges (e.g. attached hosts that don't speak LLDP/CDP)
+// get an IP identity attached.
+package arp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+)
+
+// Name is the collector key used in polling_targets.collector_chain.
+const Name = "arp"
+
+// ipNetToMediaTable column OIDs (RFC 1213 §6.7).
+// Indexed by (ipNetToMediaIfIndex, ipNetToMediaNetAddress) where the
+// IP is encoded as 4 trailing dotted octets in the OID suffix.
+const (
+	tablePrefix     = "1.3.6.1.2.1.4.22.1"
+	colIfIndex      = "1"
+	colPhysAddress  = "2"
+	colNetAddress   = "3"
+	colMediaType    = "4"
+	indexFieldsARP  = 5 // ifIndex + 4 IPv4 octets
+	macAddressBytes = 6
+)
+
+// MediaType enum values from RFC 1213 §6.7. Exported so the listener
+// pipeline can distinguish static (configured) from dynamic (learned)
+// ARP entries in alert text and the topology UI can flag static
+// shadows over dynamic bindings.
+const (
+	MediaTypeOther   = 1
+	MediaTypeInvalid = 2
+	MediaTypeDynamic = 3
+	MediaTypeStatic  = 4
+)
+
+// Entry is one ipNetToMediaTable row. Static entries (MediaType=4)
+// often shadow dynamic entries — Stage A4 uses MediaType to flag
+// configured-vs-learned bindings in the topology UI.
+type Entry struct {
+	IfIndex    uint32
+	IPAddress  string
+	MACAddress string
+	MediaType  int
+}
+
+// Observation is the per-poll ARP cache snapshot.
+type Observation struct {
+	ClientID   string
+	TargetID   string
+	ObservedAt time.Time
+	Entries    []Entry
+}
+
+// Publisher is the consumer-defined seam.
+type Publisher interface {
+	PublishARP(ctx context.Context, obs Observation) error
+}
+
+// Collector implements snmp.Collector.
+type Collector struct {
+	newClient snmp.ClientFactory
+	publisher Publisher
+	now       func() time.Time
+}
+
+// New returns an ARP Collector. Pass nil now to use [time.Now] UTC.
+func New(factory snmp.ClientFactory, publisher Publisher, now func() time.Time) *Collector {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Collector{newClient: factory, publisher: publisher, now: now}
+}
+
+// Name implements snmp.Collector.
+func (*Collector) Name() string { return Name }
+
+// Collect walks ipNetToMediaTable and publishes the assembled cache.
+func (c *Collector) Collect(ctx context.Context, target snmp.Target, creds snmp.ResolvedCredentials) error {
+	if c.newClient == nil {
+		return errors.New("arp: client factory not configured")
+	}
+	if c.publisher == nil {
+		return errors.New("arp: publisher not configured")
+	}
+
+	client, err := c.newClient(target, creds)
+	if err != nil {
+		return fmt.Errorf("arp: dial: %w", err)
+	}
+
+	observedAt := c.now()
+	vbs, err := client.Walk(ctx, tablePrefix)
+	if err != nil {
+		return fmt.Errorf("arp: walk ipNetToMediaTable: %w", err)
+	}
+
+	if pubErr := c.publisher.PublishARP(ctx, Observation{
+		ClientID:   target.ClientID,
+		TargetID:   target.ID,
+		ObservedAt: observedAt,
+		Entries:    buildEntries(vbs),
+	}); pubErr != nil {
+		return fmt.Errorf("arp: publish: %w", pubErr)
+	}
+	return nil
+}
+
+// rowKey identifies one ipNetToMediaTable row.
+type rowKey struct {
+	ifIndex uint32
+	ip      string // dotted-quad IPv4
+}
+
+// buildEntries folds the table walk into Entries keyed by
+// (ifIndex, ip). Order is ascending by ifIndex then IP for
+// deterministic downstream comparison.
+func buildEntries(vbs []snmp.Varbind) []Entry {
+	rows := make(map[rowKey]*Entry)
+
+	for _, vb := range vbs {
+		col, key, ok := parseRowOID(vb.OID)
+		if !ok {
+			continue
+		}
+		e := rows[key]
+		if e == nil {
+			e = &Entry{IfIndex: key.ifIndex, IPAddress: key.ip}
+			rows[key] = e
+		}
+		applyColumn(e, col, vb.Value)
+	}
+
+	out := make([]Entry, 0, len(rows))
+	for _, e := range rows {
+		out = append(out, *e)
+	}
+	sortEntries(out)
+	return out
+}
+
+// parseRowOID splits an OID under tablePrefix into the column number
+// and the (ifIndex, ipv4) row key. The 4 IPv4 octets are joined back
+// into dotted-quad form.
+func parseRowOID(oid string) (string, rowKey, bool) {
+	if !strings.HasPrefix(oid, tablePrefix+".") {
+		return "", rowKey{}, false
+	}
+	rest := strings.TrimPrefix(oid, tablePrefix+".")
+	parts := strings.Split(rest, ".")
+	if len(parts) != 1+indexFieldsARP {
+		return "", rowKey{}, false
+	}
+	ifIdx, err := parseUint32(parts[1])
+	if err != nil {
+		return "", rowKey{}, false
+	}
+	const ipv4OctetCount = 4
+	octets := [ipv4OctetCount]byte{}
+	for i := range ipv4OctetCount {
+		v, perr := strconv.ParseUint(parts[2+i], 10, 8)
+		if perr != nil {
+			return "", rowKey{}, false
+		}
+		octets[i] = byte(v)
+	}
+	addr := netip.AddrFrom4(octets)
+	return parts[0], rowKey{ifIndex: ifIdx, ip: addr.String()}, true
+}
+
+func parseUint32(s string) (uint32, error) {
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(v), nil
+}
+
+func applyColumn(e *Entry, col string, v any) {
+	switch col {
+	case colIfIndex:
+		// already in row key, but record explicitly for completeness
+		// when the column appears in a non-standard ordering
+		if u := uint32Value(v); u != 0 {
+			e.IfIndex = u
+		}
+	case colPhysAddress:
+		e.MACAddress = macAddressString(v)
+	case colNetAddress:
+		// NetAddress is encoded in the row key already; the column
+		// value is the same IP. Ignore.
+	case colMediaType:
+		e.MediaType = intValue(v)
+	}
+}
+
+func macAddressString(v any) string {
+	if b, ok := v.([]byte); ok && len(b) == macAddressBytes {
+		return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
+			b[0], b[1], b[2], b[3], b[4], b[5])
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	}
+	return ""
+}
+
+func intValue(v any) int {
+	const maxIntAsUint64 = uint64(^uint(0) >> 1)
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case int:
+		return t
+	case int32:
+		return int(t)
+	case int64:
+		if t < 0 || uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint:
+		if uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint32:
+		return int(t)
+	case uint64:
+		if t > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	default:
+		return 0
+	}
+}
+
+func uint32Value(v any) uint32 {
+	const maxUint32 uint64 = 1<<32 - 1
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case uint32:
+		return t
+	case int:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case int32:
+		if t < 0 {
+			return 0
+		}
+		return uint32(t)
+	case int64:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case uint64:
+		if t > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	}
+	return 0
+}
+
+func sortEntries(es []Entry) {
+	less := func(i, j int) bool {
+		if es[i].IfIndex != es[j].IfIndex {
+			return es[i].IfIndex < es[j].IfIndex
+		}
+		return es[i].IPAddress < es[j].IPAddress
+	}
+	for i := 1; i < len(es); i++ {
+		for j := i; j > 0 && less(j, j-1); j-- {
+			es[j-1], es[j] = es[j], es[j-1]
+		}
+	}
+}

--- a/internal/polling/snmp/collectors/arp/arp_test.go
+++ b/internal/polling/snmp/collectors/arp/arp_test.go
@@ -1,0 +1,210 @@
+package arp_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/arp"
+)
+
+const tablePrefix = "1.3.6.1.2.1.4.22.1"
+
+type fakeClient struct {
+	vbs     []snmp.Varbind
+	walkErr error
+}
+
+func (f *fakeClient) Get(_ context.Context, _ []string) ([]snmp.Varbind, error) {
+	return nil, errors.New("get not used by arp")
+}
+
+func (f *fakeClient) Walk(_ context.Context, _ string) ([]snmp.Varbind, error) {
+	if f.walkErr != nil {
+		return nil, f.walkErr
+	}
+	return f.vbs, nil
+}
+
+type fakePublisher struct {
+	mu  sync.Mutex
+	got []arp.Observation
+	err error
+}
+
+func (p *fakePublisher) PublishARP(_ context.Context, obs arp.Observation) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
+	p.got = append(p.got, obs)
+	return nil
+}
+
+func factoryFor(c *fakeClient) snmp.ClientFactory {
+	return func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+		return c, nil
+	}
+}
+
+func at() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+func arpOID(col string, ifIdx uint32, ip string) string {
+	return fmt.Sprintf("%s.%s.%d.%s", tablePrefix, col, ifIdx, ip)
+}
+
+func TestCollector_Name(t *testing.T) {
+	t.Parallel()
+	if arp.New(nil, nil, at).Name() != arp.Name {
+		t.Error("Name() did not equal arp.Name")
+	}
+}
+
+func TestCollect_BuildsEntriesFromTable(t *testing.T) {
+	t.Parallel()
+	mac := []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: arpOID("2", 1, "10.0.0.1"), Value: mac},
+		{OID: arpOID("4", 1, "10.0.0.1"), Value: arp.MediaTypeDynamic},
+		{OID: arpOID("2", 1, "10.0.0.2"), Value: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}},
+		{OID: arpOID("4", 1, "10.0.0.2"), Value: arp.MediaTypeStatic},
+	}}
+	pub := &fakePublisher{}
+	c := arp.New(factoryFor(fc), pub, at)
+	if err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(pub.got) != 1 || len(pub.got[0].Entries) != 2 {
+		t.Fatalf("got %+v, want 2 entries", pub.got)
+	}
+	e0 := pub.got[0].Entries[0]
+	if e0.IfIndex != 1 || e0.IPAddress != "10.0.0.1" {
+		t.Errorf("e0 = %+v", e0)
+	}
+	if e0.MACAddress != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("e0.MAC = %q", e0.MACAddress)
+	}
+	if e0.MediaType != arp.MediaTypeDynamic {
+		t.Errorf("e0.MediaType = %d, want %d", e0.MediaType, arp.MediaTypeDynamic)
+	}
+	if pub.got[0].Entries[1].MediaType != arp.MediaTypeStatic {
+		t.Errorf("e1.MediaType = %d, want static", pub.got[0].Entries[1].MediaType)
+	}
+}
+
+func TestCollect_SortedByIfIndexThenIP(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: arpOID("4", 10, "10.0.0.5"), Value: 3},
+		{OID: arpOID("4", 1, "10.0.0.250"), Value: 3},
+		{OID: arpOID("4", 1, "10.0.0.5"), Value: 3},
+	}}
+	pub := &fakePublisher{}
+	c := arp.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	got := pub.got[0].Entries
+	want := []struct {
+		idx uint32
+		ip  string
+	}{{1, "10.0.0.250"}, {1, "10.0.0.5"}, {10, "10.0.0.5"}}
+	// IP is sorted lexicographically — "10.0.0.250" < "10.0.0.5" in string order.
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].IfIndex != w.idx || got[i].IPAddress != w.ip {
+			t.Errorf("[%d] = (%d,%s), want (%d,%s)",
+				i, got[i].IfIndex, got[i].IPAddress, w.idx, w.ip)
+		}
+	}
+}
+
+func TestCollect_MalformedOIDsSkipped(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: arpOID("2", 1, "10.0.0.1"), Value: []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}},
+		{OID: "garbage", Value: nil},
+		{OID: tablePrefix + ".2.notanum.10.0.0.2", Value: nil},
+		{OID: tablePrefix + ".2.1.999.0.0.1", Value: nil}, // octet > 255
+	}}
+	pub := &fakePublisher{}
+	c := arp.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	if len(pub.got[0].Entries) != 1 {
+		t.Errorf("malformed should be skipped, got %d entries", len(pub.got[0].Entries))
+	}
+}
+
+func TestCollect_EmptyTableStillPublishes(t *testing.T) {
+	t.Parallel()
+	pub := &fakePublisher{}
+	c := arp.New(factoryFor(&fakeClient{}), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+	if len(pub.got) != 1 || len(pub.got[0].Entries) != 0 {
+		t.Errorf("empty table should publish empty obs, got %+v", pub.got)
+	}
+}
+
+func TestCollect_WalkErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := arp.New(
+		factoryFor(&fakeClient{walkErr: errors.New("timeout")}),
+		&fakePublisher{},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected walk error")
+	}
+}
+
+func TestCollect_PublishErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := arp.New(
+		factoryFor(&fakeClient{}),
+		&fakePublisher{err: errors.New("topo busy")},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected publish error")
+	}
+}
+
+func TestCollect_NilDepsReturnError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		c    *arp.Collector
+	}{
+		{"nil factory", arp.New(nil, &fakePublisher{}, at)},
+		{"nil publisher", arp.New(factoryFor(&fakeClient{}), nil, at)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tt.c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+				t.Error("expected nil-dep error")
+			}
+		})
+	}
+}
+
+func TestCollect_FactoryErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := arp.New(
+		func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+			return nil, errors.New("creds failed")
+		},
+		&fakePublisher{},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected factory error")
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.5 — ARP collector. Walks `ipNetToMediaTable`, emits one
`Observation` with every IP↔MAC binding the target has learned. Used
by Stage A4 topology to attach IP identity to L2-only neighbor edges
(hosts that don't speak LLDP/CDP/FDP).

## Changes
- `collectors/arp.Collector` — walks `1.3.6.1.2.1.4.22.1`
- 4 columns parsed (ifIndex, physAddress, netAddress, mediaType)
- `MediaType*` constants exported for downstream alert + UI use
- IPv4 octets parsed from OID suffix via `netip.AddrFrom4` (canonical form, validates octet ≤ 255)
- 9 unit tests

## Validation
- `go test ./internal/polling/...` → 71 tests across A3.x, all green
- `golangci-lint run` → 0 issues

## Next
Stage A3.6 — FDB collector (Q-BRIDGE-MIB.dot1qTpFdbTable) — L2 MAC-to-port mapping. Larger walk, big tables (often 10k+ rows).