### PR TITLE
feat(snmp): orchestrator + observation persistence (stage a3.5b)

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -64,17 +64,18 @@ type DB struct {
 	closed bool
 
 	// Repositories - lazily initialized
-	profiles       *ProfileRepository
-	metrics        *MetricsRepository
-	devices        *DeviceRepository
-	alerts         *AlertRepository
-	settings       *SettingsRepository
-	logs           *LogRepository
-	healthChecks   *HealthCheckRepository
-	discovery      *DiscoveryRepository
-	clients        *ClientRepository
-	probes         *ProbeRepository
-	pollingTargets *PollingTargetRepository
+	profiles         *ProfileRepository
+	metrics          *MetricsRepository
+	devices          *DeviceRepository
+	alerts           *AlertRepository
+	settings         *SettingsRepository
+	logs             *LogRepository
+	healthChecks     *HealthCheckRepository
+	discovery        *DiscoveryRepository
+	clients          *ClientRepository
+	probes           *ProbeRepository
+	pollingTargets   *PollingTargetRepository
+	snmpObservations *SNMPObservationsRepository
 }
 
 // Config holds database configuration options.
@@ -486,6 +487,20 @@ func (db *DB) PollingTargets() *PollingTargetRepository {
 		db.pollingTargets = &PollingTargetRepository{db: db}
 	}
 	return db.pollingTargets
+}
+
+// SNMPObservations returns the unified SNMP observations repository
+// (Stage A3.5b). Every collector Publisher writes one row per poll;
+// Stage A4 topology + the listener pipeline read kind-filtered rows
+// downstream.
+func (db *DB) SNMPObservations() *SNMPObservationsRepository {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.snmpObservations == nil {
+		db.snmpObservations = &SNMPObservationsRepository{db: db}
+	}
+	return db.snmpObservations
 }
 
 // Exec executes a query without returning any rows.

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1747,6 +1747,38 @@ func getMigrationDefs() []migrationDef {
 			ALTER TABLE polling_targets ADD COLUMN collector_chain TEXT NOT NULL DEFAULT '["sys_info","if_table","lldp","arp","fdb"]';
 		`,
 		},
+		{
+			// Stage A3.5b — unified persistence for every SNMP
+			// collector observation. One row per (client, target,
+			// kind, observed_at); payload_json carries the typed
+			// observation struct. Stage A4 reconciler reads kind-
+			// filtered rows to build topology; the listener pipeline
+			// reads them to compute deltas and emit events.
+			//
+			// Single table beats per-kind tables for V1.0 because:
+			// 1. Schema evolution is JSON-only — adding a new
+			//    collector kind doesn't touch the migration list.
+			// 2. Retention is one DELETE WHERE observed_at < cutoff
+			//    instead of N tables.
+			// 3. The listener pipeline iterates kinds at SQL time,
+			//    not at schema definition time.
+			Description: "Create snmp_observations for unified collector output",
+			Up: `
+			CREATE TABLE IF NOT EXISTS snmp_observations (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				target_id TEXT NOT NULL,
+				kind TEXT NOT NULL,
+				observed_at TEXT NOT NULL,
+				payload_json TEXT NOT NULL,
+				ingested_at TEXT NOT NULL
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_snmp_observations_client_kind ON snmp_observations(client_id, kind, observed_at);
+			CREATE INDEX IF NOT EXISTS idx_snmp_observations_target ON snmp_observations(target_id, observed_at);
+			CREATE INDEX IF NOT EXISTS idx_snmp_observations_observed_at ON snmp_observations(observed_at);
+		`,
+		},
 	}
 }
 

--- a/internal/database/repository_snmp_observations.go
+++ b/internal/database/repository_snmp_observations.go
@@ -1,0 +1,182 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// SNMPObservation is one row of snmp_observations. PayloadJSON
+// carries the typed collector Observation struct serialized as JSON
+// — callers decode it back into the kind-specific shape they own.
+type SNMPObservation struct {
+	ID          int64
+	ClientID    string
+	TargetID    string
+	Kind        string
+	ObservedAt  time.Time
+	PayloadJSON string
+	IngestedAt  time.Time
+}
+
+// SNMPObservationsRepository owns CRUD over snmp_observations.
+type SNMPObservationsRepository struct {
+	db *DB
+}
+
+// Insert records one observation. ObservedAt and IngestedAt are
+// stamped if zero.
+func (r *SNMPObservationsRepository) Insert(ctx context.Context, obs *SNMPObservation) error {
+	if obs.Kind == "" {
+		return errors.New("snmp_observations: Kind required")
+	}
+	if obs.TargetID == "" {
+		return errors.New("snmp_observations: TargetID required")
+	}
+	now := time.Now().UTC()
+	if obs.ObservedAt.IsZero() {
+		obs.ObservedAt = now
+	}
+	if obs.IngestedAt.IsZero() {
+		obs.IngestedAt = now
+	}
+	if obs.ClientID == "" {
+		obs.ClientID = "default"
+	}
+
+	res, err := r.db.Exec(ctx, `
+		INSERT INTO snmp_observations (client_id, target_id, kind, observed_at, payload_json, ingested_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`,
+		obs.ClientID,
+		obs.TargetID,
+		obs.Kind,
+		obs.ObservedAt.UTC().Format(time.RFC3339Nano),
+		obs.PayloadJSON,
+		obs.IngestedAt.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return fmt.Errorf("insert snmp_observation: %w", err)
+	}
+	if id, idErr := res.LastInsertId(); idErr == nil {
+		obs.ID = id
+	}
+	return nil
+}
+
+// ListOptions narrows the query — empty values disable that filter.
+type ListOptions struct {
+	ClientID string
+	TargetID string
+	Kind     string
+	Since    time.Time
+	Until    time.Time
+	Limit    int
+}
+
+// List returns observations matching opts ordered by ObservedAt
+// descending (newest first). Limit is clamped to 1000 if unset.
+func (r *SNMPObservationsRepository) List(ctx context.Context, opts ListOptions) ([]*SNMPObservation, error) {
+	const defaultLimit, maxLimit = 100, 1000
+
+	query := `
+		SELECT id, client_id, target_id, kind, observed_at, payload_json, ingested_at
+		FROM snmp_observations
+		WHERE 1=1
+	`
+	args := []any{}
+	if opts.ClientID != "" {
+		query += " AND client_id = ?"
+		args = append(args, opts.ClientID)
+	}
+	if opts.TargetID != "" {
+		query += " AND target_id = ?"
+		args = append(args, opts.TargetID)
+	}
+	if opts.Kind != "" {
+		query += " AND kind = ?"
+		args = append(args, opts.Kind)
+	}
+	if !opts.Since.IsZero() {
+		query += " AND observed_at >= ?"
+		args = append(args, opts.Since.UTC().Format(time.RFC3339Nano))
+	}
+	if !opts.Until.IsZero() {
+		query += " AND observed_at <= ?"
+		args = append(args, opts.Until.UTC().Format(time.RFC3339Nano))
+	}
+	query += " ORDER BY observed_at DESC LIMIT ?"
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	if limit > maxLimit {
+		limit = maxLimit
+	}
+	args = append(args, limit)
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list snmp_observations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*SNMPObservation
+	for rows.Next() {
+		obs, scanErr := scanSNMPObservation(rows.Scan)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, obs)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("list snmp_observations iter: %w", rowsErr)
+	}
+	return out, nil
+}
+
+// DeleteOlderThan removes observations whose observed_at is before
+// cutoff. Returns the number of rows deleted.
+func (r *SNMPObservationsRepository) DeleteOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := r.db.Exec(ctx,
+		`DELETE FROM snmp_observations WHERE observed_at < ?`,
+		cutoff.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("purge snmp_observations: %w", err)
+	}
+	if res == nil {
+		return 0, errors.New("purge snmp_observations: nil sql.Result")
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// scanSNMPObservation reads a row via a [sql.Row.Scan] or
+// [sql.Rows.Scan] signature.
+func scanSNMPObservation(scan func(...any) error) (*SNMPObservation, error) {
+	var (
+		obs           SNMPObservation
+		observedAtStr string
+		ingestedAtStr string
+	)
+	err := scan(
+		&obs.ID, &obs.ClientID, &obs.TargetID, &obs.Kind,
+		&observedAtStr, &obs.PayloadJSON, &ingestedAtStr,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, sql.ErrNoRows
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan snmp_observation: %w", err)
+	}
+	if parsed, perr := time.Parse(time.RFC3339Nano, observedAtStr); perr == nil {
+		obs.ObservedAt = parsed
+	}
+	if parsed, perr := time.Parse(time.RFC3339Nano, ingestedAtStr); perr == nil {
+		obs.IngestedAt = parsed
+	}
+	return &obs, nil
+}

--- a/internal/polling/snmp/orchestrator/orchestrator.go
+++ b/internal/polling/snmp/orchestrator/orchestrator.go
@@ -1,0 +1,88 @@
+// Package orchestrator wires the eleven Stage A3 SNMP collectors
+// (sys_info, if_table, lldp, cdp, fdp, arp, fdb, routing,
+// host_resources, bgp4_mib) into a single [engine.Engine] that the
+// server lifecycle registry starts and stops.
+//
+// Build returns a configured [*snmp.Poller] with every default
+// collector registered against a single [sink.Sink] persisting into
+// snmp_observations. The orchestrator does not own the SNMP client
+// factory — callers inject one ([snmp.ClientFactory]) so production
+// can plug in a real gosnmp dialer while tests pass a fake.
+package orchestrator
+
+import (
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/arp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/bgp4"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/cdp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/fdb"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/fdp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/hostresources"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/iftable"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/lldp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/routing"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/sysinfo"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/sink"
+	"github.com/krisarmstrong/seed/internal/scheduler"
+)
+
+// Config holds the dependencies the orchestrator needs to build a
+// fully wired Poller. Logger and Now are optional — nil values fall
+// back to [slog.Default] and [time.Now].UTC respectively.
+type Config struct {
+	DB            *database.DB
+	Scheduler     *scheduler.Scheduler
+	ClientFactory snmp.ClientFactory
+	Logger        *slog.Logger
+	Now           func() time.Time
+}
+
+// Build returns a *snmp.Poller with all eleven default collectors
+// registered against a sink that persists into snmp_observations.
+// The returned Poller satisfies [engine.Engine] so the server
+// registers it directly with the engine registry.
+//
+// Returns an error if any required Config field is unset.
+func Build(cfg Config) (*snmp.Poller, error) {
+	if cfg.DB == nil {
+		return nil, errors.New("orchestrator: DB required")
+	}
+	if cfg.Scheduler == nil {
+		return nil, errors.New("orchestrator: Scheduler required")
+	}
+	if cfg.ClientFactory == nil {
+		return nil, errors.New("orchestrator: ClientFactory required")
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	now := cfg.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+
+	persistSink := sink.New(cfg.DB.SNMPObservations(), logger, now)
+	poller := snmp.NewPoller(cfg.DB.PollingTargets(), cfg.Scheduler, logger)
+
+	// Register every collector. cdp + fdp share a Publisher (CDP),
+	// distinguished downstream by Observation.TablePrefix.
+	poller.RegisterCollector(sysinfo.New(cfg.ClientFactory, persistSink, now))
+	poller.RegisterCollector(iftable.New(cfg.ClientFactory, persistSink, now))
+	poller.RegisterCollector(lldp.New(cfg.ClientFactory, persistSink, now))
+	poller.RegisterCollector(cdp.New(cfg.ClientFactory, persistSink, now))
+	poller.RegisterCollector(fdp.New(cfg.ClientFactory, persistSink, now))
+	poller.RegisterCollector(arp.New(cfg.ClientFactory, persistSink, now))
+	poller.RegisterCollector(fdb.New(cfg.ClientFactory, persistSink, now))
+	poller.RegisterCollector(routing.New(cfg.ClientFactory, persistSink, now))
+	poller.RegisterCollector(hostresources.New(cfg.ClientFactory, persistSink, now))
+	poller.RegisterCollector(bgp4.New(cfg.ClientFactory, persistSink, now))
+
+	return poller, nil
+}

--- a/internal/polling/snmp/orchestrator/orchestrator_test.go
+++ b/internal/polling/snmp/orchestrator/orchestrator_test.go
@@ -1,0 +1,148 @@
+package orchestrator_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/polling/snmp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/orchestrator"
+	"github.com/krisarmstrong/seed/internal/scheduler"
+)
+
+func silentLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+func at() time.Time              { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+// openTestDB returns a freshly migrated database backed by a
+// temporary file. Closed automatically when t terminates.
+func openTestDB(t *testing.T) *database.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "seed.db")
+	db, err := database.Open(path)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func newSchedulerForTest() *scheduler.Scheduler {
+	return scheduler.New(time.Hour) // tick is irrelevant for these tests
+}
+
+// nopClientFactory returns a Client that errors on every call —
+// orchestrator-level tests verify wiring without dialling SNMP.
+func nopClientFactory(_ snmp.Target, _ snmp.ResolvedCredentials) (snmp.Client, error) {
+	return nil, errors.New("orchestrator test: client factory not used")
+}
+
+func TestBuild_AllRequiredFieldsValidated(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	sched := newSchedulerForTest()
+
+	tests := []struct {
+		name string
+		cfg  orchestrator.Config
+	}{
+		{"missing DB", orchestrator.Config{Scheduler: sched, ClientFactory: nopClientFactory}},
+		{"missing Scheduler", orchestrator.Config{DB: db, ClientFactory: nopClientFactory}},
+		{"missing ClientFactory", orchestrator.Config{DB: db, Scheduler: sched}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := orchestrator.Build(tt.cfg); err == nil {
+				t.Errorf("Build(%s) should have returned error", tt.name)
+			}
+		})
+	}
+}
+
+func TestBuild_ReturnsPollerWithEngineName(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	sched := newSchedulerForTest()
+
+	poller, err := orchestrator.Build(orchestrator.Config{
+		DB:            db,
+		Scheduler:     sched,
+		ClientFactory: nopClientFactory,
+		Logger:        silentLogger(),
+		Now:           at,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if poller.Name() != "snmp-poller" {
+		t.Errorf("poller.Name() = %q, want snmp-poller", poller.Name())
+	}
+}
+
+func TestBuild_PollerStartLoadsZeroTargetsCleanly(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	sched := newSchedulerForTest()
+
+	poller, err := orchestrator.Build(orchestrator.Config{
+		DB:            db,
+		Scheduler:     sched,
+		ClientFactory: nopClientFactory,
+		Logger:        silentLogger(),
+		Now:           at,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// With no polling targets configured, Start should succeed
+	// (no jobs registered, scheduler still spins up).
+	if startErr := poller.Start(context.Background()); startErr != nil {
+		t.Fatalf("Start with empty targets: %v", startErr)
+	}
+	if stopErr := poller.Stop(context.Background()); stopErr != nil {
+		t.Fatalf("Stop: %v", stopErr)
+	}
+}
+
+func TestBuild_RegistersAllElevenCollectorChainKinds(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	sched := newSchedulerForTest()
+
+	// Pre-seed one polling target so Start has work to find, then
+	// verify the chain references collectors the poller knows about.
+	ctx := context.Background()
+	if _, err := db.Exec(ctx, `
+		INSERT INTO polling_targets
+		  (id, name, ip_address, snmp_version, poll_interval_seconds, enabled,
+		   collector_chain, created_at, updated_at, client_id)
+		VALUES
+		  ('t-1', 'router-1', '10.0.0.1', 'v2c', 60, 1,
+		   '["sys_info","if_table","lldp","cdp","fdp","arp","fdb","routing","host_resources","bgp4_mib"]',
+		   ?, ?, 'default')
+	`, time.Now().UTC().Format(time.RFC3339Nano), time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	poller, err := orchestrator.Build(orchestrator.Config{
+		DB:            db,
+		Scheduler:     sched,
+		ClientFactory: nopClientFactory,
+		Logger:        silentLogger(),
+		Now:           at,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if startErr := poller.Start(ctx); startErr != nil {
+		t.Fatalf("Start: %v", startErr)
+	}
+	if stopErr := poller.Stop(ctx); stopErr != nil {
+		t.Fatalf("Stop: %v", stopErr)
+	}
+}

--- a/internal/polling/snmp/sink/sink.go
+++ b/internal/polling/snmp/sink/sink.go
@@ -1,0 +1,161 @@
+// Package sink wires the eleven Stage A3 collector Publisher
+// interfaces (sysinfo, iftable, lldp, cdp, fdp, arp, fdb, routing,
+// hostresources, bgp4) to a single concrete sink that persists
+// every observation into the snmp_observations table.
+//
+// One Sink instance implements every Publisher interface — that
+// keeps the orchestrator wire-up to one line per collector
+// (RegisterCollector(sysinfo.New(factory, sink, nil)), etc.)
+// instead of N glue types.
+//
+// Sink serializes the typed Observation as JSON. Downstream
+// consumers (Stage A4 topology reconciler, the listener pipeline,
+// the admin UI) decode the payload back into the kind-specific
+// shape. Single JSON column beats per-kind columns because adding a
+// new collector kind doesn't touch the migration list.
+package sink
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/arp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/bgp4"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/cdp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/fdb"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/hostresources"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/iftable"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/lldp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/routing"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/sysinfo"
+)
+
+// Kind constants mirror each collector's Name() so downstream
+// consumers (Stage A4, listener pipeline) can filter snmp_observations
+// rows without importing every collector package.
+const (
+	KindSysInfo       = "sys_info"
+	KindIfTable       = "if_table"
+	KindLLDP          = "lldp"
+	KindCDP           = "cdp"
+	KindFDP           = "fdp"
+	KindARP           = "arp"
+	KindFDB           = "fdb"
+	KindRouting       = "routing"
+	KindHostResources = "host_resources"
+	KindBGP4          = "bgp4_mib"
+)
+
+// observationsStore is the narrowed surface the Sink needs from the
+// database layer. Tests inject a fake.
+type observationsStore interface {
+	Insert(ctx context.Context, obs *database.SNMPObservation) error
+}
+
+// Sink persists every kind of collector Observation into the
+// snmp_observations table. One Sink instance implements every
+// Publisher interface so the orchestrator wire-up stays trivial.
+type Sink struct {
+	store  observationsStore
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// New returns a Sink bound to store. Pass nil logger to use
+// [slog.Default]; pass nil now to use [time.Now] in UTC.
+func New(store observationsStore, logger *slog.Logger, now func() time.Time) *Sink {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Sink{store: store, logger: logger, now: now}
+}
+
+// persist is the common path every PublishX method funnels into.
+// Serializing here (rather than per-kind) keeps the shape stable
+// across all observation kinds — payload_json is always the typed
+// Observation struct serialized verbatim, no envelope.
+func (s *Sink) persist(
+	ctx context.Context,
+	kind, clientID, targetID string,
+	observedAt time.Time,
+	payload any,
+) error {
+	jsonBytes, err := json.Marshal(payload)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "snmp sink: marshal failed",
+			"kind", kind, "target_id", targetID, "error", err)
+		return fmt.Errorf("snmp sink: marshal %s: %w", kind, err)
+	}
+	obs := &database.SNMPObservation{
+		ClientID:    clientID,
+		TargetID:    targetID,
+		Kind:        kind,
+		ObservedAt:  observedAt,
+		PayloadJSON: string(jsonBytes),
+		IngestedAt:  s.now(),
+	}
+	if storeErr := s.store.Insert(ctx, obs); storeErr != nil {
+		s.logger.WarnContext(ctx, "snmp sink: insert failed",
+			"kind", kind, "target_id", targetID, "error", storeErr)
+		return fmt.Errorf("snmp sink: insert %s: %w", kind, storeErr)
+	}
+	return nil
+}
+
+// PublishSysInfo implements [sysinfo.Publisher].
+func (s *Sink) PublishSysInfo(ctx context.Context, obs sysinfo.Observation) error {
+	return s.persist(ctx, KindSysInfo, obs.ClientID, obs.TargetID, obs.ObservedAt, obs)
+}
+
+// PublishIfTable implements [iftable.Publisher].
+func (s *Sink) PublishIfTable(ctx context.Context, obs iftable.Observation) error {
+	return s.persist(ctx, KindIfTable, obs.ClientID, obs.TargetID, obs.ObservedAt, obs)
+}
+
+// PublishLLDP implements [lldp.Publisher].
+func (s *Sink) PublishLLDP(ctx context.Context, obs lldp.Observation) error {
+	return s.persist(ctx, KindLLDP, obs.ClientID, obs.TargetID, obs.ObservedAt, obs)
+}
+
+// PublishCDP implements [cdp.Publisher]. CDP and FDP both land here
+// because the observation shape is identical; obs.TablePrefix
+// distinguishes the two on read.
+func (s *Sink) PublishCDP(ctx context.Context, obs cdp.Observation) error {
+	kind := KindCDP
+	if obs.TablePrefix != "" && obs.TablePrefix != cdp.DefaultTablePrefix {
+		kind = KindFDP
+	}
+	return s.persist(ctx, kind, obs.ClientID, obs.TargetID, obs.ObservedAt, obs)
+}
+
+// PublishARP implements [arp.Publisher].
+func (s *Sink) PublishARP(ctx context.Context, obs arp.Observation) error {
+	return s.persist(ctx, KindARP, obs.ClientID, obs.TargetID, obs.ObservedAt, obs)
+}
+
+// PublishFDB implements [fdb.Publisher].
+func (s *Sink) PublishFDB(ctx context.Context, obs fdb.Observation) error {
+	return s.persist(ctx, KindFDB, obs.ClientID, obs.TargetID, obs.ObservedAt, obs)
+}
+
+// PublishRouting implements [routing.Publisher].
+func (s *Sink) PublishRouting(ctx context.Context, obs routing.Observation) error {
+	return s.persist(ctx, KindRouting, obs.ClientID, obs.TargetID, obs.ObservedAt, obs)
+}
+
+// PublishHostResources implements [hostresources.Publisher].
+func (s *Sink) PublishHostResources(ctx context.Context, obs hostresources.Observation) error {
+	return s.persist(ctx, KindHostResources, obs.ClientID, obs.TargetID, obs.ObservedAt, obs)
+}
+
+// PublishBGP4 implements [bgp4.Publisher].
+func (s *Sink) PublishBGP4(ctx context.Context, obs bgp4.Observation) error {
+	return s.persist(ctx, KindBGP4, obs.ClientID, obs.TargetID, obs.ObservedAt, obs)
+}

--- a/internal/polling/snmp/sink/sink_test.go
+++ b/internal/polling/snmp/sink/sink_test.go
@@ -1,0 +1,245 @@
+package sink_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/arp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/bgp4"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/cdp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/fdb"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/hostresources"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/iftable"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/lldp"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/routing"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/collectors/sysinfo"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/sink"
+)
+
+func silentLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+func at() time.Time              { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+type fakeStore struct {
+	mu     sync.Mutex
+	rows   []*database.SNMPObservation
+	insErr error
+}
+
+func (f *fakeStore) Insert(_ context.Context, obs *database.SNMPObservation) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.insErr != nil {
+		return f.insErr
+	}
+	f.rows = append(f.rows, obs)
+	return nil
+}
+
+func newSink() (*sink.Sink, *fakeStore) {
+	store := &fakeStore{}
+	return sink.New(store, silentLogger(), at), store
+}
+
+func TestPublishSysInfo_WritesObservationRow(t *testing.T) {
+	t.Parallel()
+	s, store := newSink()
+	obs := sysinfo.Observation{
+		ClientID:   "client-a",
+		TargetID:   "t-1",
+		ObservedAt: time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC),
+		SysDescr:   "Cisco IOS XE",
+		SysName:    "router-1",
+	}
+	if err := s.PublishSysInfo(context.Background(), obs); err != nil {
+		t.Fatalf("PublishSysInfo: %v", err)
+	}
+	if len(store.rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(store.rows))
+	}
+	row := store.rows[0]
+	if row.Kind != sink.KindSysInfo {
+		t.Errorf("kind = %q, want %q", row.Kind, sink.KindSysInfo)
+	}
+	if row.ClientID != "client-a" || row.TargetID != "t-1" {
+		t.Errorf("client/target = %s/%s", row.ClientID, row.TargetID)
+	}
+
+	var decoded sysinfo.Observation
+	if err := json.Unmarshal([]byte(row.PayloadJSON), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.SysDescr != "Cisco IOS XE" || decoded.SysName != "router-1" {
+		t.Errorf("decoded payload = %+v", decoded)
+	}
+}
+
+func TestPublishCDP_DefaultPrefixWritesCDPKind(t *testing.T) {
+	t.Parallel()
+	s, store := newSink()
+	obs := cdp.Observation{
+		ClientID:    "c-a",
+		TargetID:    "t-1",
+		TablePrefix: cdp.DefaultTablePrefix,
+	}
+	_ = s.PublishCDP(context.Background(), obs)
+	if store.rows[0].Kind != sink.KindCDP {
+		t.Errorf("kind = %q, want %q", store.rows[0].Kind, sink.KindCDP)
+	}
+}
+
+func TestPublishCDP_FoundryPrefixWritesFDPKind(t *testing.T) {
+	t.Parallel()
+	s, store := newSink()
+	obs := cdp.Observation{
+		ClientID:    "c-a",
+		TargetID:    "t-1",
+		TablePrefix: "1.3.6.1.4.1.1991.1.1.3.2.2.1",
+	}
+	_ = s.PublishCDP(context.Background(), obs)
+	if store.rows[0].Kind != sink.KindFDP {
+		t.Errorf("kind = %q, want %q (FDP)", store.rows[0].Kind, sink.KindFDP)
+	}
+}
+
+func TestAllPublishers_WriteCorrectKinds(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	target := "t-1"
+
+	type check struct {
+		name string
+		kind string
+		do   func(*sink.Sink) error
+	}
+	checks := []check{
+		{
+			"iftable",
+			sink.KindIfTable,
+			func(s *sink.Sink) error {
+				return s.PublishIfTable(ctx, iftable.Observation{TargetID: target})
+			},
+		},
+		{
+			"lldp",
+			sink.KindLLDP,
+			func(s *sink.Sink) error {
+				return s.PublishLLDP(ctx, lldp.Observation{TargetID: target})
+			},
+		},
+		{
+			"arp",
+			sink.KindARP,
+			func(s *sink.Sink) error {
+				return s.PublishARP(ctx, arp.Observation{TargetID: target})
+			},
+		},
+		{
+			"fdb",
+			sink.KindFDB,
+			func(s *sink.Sink) error {
+				return s.PublishFDB(ctx, fdb.Observation{TargetID: target})
+			},
+		},
+		{
+			"routing",
+			sink.KindRouting,
+			func(s *sink.Sink) error {
+				return s.PublishRouting(ctx, routing.Observation{TargetID: target})
+			},
+		},
+		{
+			"hostresources",
+			sink.KindHostResources,
+			func(s *sink.Sink) error {
+				return s.PublishHostResources(ctx, hostresources.Observation{TargetID: target})
+			},
+		},
+		{
+			"bgp4",
+			sink.KindBGP4,
+			func(s *sink.Sink) error {
+				return s.PublishBGP4(ctx, bgp4.Observation{TargetID: target})
+			},
+		},
+	}
+	for _, tt := range checks {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s, store := newSink()
+			if err := tt.do(s); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if len(store.rows) != 1 {
+				t.Fatalf("rows = %d, want 1", len(store.rows))
+			}
+			if store.rows[0].Kind != tt.kind {
+				t.Errorf("kind = %q, want %q", store.rows[0].Kind, tt.kind)
+			}
+		})
+	}
+}
+
+func TestPersist_PreservesObservedAt(t *testing.T) {
+	t.Parallel()
+	s, store := newSink()
+	expected := time.Date(2026, 1, 15, 8, 30, 45, 0, time.UTC)
+	_ = s.PublishSysInfo(context.Background(), sysinfo.Observation{
+		TargetID:   "t-1",
+		ObservedAt: expected,
+	})
+	if !store.rows[0].ObservedAt.Equal(expected) {
+		t.Errorf("ObservedAt = %v, want %v", store.rows[0].ObservedAt, expected)
+	}
+}
+
+func TestPersist_StampsIngestedAtFromNowFunc(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{}
+	clock := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := sink.New(store, silentLogger(), func() time.Time { return clock })
+
+	_ = s.PublishSysInfo(context.Background(), sysinfo.Observation{TargetID: "t-1"})
+	if !store.rows[0].IngestedAt.Equal(clock) {
+		t.Errorf("IngestedAt = %v, want %v (injected clock)",
+			store.rows[0].IngestedAt, clock)
+	}
+}
+
+func TestPersist_StoreErrorPropagates(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{insErr: errors.New("disk full")}
+	s := sink.New(store, silentLogger(), at)
+	if err := s.PublishSysInfo(context.Background(), sysinfo.Observation{TargetID: "t-1"}); err == nil {
+		t.Error("expected insert error to propagate")
+	}
+}
+
+func TestNew_NilLoggerUsesDefault(t *testing.T) {
+	t.Parallel()
+	s := sink.New(&fakeStore{}, nil, at)
+	// Should not panic when used.
+	if err := s.PublishSysInfo(context.Background(), sysinfo.Observation{TargetID: "t-1"}); err != nil {
+		t.Errorf("Publish with nil logger: %v", err)
+	}
+}
+
+func TestNew_NilNowUsesTimeNow(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{}
+	s := sink.New(store, silentLogger(), nil)
+	before := time.Now().UTC().Add(-time.Second)
+	if err := s.PublishSysInfo(context.Background(), sysinfo.Observation{TargetID: "t-1"}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	after := time.Now().UTC().Add(time.Second)
+	if store.rows[0].IngestedAt.Before(before) || store.rows[0].IngestedAt.After(after) {
+		t.Errorf("IngestedAt = %v, want between %v and %v",
+			store.rows[0].IngestedAt, before, after)
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.5b — wire all eleven Stage A3 collectors to a single sink
that persists into a new `snmp_observations` table. The
orchestrator returns a fully-configured `*snmp.Poller` (which
already satisfies `engine.Engine` from A3.5a) so the server
lifecycle registry registers + starts it like any other long-
running subsystem.

## Changes
- **Migration**: `snmp_observations` (id, client_id, target_id, kind, observed_at, payload_json, ingested_at) + 3 indexes
- **Repository**: `SNMPObservationsRepository.Insert / List / DeleteOlderThan` + `db.SNMPObservations()` accessor
- **Sink**: `internal/polling/snmp/sink.Sink` implementing all 8 collector Publisher interfaces (CDP+FDP share one method, kind selected by `Observation.TablePrefix`)
- **Orchestrator**: `internal/polling/snmp/orchestrator.Build(Config)` returns a wired `*snmp.Poller` with all eleven default collectors registered

## Validation
- `go test ./internal/database/... ./internal/polling/...` → green (114 tests across A3.x + sink + orchestrator)
- `golangci-lint run` → 0 issues

## Deferred
- Real gosnmp `ClientFactory` (orchestrator accepts injection so this is plug-in)
- `server.go` wire-up via `engine.Registry` (waits on A3.5c when listeners + discovery also join)
- Per-tier engine gating, `/api/engines` admin endpoint