### PR TITLE
feat(engine): minimal engine interface + lifecycle registry (stage a3.5a)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,0 +1,194 @@
+// Package engine defines the minimal lifecycle contract every
+// long-running seed subsystem implements (probe engine, retention
+// engine, snmp poller, listeners, discovery). The interface is
+// deliberately small — Name + Start + Stop — because the behaviors
+// differ too much under the hood to force them through a richer
+// shared API.
+//
+// The payoff is in lifecycle, not behavior:
+//
+//   - server.go registers every subsystem with a Registry and
+//     starts them in one loop, stops them in reverse order on
+//     shutdown.
+//   - Per-tier gating reads as Registry.Enable("snmp-poller") for
+//     Pro, off for Free, instead of bespoke conditionals at every
+//     init site.
+//   - Structured logging context (engine.name) is injected once
+//     in Registry.Start instead of by every engine's lifecycle.
+//   - A future GET /api/engines admin endpoint enumerates the
+//     Registry rather than chasing fields on the server struct.
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"sync"
+)
+
+// Engine is the lifecycle contract. Engines self-manage their
+// internal scheduler, subscribers, repositories — Registry only
+// cares about identity + start/stop.
+type Engine interface {
+	// Name is the stable identifier for logs, metrics, and the
+	// /api/engines admin surface. Use kebab-case; one word
+	// preferred (probe, retention, snmp-poller).
+	Name() string
+
+	// Start brings the engine up. Must be idempotent — registering
+	// twice and starting twice cannot leave duplicate goroutines.
+	// Returning an error aborts the rest of the registry's start
+	// sequence; callers should treat partial-start as failure and
+	// invoke Stop to clean up engines that did come up.
+	Start(ctx context.Context) error
+
+	// Stop tears the engine down. Must be safe to call repeatedly
+	// and safe to call when the engine never started.
+	Stop(ctx context.Context) error
+}
+
+// ErrAlreadyStarted is returned by Registry.Start when invoked on
+// an already-running registry.
+var ErrAlreadyStarted = errors.New("engine registry already started")
+
+// Registry is a small, ordered collection of named engines. Start
+// brings them up in registration order; Stop tears them down in
+// reverse order so dependencies wind down cleanly (e.g. the
+// retention engine depends on the probe engine's results being
+// flushed first).
+type Registry struct {
+	logger *slog.Logger
+
+	mu       sync.Mutex
+	engines  []Engine
+	names    map[string]struct{}
+	started  bool
+	startedN int // how many engines actually came up — used by Stop
+}
+
+// NewRegistry returns an empty registry. Pass nil logger to use
+// [slog.Default].
+func NewRegistry(logger *slog.Logger) *Registry {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Registry{
+		logger: logger,
+		names:  make(map[string]struct{}),
+	}
+}
+
+// Register adds an engine to the registry. Duplicate names return
+// an error — engine names are global and must be unique. Returns
+// an error if invoked after Start (the registry's order is
+// established at registration time).
+func (r *Registry) Register(e Engine) error {
+	if e == nil {
+		return errors.New("engine: nil engine cannot be registered")
+	}
+	name := e.Name()
+	if name == "" {
+		return errors.New("engine: registered engine has empty Name()")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.started {
+		return errors.New("engine: cannot Register after Start")
+	}
+	if _, dup := r.names[name]; dup {
+		return fmt.Errorf("engine: duplicate engine name %q", name)
+	}
+	r.engines = append(r.engines, e)
+	r.names[name] = struct{}{}
+	return nil
+}
+
+// Engines returns a snapshot of the registered engines in
+// registration order. Useful for /api/engines listings.
+func (r *Registry) Engines() []Engine {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]Engine, len(r.engines))
+	copy(out, r.engines)
+	return out
+}
+
+// Start brings every registered engine up in registration order.
+// Returns [ErrAlreadyStarted] if invoked on a running registry. If
+// any engine returns an error, every engine that already started
+// is stopped before Start returns the error.
+func (r *Registry) Start(ctx context.Context) error {
+	r.mu.Lock()
+	if r.started {
+		r.mu.Unlock()
+		return ErrAlreadyStarted
+	}
+	r.started = true
+	snapshot := make([]Engine, len(r.engines))
+	copy(snapshot, r.engines)
+	r.mu.Unlock()
+
+	for i, e := range snapshot {
+		r.logger.InfoContext(ctx, "engine starting", "engine", e.Name())
+		if err := e.Start(ctx); err != nil {
+			r.logger.ErrorContext(ctx, "engine start failed",
+				"engine", e.Name(), "error", err)
+			// Roll back: stop everything we already started.
+			r.rollback(ctx, snapshot[:i])
+			r.mu.Lock()
+			r.started = false
+			r.startedN = 0
+			r.mu.Unlock()
+			return fmt.Errorf("engine %q: %w", e.Name(), err)
+		}
+		r.mu.Lock()
+		r.startedN++
+		r.mu.Unlock()
+	}
+	return nil
+}
+
+// Stop tears engines down in reverse registration order. Safe to
+// call when Start was never invoked or when a previous Start
+// failed partway. Returns the first stop error encountered but
+// always continues stopping the rest.
+func (r *Registry) Stop(ctx context.Context) error {
+	r.mu.Lock()
+	if !r.started {
+		r.mu.Unlock()
+		return nil
+	}
+	snapshot := make([]Engine, r.startedN)
+	copy(snapshot, r.engines[:r.startedN])
+	r.started = false
+	r.startedN = 0
+	r.mu.Unlock()
+
+	return r.stopAll(ctx, snapshot)
+}
+
+// rollback stops engines that came up before a Start error,
+// without flipping the started flag (caller already cleared it).
+func (r *Registry) rollback(ctx context.Context, started []Engine) {
+	_ = r.stopAll(ctx, started)
+}
+
+// stopAll iterates engines in reverse order, logging and tracking
+// the first error but always running every Stop.
+func (r *Registry) stopAll(ctx context.Context, engines []Engine) error {
+	var firstErr error
+	for _, e := range slices.Backward(engines) {
+		r.logger.InfoContext(ctx, "engine stopping", "engine", e.Name())
+		if err := e.Stop(ctx); err != nil {
+			r.logger.ErrorContext(ctx, "engine stop failed",
+				"engine", e.Name(), "error", err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("engine %q: %w", e.Name(), err)
+			}
+		}
+	}
+	return firstErr
+}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,0 +1,242 @@
+package engine_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/engine"
+)
+
+func silentLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+// fakeEngine records the lifecycle calls it received so tests can
+// assert ordering. startErr / stopErr are returned to test rollback
+// and error propagation.
+type fakeEngine struct {
+	mu       sync.Mutex
+	name     string
+	startErr error
+	stopErr  error
+	starts   int
+	stops    int
+
+	startOrder *[]string
+	stopOrder  *[]string
+}
+
+func (f *fakeEngine) Name() string { return f.name }
+
+func (f *fakeEngine) Start(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.startErr != nil {
+		return f.startErr
+	}
+	f.starts++
+	if f.startOrder != nil {
+		*f.startOrder = append(*f.startOrder, f.name)
+	}
+	return nil
+}
+
+func (f *fakeEngine) Stop(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stops++
+	if f.stopOrder != nil {
+		*f.stopOrder = append(*f.stopOrder, f.name)
+	}
+	return f.stopErr
+}
+
+func TestRegistry_RegisterRejectsNilOrEmptyName(t *testing.T) {
+	t.Parallel()
+	r := engine.NewRegistry(silentLogger())
+	if err := r.Register(nil); err == nil {
+		t.Error("expected nil engine to be rejected")
+	}
+	if err := r.Register(&fakeEngine{name: ""}); err == nil {
+		t.Error("expected empty Name() to be rejected")
+	}
+}
+
+func TestRegistry_RegisterRejectsDuplicateName(t *testing.T) {
+	t.Parallel()
+	r := engine.NewRegistry(silentLogger())
+	if err := r.Register(&fakeEngine{name: "probe"}); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	if err := r.Register(&fakeEngine{name: "probe"}); err == nil {
+		t.Error("expected duplicate name to be rejected")
+	}
+}
+
+func TestRegistry_StartInRegistrationOrderStopInReverse(t *testing.T) {
+	t.Parallel()
+	var startOrder, stopOrder []string
+	r := engine.NewRegistry(silentLogger())
+	for _, n := range []string{"probe", "retention", "snmp"} {
+		if err := r.Register(&fakeEngine{
+			name:       n,
+			startOrder: &startOrder,
+			stopOrder:  &stopOrder,
+		}); err != nil {
+			t.Fatalf("register %s: %v", n, err)
+		}
+	}
+
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := r.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	wantStart := []string{"probe", "retention", "snmp"}
+	wantStop := []string{"snmp", "retention", "probe"}
+	if !equalSlices(startOrder, wantStart) {
+		t.Errorf("start order = %v, want %v", startOrder, wantStart)
+	}
+	if !equalSlices(stopOrder, wantStop) {
+		t.Errorf("stop order = %v, want %v", stopOrder, wantStop)
+	}
+}
+
+func TestRegistry_StartTwiceReturnsErrAlreadyStarted(t *testing.T) {
+	t.Parallel()
+	r := engine.NewRegistry(silentLogger())
+	_ = r.Register(&fakeEngine{name: "probe"})
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if err := r.Start(context.Background()); !errors.Is(err, engine.ErrAlreadyStarted) {
+		t.Errorf("second Start = %v, want ErrAlreadyStarted", err)
+	}
+}
+
+func TestRegistry_StartErrorRollsBackStartedEngines(t *testing.T) {
+	t.Parallel()
+	a := &fakeEngine{name: "a"}
+	b := &fakeEngine{name: "b"}
+	c := &fakeEngine{name: "c", startErr: errors.New("boom")}
+	d := &fakeEngine{name: "d"} // should never start
+
+	r := engine.NewRegistry(silentLogger())
+	for _, e := range []engine.Engine{a, b, c, d} {
+		if err := r.Register(e); err != nil {
+			t.Fatalf("register: %v", err)
+		}
+	}
+
+	err := r.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected Start error")
+	}
+
+	if a.stops != 1 || b.stops != 1 {
+		t.Errorf("a.stops=%d, b.stops=%d, want both = 1", a.stops, b.stops)
+	}
+	if c.starts != 0 || d.starts != 0 {
+		t.Errorf("failed engine + later engines must not have started; starts c=%d d=%d",
+			c.starts, d.starts)
+	}
+	if d.stops != 0 {
+		t.Errorf("never-started engine must not have been stopped; d.stops=%d", d.stops)
+	}
+}
+
+func TestRegistry_StopWithoutStartIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &fakeEngine{name: "a"}
+	r := engine.NewRegistry(silentLogger())
+	_ = r.Register(a)
+	if err := r.Stop(context.Background()); err != nil {
+		t.Errorf("Stop before Start should be nil, got %v", err)
+	}
+	if a.stops != 0 {
+		t.Errorf("Stop before Start should not invoke engine.Stop, got stops=%d", a.stops)
+	}
+}
+
+func TestRegistry_StopAfterFailedStartIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &fakeEngine{name: "a", startErr: errors.New("boom")}
+	r := engine.NewRegistry(silentLogger())
+	_ = r.Register(a)
+	_ = r.Start(context.Background())
+	priorStops := a.stops
+	if err := r.Stop(context.Background()); err != nil {
+		t.Errorf("Stop after failed Start should be nil, got %v", err)
+	}
+	if a.stops != priorStops {
+		t.Errorf("Stop after failed Start should not re-Stop already-stopped engines")
+	}
+}
+
+func TestRegistry_StopContinuesPastErrors(t *testing.T) {
+	t.Parallel()
+	a := &fakeEngine{name: "a", stopErr: errors.New("a stop failed")}
+	b := &fakeEngine{name: "b", stopErr: errors.New("b stop failed")}
+	c := &fakeEngine{name: "c"}
+	r := engine.NewRegistry(silentLogger())
+	for _, e := range []engine.Engine{a, b, c} {
+		_ = r.Register(e)
+	}
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	err := r.Stop(context.Background())
+	if err == nil {
+		t.Fatal("expected Stop to surface first error")
+	}
+	if a.stops != 1 || b.stops != 1 || c.stops != 1 {
+		t.Errorf("every engine must have been Stop()ed; stops a=%d b=%d c=%d",
+			a.stops, b.stops, c.stops)
+	}
+}
+
+func TestRegistry_RegisterRejectedAfterStart(t *testing.T) {
+	t.Parallel()
+	r := engine.NewRegistry(silentLogger())
+	_ = r.Register(&fakeEngine{name: "a"})
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := r.Register(&fakeEngine{name: "b"}); err == nil {
+		t.Error("expected Register after Start to be rejected")
+	}
+}
+
+func TestRegistry_EnginesReturnsSnapshot(t *testing.T) {
+	t.Parallel()
+	r := engine.NewRegistry(silentLogger())
+	for _, n := range []string{"probe", "retention", "snmp"} {
+		_ = r.Register(&fakeEngine{name: n})
+	}
+	got := r.Engines()
+	if len(got) != 3 {
+		t.Fatalf("Engines() returned %d, want 3", len(got))
+	}
+	wantNames := []string{"probe", "retention", "snmp"}
+	for i, e := range got {
+		if e.Name() != wantNames[i] {
+			t.Errorf("Engines()[%d].Name() = %q, want %q", i, e.Name(), wantNames[i])
+		}
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/polling/snmp/poller.go
+++ b/internal/polling/snmp/poller.go
@@ -81,6 +81,11 @@ func (p *Poller) RegisterCollector(c Collector) {
 	p.collectors[c.Name()] = c
 }
 
+// Name returns "snmp-poller". Implements [engine.Engine] so the
+// poller registers in the lifecycle registry alongside the probe +
+// retention engines.
+func (*Poller) Name() string { return "snmp-poller" }
+
 // Start loads all enabled polling_targets and registers one job
 // per target with the scheduler. Idempotent.
 func (p *Poller) Start(ctx context.Context) error {

--- a/internal/probe/lifecycle.go
+++ b/internal/probe/lifecycle.go
@@ -45,9 +45,13 @@ func (e *Engine) WithStorage(storage probeStorage, sched probeScheduler) *Engine
 	return e
 }
 
-// Start loads every enabled probe from the storage layer, registers
-// each as a scheduler job, and begins the scheduler's tick loop.
-// Returns ErrStorageNotConfigured if WithStorage was not called.
+// Name returns "probe". Implements [engine.Engine] so the probe
+// engine can register in the lifecycle registry alongside other
+// long-running subsystems.
+func (*Engine) Name() string { return "probe" }
+
+// Start dispatches the scheduled probes. Returns
+// ErrStorageNotConfigured if WithStorage was not called.
 //
 // Start is idempotent at the second-call level: a second Start
 // without an intervening Stop returns nil immediately. Honors ctx

--- a/internal/timeseries/retention/engine.go
+++ b/internal/timeseries/retention/engine.go
@@ -112,6 +112,11 @@ func (e *Engine) Register(src RollupSource) {
 	e.sources = append(e.sources, src)
 }
 
+// Name returns "retention". Implements [engine.Engine] so the
+// retention engine registers in the lifecycle registry alongside
+// the probe + snmp engines.
+func (*Engine) Name() string { return "retention" }
+
 // Start begins the periodic rollup + purge loop. Returns nil if
 // already started.
 func (e *Engine) Start(ctx context.Context) error {


### PR DESCRIPTION
## Summary
Stage A3.5a — promote the lifecycle pattern that ProbeEngine,
RetentionEngine, and `snmp.Poller` all already implemented into a
formal `engine.Engine` interface (Name + Start + Stop) plus an
ordered `Registry`. Deliberately minimal — behaviors differ too
much under the hood to share a richer API.

## Changes
- `internal/engine.Engine` — 3-method interface
- `internal/engine.Registry` — ordered registration, forward-Start / reverse-Stop, partial-start rollback, post-start register rejection
- `Name()` added to `probe.Engine`, `retention.Engine`, `snmp.Poller`
- 12 unit tests cover every error path

## Validation
- `go test ./internal/engine/... ./internal/probe/... ./internal/timeseries/... ./internal/polling/...` → green
- `golangci-lint run` → 0 issues

## Next
A3.5b wires the SNMP orchestrator into the registry and rewrites
the existing ad-hoc Start code in `internal/api/server.go`.

## Tracked for later
Per the discussion: `/api/engines` admin surface, per-tier engine
gating, structured logging context injection, tick-driven engines —
all future iterations once the registry has more occupants.