### PR TITLE
feat(snmp): fdb collector (stage a3.6)

### DIFF
--- a/internal/polling/snmp/collectors/fdb/fdb.go
+++ b/internal/polling/snmp/collectors/fdb/fdb.go
@@ -1,0 +1,323 @@
+// Package fdb implements the fdb SNMP Collector for switch-side L2
+// forwarding-database visibility. Walks two tables:
+//
+//   - dot1dBasePortTable (1.3.6.1.2.1.17.1.4.1) — bridge port to
+//     ifIndex translation, needed to resolve fdb rows back to the
+//     parent interface row in ifTable.
+//   - dot1qTpFdbTable (1.3.6.1.2.1.17.7.1.2.2.1) — VLAN-aware MAC
+//     learning table; rows are (vlan, mac) → bridge_port.
+//
+// Together they let Stage A4 topology stitch L2 edges to host MACs
+// behind access ports (printers, IP phones, security cameras, etc.).
+// FDB tables are large (10k+ rows on enterprise switches), so the
+// collector streams via Walk rather than per-row Get.
+package fdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+)
+
+// Name is the collector key used in polling_targets.collector_chain.
+const Name = "fdb"
+
+const (
+	// dot1dBasePortTable: bridge port number → ifIndex.
+	basePortTablePrefix = "1.3.6.1.2.1.17.1.4.1"
+	colBasePortIfIndex  = "2"
+
+	// dot1qTpFdbTable: per-VLAN MAC learning table.
+	tpFdbTablePrefix = "1.3.6.1.2.1.17.7.1.2.2.1"
+	colTpFdbPort     = "2"
+	colTpFdbStatus   = "3"
+
+	macAddressBytes = 6
+	indexFieldsFdb  = 7 // vlanID + 6 MAC octets
+	indexFieldsBase = 1 // bridge port number
+)
+
+// FdbStatus values from RFC 4188.
+const (
+	StatusOther   = 1
+	StatusInvalid = 2
+	StatusLearned = 3
+	StatusSelf    = 4
+	StatusMgmt    = 5
+)
+
+// Entry is one dot1qTpFdbTable row joined with its bridge-port→
+// ifIndex translation. IfIndex is 0 when the bridge port has no
+// corresponding ifTable row (rare but valid on some agents).
+type Entry struct {
+	VLANID     uint32
+	MACAddress string
+	BridgePort uint32
+	IfIndex    uint32
+	Status     int
+}
+
+// Observation is the per-poll forwarding-database snapshot.
+type Observation struct {
+	ClientID   string
+	TargetID   string
+	ObservedAt time.Time
+	Entries    []Entry
+}
+
+// Publisher is the consumer-defined seam.
+type Publisher interface {
+	PublishFDB(ctx context.Context, obs Observation) error
+}
+
+// Collector implements snmp.Collector.
+type Collector struct {
+	newClient snmp.ClientFactory
+	publisher Publisher
+	now       func() time.Time
+}
+
+// New returns an FDB Collector. Pass nil now to use [time.Now] UTC.
+func New(factory snmp.ClientFactory, publisher Publisher, now func() time.Time) *Collector {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Collector{newClient: factory, publisher: publisher, now: now}
+}
+
+// Name implements snmp.Collector.
+func (*Collector) Name() string { return Name }
+
+// Collect walks dot1dBasePortTable + dot1qTpFdbTable, joins them by
+// bridge-port number, and publishes the resulting Entry list.
+func (c *Collector) Collect(ctx context.Context, target snmp.Target, creds snmp.ResolvedCredentials) error {
+	if c.newClient == nil {
+		return errors.New("fdb: client factory not configured")
+	}
+	if c.publisher == nil {
+		return errors.New("fdb: publisher not configured")
+	}
+
+	client, err := c.newClient(target, creds)
+	if err != nil {
+		return fmt.Errorf("fdb: dial: %w", err)
+	}
+
+	observedAt := c.now()
+
+	basePortVbs, err := client.Walk(ctx, basePortTablePrefix)
+	if err != nil {
+		return fmt.Errorf("fdb: walk dot1dBasePortTable: %w", err)
+	}
+	fdbVbs, err := client.Walk(ctx, tpFdbTablePrefix)
+	if err != nil {
+		return fmt.Errorf("fdb: walk dot1qTpFdbTable: %w", err)
+	}
+
+	portToIfIndex := buildBasePortMap(basePortVbs)
+	entries := buildEntries(fdbVbs, portToIfIndex)
+
+	if pubErr := c.publisher.PublishFDB(ctx, Observation{
+		ClientID:   target.ClientID,
+		TargetID:   target.ID,
+		ObservedAt: observedAt,
+		Entries:    entries,
+	}); pubErr != nil {
+		return fmt.Errorf("fdb: publish: %w", pubErr)
+	}
+	return nil
+}
+
+// buildBasePortMap turns a dot1dBasePortTable walk into a
+// bridgePort → ifIndex map.
+func buildBasePortMap(vbs []snmp.Varbind) map[uint32]uint32 {
+	m := make(map[uint32]uint32)
+	for _, vb := range vbs {
+		col, port, ok := parseBasePortOID(vb.OID)
+		if !ok || col != colBasePortIfIndex {
+			continue
+		}
+		m[port] = uint32Value(vb.Value)
+	}
+	return m
+}
+
+// parseBasePortOID expects basePortTablePrefix.col.bridgePort.
+func parseBasePortOID(oid string) (string, uint32, bool) {
+	if !strings.HasPrefix(oid, basePortTablePrefix+".") {
+		return "", 0, false
+	}
+	rest := strings.TrimPrefix(oid, basePortTablePrefix+".")
+	parts := strings.Split(rest, ".")
+	if len(parts) != 1+indexFieldsBase {
+		return "", 0, false
+	}
+	port, err := parseUint32(parts[1])
+	if err != nil {
+		return "", 0, false
+	}
+	return parts[0], port, true
+}
+
+// fdbRowKey identifies one dot1qTpFdbTable row by (vlanID, mac).
+type fdbRowKey struct {
+	vlanID uint32
+	mac    string // canonical aa:bb:cc:dd:ee:ff
+}
+
+// buildEntries folds the fdb walk into one Entry per (vlan, mac),
+// joined with the basePort→ifIndex map.
+func buildEntries(vbs []snmp.Varbind, portToIfIndex map[uint32]uint32) []Entry {
+	rows := make(map[fdbRowKey]*Entry)
+	for _, vb := range vbs {
+		col, key, ok := parseFdbOID(vb.OID)
+		if !ok {
+			continue
+		}
+		e := rows[key]
+		if e == nil {
+			e = &Entry{VLANID: key.vlanID, MACAddress: key.mac}
+			rows[key] = e
+		}
+		switch col {
+		case colTpFdbPort:
+			port := uint32Value(vb.Value)
+			e.BridgePort = port
+			if ifIdx, found := portToIfIndex[port]; found {
+				e.IfIndex = ifIdx
+			}
+		case colTpFdbStatus:
+			e.Status = intValue(vb.Value)
+		}
+	}
+
+	out := make([]Entry, 0, len(rows))
+	for _, e := range rows {
+		out = append(out, *e)
+	}
+	sortEntries(out)
+	return out
+}
+
+// parseFdbOID expects tpFdbTablePrefix.col.vlanID.<6 MAC octets>.
+func parseFdbOID(oid string) (string, fdbRowKey, bool) {
+	if !strings.HasPrefix(oid, tpFdbTablePrefix+".") {
+		return "", fdbRowKey{}, false
+	}
+	rest := strings.TrimPrefix(oid, tpFdbTablePrefix+".")
+	parts := strings.Split(rest, ".")
+	if len(parts) != 1+indexFieldsFdb {
+		return "", fdbRowKey{}, false
+	}
+	vlan, err := parseUint32(parts[1])
+	if err != nil {
+		return "", fdbRowKey{}, false
+	}
+	macBytes := [macAddressBytes]byte{}
+	for i := range macAddressBytes {
+		v, perr := strconv.ParseUint(parts[2+i], 10, 8)
+		if perr != nil {
+			return "", fdbRowKey{}, false
+		}
+		macBytes[i] = byte(v)
+	}
+	mac := fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
+		macBytes[0], macBytes[1], macBytes[2],
+		macBytes[3], macBytes[4], macBytes[5])
+	return parts[0], fdbRowKey{vlanID: vlan, mac: mac}, true
+}
+
+func parseUint32(s string) (uint32, error) {
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(v), nil
+}
+
+func intValue(v any) int {
+	const maxIntAsUint64 = uint64(^uint(0) >> 1)
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case int:
+		return t
+	case int32:
+		return int(t)
+	case int64:
+		if t < 0 || uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint:
+		if uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint32:
+		return int(t)
+	case uint64:
+		if t > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	default:
+		return 0
+	}
+}
+
+func uint32Value(v any) uint32 {
+	const maxUint32 uint64 = 1<<32 - 1
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case uint32:
+		return t
+	case int:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case int32:
+		if t < 0 {
+			return 0
+		}
+		return uint32(t)
+	case int64:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case uint64:
+		if t > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	}
+	return 0
+}
+
+func sortEntries(es []Entry) {
+	less := func(i, j int) bool {
+		if es[i].VLANID != es[j].VLANID {
+			return es[i].VLANID < es[j].VLANID
+		}
+		return es[i].MACAddress < es[j].MACAddress
+	}
+	for i := 1; i < len(es); i++ {
+		for j := i; j > 0 && less(j, j-1); j-- {
+			es[j-1], es[j] = es[j], es[j-1]
+		}
+	}
+}

--- a/internal/polling/snmp/collectors/fdb/fdb_test.go
+++ b/internal/polling/snmp/collectors/fdb/fdb_test.go
@@ -1,0 +1,240 @@
+package fdb_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/fdb"
+)
+
+const (
+	basePortPrefix = "1.3.6.1.2.1.17.1.4.1"
+	tpFdbPrefix    = "1.3.6.1.2.1.17.7.1.2.2.1"
+)
+
+type fakeClient struct {
+	basePortVbs []snmp.Varbind
+	tpFdbVbs    []snmp.Varbind
+	walkErr     error
+}
+
+func (f *fakeClient) Get(_ context.Context, _ []string) ([]snmp.Varbind, error) {
+	return nil, errors.New("get not used by fdb")
+}
+
+func (f *fakeClient) Walk(_ context.Context, prefix string) ([]snmp.Varbind, error) {
+	if f.walkErr != nil {
+		return nil, f.walkErr
+	}
+	switch {
+	case strings.HasPrefix(prefix, basePortPrefix):
+		return f.basePortVbs, nil
+	case strings.HasPrefix(prefix, tpFdbPrefix):
+		return f.tpFdbVbs, nil
+	}
+	return nil, nil
+}
+
+type fakePublisher struct {
+	mu  sync.Mutex
+	got []fdb.Observation
+	err error
+}
+
+func (p *fakePublisher) PublishFDB(_ context.Context, obs fdb.Observation) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
+	p.got = append(p.got, obs)
+	return nil
+}
+
+func factoryFor(c *fakeClient) snmp.ClientFactory {
+	return func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+		return c, nil
+	}
+}
+
+func at() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+func basePortOID(col string, port uint32) string {
+	return fmt.Sprintf("%s.%s.%d", basePortPrefix, col, port)
+}
+
+func fdbOID(col string, vlan uint32, mac [6]uint32) string {
+	return fmt.Sprintf("%s.%s.%d.%d.%d.%d.%d.%d.%d",
+		tpFdbPrefix, col, vlan, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5])
+}
+
+func TestCollector_Name(t *testing.T) {
+	t.Parallel()
+	if fdb.New(nil, nil, at).Name() != fdb.Name {
+		t.Error("Name mismatch")
+	}
+}
+
+func TestCollect_JoinsBasePortMapWithFdbRows(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		basePortVbs: []snmp.Varbind{
+			{OID: basePortOID("2", 24), Value: uint32(10024)},
+			{OID: basePortOID("2", 48), Value: uint32(10048)},
+		},
+		tpFdbVbs: []snmp.Varbind{
+			{OID: fdbOID("2", 100, [6]uint32{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}), Value: uint32(24)},
+			{OID: fdbOID("3", 100, [6]uint32{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}), Value: 3},
+			{OID: fdbOID("2", 200, [6]uint32{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}), Value: uint32(48)},
+			{OID: fdbOID("3", 200, [6]uint32{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}), Value: 3},
+		},
+	}
+	pub := &fakePublisher{}
+	c := fdb.New(factoryFor(fc), pub, at)
+	if err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(pub.got) != 1 || len(pub.got[0].Entries) != 2 {
+		t.Fatalf("got %+v, want 2 entries", pub.got)
+	}
+	e0 := pub.got[0].Entries[0]
+	if e0.VLANID != 100 || e0.MACAddress != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("e0 = %+v", e0)
+	}
+	if e0.BridgePort != 24 || e0.IfIndex != 10024 {
+		t.Errorf("e0 port/ifindex = %d/%d, want 24/10024", e0.BridgePort, e0.IfIndex)
+	}
+	if e0.Status != fdb.StatusLearned {
+		t.Errorf("e0.Status = %d, want %d", e0.Status, fdb.StatusLearned)
+	}
+}
+
+func TestCollect_UnknownBridgePortIfIndexZero(t *testing.T) {
+	t.Parallel()
+	// basePortTable has port 24 → ifindex 10024 but the fdb row
+	// references port 99 which has no mapping.
+	fc := &fakeClient{
+		basePortVbs: []snmp.Varbind{
+			{OID: basePortOID("2", 24), Value: uint32(10024)},
+		},
+		tpFdbVbs: []snmp.Varbind{
+			{OID: fdbOID("2", 100, [6]uint32{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}), Value: uint32(99)},
+		},
+	}
+	pub := &fakePublisher{}
+	c := fdb.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	e := pub.got[0].Entries[0]
+	if e.BridgePort != 99 {
+		t.Errorf("BridgePort = %d, want 99", e.BridgePort)
+	}
+	if e.IfIndex != 0 {
+		t.Errorf("IfIndex = %d, want 0 for unmapped port", e.IfIndex)
+	}
+}
+
+func TestCollect_SortedByVLANThenMAC(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		tpFdbVbs: []snmp.Varbind{
+			{OID: fdbOID("2", 200, [6]uint32{0xff, 0, 0, 0, 0, 0}), Value: uint32(1)},
+			{OID: fdbOID("2", 100, [6]uint32{0xff, 0, 0, 0, 0, 0}), Value: uint32(1)},
+			{OID: fdbOID("2", 100, [6]uint32{0x11, 0, 0, 0, 0, 0}), Value: uint32(1)},
+		},
+	}
+	pub := &fakePublisher{}
+	c := fdb.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	got := pub.got[0].Entries
+	want := []struct {
+		vlan uint32
+		mac  string
+	}{{100, "11:00:00:00:00:00"}, {100, "ff:00:00:00:00:00"}, {200, "ff:00:00:00:00:00"}}
+	for i, w := range want {
+		if got[i].VLANID != w.vlan || got[i].MACAddress != w.mac {
+			t.Errorf("[%d] = (%d,%s), want (%d,%s)",
+				i, got[i].VLANID, got[i].MACAddress, w.vlan, w.mac)
+		}
+	}
+}
+
+func TestCollect_MalformedOIDsSkipped(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		tpFdbVbs: []snmp.Varbind{
+			{OID: fdbOID("2", 100, [6]uint32{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}), Value: uint32(1)},
+			{OID: tpFdbPrefix + ".2.100.999.0.0.0.0.0", Value: uint32(1)}, // octet > 255
+			{OID: "garbage", Value: nil},
+		},
+	}
+	pub := &fakePublisher{}
+	c := fdb.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	if len(pub.got[0].Entries) != 1 {
+		t.Errorf("malformed should be skipped, got %d entries", len(pub.got[0].Entries))
+	}
+}
+
+func TestCollect_EmptyTablesStillPublish(t *testing.T) {
+	t.Parallel()
+	pub := &fakePublisher{}
+	c := fdb.New(factoryFor(&fakeClient{}), pub, at)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(pub.got) != 1 || len(pub.got[0].Entries) != 0 {
+		t.Errorf("empty FDB should publish empty obs, got %+v", pub.got)
+	}
+}
+
+func TestCollect_BasePortWalkErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := fdb.New(
+		factoryFor(&fakeClient{walkErr: errors.New("timeout")}),
+		&fakePublisher{},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected walk error")
+	}
+}
+
+func TestCollect_PublishErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := fdb.New(
+		factoryFor(&fakeClient{}),
+		&fakePublisher{err: errors.New("topo busy")},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected publish error")
+	}
+}
+
+func TestCollect_NilDepsReturnError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		c    *fdb.Collector
+	}{
+		{"nil factory", fdb.New(nil, &fakePublisher{}, at)},
+		{"nil publisher", fdb.New(factoryFor(&fakeClient{}), nil, at)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tt.c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+				t.Error("expected nil-dep error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.6 — Forwarding Database collector. Walks
`dot1qTpFdbTable` + `dot1dBasePortTable` and emits one
`Observation` per poll joining MAC-learning rows with their
bridge-port-to-ifIndex translation. Lets Stage A4 topology stitch
L2 edges back to host MACs behind access ports.

## Changes
- `collectors/fdb.Collector` — two walks:
  - `1.3.6.1.2.1.17.1.4.1` (`dot1dBasePortTable`) for bridgePort → ifIndex
  - `1.3.6.1.2.1.17.7.1.2.2.1` (`dot1qTpFdbTable`) for VLAN-aware MAC learning
- `buildBasePortMap` + `buildEntries` perform the in-memory join
- MAC decoded from 6-octet OID suffix into canonical colon-hex form
- `Status*` constants exported (other / invalid / learned / self / mgmt)
- 10 unit tests

## Validation
- `go test ./internal/polling/...` → 81 tests across A3.x, all green
- `golangci-lint run` → 0 issues