### PR TITLE
feat(snmp): host_resources collector (stage a3.8)

### DIFF
--- a/internal/polling/snmp/collectors/hostresources/hostresources.go
+++ b/internal/polling/snmp/collectors/hostresources/hostresources.go
@@ -1,0 +1,409 @@
+// Package hostresources implements the host_resources SNMP Collector.
+// Walks the three HOST-RESOURCES-MIB (RFC 2790) subtrees the listener
+// pipeline + topology Node UI need:
+//
+//   - hrSystemUptime scalar — sanity-check against sysUpTime (sysUpTime
+//     resets on agent restart; hrSystemUptime tracks the host).
+//   - hrStorageTable — per-filesystem size/used in canonical bytes.
+//   - hrProcessorTable — per-processor load percentage.
+//
+// Storage and processor data drive the "running hot" alert: stage
+// a3.5 listener tracks the trend, fires when an FS crosses 85% or a
+// CPU averages >80% for >5min.
+package hostresources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+)
+
+// Name is the collector key used in polling_targets.collector_chain.
+const Name = "host_resources"
+
+const (
+	oidHrSystemUptime = "1.3.6.1.2.1.25.1.1.0"
+
+	storageTablePrefix   = "1.3.6.1.2.1.25.2.3.1"
+	colStorageType       = "2"
+	colStorageDescr      = "3"
+	colStorageAllocUnits = "4"
+	colStorageSize       = "5"
+	colStorageUsed       = "6"
+	indexFieldsStorage   = 1
+
+	processorTablePrefix = "1.3.6.1.2.1.25.3.3.1"
+	colProcessorLoad     = "2"
+	indexFieldsProcessor = 1
+)
+
+// Well-known hrStorageType OID values (RFC 2790 §3.1). Compared as
+// strings (gosnmp emits ObjectIdentifier as either string or []byte).
+const (
+	StorageTypeOther         = "1.3.6.1.2.1.25.2.1.1"
+	StorageTypeRAM           = "1.3.6.1.2.1.25.2.1.2"
+	StorageTypeVirtualMemory = "1.3.6.1.2.1.25.2.1.3"
+	StorageTypeFixedDisk     = "1.3.6.1.2.1.25.2.1.4"
+	StorageTypeRemovableDisk = "1.3.6.1.2.1.25.2.1.5"
+	StorageTypeFloppyDisk    = "1.3.6.1.2.1.25.2.1.6"
+	StorageTypeCompactDisc   = "1.3.6.1.2.1.25.2.1.7"
+	StorageTypeRAMDisk       = "1.3.6.1.2.1.25.2.1.8"
+	StorageTypeFlashMemory   = "1.3.6.1.2.1.25.2.1.9"
+	StorageTypeNetworkDisk   = "1.3.6.1.2.1.25.2.1.10"
+)
+
+// Storage is one hrStorageTable row, with allocation units already
+// multiplied through so SizeBytes / UsedBytes are absolute.
+type Storage struct {
+	Index           uint32
+	TypeOID         string // canonical OID string of hrStorageType
+	Description     string
+	AllocationUnits uint32
+	SizeBytes       uint64
+	UsedBytes       uint64
+}
+
+// Processor is one hrProcessorTable row.
+type Processor struct {
+	Index   uint32
+	LoadPct int // 0..100, "average load over last minute"
+}
+
+// Observation is the per-poll host-resources snapshot.
+type Observation struct {
+	ClientID     string
+	TargetID     string
+	ObservedAt   time.Time
+	SystemUptime uint32 // TimeTicks (hundredths of a second since boot)
+	Storage      []Storage
+	Processors   []Processor
+}
+
+// Publisher is the consumer-defined seam.
+type Publisher interface {
+	PublishHostResources(ctx context.Context, obs Observation) error
+}
+
+// Collector implements snmp.Collector.
+type Collector struct {
+	newClient snmp.ClientFactory
+	publisher Publisher
+	now       func() time.Time
+}
+
+// New returns a host-resources Collector. Pass nil now to use
+// [time.Now] in UTC.
+func New(factory snmp.ClientFactory, publisher Publisher, now func() time.Time) *Collector {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Collector{newClient: factory, publisher: publisher, now: now}
+}
+
+// Name implements snmp.Collector.
+func (*Collector) Name() string { return Name }
+
+// Collect performs one Get + two Walks and publishes the result.
+func (c *Collector) Collect(ctx context.Context, target snmp.Target, creds snmp.ResolvedCredentials) error {
+	if c.newClient == nil {
+		return errors.New("hostresources: client factory not configured")
+	}
+	if c.publisher == nil {
+		return errors.New("hostresources: publisher not configured")
+	}
+
+	client, err := c.newClient(target, creds)
+	if err != nil {
+		return fmt.Errorf("hostresources: dial: %w", err)
+	}
+
+	observedAt := c.now()
+
+	scalar, err := client.Get(ctx, []string{oidHrSystemUptime})
+	if err != nil {
+		return fmt.Errorf("hostresources: get hrSystemUptime: %w", err)
+	}
+	storageVbs, err := client.Walk(ctx, storageTablePrefix)
+	if err != nil {
+		return fmt.Errorf("hostresources: walk hrStorageTable: %w", err)
+	}
+	procVbs, err := client.Walk(ctx, processorTablePrefix)
+	if err != nil {
+		return fmt.Errorf("hostresources: walk hrProcessorTable: %w", err)
+	}
+
+	obs := Observation{
+		ClientID:     target.ClientID,
+		TargetID:     target.ID,
+		ObservedAt:   observedAt,
+		SystemUptime: extractUptime(scalar),
+		Storage:      buildStorage(storageVbs),
+		Processors:   buildProcessors(procVbs),
+	}
+	if pubErr := c.publisher.PublishHostResources(ctx, obs); pubErr != nil {
+		return fmt.Errorf("hostresources: publish: %w", pubErr)
+	}
+	return nil
+}
+
+// extractUptime pulls the TimeTicks scalar from a single-element Get
+// response. Missing or wrong-typed values yield 0.
+func extractUptime(vbs []snmp.Varbind) uint32 {
+	for _, vb := range vbs {
+		if vb.OID == oidHrSystemUptime {
+			return uint32Value(vb.Value)
+		}
+	}
+	return 0
+}
+
+// storageRow holds raw + computed fields during the build pass — the
+// allocation-unit multiply happens after the walk completes so column
+// order in the varbind stream doesn't matter.
+type storageRow struct {
+	row           Storage
+	hasAllocUnits bool
+	rawSizeUnits  uint64
+	rawUsedUnits  uint64
+}
+
+func buildStorage(vbs []snmp.Varbind) []Storage {
+	rows := make(map[uint32]*storageRow)
+	for _, vb := range vbs {
+		col, idx, ok := parseTableOID(vb.OID, storageTablePrefix, indexFieldsStorage)
+		if !ok {
+			continue
+		}
+		r := rows[idx]
+		if r == nil {
+			r = &storageRow{row: Storage{Index: idx}}
+			rows[idx] = r
+		}
+		applyStorageColumn(r, col, vb.Value)
+	}
+
+	out := make([]Storage, 0, len(rows))
+	for _, r := range rows {
+		if r.hasAllocUnits {
+			r.row.SizeBytes = r.rawSizeUnits * uint64(r.row.AllocationUnits)
+			r.row.UsedBytes = r.rawUsedUnits * uint64(r.row.AllocationUnits)
+		}
+		out = append(out, r.row)
+	}
+	sortStorage(out)
+	return out
+}
+
+func applyStorageColumn(r *storageRow, col string, v any) {
+	switch col {
+	case colStorageType:
+		r.row.TypeOID = oidString(v)
+	case colStorageDescr:
+		r.row.Description = stringValue(v)
+	case colStorageAllocUnits:
+		r.row.AllocationUnits = uint32Value(v)
+		r.hasAllocUnits = r.row.AllocationUnits > 0
+	case colStorageSize:
+		r.rawSizeUnits = uint64Value(v)
+	case colStorageUsed:
+		r.rawUsedUnits = uint64Value(v)
+	}
+}
+
+func buildProcessors(vbs []snmp.Varbind) []Processor {
+	rows := make(map[uint32]*Processor)
+	for _, vb := range vbs {
+		col, idx, ok := parseTableOID(vb.OID, processorTablePrefix, indexFieldsProcessor)
+		if !ok {
+			continue
+		}
+		p := rows[idx]
+		if p == nil {
+			p = &Processor{Index: idx}
+			rows[idx] = p
+		}
+		if col == colProcessorLoad {
+			p.LoadPct = intValue(vb.Value)
+		}
+	}
+
+	out := make([]Processor, 0, len(rows))
+	for _, p := range rows {
+		out = append(out, *p)
+	}
+	sortProcessors(out)
+	return out
+}
+
+// parseTableOID splits an OID under prefix into (column, index). The
+// expected suffix is <column>.<index> when indexFields==1.
+func parseTableOID(oid, prefix string, indexFields int) (string, uint32, bool) {
+	if !strings.HasPrefix(oid, prefix+".") {
+		return "", 0, false
+	}
+	rest := strings.TrimPrefix(oid, prefix+".")
+	parts := strings.Split(rest, ".")
+	if len(parts) != 1+indexFields {
+		return "", 0, false
+	}
+	idx, err := parseUint32(parts[1])
+	if err != nil {
+		return "", 0, false
+	}
+	return parts[0], idx, true
+}
+
+func parseUint32(s string) (uint32, error) {
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(v), nil
+}
+
+// oidString accepts both the gosnmp OID variants: string ("1.2.3.4")
+// or []byte (BER-encoded).
+func oidString(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	}
+	return ""
+}
+
+func stringValue(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	}
+	return ""
+}
+
+func intValue(v any) int {
+	const maxIntAsUint64 = uint64(^uint(0) >> 1)
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case int:
+		return t
+	case int32:
+		return int(t)
+	case int64:
+		if t < 0 || uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint:
+		if uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint32:
+		return int(t)
+	case uint64:
+		if t > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	default:
+		return 0
+	}
+}
+
+func uint32Value(v any) uint32 {
+	const maxUint32 uint64 = 1<<32 - 1
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case uint32:
+		return t
+	case int:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case int32:
+		if t < 0 {
+			return 0
+		}
+		return uint32(t)
+	case int64:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case uint64:
+		if t > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	}
+	return 0
+}
+
+// uint64Value extracts a 64-bit unsigned (hrStorageSize/Used are
+// INTEGER in the MIB but real values exceed 2^31 — many agents emit
+// uint64 or wrap via Counter64).
+func uint64Value(v any) uint64 {
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case uint:
+		return uint64(t)
+	case uint32:
+		return uint64(t)
+	case uint64:
+		return t
+	case int:
+		if t < 0 {
+			return 0
+		}
+		return uint64(t)
+	case int32:
+		if t < 0 {
+			return 0
+		}
+		return uint64(t)
+	case int64:
+		if t < 0 {
+			return 0
+		}
+		return uint64(t)
+	}
+	return 0
+}
+
+func sortStorage(ss []Storage) {
+	for i := 1; i < len(ss); i++ {
+		for j := i; j > 0 && ss[j-1].Index > ss[j].Index; j-- {
+			ss[j-1], ss[j] = ss[j], ss[j-1]
+		}
+	}
+}
+
+func sortProcessors(ps []Processor) {
+	for i := 1; i < len(ps); i++ {
+		for j := i; j > 0 && ps[j-1].Index > ps[j].Index; j-- {
+			ps[j-1], ps[j] = ps[j], ps[j-1]
+		}
+	}
+}

--- a/internal/polling/snmp/collectors/hostresources/hostresources_test.go
+++ b/internal/polling/snmp/collectors/hostresources/hostresources_test.go
@@ -1,0 +1,298 @@
+package hostresources_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/hostresources"
+)
+
+const (
+	uptimeOID       = "1.3.6.1.2.1.25.1.1.0"
+	storagePrefix   = "1.3.6.1.2.1.25.2.3.1"
+	processorPrefix = "1.3.6.1.2.1.25.3.3.1"
+)
+
+type fakeClient struct {
+	scalar     []snmp.Varbind
+	storage    []snmp.Varbind
+	processors []snmp.Varbind
+	getErr     error
+	walkErr    error
+}
+
+func (f *fakeClient) Get(_ context.Context, oids []string) ([]snmp.Varbind, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	out := make([]snmp.Varbind, 0)
+	for _, want := range oids {
+		for _, vb := range f.scalar {
+			if vb.OID == want {
+				out = append(out, vb)
+			}
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeClient) Walk(_ context.Context, prefix string) ([]snmp.Varbind, error) {
+	if f.walkErr != nil {
+		return nil, f.walkErr
+	}
+	switch {
+	case strings.HasPrefix(prefix, storagePrefix):
+		return f.storage, nil
+	case strings.HasPrefix(prefix, processorPrefix):
+		return f.processors, nil
+	}
+	return nil, nil
+}
+
+type fakePublisher struct {
+	mu  sync.Mutex
+	got []hostresources.Observation
+	err error
+}
+
+func (p *fakePublisher) PublishHostResources(_ context.Context, obs hostresources.Observation) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
+	p.got = append(p.got, obs)
+	return nil
+}
+
+func factoryFor(c *fakeClient) snmp.ClientFactory {
+	return func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+		return c, nil
+	}
+}
+
+func at() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+func storageOID(col string, idx uint32) string {
+	return fmt.Sprintf("%s.%s.%d", storagePrefix, col, idx)
+}
+
+func processorOID(idx uint32) string {
+	return fmt.Sprintf("%s.2.%d", processorPrefix, idx)
+}
+
+func TestCollector_Name(t *testing.T) {
+	t.Parallel()
+	if hostresources.New(nil, nil, at).Name() != hostresources.Name {
+		t.Error("Name mismatch")
+	}
+}
+
+func TestCollect_AggregatesUptimeStorageAndProcessors(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		scalar: []snmp.Varbind{
+			{OID: uptimeOID, Value: uint32(123456789)},
+		},
+		storage: []snmp.Varbind{
+			{OID: storageOID("2", 1), Value: hostresources.StorageTypeRAM},
+			{OID: storageOID("3", 1), Value: "Physical RAM"},
+			{OID: storageOID("4", 1), Value: uint32(1024)},
+			{OID: storageOID("5", 1), Value: 16777216}, // 16 GiB / 1024 = 16384 KiB units
+			{OID: storageOID("6", 1), Value: 8388608},
+			{OID: storageOID("2", 2), Value: hostresources.StorageTypeFixedDisk},
+			{OID: storageOID("3", 2), Value: "/"},
+			{OID: storageOID("4", 2), Value: uint32(4096)},
+			{OID: storageOID("5", 2), Value: 1000000},
+			{OID: storageOID("6", 2), Value: 500000},
+		},
+		processors: []snmp.Varbind{
+			{OID: processorOID(1), Value: 42},
+			{OID: processorOID(2), Value: 7},
+		},
+	}
+	pub := &fakePublisher{}
+	c := hostresources.New(factoryFor(fc), pub, at)
+	if err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	obs := pub.got[0]
+	if obs.SystemUptime != 123456789 {
+		t.Errorf("SystemUptime = %d, want 123456789", obs.SystemUptime)
+	}
+	if len(obs.Storage) != 2 {
+		t.Fatalf("Storage rows = %d, want 2", len(obs.Storage))
+	}
+	if obs.Storage[0].TypeOID != hostresources.StorageTypeRAM {
+		t.Errorf("Storage[0].TypeOID = %q", obs.Storage[0].TypeOID)
+	}
+	if obs.Storage[0].SizeBytes != 16777216*1024 {
+		t.Errorf("Storage[0].SizeBytes = %d, want %d",
+			obs.Storage[0].SizeBytes, uint64(16777216)*1024)
+	}
+	if obs.Storage[1].UsedBytes != 500000*4096 {
+		t.Errorf("Storage[1].UsedBytes = %d, want %d",
+			obs.Storage[1].UsedBytes, uint64(500000)*4096)
+	}
+	if len(obs.Processors) != 2 {
+		t.Fatalf("Processor rows = %d, want 2", len(obs.Processors))
+	}
+	if obs.Processors[0].LoadPct != 42 || obs.Processors[1].LoadPct != 7 {
+		t.Errorf("Processor loads = %d, %d, want 42, 7",
+			obs.Processors[0].LoadPct, obs.Processors[1].LoadPct)
+	}
+}
+
+func TestCollect_StorageWithZeroAllocUnitsLeavesBytesZero(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		storage: []snmp.Varbind{
+			{OID: storageOID("4", 1), Value: uint32(0)},
+			{OID: storageOID("5", 1), Value: 100},
+			{OID: storageOID("6", 1), Value: 50},
+		},
+	}
+	pub := &fakePublisher{}
+	c := hostresources.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	if pub.got[0].Storage[0].SizeBytes != 0 {
+		t.Errorf("zero alloc-units should yield SizeBytes=0, got %d",
+			pub.got[0].Storage[0].SizeBytes)
+	}
+}
+
+func TestCollect_SortedByIndex(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		storage: []snmp.Varbind{
+			{OID: storageOID("3", 10), Value: "z"},
+			{OID: storageOID("3", 1), Value: "a"},
+			{OID: storageOID("3", 5), Value: "m"},
+		},
+		processors: []snmp.Varbind{
+			{OID: processorOID(99), Value: 90},
+			{OID: processorOID(1), Value: 10},
+		},
+	}
+	pub := &fakePublisher{}
+	c := hostresources.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	storage := pub.got[0].Storage
+	if storage[0].Index != 1 || storage[1].Index != 5 || storage[2].Index != 10 {
+		t.Errorf("storage sort = %d/%d/%d, want 1/5/10",
+			storage[0].Index, storage[1].Index, storage[2].Index)
+	}
+	procs := pub.got[0].Processors
+	if procs[0].Index != 1 || procs[1].Index != 99 {
+		t.Errorf("processor sort = %d/%d, want 1/99", procs[0].Index, procs[1].Index)
+	}
+}
+
+func TestCollect_StorageTypeAcceptsByteOID(t *testing.T) {
+	t.Parallel()
+	// Some agents emit ObjectIdentifier as []byte.
+	fc := &fakeClient{
+		storage: []snmp.Varbind{
+			{OID: storageOID("2", 1), Value: []byte(hostresources.StorageTypeFixedDisk)},
+		},
+	}
+	pub := &fakePublisher{}
+	c := hostresources.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+	if pub.got[0].Storage[0].TypeOID != hostresources.StorageTypeFixedDisk {
+		t.Errorf("byte-slice TypeOID = %q", pub.got[0].Storage[0].TypeOID)
+	}
+}
+
+func TestCollect_MalformedTableOIDsSkipped(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{
+		storage: []snmp.Varbind{
+			{OID: storageOID("3", 1), Value: "good"},
+			{OID: "garbage", Value: nil},
+			{OID: storagePrefix + ".3.notanint", Value: nil},
+		},
+	}
+	pub := &fakePublisher{}
+	c := hostresources.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+	if len(pub.got[0].Storage) != 1 || pub.got[0].Storage[0].Description != "good" {
+		t.Errorf("malformed should be skipped, got %+v", pub.got[0].Storage)
+	}
+}
+
+func TestCollect_GetUptimeErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := hostresources.New(
+		factoryFor(&fakeClient{getErr: errors.New("timeout")}),
+		&fakePublisher{},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected get error")
+	}
+}
+
+func TestCollect_StorageWalkErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := hostresources.New(
+		factoryFor(&fakeClient{walkErr: errors.New("timeout")}),
+		&fakePublisher{},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected walk error")
+	}
+}
+
+func TestCollect_PublishErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := hostresources.New(
+		factoryFor(&fakeClient{}),
+		&fakePublisher{err: errors.New("topo busy")},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected publish error")
+	}
+}
+
+func TestCollect_NilDepsReturnError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		c    *hostresources.Collector
+	}{
+		{"nil factory", hostresources.New(nil, &fakePublisher{}, at)},
+		{"nil publisher", hostresources.New(factoryFor(&fakeClient{}), nil, at)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tt.c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+				t.Error("expected nil-dep error")
+			}
+		})
+	}
+}
+
+func TestCollect_EmptyTablesStillPublish(t *testing.T) {
+	t.Parallel()
+	pub := &fakePublisher{}
+	c := hostresources.New(factoryFor(&fakeClient{}), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+	if len(pub.got) != 1 {
+		t.Fatalf("publisher should be called once for empty tables")
+	}
+	if len(pub.got[0].Storage) != 0 || len(pub.got[0].Processors) != 0 {
+		t.Errorf("expected empty slices, got %+v", pub.got[0])
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.8 — host-resources collector. Walks the three HOST-RESOURCES-MIB
subtrees the listener pipeline + topology Node UI need:
hrSystemUptime, hrStorageTable, hrProcessorTable.

Drives the "running hot" alert: FS >85% or CPU >80% for >5min.

## Changes
- `collectors/hostresources.Collector` — 1 Get + 2 Walks
- 10 hrStorageType constants exported (RAM, VirtualMemory, FixedDisk, …)
- Allocation-units multiplied through after the walk so column order is irrelevant
- 12 unit tests including byte-slice OID variants

## Validation
- `go test ./internal/polling/...` → all green
- `golangci-lint run` → 0 issues