### PR TITLE
feat(api): wire syslog + snmp trap listeners via engine.registry (stage a3.5e-4)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,6 +9,7 @@ package api
 
 import (
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -20,6 +21,9 @@ import (
 	"github.com/krisarmstrong/seed/internal/dhcp"
 	"github.com/krisarmstrong/seed/internal/health"
 	"github.com/krisarmstrong/seed/internal/license"
+	listenersink "github.com/krisarmstrong/seed/internal/listener/sink"
+	"github.com/krisarmstrong/seed/internal/listener/snmptrap"
+	"github.com/krisarmstrong/seed/internal/listener/syslog"
 	"github.com/krisarmstrong/seed/internal/logging"
 	"github.com/krisarmstrong/seed/internal/mibdb"
 	"github.com/krisarmstrong/seed/internal/netif"
@@ -257,6 +261,7 @@ func initDatabaseDependentServices(services *ServiceContainer, db *database.DB) 
 	initHealthServices(services, db)
 	initProbeEngine(services, db)
 	initRetentionEngine(services, db)
+	initListeners(services, db)
 }
 
 // initLicenseAndAPITokens wires the Phase D-2 license manager + API
@@ -311,6 +316,45 @@ func initProbeEngine(services *ServiceContainer, db *database.DB) {
 // it checks whether any registered Job is due. Production default
 // 5s; tests can run faster via direct scheduler.New construction.
 const probeSchedulerTick = 5 * time.Second
+
+// initListeners wires the passive-ingress listeners (syslog UDP +
+// SNMPv2c traps) into the engine registry. Both are opt-in via env
+// variables — operators set SEED_SYSLOG_BIND / SEED_SNMP_TRAP_BIND
+// (e.g. ":514", ":162") to enable them. Default is off because
+// binding to <1024 requires elevated privileges and we don't want
+// the server to crash out of the box when run as a non-root user.
+//
+// V1.0 NMS expansion — Stage A3.5e-4.
+func initListeners(services *ServiceContainer, db *database.DB) {
+	persistSink := listenersink.New(db.ListenerEvents(), logging.GetLogger(), nil)
+	logger := logging.GetLogger()
+
+	if addr := os.Getenv("SEED_SYSLOG_BIND"); addr != "" {
+		l, err := syslog.New(syslog.Config{
+			BindAddr: addr,
+			Sink:     persistSink,
+			Logger:   logger,
+		})
+		if err != nil {
+			logger.Warn("syslog listener init failed", "error", err)
+		} else if regErr := services.Engines.Register(l); regErr != nil {
+			logger.Warn("syslog listener registry registration failed", "error", regErr)
+		}
+	}
+
+	if addr := os.Getenv("SEED_SNMP_TRAP_BIND"); addr != "" {
+		l, err := snmptrap.New(snmptrap.Config{
+			BindAddr: addr,
+			Sink:     persistSink,
+			Logger:   logger,
+		})
+		if err != nil {
+			logger.Warn("snmp trap listener init failed", "error", err)
+		} else if regErr := services.Engines.Register(l); regErr != nil {
+			logger.Warn("snmp trap listener registry registration failed", "error", regErr)
+		}
+	}
+}
 
 // initRetentionEngine constructs the unified retention engine and
 // registers V1.0 sources (probe_results, metrics). The engine is

--- a/internal/api/server_listeners_internal_test.go
+++ b/internal/api/server_listeners_internal_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// freeAddr returns a free UDP loopback address as a "host:port"
+// string. Used to seed env vars for listener wire-up tests so the
+// integration doesn't collide with real :514 / :162.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	c, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("freeAddr: %v", err)
+	}
+	addr := c.LocalAddr().String()
+	_ = c.Close()
+	return addr
+}
+
+func newTestDB(t *testing.T) *database.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "seed.db")
+	db, err := database.Open(path)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestInitListeners_NoEnvVarsRegistersNoListeners(t *testing.T) {
+	t.Setenv("SEED_SYSLOG_BIND", "")
+	t.Setenv("SEED_SNMP_TRAP_BIND", "")
+
+	services := NewServiceContainer()
+	before := len(services.Engines.Engines())
+	initListeners(services, newTestDB(t))
+	after := len(services.Engines.Engines())
+
+	if after != before {
+		t.Errorf("engines after init = %d, want %d (no listeners enabled)", after, before)
+	}
+}
+
+func TestInitListeners_SyslogEnvVarRegistersListener(t *testing.T) {
+	t.Setenv("SEED_SYSLOG_BIND", freeAddr(t))
+	t.Setenv("SEED_SNMP_TRAP_BIND", "")
+
+	services := NewServiceContainer()
+	initListeners(services, newTestDB(t))
+
+	names := make(map[string]bool)
+	for _, e := range services.Engines.Engines() {
+		names[e.Name()] = true
+	}
+	if !names["syslog-udp"] {
+		t.Errorf("syslog-udp not registered; got engines = %v", names)
+	}
+	if names["snmp-trap-v2c"] {
+		t.Errorf("snmp-trap-v2c should NOT be registered when env unset")
+	}
+}
+
+func TestInitListeners_SnmpTrapEnvVarRegistersListener(t *testing.T) {
+	t.Setenv("SEED_SYSLOG_BIND", "")
+	t.Setenv("SEED_SNMP_TRAP_BIND", freeAddr(t))
+
+	services := NewServiceContainer()
+	initListeners(services, newTestDB(t))
+
+	names := make(map[string]bool)
+	for _, e := range services.Engines.Engines() {
+		names[e.Name()] = true
+	}
+	if !names["snmp-trap-v2c"] {
+		t.Errorf("snmp-trap-v2c not registered; got engines = %v", names)
+	}
+}
+
+func TestInitListeners_BothEnvVarsRegistersBoth(t *testing.T) {
+	t.Setenv("SEED_SYSLOG_BIND", freeAddr(t))
+	t.Setenv("SEED_SNMP_TRAP_BIND", freeAddr(t))
+
+	services := NewServiceContainer()
+	initListeners(services, newTestDB(t))
+
+	names := make(map[string]bool)
+	for _, e := range services.Engines.Engines() {
+		names[e.Name()] = true
+	}
+	if !names["syslog-udp"] || !names["snmp-trap-v2c"] {
+		t.Errorf("expected both listeners registered, got %v", names)
+	}
+}


### PR DESCRIPTION
## Summary
Stage A3.5e-4 — closes the loop on Stage A3.5e. The syslog + trap
listeners introduced in A3.5e-1/2 are now first-class engines in
the lifecycle registry. `Server.Start` brings them up alongside
probe + retention + snmp-poller; `Server.Shutdown` tears them down
in reverse order with one `Registry.Stop` call.

## Changes
- `initListeners(services, db)` — constructs shared `listener.Sink` (DB-backed) and registers each listener with `services.Engines`
- Listeners env-var-gated:
  - `SEED_SYSLOG_BIND=":514"` → syslog-udp listener
  - `SEED_SNMP_TRAP_BIND=":162"` → snmp-trap-v2c listener
- Default is off — binding to <1024 needs elevated privileges; operators opt in deliberately
- Both listeners share one `*listener.Sink` so every syslog frame + every trap PDU lands in the same `listener_events` table Stage A4 alert rules read from
- 4 integration tests via `t.Setenv` covering all (un)set combinations

## Validation
- `go test ./internal/api/... ./internal/listener/... ./internal/engine/... ./internal/database/...` → all green
- `golangci-lint run` → 0 issues

## Stage A3 closes here
- 11 SNMP collectors (#1332-#1342)
- engine interface + registry (#1343)
- SNMP orchestrator + persistence (#1344)
- server.go via registry (#1345)
- gosnmp client factory (#1346)
- listener interface + syslog (#1347)
- SNMP trap listener (#1348)
- listeners wired via registry (this PR)

## Deferred to Stage B
- Syslog TLS (RFC 5425 port 6514) — needs cert plumbing
- SNMPv3 traps (gosnmp upstream-flagged unreliable)
- `/api/engines` admin endpoint
- Per-tier engine gating