### PR TITLE
feat(topology): sys_info reconciler upserts topology_nodes (stage a4.1)

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -77,6 +77,7 @@ type DB struct {
 	pollingTargets   *PollingTargetRepository
 	snmpObservations *SNMPObservationsRepository
 	listenerEvents   *ListenerEventsRepository
+	topology         *TopologyRepository
 }
 
 // Config holds database configuration options.
@@ -515,6 +516,19 @@ func (db *DB) ListenerEvents() *ListenerEventsRepository {
 		db.listenerEvents = &ListenerEventsRepository{db: db}
 	}
 	return db.listenerEvents
+}
+
+// Topology returns the topology repository (Stage A4). Reconcilers
+// in internal/topology own writes; the operator UI + alert rules
+// own reads.
+func (db *DB) Topology() *TopologyRepository {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.topology == nil {
+		db.topology = &TopologyRepository{db: db}
+	}
+	return db.topology
 }
 
 // Exec executes a query without returning any rows.

--- a/internal/database/repository_topology.go
+++ b/internal/database/repository_topology.go
@@ -1,0 +1,235 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// TopologyNode is one row of topology_nodes. The fat-Node carries
+// every observation source's contribution: identity from sys_info,
+// per-interface state from if_table (folded into MetadataJSON),
+// addresses from arp, neighbors from lldp/cdp/fdp. Reconcilers in
+// internal/topology own writes; alert rules + the operator UI own
+// reads.
+type TopologyNode struct {
+	ID           string
+	ClientID     string
+	IdentityHash string
+	DisplayName  string
+	DeviceType   string
+	ChassisID    string
+	SysName      string
+	PrimaryMAC   string
+	PrimaryIP    string
+	FirstSeen    time.Time
+	LastSeen     time.Time
+	ExpiresAt    time.Time
+	MetadataJSON string
+}
+
+// TopologyRepository owns CRUD over topology_nodes + topology_links.
+// Stage A4.1 wires the nodes side; links arrive in A4.3.
+type TopologyRepository struct {
+	db *DB
+}
+
+// GetByIdentityHash returns the node with the given identity hash
+// or ErrTopologyNodeNotFound when absent.
+func (r *TopologyRepository) GetByIdentityHash(ctx context.Context, hash string) (*TopologyNode, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, client_id, identity_hash, display_name, device_type,
+		       chassis_id, sys_name, primary_mac, primary_ip,
+		       first_seen, last_seen, expires_at, metadata_json
+		FROM topology_nodes WHERE identity_hash = ?
+	`, hash)
+	return scanTopologyNode(row.Scan)
+}
+
+// ErrTopologyNodeNotFound is returned when a node lookup misses.
+var ErrTopologyNodeNotFound = errors.New("topology node not found")
+
+// Upsert inserts or updates a node by identity_hash. The hash is
+// the merge key — same hash = same physical device regardless of
+// how it was observed. FirstSeen is preserved on update; LastSeen
+// is always set to node.LastSeen (which the caller should set to
+// the observation's ObservedAt).
+//
+// Returns the up-to-date row including any FirstSeen the existing
+// record carried.
+func (r *TopologyRepository) Upsert(ctx context.Context, node *TopologyNode) (*TopologyNode, error) {
+	if node.IdentityHash == "" {
+		return nil, errors.New("topology_nodes: IdentityHash required")
+	}
+	if node.ID == "" {
+		return nil, errors.New("topology_nodes: ID required")
+	}
+	if node.ClientID == "" {
+		node.ClientID = "default"
+	}
+	if node.LastSeen.IsZero() {
+		node.LastSeen = time.Now().UTC()
+	}
+	if node.FirstSeen.IsZero() {
+		node.FirstSeen = node.LastSeen
+	}
+
+	existing, err := r.GetByIdentityHash(ctx, node.IdentityHash)
+	switch {
+	case err == nil:
+		// Update — preserve FirstSeen from existing row.
+		node.FirstSeen = existing.FirstSeen
+		node.ID = existing.ID // keep stable id across upserts
+		if updErr := r.update(ctx, node); updErr != nil {
+			return nil, updErr
+		}
+	case errors.Is(err, ErrTopologyNodeNotFound):
+		if insErr := r.insert(ctx, node); insErr != nil {
+			return nil, insErr
+		}
+	default:
+		return nil, err
+	}
+	return node, nil
+}
+
+func (r *TopologyRepository) insert(ctx context.Context, node *TopologyNode) error {
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO topology_nodes
+		  (id, client_id, identity_hash, display_name, device_type,
+		   chassis_id, sys_name, primary_mac, primary_ip,
+		   first_seen, last_seen, expires_at, metadata_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		node.ID, node.ClientID, node.IdentityHash, node.DisplayName,
+		toNullString(node.DeviceType), toNullString(node.ChassisID),
+		toNullString(node.SysName), toNullString(node.PrimaryMAC),
+		toNullString(node.PrimaryIP),
+		node.FirstSeen.UTC().Format(time.RFC3339Nano),
+		node.LastSeen.UTC().Format(time.RFC3339Nano),
+		toNullTime(node.ExpiresAt),
+		toNullString(node.MetadataJSON),
+	)
+	if err != nil {
+		return fmt.Errorf("insert topology_node: %w", err)
+	}
+	return nil
+}
+
+func (r *TopologyRepository) update(ctx context.Context, node *TopologyNode) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE topology_nodes SET
+			display_name = ?, device_type = ?, chassis_id = ?, sys_name = ?,
+			primary_mac = ?, primary_ip = ?, last_seen = ?, expires_at = ?,
+			metadata_json = ?
+		WHERE identity_hash = ?
+	`,
+		node.DisplayName,
+		toNullString(node.DeviceType), toNullString(node.ChassisID),
+		toNullString(node.SysName), toNullString(node.PrimaryMAC),
+		toNullString(node.PrimaryIP),
+		node.LastSeen.UTC().Format(time.RFC3339Nano),
+		toNullTime(node.ExpiresAt),
+		toNullString(node.MetadataJSON),
+		node.IdentityHash,
+	)
+	if err != nil {
+		return fmt.Errorf("update topology_node: %w", err)
+	}
+	return nil
+}
+
+// TopologyListOptions narrows a topology_nodes query.
+type TopologyListOptions struct {
+	ClientID   string
+	DeviceType string
+	SeenSince  time.Time
+	Limit      int
+}
+
+// List returns nodes matching opts ordered by LastSeen desc.
+func (r *TopologyRepository) List(ctx context.Context, opts TopologyListOptions) ([]*TopologyNode, error) {
+	const defaultLimit, maxLimit = 100, 5000
+
+	query, args := newListQueryBuilder(`
+		SELECT id, client_id, identity_hash, display_name, device_type,
+		       chassis_id, sys_name, primary_mac, primary_ip,
+		       first_seen, last_seen, expires_at, metadata_json
+		FROM topology_nodes
+		WHERE 1=1
+	`).
+		Where("AND client_id = ?", opts.ClientID).
+		Where("AND device_type = ?", opts.DeviceType).
+		WhereTime("AND last_seen >= ?", opts.SeenSince).
+		OrderLimit("ORDER BY last_seen DESC", opts.Limit, defaultLimit, maxLimit).
+		Build()
+
+	return queryRows(ctx, r.db, query, args, scanTopologyNode, "list topology_nodes")
+}
+
+// toNullTime returns a NullString that's invalid when t is zero.
+// Stored times use RFC3339Nano UTC.
+func toNullTime(t time.Time) sql.NullString {
+	if t.IsZero() {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: t.UTC().Format(time.RFC3339Nano), Valid: true}
+}
+
+func scanTopologyNode(scan func(...any) error) (*TopologyNode, error) {
+	var (
+		node         TopologyNode
+		deviceType   sql.NullString
+		chassisID    sql.NullString
+		sysName      sql.NullString
+		primaryMAC   sql.NullString
+		primaryIP    sql.NullString
+		expiresAt    sql.NullString
+		metadataJSON sql.NullString
+		firstSeenStr string
+		lastSeenStr  string
+	)
+	err := scan(
+		&node.ID, &node.ClientID, &node.IdentityHash, &node.DisplayName,
+		&deviceType, &chassisID, &sysName, &primaryMAC, &primaryIP,
+		&firstSeenStr, &lastSeenStr, &expiresAt, &metadataJSON,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrTopologyNodeNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan topology_node: %w", err)
+	}
+	if deviceType.Valid {
+		node.DeviceType = deviceType.String
+	}
+	if chassisID.Valid {
+		node.ChassisID = chassisID.String
+	}
+	if sysName.Valid {
+		node.SysName = sysName.String
+	}
+	if primaryMAC.Valid {
+		node.PrimaryMAC = primaryMAC.String
+	}
+	if primaryIP.Valid {
+		node.PrimaryIP = primaryIP.String
+	}
+	if metadataJSON.Valid {
+		node.MetadataJSON = metadataJSON.String
+	}
+	if parsed, perr := time.Parse(time.RFC3339Nano, firstSeenStr); perr == nil {
+		node.FirstSeen = parsed
+	}
+	if parsed, perr := time.Parse(time.RFC3339Nano, lastSeenStr); perr == nil {
+		node.LastSeen = parsed
+	}
+	if expiresAt.Valid {
+		if parsed, perr := time.Parse(time.RFC3339Nano, expiresAt.String); perr == nil {
+			node.ExpiresAt = parsed
+		}
+	}
+	return &node, nil
+}

--- a/internal/topology/sysinfo_reconciler.go
+++ b/internal/topology/sysinfo_reconciler.go
@@ -1,0 +1,370 @@
+// Package topology reconciles snmp_observations into the fat-Node
+// + edge topology graph. One reconciler per observation kind:
+// sys_info builds identity (A4.1, here), if_table folds interface
+// state (A4.2), lldp/cdp/fdp build neighbor edges (A4.3), arp
+// attaches IP↔MAC bindings (A4.4).
+//
+// Each reconciler is an [engine.Engine] that polls
+// snmp_observations on a scheduler tick, processes new rows since
+// a persisted high-water mark, and upserts the relevant slice of
+// topology state. The high-water mark lives in the settings table
+// so a restart resumes where it left off.
+package topology
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// SysInfoReconcilerName is the engine identifier.
+const SysInfoReconcilerName = "topology-sysinfo-reconciler"
+
+// sysInfoHighWaterKey is the settings key holding the latest
+// ObservedAt timestamp this reconciler has already processed.
+// A restart resumes from here so we don't reprocess every prior
+// observation on every cold start.
+const sysInfoHighWaterKey = "topology.sysinfo.high_water"
+
+// Tunables. Production defaults — tests override via config.
+const (
+	defaultBatchLimit = 500
+
+	// minPollInterval guards against a misconfigured tick that would
+	// hammer snmp_observations every millisecond.
+	minPollInterval = 100 * time.Millisecond
+
+	// defaultPollInterval matches the typical snmp poll cadence so
+	// reconciliation runs at the same heartbeat as ingestion.
+	defaultPollInterval = 30 * time.Second
+)
+
+// observationsReader is the narrowed surface the reconciler needs
+// from the SNMP observations repo. Tests inject a fake.
+type observationsReader interface {
+	List(ctx context.Context, opts database.ListOptions) ([]*database.SNMPObservation, error)
+}
+
+// nodeUpserter is the narrowed surface for topology_nodes writes.
+type nodeUpserter interface {
+	Upsert(ctx context.Context, node *database.TopologyNode) (*database.TopologyNode, error)
+}
+
+// settingsKV is the high-water-mark store.
+type settingsKV interface {
+	GetWithDefault(ctx context.Context, key, defaultValue string) (string, error)
+	Set(ctx context.Context, key, value string) error
+}
+
+// SysInfoReconciler turns sys_info observations into topology_nodes.
+// Each observation maps to one node, deduped by identity_hash.
+type SysInfoReconciler struct {
+	obs      observationsReader
+	nodes    nodeUpserter
+	settings settingsKV
+	logger   *slog.Logger
+	now      func() time.Time
+	interval time.Duration
+
+	mu      sync.Mutex
+	started bool
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+// Config wires the dependencies.
+type Config struct {
+	Observations observationsReader
+	Nodes        nodeUpserter
+	Settings     settingsKV
+	Logger       *slog.Logger
+	Now          func() time.Time
+	Interval     time.Duration
+}
+
+// NewSysInfoReconciler returns an unstarted reconciler.
+func NewSysInfoReconciler(cfg Config) (*SysInfoReconciler, error) {
+	if cfg.Observations == nil {
+		return nil, errors.New("topology: Observations required")
+	}
+	if cfg.Nodes == nil {
+		return nil, errors.New("topology: Nodes required")
+	}
+	if cfg.Settings == nil {
+		return nil, errors.New("topology: Settings required")
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.Now == nil {
+		cfg.Now = func() time.Time { return time.Now().UTC() }
+	}
+	if cfg.Interval <= 0 {
+		cfg.Interval = defaultPollInterval
+	}
+	if cfg.Interval < minPollInterval {
+		cfg.Interval = minPollInterval
+	}
+	return &SysInfoReconciler{
+		obs:      cfg.Observations,
+		nodes:    cfg.Nodes,
+		settings: cfg.Settings,
+		logger:   cfg.Logger,
+		now:      cfg.Now,
+		interval: cfg.Interval,
+	}, nil
+}
+
+// Name implements [engine.Engine].
+func (*SysInfoReconciler) Name() string { return SysInfoReconcilerName }
+
+// Start kicks off the reconcile loop. Idempotent.
+func (r *SysInfoReconciler) Start(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.started {
+		return nil
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	r.started = true
+	r.wg.Add(1)
+	go r.loop(loopCtx)
+	r.logger.InfoContext(ctx, "sysinfo reconciler started", "interval", r.interval)
+	return nil
+}
+
+// Stop terminates the reconcile loop. Honors ctx deadline.
+func (r *SysInfoReconciler) Stop(ctx context.Context) error {
+	r.mu.Lock()
+	if !r.started {
+		r.mu.Unlock()
+		return nil
+	}
+	r.started = false
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.mu.Unlock()
+
+	doneCh := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	r.logger.InfoContext(ctx, "sysinfo reconciler stopped")
+	return nil
+}
+
+// loop ticks every r.interval and runs one ReconcileOnce pass.
+func (r *SysInfoReconciler) loop(ctx context.Context) {
+	defer r.wg.Done()
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	// Tick immediately so the first pass doesn't wait a full
+	// interval for the loop's initial reconcile.
+	if err := r.ReconcileOnce(ctx); err != nil {
+		r.logger.WarnContext(ctx, "sysinfo reconcile failed", "error", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := r.ReconcileOnce(ctx); err != nil {
+				r.logger.WarnContext(ctx, "sysinfo reconcile failed", "error", err)
+			}
+		}
+	}
+}
+
+// ReconcileOnce processes one batch of new sys_info observations.
+// Exposed for tests and for the engine loop alike.
+func (r *SysInfoReconciler) ReconcileOnce(ctx context.Context) error {
+	since, err := r.loadHighWater(ctx)
+	if err != nil {
+		return fmt.Errorf("load high-water: %w", err)
+	}
+	observations, err := r.obs.List(ctx, database.ListOptions{
+		Kind:  "sys_info",
+		Since: since,
+		Limit: defaultBatchLimit,
+	})
+	if err != nil {
+		return fmt.Errorf("list sys_info observations: %w", err)
+	}
+	if len(observations) == 0 {
+		return nil
+	}
+
+	var maxObservedAt time.Time
+	upserted := 0
+	for _, obs := range observations {
+		// observations are returned newest-first; track the max
+		// across the batch for the new high-water mark.
+		if obs.ObservedAt.After(maxObservedAt) {
+			maxObservedAt = obs.ObservedAt
+		}
+		node, buildErr := r.buildNode(obs)
+		if buildErr != nil {
+			r.logger.WarnContext(ctx, "skip sysinfo observation",
+				"target_id", obs.TargetID, "error", buildErr)
+			continue
+		}
+		if _, upsertErr := r.nodes.Upsert(ctx, node); upsertErr != nil {
+			r.logger.WarnContext(ctx, "upsert topology_node failed",
+				"target_id", obs.TargetID, "identity", node.IdentityHash, "error", upsertErr)
+			continue
+		}
+		upserted++
+	}
+	r.logger.DebugContext(ctx, "sysinfo reconcile pass",
+		"batch", len(observations), "upserted", upserted, "max_observed_at", maxObservedAt)
+
+	if !maxObservedAt.IsZero() {
+		// Save high-water = newest observation's timestamp.
+		// Next pass uses Since = high-water so we re-read it only
+		// if a duplicate row arrives (same observedAt).
+		if saveErr := r.saveHighWater(ctx, maxObservedAt); saveErr != nil {
+			return fmt.Errorf("save high-water: %w", saveErr)
+		}
+	}
+	return nil
+}
+
+// sysInfoPayload mirrors the relevant subset of the sysinfo
+// collector's Observation JSON. Keep field names aligned with
+// internal/polling/snmp/collectors/sysinfo.Observation.
+type sysInfoPayload struct {
+	ClientID    string `json:"ClientID"`
+	TargetID    string `json:"TargetID"`
+	SysDescr    string `json:"SysDescr"`
+	SysObjectID string `json:"SysObjectID"`
+	SysName     string `json:"SysName"`
+	SysLocation string `json:"SysLocation"`
+	SysContact  string `json:"SysContact"`
+}
+
+// buildNode decodes the observation payload into a TopologyNode
+// ready for upsert.
+func (r *SysInfoReconciler) buildNode(obs *database.SNMPObservation) (*database.TopologyNode, error) {
+	var p sysInfoPayload
+	if err := json.Unmarshal([]byte(obs.PayloadJSON), &p); err != nil {
+		return nil, fmt.Errorf("unmarshal sysinfo payload: %w", err)
+	}
+	if p.SysName == "" && p.SysObjectID == "" {
+		// Without any identifying scalar there's no value in a node row;
+		// downstream reconcilers (if_table, lldp) still attach against
+		// the same identity once it's populated on a future poll.
+		return nil, errors.New("no SysName / SysObjectID — observation has no identity")
+	}
+
+	hash := identityHashFor(obs.ClientID, p.SysObjectID, p.SysName, obs.TargetID)
+	displayName := p.SysName
+	if displayName == "" {
+		displayName = obs.TargetID
+	}
+
+	metadata, _ := json.Marshal(map[string]string{
+		"sys_descr":    p.SysDescr,
+		"sys_location": p.SysLocation,
+		"sys_contact":  p.SysContact,
+	})
+
+	node := &database.TopologyNode{
+		ID:           "node-" + hash[:16],
+		ClientID:     obs.ClientID,
+		IdentityHash: hash,
+		DisplayName:  displayName,
+		DeviceType:   deviceTypeFromObjectID(p.SysObjectID),
+		SysName:      p.SysName,
+		LastSeen:     obs.ObservedAt,
+		MetadataJSON: string(metadata),
+	}
+	return node, nil
+}
+
+// identityHashFor computes the merge key for a node. Same (client,
+// sysObjectID, sysName) = same physical device. We include client_id
+// so two clients can have devices with identical sysName + OID
+// without collapsing into one topology row.
+//
+// Falls back to client_id + target_id when sysObjectID/sysName are
+// missing — preserves identity at least within a single Seed install.
+func identityHashFor(clientID, sysObjectID, sysName, targetID string) string {
+	h := sha256.New()
+	h.Write([]byte(clientID))
+	h.Write([]byte{0x00})
+	if sysObjectID != "" || sysName != "" {
+		h.Write([]byte(sysObjectID))
+		h.Write([]byte{0x00})
+		h.Write([]byte(sysName))
+	} else {
+		h.Write([]byte(targetID))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// deviceTypeFromObjectID maps a few common Cisco/Juniper/Arista
+// enterprise OIDs to coarse device categories. V1.0 ships a small
+// lookup; future iterations replace with a MIB-driven extension
+// table.
+func deviceTypeFromObjectID(oid string) string {
+	switch {
+	case oid == "":
+		return ""
+	case len(oid) > len(ciscoPrefix) && oid[:len(ciscoPrefix)] == ciscoPrefix:
+		return "cisco"
+	case len(oid) > len(juniperPrefix) && oid[:len(juniperPrefix)] == juniperPrefix:
+		return "juniper"
+	case len(oid) > len(aristaPrefix) && oid[:len(aristaPrefix)] == aristaPrefix:
+		return "arista"
+	case len(oid) > len(linuxPrefix) && oid[:len(linuxPrefix)] == linuxPrefix:
+		return "linux"
+	case len(oid) > len(mikrotikPrefix) && oid[:len(mikrotikPrefix)] == mikrotikPrefix:
+		return "mikrotik"
+	}
+	return "unknown"
+}
+
+const (
+	ciscoPrefix    = "1.3.6.1.4.1.9."
+	juniperPrefix  = "1.3.6.1.4.1.2636."
+	aristaPrefix   = "1.3.6.1.4.1.30065."
+	linuxPrefix    = "1.3.6.1.4.1.8072.3.2.10"
+	mikrotikPrefix = "1.3.6.1.4.1.14988."
+)
+
+// loadHighWater reads the persisted timestamp; returns zero time
+// when no row has been processed yet (first-run case).
+func (r *SysInfoReconciler) loadHighWater(ctx context.Context) (time.Time, error) {
+	raw, err := r.settings.GetWithDefault(ctx, sysInfoHighWaterKey, "")
+	if err != nil {
+		return time.Time{}, err
+	}
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse high-water %q: %w", raw, err)
+	}
+	return parsed, nil
+}
+
+func (r *SysInfoReconciler) saveHighWater(ctx context.Context, t time.Time) error {
+	return r.settings.Set(ctx, sysInfoHighWaterKey, t.UTC().Format(time.RFC3339Nano))
+}

--- a/internal/topology/sysinfo_reconciler_test.go
+++ b/internal/topology/sysinfo_reconciler_test.go
@@ -1,0 +1,329 @@
+package topology_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/topology"
+)
+
+func silentLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+func at() time.Time              { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+type fakeObservations struct {
+	mu      sync.Mutex
+	rows    []*database.SNMPObservation
+	listErr error
+}
+
+func (f *fakeObservations) List(_ context.Context, _ database.ListOptions) ([]*database.SNMPObservation, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]*database.SNMPObservation, len(f.rows))
+	copy(out, f.rows)
+	return out, nil
+}
+
+type fakeNodes struct {
+	mu        sync.Mutex
+	upserts   []*database.TopologyNode
+	upsertErr error
+}
+
+func (f *fakeNodes) Upsert(_ context.Context, node *database.TopologyNode) (*database.TopologyNode, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.upsertErr != nil {
+		return nil, f.upsertErr
+	}
+	f.upserts = append(f.upserts, node)
+	return node, nil
+}
+
+type fakeSettings struct {
+	mu     sync.Mutex
+	values map[string]string
+}
+
+func newFakeSettings() *fakeSettings {
+	return &fakeSettings{values: make(map[string]string)}
+}
+
+func (f *fakeSettings) GetWithDefault(_ context.Context, key, def string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.values[key]
+	if !ok {
+		return def, nil
+	}
+	return v, nil
+}
+
+func (f *fakeSettings) Set(_ context.Context, key, value string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.values[key] = value
+	return nil
+}
+
+func payload(client, target, sysName, sysObjectID string) string {
+	b, _ := json.Marshal(map[string]string{
+		"ClientID":    client,
+		"TargetID":    target,
+		"SysName":     sysName,
+		"SysObjectID": sysObjectID,
+		"SysDescr":    "Test Device",
+	})
+	return string(b)
+}
+
+func obs(client, target, sysName, sysObjectID string, observed time.Time) *database.SNMPObservation {
+	return &database.SNMPObservation{
+		ClientID:    client,
+		TargetID:    target,
+		Kind:        "sys_info",
+		ObservedAt:  observed,
+		PayloadJSON: payload(client, target, sysName, sysObjectID),
+	}
+}
+
+func TestNew_RejectsMissingDeps(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cfg  topology.Config
+	}{
+		{"missing Observations", topology.Config{Nodes: &fakeNodes{}, Settings: newFakeSettings()}},
+		{"missing Nodes", topology.Config{Observations: &fakeObservations{}, Settings: newFakeSettings()}},
+		{"missing Settings", topology.Config{Observations: &fakeObservations{}, Nodes: &fakeNodes{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := topology.NewSysInfoReconciler(tt.cfg); err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestNew_EngineName(t *testing.T) {
+	t.Parallel()
+	r, err := topology.NewSysInfoReconciler(topology.Config{
+		Observations: &fakeObservations{},
+		Nodes:        &fakeNodes{},
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if r.Name() != topology.SysInfoReconcilerName {
+		t.Errorf("Name() = %q, want %q", r.Name(), topology.SysInfoReconcilerName)
+	}
+}
+
+func TestReconcileOnce_UpsertsOneNodePerObservation(t *testing.T) {
+	t.Parallel()
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		obs("client-a", "t-1", "router-1", "1.3.6.1.4.1.9.1.123", at()),
+		obs("client-a", "t-2", "router-2", "1.3.6.1.4.1.9.1.456", at()),
+	}}
+	n := &fakeNodes{}
+	r, _ := topology.NewSysInfoReconciler(topology.Config{
+		Observations: o, Nodes: n, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if len(n.upserts) != 2 {
+		t.Fatalf("upserts = %d, want 2", len(n.upserts))
+	}
+	if n.upserts[0].DeviceType != "cisco" {
+		t.Errorf("expected cisco DeviceType from 1.3.6.1.4.1.9 OID, got %q",
+			n.upserts[0].DeviceType)
+	}
+	if n.upserts[0].SysName != "router-1" {
+		t.Errorf("SysName = %q", n.upserts[0].SysName)
+	}
+}
+
+func TestReconcileOnce_PersistsHighWaterMark(t *testing.T) {
+	t.Parallel()
+	old := at().Add(-1 * time.Hour)
+	newer := at()
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		obs("c", "t-1", "h-1", "1.3.6.1.4.1.9.1.1", newer),
+		obs("c", "t-2", "h-2", "1.3.6.1.4.1.9.1.2", old),
+	}}
+	s := newFakeSettings()
+	r, _ := topology.NewSysInfoReconciler(topology.Config{
+		Observations: o, Nodes: &fakeNodes{}, Settings: s,
+		Logger: silentLogger(), Now: at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	saved, _ := s.GetWithDefault(context.Background(), "topology.sysinfo.high_water", "")
+	parsed, perr := time.Parse(time.RFC3339Nano, saved)
+	if perr != nil {
+		t.Fatalf("parse high water %q: %v", saved, perr)
+	}
+	if !parsed.Equal(newer) {
+		t.Errorf("high-water = %v, want %v (newest of batch)", parsed, newer)
+	}
+}
+
+func TestReconcileOnce_IdentityHashMergesObservationsFromSameDevice(t *testing.T) {
+	t.Parallel()
+	// Same client + sysName + sysObjectID across two observations
+	// at different times -> same identity_hash -> same node.
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		obs("c", "t-1", "router-1", "1.3.6.1.4.1.9.1.1", at().Add(-1*time.Minute)),
+		obs("c", "t-1", "router-1", "1.3.6.1.4.1.9.1.1", at()),
+	}}
+	n := &fakeNodes{}
+	r, _ := topology.NewSysInfoReconciler(topology.Config{
+		Observations: o, Nodes: n, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	if len(n.upserts) != 2 {
+		t.Fatalf("upserts = %d, want 2", len(n.upserts))
+	}
+	if n.upserts[0].IdentityHash != n.upserts[1].IdentityHash {
+		t.Errorf("same device should hash identically; got %q vs %q",
+			n.upserts[0].IdentityHash, n.upserts[1].IdentityHash)
+	}
+}
+
+func TestReconcileOnce_DifferentClientsGetDifferentNodes(t *testing.T) {
+	t.Parallel()
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		obs("client-a", "t-1", "router-1", "1.3.6.1.4.1.9.1.1", at()),
+		obs("client-b", "t-1", "router-1", "1.3.6.1.4.1.9.1.1", at()),
+	}}
+	n := &fakeNodes{}
+	r, _ := topology.NewSysInfoReconciler(topology.Config{
+		Observations: o, Nodes: n, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	if n.upserts[0].IdentityHash == n.upserts[1].IdentityHash {
+		t.Error("two clients with identical sysName/OID must not collapse to one node")
+	}
+}
+
+func TestReconcileOnce_EmptyObservationsListIsNoOp(t *testing.T) {
+	t.Parallel()
+	s := newFakeSettings()
+	r, _ := topology.NewSysInfoReconciler(topology.Config{
+		Observations: &fakeObservations{},
+		Nodes:        &fakeNodes{},
+		Settings:     s,
+		Logger:       silentLogger(),
+		Now:          at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("empty list: %v", err)
+	}
+	v, _ := s.GetWithDefault(context.Background(), "topology.sysinfo.high_water", "")
+	if v != "" {
+		t.Errorf("high-water should not be touched on empty batch, got %q", v)
+	}
+}
+
+func TestReconcileOnce_ListErrorPropagates(t *testing.T) {
+	t.Parallel()
+	r, _ := topology.NewSysInfoReconciler(topology.Config{
+		Observations: &fakeObservations{listErr: errors.New("db down")},
+		Nodes:        &fakeNodes{},
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err == nil {
+		t.Error("expected list error to propagate")
+	}
+}
+
+func TestReconcileOnce_UpsertFailureContinuesBatch(t *testing.T) {
+	t.Parallel()
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		obs("c", "t-1", "h-1", "1.3.6.1.4.1.9.1.1", at()),
+		obs("c", "t-2", "h-2", "1.3.6.1.4.1.9.1.2", at()),
+	}}
+	// upsertErr fails the first call only? our fakeNodes always
+	// errors when upsertErr is set; that's fine for "all rows
+	// fail" coverage. The contract is: a per-row failure does
+	// not abort the batch — high-water still advances.
+	n := &fakeNodes{upsertErr: errors.New("constraint")}
+	s := newFakeSettings()
+	r, _ := topology.NewSysInfoReconciler(topology.Config{
+		Observations: o, Nodes: n, Settings: s,
+		Logger: silentLogger(), Now: at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce should continue past row errors; got %v", err)
+	}
+	saved, _ := s.GetWithDefault(context.Background(), "topology.sysinfo.high_water", "")
+	if saved == "" {
+		t.Error("high-water should still advance even when every upsert fails")
+	}
+}
+
+func TestReconcileOnce_SkipsObservationWithoutIdentity(t *testing.T) {
+	t.Parallel()
+	// Empty SysName + SysObjectID — buildNode rejects this.
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		obs("c", "t-1", "", "", at()),
+	}}
+	n := &fakeNodes{}
+	r, _ := topology.NewSysInfoReconciler(topology.Config{
+		Observations: o, Nodes: n, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+	if len(n.upserts) != 0 {
+		t.Errorf("expected zero upserts for empty-identity row, got %d", len(n.upserts))
+	}
+}
+
+func TestStartStop_Idempotent(t *testing.T) {
+	t.Parallel()
+	r, _ := topology.NewSysInfoReconciler(topology.Config{
+		Observations: &fakeObservations{},
+		Nodes:        &fakeNodes{},
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+		Interval:     500 * time.Millisecond,
+	})
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := r.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if err := r.Stop(stopCtx); err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Stage A4.1 — first topology reconciler. Consumes `sys_info`
observations from `snmp_observations` and upserts `topology_nodes`
with identity-merged sysName / sysObjectID. Sets the pattern for
A4.2 (if_table fold-in), A4.3 (edge reconciler), A4.4 (arp).

## Changes
- **`TopologyRepository`** — Upsert preserves FirstSeen on update; List uses the shared `listQueryBuilder` + `queryRows` helper from A3.5e
- **`db.Topology()`** accessor
- **`internal/topology.SysInfoReconciler`** — engine.Engine that ticks every 30s (configurable, ≥100ms guard), processes batches of 500 observations
- High-water mark persisted in `settings` so restarts resume — no backlog reprocessing
- `buildNode` → `identityHashFor(client_id, sys_object_id, sys_name)` with target_id fallback
- Different clients with identical sysName do NOT collapse to one node
- `deviceTypeFromObjectID` maps enterprise OID prefixes to coarse types (cisco/juniper/arista/linux/mikrotik)
- 10 unit tests covering identity, batching, error paths, lifecycle

## Validation
- `go test ./internal/topology/... ./internal/database/...` → green
- `golangci-lint run` → 0 issues

## Next
A4.2 — if_table reconciler attaches per-interface state to each node (separate table or JSON column TBD; will decide based on alert-rule query patterns)