### PR TITLE
feat(api): server lifecycle via engine.registry (stage a3.5d)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -285,23 +285,26 @@ func initLicenseAndAPITokens(services *ServiceContainer, db *database.DB) {
 func initProbeEngine(services *ServiceContainer, db *database.DB) {
 	sched := scheduler.New(probeSchedulerTick)
 
-	engine := probe.NewEngine(logging.GetLogger()).
+	probeEngine := probe.NewEngine(logging.GetLogger()).
 		WithStorage(db.Probes(), sched)
 
 	// Register V1.0 baseline checkers. Stage A1.7 will absorb the
 	// remaining 11 internal/api/health_checks_*.go kinds.
-	engine.RegisterChecker(checkers.NewDNSChecker())
-	engine.RegisterChecker(checkers.NewTLSChecker())
-	engine.RegisterChecker(checkers.NewPingChecker())
-	engine.RegisterChecker(checkers.NewTCPChecker())
-	engine.RegisterChecker(checkers.NewUDPChecker())
-	engine.RegisterChecker(checkers.NewHTTPChecker())
-	engine.RegisterChecker(checkers.NewHTTPSChecker())
-	engine.RegisterChecker(checkers.NewRTSPChecker())
-	engine.RegisterChecker(checkers.NewDICOMChecker())
+	probeEngine.RegisterChecker(checkers.NewDNSChecker())
+	probeEngine.RegisterChecker(checkers.NewTLSChecker())
+	probeEngine.RegisterChecker(checkers.NewPingChecker())
+	probeEngine.RegisterChecker(checkers.NewTCPChecker())
+	probeEngine.RegisterChecker(checkers.NewUDPChecker())
+	probeEngine.RegisterChecker(checkers.NewHTTPChecker())
+	probeEngine.RegisterChecker(checkers.NewHTTPSChecker())
+	probeEngine.RegisterChecker(checkers.NewRTSPChecker())
+	probeEngine.RegisterChecker(checkers.NewDICOMChecker())
 
-	services.Probe.Engine = engine
+	services.Probe.Engine = probeEngine
 	services.Probe.Scheduler = sched
+	if regErr := services.Engines.Register(probeEngine); regErr != nil {
+		logging.GetLogger().Warn("probe engine registry registration failed", "error", regErr)
+	}
 }
 
 // probeSchedulerTick is the scheduler's tick interval — how often
@@ -316,10 +319,16 @@ const probeSchedulerTick = 5 * time.Second
 //
 // V1.0 NMS expansion — Stage A2.
 func initRetentionEngine(services *ServiceContainer, db *database.DB) {
-	engine := retention.New(licenseTierAdapter{lm: services.Auth.License}, logging.GetLogger())
-	engine.Register(retention.NewProbeResultsSource(db))
-	engine.Register(retention.NewMetricsSource(db))
-	services.Probe.Retention = engine
+	retentionEngine := retention.New(
+		licenseTierAdapter{lm: services.Auth.License},
+		logging.GetLogger(),
+	)
+	retentionEngine.Register(retention.NewProbeResultsSource(db))
+	retentionEngine.Register(retention.NewMetricsSource(db))
+	services.Probe.Retention = retentionEngine
+	if regErr := services.Engines.Register(retentionEngine); regErr != nil {
+		logging.GetLogger().Warn("retention engine registry registration failed", "error", regErr)
+	}
 }
 
 // licenseTierAdapter satisfies retention.TierProvider by reading the

--- a/internal/api/server_lifecycle.go
+++ b/internal/api/server_lifecycle.go
@@ -22,30 +22,42 @@ import (
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 
+	"github.com/krisarmstrong/seed/internal/engine"
 	"github.com/krisarmstrong/seed/internal/i18n"
 	"github.com/krisarmstrong/seed/internal/logging"
 )
 
 // Start starts the HTTP/HTTPS server.
-// startBackgroundEngines fires up the probe + retention engines.
-// Both are non-fatal — failure logs a warning and the API surface
-// stays available. Extracted from Start() to keep that function
-// under the gocognit complexity limit.
+// startBackgroundEngines fires up every engine registered with the
+// service container's engine.Registry — probe + retention today,
+// snmp-poller + listeners as they land. Lifecycle ordering is
+// established at registration time; Registry.Start brings them up
+// in that order and rolls back already-started engines if any one
+// fails. Non-fatal: a failed Start logs a warning and the API
+// surface stays available. Extracted from Start() to keep that
+// function under the gocognit complexity limit.
+//
+// V1.0 NMS expansion — Stage A3.5d.
 func (s *Server) startBackgroundEngines() {
-	if engine := s.services.Probe.Engine; engine != nil {
-		if err := engine.Start(context.Background()); err != nil {
-			logging.GetLogger().Warn("probe engine failed to start", "error", err)
-		} else {
-			logging.GetLogger().Info("probe engine started")
-		}
+	if s.services.Engines == nil {
+		return
 	}
-	if engine := s.services.Probe.Retention; engine != nil {
-		if err := engine.Start(context.Background()); err != nil {
-			logging.GetLogger().Warn("retention engine failed to start", "error", err)
-		} else {
-			logging.GetLogger().Info("retention engine started")
-		}
+	if err := s.services.Engines.Start(context.Background()); err != nil {
+		logging.GetLogger().Warn("engine registry start failed", "error", err)
+		return
 	}
+	logging.GetLogger().Info("engine registry started",
+		"engines", engineNames(s.services.Engines.Engines()))
+}
+
+// engineNames extracts Name() from each engine for structured-log
+// emission without leaking the engine pointers.
+func engineNames(engines []engine.Engine) []string {
+	out := make([]string, 0, len(engines))
+	for _, e := range engines {
+		out = append(out, e.Name())
+	}
+	return out
 }
 
 func (s *Server) Start() error {

--- a/internal/api/server_shutdown.go
+++ b/internal/api/server_shutdown.go
@@ -104,21 +104,17 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	logging.GetLogger().InfoContext(ctx, "Stopping VLAN traffic monitor...")
 	s.vlanTrafficMonitor().Stop()
 
-	// Stop probe engine (Stage A1.8) — drains in-flight probes via
-	// the scheduler's WaitGroup.
-	if engine := s.services.Probe.Engine; engine != nil {
-		logging.GetLogger().InfoContext(ctx, "Stopping probe engine...")
-		if stopErr := engine.Stop(ctx); stopErr != nil {
-			logging.GetLogger().WarnContext(ctx, "probe engine stop returned error", "error", stopErr)
-		}
-	}
-
-	// Stop retention engine (Stage A2) — waits for in-flight rollup
-	// pass to complete.
-	if engine := s.services.Probe.Retention; engine != nil {
-		logging.GetLogger().InfoContext(ctx, "Stopping retention engine...")
-		if stopErr := engine.Stop(ctx); stopErr != nil {
-			logging.GetLogger().WarnContext(ctx, "retention engine stop returned error", "error", stopErr)
+	// Stop every engine registered with the lifecycle registry
+	// (probe, retention, snmp-poller, listeners, …) in reverse
+	// registration order. Registry.Stop continues past per-engine
+	// errors so a stuck engine doesn't prevent the others from
+	// winding down. Stage A3.5d unified what was previously two
+	// ad-hoc Stop blocks (probe + retention) into one registry
+	// drive.
+	if reg := s.services.Engines; reg != nil {
+		logging.GetLogger().InfoContext(ctx, "Stopping engines...")
+		if stopErr := reg.Stop(ctx); stopErr != nil {
+			logging.GetLogger().WarnContext(ctx, "engine registry stop returned error", "error", stopErr)
 		}
 	}
 

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -7,6 +7,7 @@ import (
 	"github.com/krisarmstrong/seed/internal/canopy/wifi"
 	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/dhcp"
+	"github.com/krisarmstrong/seed/internal/engine"
 	"github.com/krisarmstrong/seed/internal/health"
 	"github.com/krisarmstrong/seed/internal/license"
 	"github.com/krisarmstrong/seed/internal/logging"
@@ -43,6 +44,13 @@ type ServiceContainer struct {
 	Database  *DatabaseServices
 	Health    *HealthServices
 	Update    *update.Service
+
+	// Engines is the lifecycle registry every long-running engine
+	// registers with (probe, retention, snmp-poller, listeners,
+	// discovery). Server.Start drives Registry.Start; Server.Shutdown
+	// drives Registry.Stop in reverse registration order.
+	// V1.0 NMS expansion — Stage A3.5d.
+	Engines *engine.Registry
 }
 
 // NewServiceContainer creates a new empty ServiceContainer.
@@ -59,6 +67,7 @@ func NewServiceContainer() *ServiceContainer {
 		RealTime:  &RealTimeServices{},
 		Database:  &DatabaseServices{},
 		Health:    &HealthServices{},
+		Engines:   engine.NewRegistry(nil),
 	}
 }
 


### PR DESCRIPTION
## Summary
Stage A3.5d — route probe + retention engines through the
`engine.Registry` from A3.5a. `Server.Start` drives `Registry.Start`
(forward order); `Server.Shutdown` drives `Registry.Stop` (reverse
order). A3.5c (gosnmp client factory) and A3.5e (snmp-poller +
listeners in the registry) drop in without further `server.go`
changes.

## Changes
- `ServiceContainer.Engines *engine.Registry` — initialized in `NewServiceContainer`
- `initProbeEngine` / `initRetentionEngine` — register their engine with `services.Engines` after construction; existing `services.Probe.Engine` + `services.Probe.Retention` pointers retained for handler convenience (subscribe to ResultEvents, etc.)
- `startBackgroundEngines` — two ad-hoc start blocks collapsed into one `services.Engines.Start(ctx)` call. Partial-start rollback automatic via `Registry.Start`.
- `Shutdown` — two ad-hoc stop blocks collapsed into one `services.Engines.Stop(ctx)` call. `Registry.Stop` continues past per-engine errors so a stuck engine doesn't block siblings.
- `engineNames()` helper for structured-log emission of `engines: [probe, retention]`.

## Validation
- `go test ./internal/api/... ./internal/engine/...` → green (full integration suite incl. timing-sensitive shutdown)
- `golangci-lint run` → 0 issues

## Behavior
Unchanged for V1.0 — probe + retention are the only engines in the
registry today; same lifecycle order as before the refactor.

## Deferred
- A3.5c: real gosnmp `ClientFactory`
- A3.5e: snmp-poller + listeners registered via the same registry
- `/api/engines` admin endpoint
- Per-tier engine gating