### PR TITLE
feat(snmp): routing collector (stage a3.7)

### DIFF
--- a/internal/polling/snmp/collectors/routing/routing.go
+++ b/internal/polling/snmp/collectors/routing/routing.go
@@ -1,0 +1,339 @@
+// Package routing implements the routing SNMP Collector. Walks
+// IP-FORWARD-MIB::ipCidrRouteTable (1.3.6.1.2.1.4.24.4.1) and emits
+// one Observation per poll listing every IPv4 route entry. Used by
+// Stage A4 topology to draw L3 next-hop edges between routers and
+// by the listener pipeline to alert on flapping/withdrawn routes.
+//
+// V1.0 uses ipCidrRouteTable (RFC 2096) which is IPv4-only but
+// universally implemented. The newer inetCidrRouteTable (RFC 4292,
+// dual-stack) lands when an IPv6 customer asks for it.
+package routing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+)
+
+// Name is the collector key used in polling_targets.collector_chain.
+const Name = "routing"
+
+const (
+	tablePrefix = "1.3.6.1.2.1.4.24.4.1"
+
+	// Columns we care about. The key columns (Dest, Mask, Tos,
+	// NextHop) are redundantly present as both index suffix and
+	// column 1-4 — we read them from the index for canonicalization.
+	colIfIndex = "5"
+	colType    = "6"
+	colProto   = "7"
+	colAge     = "8"
+	colMetric1 = "11"
+
+	// 4 octets dest + 4 octets mask + 1 octet tos + 4 octets nextHop.
+	indexFieldsRouting = 13
+	ipv4OctetCount     = 4
+)
+
+// RouteType values (RFC 2096).
+const (
+	TypeOther  = 1
+	TypeReject = 2
+	TypeLocal  = 3
+	TypeRemote = 4
+)
+
+// RouteProto values (RFC 2096). Stage A4 alerting filters on these:
+// connected/local/bgp/ospf get different alert severities than
+// learned via RIP.
+const (
+	ProtoOther     = 1
+	ProtoLocal     = 2
+	ProtoNetmgmt   = 3
+	ProtoICMP      = 4
+	ProtoEGP       = 5
+	ProtoGGP       = 6
+	ProtoHello     = 7
+	ProtoRIP       = 8
+	ProtoISIS      = 9
+	ProtoESIS      = 10
+	ProtoCiscoIGRP = 11
+	ProtoBBNSpfIGP = 12
+	ProtoOSPF      = 13
+	ProtoBGP       = 14
+)
+
+// Route is one ipCidrRouteTable row.
+type Route struct {
+	Destination string // dotted-quad IPv4
+	Mask        string // dotted-quad IPv4 mask
+	Tos         uint32 // type-of-service, usually 0
+	NextHop     string // dotted-quad IPv4
+	IfIndex     uint32
+	Type        int
+	Proto       int
+	AgeSeconds  uint32
+	Metric1     int
+}
+
+// Observation is the per-poll route table snapshot.
+type Observation struct {
+	ClientID   string
+	TargetID   string
+	ObservedAt time.Time
+	Routes     []Route
+}
+
+// Publisher is the consumer-defined seam.
+type Publisher interface {
+	PublishRouting(ctx context.Context, obs Observation) error
+}
+
+// Collector implements snmp.Collector.
+type Collector struct {
+	newClient snmp.ClientFactory
+	publisher Publisher
+	now       func() time.Time
+}
+
+// New returns a routing Collector. Pass nil now to use [time.Now] UTC.
+func New(factory snmp.ClientFactory, publisher Publisher, now func() time.Time) *Collector {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Collector{newClient: factory, publisher: publisher, now: now}
+}
+
+// Name implements snmp.Collector.
+func (*Collector) Name() string { return Name }
+
+// Collect walks ipCidrRouteTable and publishes the assembled routes.
+func (c *Collector) Collect(ctx context.Context, target snmp.Target, creds snmp.ResolvedCredentials) error {
+	if c.newClient == nil {
+		return errors.New("routing: client factory not configured")
+	}
+	if c.publisher == nil {
+		return errors.New("routing: publisher not configured")
+	}
+
+	client, err := c.newClient(target, creds)
+	if err != nil {
+		return fmt.Errorf("routing: dial: %w", err)
+	}
+
+	observedAt := c.now()
+	vbs, err := client.Walk(ctx, tablePrefix)
+	if err != nil {
+		return fmt.Errorf("routing: walk ipCidrRouteTable: %w", err)
+	}
+
+	if pubErr := c.publisher.PublishRouting(ctx, Observation{
+		ClientID:   target.ClientID,
+		TargetID:   target.ID,
+		ObservedAt: observedAt,
+		Routes:     buildRoutes(vbs),
+	}); pubErr != nil {
+		return fmt.Errorf("routing: publish: %w", pubErr)
+	}
+	return nil
+}
+
+// routeKey is one ipCidrRouteTable row keyed by the 4-tuple
+// (dest, mask, tos, nextHop) — those four make a route unique.
+type routeKey struct {
+	dest    string
+	mask    string
+	tos     uint32
+	nextHop string
+}
+
+func buildRoutes(vbs []snmp.Varbind) []Route {
+	rows := make(map[routeKey]*Route)
+	for _, vb := range vbs {
+		col, key, ok := parseRouteOID(vb.OID)
+		if !ok {
+			continue
+		}
+		r := rows[key]
+		if r == nil {
+			r = &Route{
+				Destination: key.dest,
+				Mask:        key.mask,
+				Tos:         key.tos,
+				NextHop:     key.nextHop,
+			}
+			rows[key] = r
+		}
+		applyColumn(r, col, vb.Value)
+	}
+
+	out := make([]Route, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, *r)
+	}
+	sortRoutes(out)
+	return out
+}
+
+// parseRouteOID expects tablePrefix.col.<4 dest>.<4 mask>.<tos>.<4 nextHop>.
+func parseRouteOID(oid string) (string, routeKey, bool) {
+	if !strings.HasPrefix(oid, tablePrefix+".") {
+		return "", routeKey{}, false
+	}
+	rest := strings.TrimPrefix(oid, tablePrefix+".")
+	parts := strings.Split(rest, ".")
+	if len(parts) != 1+indexFieldsRouting {
+		return "", routeKey{}, false
+	}
+
+	dest, ok := parseIPv4(parts[1:5])
+	if !ok {
+		return "", routeKey{}, false
+	}
+	mask, ok := parseIPv4(parts[5:9])
+	if !ok {
+		return "", routeKey{}, false
+	}
+	tos, err := parseUint32(parts[9])
+	if err != nil {
+		return "", routeKey{}, false
+	}
+	nextHop, ok := parseIPv4(parts[10:14])
+	if !ok {
+		return "", routeKey{}, false
+	}
+	return parts[0], routeKey{
+		dest: dest, mask: mask, tos: tos, nextHop: nextHop,
+	}, true
+}
+
+// parseIPv4 reads four decimal octets from an OID suffix slice and
+// formats them as a canonical dotted quad via [netip.AddrFrom4].
+func parseIPv4(octetParts []string) (string, bool) {
+	if len(octetParts) != ipv4OctetCount {
+		return "", false
+	}
+	var b [ipv4OctetCount]byte
+	for i, s := range octetParts {
+		v, err := strconv.ParseUint(s, 10, 8)
+		if err != nil {
+			return "", false
+		}
+		b[i] = byte(v)
+	}
+	return netip.AddrFrom4(b).String(), true
+}
+
+func parseUint32(s string) (uint32, error) {
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(v), nil
+}
+
+func applyColumn(r *Route, col string, v any) {
+	switch col {
+	case colIfIndex:
+		r.IfIndex = uint32Value(v)
+	case colType:
+		r.Type = intValue(v)
+	case colProto:
+		r.Proto = intValue(v)
+	case colAge:
+		r.AgeSeconds = uint32Value(v)
+	case colMetric1:
+		r.Metric1 = intValue(v)
+	}
+}
+
+func intValue(v any) int {
+	const maxIntAsUint64 = uint64(^uint(0) >> 1)
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case int:
+		return t
+	case int32:
+		return int(t)
+	case int64:
+		if t < 0 || uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint:
+		if uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint32:
+		return int(t)
+	case uint64:
+		if t > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	default:
+		return 0
+	}
+}
+
+func uint32Value(v any) uint32 {
+	const maxUint32 uint64 = 1<<32 - 1
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case uint32:
+		return t
+	case int:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case int32:
+		if t < 0 {
+			return 0
+		}
+		return uint32(t)
+	case int64:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case uint64:
+		if t > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	}
+	return 0
+}
+
+func sortRoutes(rs []Route) {
+	less := func(i, j int) bool {
+		if rs[i].Destination != rs[j].Destination {
+			return rs[i].Destination < rs[j].Destination
+		}
+		if rs[i].Mask != rs[j].Mask {
+			return rs[i].Mask < rs[j].Mask
+		}
+		return rs[i].NextHop < rs[j].NextHop
+	}
+	for i := 1; i < len(rs); i++ {
+		for j := i; j > 0 && less(j, j-1); j-- {
+			rs[j-1], rs[j] = rs[j], rs[j-1]
+		}
+	}
+}

--- a/internal/polling/snmp/collectors/routing/routing_test.go
+++ b/internal/polling/snmp/collectors/routing/routing_test.go
@@ -1,0 +1,211 @@
+package routing_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/routing"
+)
+
+const tablePrefix = "1.3.6.1.2.1.4.24.4.1"
+
+type fakeClient struct {
+	vbs     []snmp.Varbind
+	walkErr error
+}
+
+func (f *fakeClient) Get(_ context.Context, _ []string) ([]snmp.Varbind, error) {
+	return nil, errors.New("get not used by routing")
+}
+
+func (f *fakeClient) Walk(_ context.Context, _ string) ([]snmp.Varbind, error) {
+	if f.walkErr != nil {
+		return nil, f.walkErr
+	}
+	return f.vbs, nil
+}
+
+type fakePublisher struct {
+	mu  sync.Mutex
+	got []routing.Observation
+	err error
+}
+
+func (p *fakePublisher) PublishRouting(_ context.Context, obs routing.Observation) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
+	p.got = append(p.got, obs)
+	return nil
+}
+
+func factoryFor(c *fakeClient) snmp.ClientFactory {
+	return func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+		return c, nil
+	}
+}
+
+func at() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+// routeOID composes a routing-table OID for a column + key tuple.
+// All current tests use a /24 + tos=0; if non-default tests arrive,
+// lift mask/tos into parameters.
+func routeOID(col, dest, nextHop string) string {
+	return fmt.Sprintf("%s.%s.%s.255.255.255.0.0.%s",
+		tablePrefix, col, dest, nextHop)
+}
+
+func TestCollector_Name(t *testing.T) {
+	t.Parallel()
+	if routing.New(nil, nil, at).Name() != routing.Name {
+		t.Error("Name mismatch")
+	}
+}
+
+func TestCollect_BuildsRouteFromColumns(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: routeOID("5", "10.0.0.0", "10.0.0.254"), Value: uint32(1)},
+		{OID: routeOID("6", "10.0.0.0", "10.0.0.254"), Value: routing.TypeLocal},
+		{OID: routeOID("7", "10.0.0.0", "10.0.0.254"), Value: routing.ProtoLocal},
+		{OID: routeOID("8", "10.0.0.0", "10.0.0.254"), Value: uint32(3600)},
+		{OID: routeOID("11", "10.0.0.0", "10.0.0.254"), Value: 1},
+	}}
+	pub := &fakePublisher{}
+	c := routing.New(factoryFor(fc), pub, at)
+	if err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(pub.got) != 1 || len(pub.got[0].Routes) != 1 {
+		t.Fatalf("got %+v, want 1 route", pub.got)
+	}
+	r := pub.got[0].Routes[0]
+	if r.Destination != "10.0.0.0" || r.Mask != "255.255.255.0" {
+		t.Errorf("dest/mask = %s/%s", r.Destination, r.Mask)
+	}
+	if r.NextHop != "10.0.0.254" {
+		t.Errorf("NextHop = %q", r.NextHop)
+	}
+	if r.IfIndex != 1 || r.Type != routing.TypeLocal || r.Proto != routing.ProtoLocal {
+		t.Errorf("if/type/proto = %d/%d/%d", r.IfIndex, r.Type, r.Proto)
+	}
+	if r.AgeSeconds != 3600 || r.Metric1 != 1 {
+		t.Errorf("age/metric = %d/%d", r.AgeSeconds, r.Metric1)
+	}
+}
+
+func TestCollect_SortedByDestThenMaskThenNextHop(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: routeOID("5", "192.168.1.0", "10.0.0.1"), Value: uint32(1)},
+		{OID: routeOID("5", "10.0.0.0", "10.0.0.2"), Value: uint32(1)},
+		{OID: routeOID("5", "10.0.0.0", "10.0.0.1"), Value: uint32(1)},
+	}}
+	pub := &fakePublisher{}
+	c := routing.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	got := pub.got[0].Routes
+	want := []struct{ dest, nh string }{
+		{"10.0.0.0", "10.0.0.1"},
+		{"10.0.0.0", "10.0.0.2"},
+		{"192.168.1.0", "10.0.0.1"},
+	}
+	for i, w := range want {
+		if got[i].Destination != w.dest || got[i].NextHop != w.nh {
+			t.Errorf("[%d] = (%s,%s), want (%s,%s)",
+				i, got[i].Destination, got[i].NextHop, w.dest, w.nh)
+		}
+	}
+}
+
+func TestCollect_MalformedOIDsSkipped(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: routeOID("5", "10.0.0.0", "10.0.0.254"), Value: uint32(1)},
+		{OID: tablePrefix + ".5.10.0.0.0.255.255.255.0.0.10.0.0", Value: 1}, // 12 fields (wrong)
+		{OID: "garbage", Value: nil},
+	}}
+	pub := &fakePublisher{}
+	c := routing.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	if len(pub.got[0].Routes) != 1 {
+		t.Errorf("malformed should be skipped, got %d routes", len(pub.got[0].Routes))
+	}
+}
+
+func TestCollect_EmptyTableStillPublishes(t *testing.T) {
+	t.Parallel()
+	pub := &fakePublisher{}
+	c := routing.New(factoryFor(&fakeClient{}), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+	if len(pub.got) != 1 || len(pub.got[0].Routes) != 0 {
+		t.Errorf("empty table should publish empty obs, got %+v", pub.got)
+	}
+}
+
+func TestCollect_WalkErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := routing.New(
+		factoryFor(&fakeClient{walkErr: errors.New("timeout")}),
+		&fakePublisher{},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected walk error")
+	}
+}
+
+func TestCollect_PublishErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := routing.New(
+		factoryFor(&fakeClient{}),
+		&fakePublisher{err: errors.New("topo busy")},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected publish error")
+	}
+}
+
+func TestCollect_NilDepsReturnError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		c    *routing.Collector
+	}{
+		{"nil factory", routing.New(nil, &fakePublisher{}, at)},
+		{"nil publisher", routing.New(factoryFor(&fakeClient{}), nil, at)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tt.c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+				t.Error("expected nil-dep error")
+			}
+		})
+	}
+}
+
+func TestCollect_OctetOverflowRejected(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		// Dest octet > 255 — should not produce a route.
+		{OID: tablePrefix + ".5.999.0.0.1.255.255.255.0.0.10.0.0.1", Value: uint32(1)},
+	}}
+	pub := &fakePublisher{}
+	c := routing.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	if len(pub.got[0].Routes) != 0 {
+		t.Errorf("overflow should be skipped, got %d routes", len(pub.got[0].Routes))
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.7 — IPv4 routing collector. Walks `ipCidrRouteTable`, emits
one `Observation` per poll. Stage A4 uses these for L3 next-hop
edges; the listener pipeline alerts on flapping/withdrawn routes.

## Changes
- `collectors/routing.Collector` — walks `1.3.6.1.2.1.4.24.4.1`
- 5 columns parsed (ifIndex, type, proto, age, metric1)
- 13-field index decoded into `routeKey`, IPv4 octets validated via `netip.AddrFrom4`
- `Type*` (4 values) + `Proto*` (14 values) constants exported
- 9 unit tests

## Validation
- `go test ./internal/polling/...` → all green
- `golangci-lint run` → 0 issues

## Scope
IPv4-only (RFC 2096). Dual-stack `inetCidrRouteTable` (RFC 4292) deferred until a customer asks for IPv6.