### PR TITLE
feat(snmp): bgp4_mib peer collector (stage a3.9)

### DIFF
--- a/internal/polling/snmp/collectors/bgp4/bgp4.go
+++ b/internal/polling/snmp/collectors/bgp4/bgp4.go
@@ -1,0 +1,346 @@
+// Package bgp4 implements the bgp4_mib SNMP Collector. Walks
+// BGP4-MIB::bgpPeerTable (1.3.6.1.2.1.15.3.1) and emits one
+// Observation per poll listing every BGP peer the target has
+// configured.
+//
+// BGP peer state + the EstablishedTransitions counter are the bread
+// and butter of network-wide alerting: a peer flapping between
+// established and not-established is one of the most expensive
+// silent outages SP/ISP/large-enterprise customers face.
+package bgp4
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+)
+
+// Name is the collector key used in polling_targets.collector_chain.
+const Name = "bgp4_mib"
+
+const (
+	tablePrefix = "1.3.6.1.2.1.15.3.1"
+
+	colIdentifier          = "1"
+	colState               = "2"
+	colAdminStatus         = "3"
+	colNegotiatedVersion   = "4"
+	colLocalAddr           = "5"
+	colLocalPort           = "6"
+	colRemotePort          = "8"
+	colRemoteAs            = "9"
+	colInUpdates           = "10"
+	colOutUpdates          = "11"
+	colInTotalMessages     = "12"
+	colOutTotalMessages    = "13"
+	colFsmEstablishedTrans = "15"
+	colFsmEstablishedTime  = "16"
+
+	indexFieldsBGP = 4 // 4-octet IPv4 peer-remote-addr
+	ipv4OctetCount = 4
+)
+
+// PeerState values (RFC 4273).
+const (
+	StateIdle        = 1
+	StateConnect     = 2
+	StateActive      = 3
+	StateOpenSent    = 4
+	StateOpenConfirm = 5
+	StateEstablished = 6
+)
+
+// PeerAdminStatus values (RFC 4273).
+const (
+	AdminStop  = 1
+	AdminStart = 2
+)
+
+// Peer is one bgpPeerTable row. Counter columns are surfaced as raw
+// uint64 (Counter32 widened) — Stage A3.5 listener tracks deltas
+// across consecutive observations to compute rate.
+type Peer struct {
+	RemoteAddr             string // dotted-quad IPv4 (the row index)
+	Identifier             string // dotted-quad IPv4 BGP ID
+	State                  int
+	AdminStatus            int
+	NegotiatedVersion      int
+	LocalAddr              string
+	LocalPort              int
+	RemotePort             int
+	RemoteAS               uint32
+	InUpdates              uint64
+	OutUpdates             uint64
+	InTotalMessages        uint64
+	OutTotalMessages       uint64
+	EstablishedTransitions uint32
+	EstablishedTimeSeconds uint32
+}
+
+// Observation is the per-poll BGP peer snapshot.
+type Observation struct {
+	ClientID   string
+	TargetID   string
+	ObservedAt time.Time
+	Peers      []Peer
+}
+
+// Publisher is the consumer-defined seam.
+type Publisher interface {
+	PublishBGP4(ctx context.Context, obs Observation) error
+}
+
+// Collector implements snmp.Collector.
+type Collector struct {
+	newClient snmp.ClientFactory
+	publisher Publisher
+	now       func() time.Time
+}
+
+// New returns a BGP4 Collector. Pass nil now to use [time.Now] UTC.
+func New(factory snmp.ClientFactory, publisher Publisher, now func() time.Time) *Collector {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Collector{newClient: factory, publisher: publisher, now: now}
+}
+
+// Name implements snmp.Collector.
+func (*Collector) Name() string { return Name }
+
+// Collect walks bgpPeerTable and publishes the assembled Peer list.
+func (c *Collector) Collect(ctx context.Context, target snmp.Target, creds snmp.ResolvedCredentials) error {
+	if c.newClient == nil {
+		return errors.New("bgp4: client factory not configured")
+	}
+	if c.publisher == nil {
+		return errors.New("bgp4: publisher not configured")
+	}
+
+	client, err := c.newClient(target, creds)
+	if err != nil {
+		return fmt.Errorf("bgp4: dial: %w", err)
+	}
+
+	observedAt := c.now()
+	vbs, err := client.Walk(ctx, tablePrefix)
+	if err != nil {
+		return fmt.Errorf("bgp4: walk bgpPeerTable: %w", err)
+	}
+
+	if pubErr := c.publisher.PublishBGP4(ctx, Observation{
+		ClientID:   target.ClientID,
+		TargetID:   target.ID,
+		ObservedAt: observedAt,
+		Peers:      buildPeers(vbs),
+	}); pubErr != nil {
+		return fmt.Errorf("bgp4: publish: %w", pubErr)
+	}
+	return nil
+}
+
+func buildPeers(vbs []snmp.Varbind) []Peer {
+	rows := make(map[string]*Peer)
+	for _, vb := range vbs {
+		col, remoteAddr, ok := parsePeerOID(vb.OID)
+		if !ok {
+			continue
+		}
+		p := rows[remoteAddr]
+		if p == nil {
+			p = &Peer{RemoteAddr: remoteAddr}
+			rows[remoteAddr] = p
+		}
+		applyColumn(p, col, vb.Value)
+	}
+
+	out := make([]Peer, 0, len(rows))
+	for _, p := range rows {
+		out = append(out, *p)
+	}
+	sortPeers(out)
+	return out
+}
+
+// parsePeerOID expects tablePrefix.col.<4 octet peer IPv4>.
+func parsePeerOID(oid string) (string, string, bool) {
+	if !strings.HasPrefix(oid, tablePrefix+".") {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(oid, tablePrefix+".")
+	parts := strings.Split(rest, ".")
+	if len(parts) != 1+indexFieldsBGP {
+		return "", "", false
+	}
+	var octets [ipv4OctetCount]byte
+	for i := range ipv4OctetCount {
+		v, err := strconv.ParseUint(parts[1+i], 10, 8)
+		if err != nil {
+			return "", "", false
+		}
+		octets[i] = byte(v)
+	}
+	return parts[0], netip.AddrFrom4(octets).String(), true
+}
+
+func applyColumn(p *Peer, col string, v any) {
+	switch col {
+	case colIdentifier:
+		p.Identifier = ipv4OrString(v)
+	case colState:
+		p.State = intValue(v)
+	case colAdminStatus:
+		p.AdminStatus = intValue(v)
+	case colNegotiatedVersion:
+		p.NegotiatedVersion = intValue(v)
+	case colLocalAddr:
+		p.LocalAddr = ipv4OrString(v)
+	case colLocalPort:
+		p.LocalPort = intValue(v)
+	case colRemotePort:
+		p.RemotePort = intValue(v)
+	case colRemoteAs:
+		p.RemoteAS = uint32Value(v)
+	case colInUpdates:
+		p.InUpdates = uint64Value(v)
+	case colOutUpdates:
+		p.OutUpdates = uint64Value(v)
+	case colInTotalMessages:
+		p.InTotalMessages = uint64Value(v)
+	case colOutTotalMessages:
+		p.OutTotalMessages = uint64Value(v)
+	case colFsmEstablishedTrans:
+		p.EstablishedTransitions = uint32Value(v)
+	case colFsmEstablishedTime:
+		p.EstablishedTimeSeconds = uint32Value(v)
+	}
+}
+
+// ipv4OrString decodes a BGP IP-address column. RFC 4273 emits these
+// as 4-byte OCTET STRINGs; some agents emit them as already-formatted
+// strings.
+func ipv4OrString(v any) string {
+	if b, ok := v.([]byte); ok && len(b) == ipv4OctetCount {
+		var octets [ipv4OctetCount]byte
+		copy(octets[:], b)
+		return netip.AddrFrom4(octets).String()
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	}
+	return ""
+}
+
+func intValue(v any) int {
+	const maxIntAsUint64 = uint64(^uint(0) >> 1)
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case int:
+		return t
+	case int32:
+		return int(t)
+	case int64:
+		if t < 0 || uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint:
+		if uint64(t) > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	case uint32:
+		return int(t)
+	case uint64:
+		if t > maxIntAsUint64 {
+			return 0
+		}
+		return int(t)
+	default:
+		return 0
+	}
+}
+
+func uint32Value(v any) uint32 {
+	const maxUint32 uint64 = 1<<32 - 1
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case uint32:
+		return t
+	case int:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case int32:
+		if t < 0 {
+			return 0
+		}
+		return uint32(t)
+	case int64:
+		if t < 0 {
+			return 0
+		}
+		if uint64(t) > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	case uint64:
+		if t > maxUint32 {
+			return uint32(maxUint32)
+		}
+		return uint32(t)
+	}
+	return 0
+}
+
+func uint64Value(v any) uint64 {
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case uint:
+		return uint64(t)
+	case uint32:
+		return uint64(t)
+	case uint64:
+		return t
+	case int:
+		if t < 0 {
+			return 0
+		}
+		return uint64(t)
+	case int32:
+		if t < 0 {
+			return 0
+		}
+		return uint64(t)
+	case int64:
+		if t < 0 {
+			return 0
+		}
+		return uint64(t)
+	}
+	return 0
+}
+
+func sortPeers(ps []Peer) {
+	for i := 1; i < len(ps); i++ {
+		for j := i; j > 0 && ps[j-1].RemoteAddr > ps[j].RemoteAddr; j-- {
+			ps[j-1], ps[j] = ps[j], ps[j-1]
+		}
+	}
+}

--- a/internal/polling/snmp/collectors/bgp4/bgp4_test.go
+++ b/internal/polling/snmp/collectors/bgp4/bgp4_test.go
@@ -1,0 +1,210 @@
+package bgp4_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/bgp4"
+)
+
+const tablePrefix = "1.3.6.1.2.1.15.3.1"
+
+type fakeClient struct {
+	vbs     []snmp.Varbind
+	walkErr error
+}
+
+func (f *fakeClient) Get(_ context.Context, _ []string) ([]snmp.Varbind, error) {
+	return nil, errors.New("get not used by bgp4")
+}
+
+func (f *fakeClient) Walk(_ context.Context, _ string) ([]snmp.Varbind, error) {
+	if f.walkErr != nil {
+		return nil, f.walkErr
+	}
+	return f.vbs, nil
+}
+
+type fakePublisher struct {
+	mu  sync.Mutex
+	got []bgp4.Observation
+	err error
+}
+
+func (p *fakePublisher) PublishBGP4(_ context.Context, obs bgp4.Observation) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
+	p.got = append(p.got, obs)
+	return nil
+}
+
+func factoryFor(c *fakeClient) snmp.ClientFactory {
+	return func(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+		return c, nil
+	}
+}
+
+func at() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+func peerOID(col, remoteAddr string) string {
+	return fmt.Sprintf("%s.%s.%s", tablePrefix, col, remoteAddr)
+}
+
+func TestCollector_Name(t *testing.T) {
+	t.Parallel()
+	if bgp4.New(nil, nil, at).Name() != bgp4.Name {
+		t.Error("Name mismatch")
+	}
+}
+
+func TestCollect_BuildsPeerFromColumns(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: peerOID("1", "10.0.0.1"), Value: []byte{192, 0, 2, 1}},
+		{OID: peerOID("2", "10.0.0.1"), Value: bgp4.StateEstablished},
+		{OID: peerOID("3", "10.0.0.1"), Value: bgp4.AdminStart},
+		{OID: peerOID("4", "10.0.0.1"), Value: 4},
+		{OID: peerOID("5", "10.0.0.1"), Value: []byte{10, 0, 0, 100}},
+		{OID: peerOID("6", "10.0.0.1"), Value: 179},
+		{OID: peerOID("8", "10.0.0.1"), Value: 12345},
+		{OID: peerOID("9", "10.0.0.1"), Value: uint32(65001)},
+		{OID: peerOID("10", "10.0.0.1"), Value: uint32(987654)},
+		{OID: peerOID("11", "10.0.0.1"), Value: uint32(123456)},
+		{OID: peerOID("12", "10.0.0.1"), Value: uint32(2000000)},
+		{OID: peerOID("13", "10.0.0.1"), Value: uint32(500000)},
+		{OID: peerOID("15", "10.0.0.1"), Value: uint32(3)},
+		{OID: peerOID("16", "10.0.0.1"), Value: uint32(86400)},
+	}}
+	pub := &fakePublisher{}
+	c := bgp4.New(factoryFor(fc), pub, at)
+	if err := c.Collect(context.Background(), snmp.Target{ID: "t-1"}, snmp.ResolvedCredentials{}); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(pub.got) != 1 || len(pub.got[0].Peers) != 1 {
+		t.Fatalf("got %+v, want 1 peer", pub.got)
+	}
+	p := pub.got[0].Peers[0]
+	if p.RemoteAddr != "10.0.0.1" {
+		t.Errorf("RemoteAddr = %q", p.RemoteAddr)
+	}
+	if p.Identifier != "192.0.2.1" {
+		t.Errorf("Identifier = %q, want 192.0.2.1", p.Identifier)
+	}
+	if p.LocalAddr != "10.0.0.100" {
+		t.Errorf("LocalAddr = %q", p.LocalAddr)
+	}
+	if p.State != bgp4.StateEstablished || p.AdminStatus != bgp4.AdminStart {
+		t.Errorf("state/admin = %d/%d", p.State, p.AdminStatus)
+	}
+	if p.RemoteAS != 65001 {
+		t.Errorf("RemoteAS = %d", p.RemoteAS)
+	}
+	if p.InUpdates != 987654 || p.OutUpdates != 123456 {
+		t.Errorf("updates in/out = %d/%d", p.InUpdates, p.OutUpdates)
+	}
+	if p.InTotalMessages != 2000000 || p.OutTotalMessages != 500000 {
+		t.Errorf("total in/out = %d/%d", p.InTotalMessages, p.OutTotalMessages)
+	}
+	if p.EstablishedTransitions != 3 {
+		t.Errorf("EstablishedTransitions = %d", p.EstablishedTransitions)
+	}
+	if p.EstablishedTimeSeconds != 86400 {
+		t.Errorf("EstablishedTimeSeconds = %d", p.EstablishedTimeSeconds)
+	}
+}
+
+func TestCollect_PeersSortedByRemoteAddr(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: peerOID("2", "192.168.1.1"), Value: bgp4.StateIdle},
+		{OID: peerOID("2", "10.0.0.1"), Value: bgp4.StateEstablished},
+		{OID: peerOID("2", "10.0.0.10"), Value: bgp4.StateActive},
+	}}
+	pub := &fakePublisher{}
+	c := bgp4.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	want := []string{"10.0.0.1", "10.0.0.10", "192.168.1.1"}
+	for i, w := range want {
+		if pub.got[0].Peers[i].RemoteAddr != w {
+			t.Errorf("[%d] = %s, want %s", i, pub.got[0].Peers[i].RemoteAddr, w)
+		}
+	}
+}
+
+func TestCollect_MalformedOIDsSkipped(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClient{vbs: []snmp.Varbind{
+		{OID: peerOID("2", "10.0.0.1"), Value: bgp4.StateEstablished},
+		{OID: tablePrefix + ".2.999.0.0.1", Value: bgp4.StateIdle}, // octet > 255
+		{OID: "garbage", Value: nil},
+	}}
+	pub := &fakePublisher{}
+	c := bgp4.New(factoryFor(fc), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+
+	if len(pub.got[0].Peers) != 1 {
+		t.Errorf("malformed should be skipped, got %d peers", len(pub.got[0].Peers))
+	}
+}
+
+func TestCollect_EmptyTableStillPublishes(t *testing.T) {
+	t.Parallel()
+	pub := &fakePublisher{}
+	c := bgp4.New(factoryFor(&fakeClient{}), pub, at)
+	_ = c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{})
+	if len(pub.got) != 1 || len(pub.got[0].Peers) != 0 {
+		t.Errorf("empty table should publish empty obs, got %+v", pub.got)
+	}
+}
+
+func TestCollect_WalkErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := bgp4.New(
+		factoryFor(&fakeClient{walkErr: errors.New("timeout")}),
+		&fakePublisher{},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected walk error")
+	}
+}
+
+func TestCollect_PublishErrorPropagates(t *testing.T) {
+	t.Parallel()
+	c := bgp4.New(
+		factoryFor(&fakeClient{}),
+		&fakePublisher{err: errors.New("topo busy")},
+		at,
+	)
+	if err := c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+		t.Error("expected publish error")
+	}
+}
+
+func TestCollect_NilDepsReturnError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		c    *bgp4.Collector
+	}{
+		{"nil factory", bgp4.New(nil, &fakePublisher{}, at)},
+		{"nil publisher", bgp4.New(factoryFor(&fakeClient{}), nil, at)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tt.c.Collect(context.Background(), snmp.Target{}, snmp.ResolvedCredentials{}); err == nil {
+				t.Error("expected nil-dep error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.9 — BGP peer collector. Walks `bgpPeerTable`, emits one
`Observation` per poll. Peer state + EstablishedTransitions are the
heart of BGP alerting — flapping peers cause silent outages SP/ISP/
large-enterprise customers can't afford.

## Changes
- `collectors/bgp4.Collector` — walks `1.3.6.1.2.1.15.3.1`
- 14 columns parsed (identifier, state, admin, version, local/remote addr+port, remote AS, in/out counters, FSM transitions/time)
- `State*` constants (6 values) + `Admin*` constants exported
- Counter32 widened to uint64 for Stage A3.5 listener delta math
- IPv4-address columns decoded from 4-byte OCTET STRING (RFC 4273)
- 8 unit tests

## Validation
- `go test ./internal/polling/...` → 99 tests across A3.x, all green
- `golangci-lint run` → 0 issues

## Scope
IPv4-only `bgpPeerTable`. IPv6 (bgp4v2 / draft-ietf-idr-bgp4-mibv2) deferred.