### PR TITLE
feat(topology): if_table reconciler attaches interfaces to nodes (stage a4.2)

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1809,6 +1809,57 @@ func getMigrationDefs() []migrationDef {
 			CREATE INDEX IF NOT EXISTS idx_listener_events_observed_at ON listener_events(observed_at);
 		`,
 		},
+		{
+			// Stage A4.2 — target -> node mapping. Most A4 reconcilers
+			// only see (client_id, target_id) on their observations
+			// (if_table, lldp, arp, fdb, routing, bgp4) and need to
+			// look up the topology_node that sysinfo identified. This
+			// table is the join: sysinfo reconciler writes
+			// (client_id, target_id, node_id) on every upsert; later
+			// reconcilers read it to attach their slice of state.
+			Description: "Create topology_target_nodes mapping",
+			Up: `
+			CREATE TABLE IF NOT EXISTS topology_target_nodes (
+				client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				target_id TEXT NOT NULL,
+				node_id TEXT NOT NULL REFERENCES topology_nodes(id) ON DELETE CASCADE,
+				last_seen TEXT NOT NULL,
+				PRIMARY KEY (client_id, target_id)
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_topology_target_nodes_node ON topology_target_nodes(node_id);
+		`,
+		},
+		{
+			// Stage A4.2 — per-node interface state. One row per
+			// (node_id, if_index); reconciled from if_table
+			// observations. Status + speed live as columns so alert
+			// rules can index them cheaply ("WHERE if_oper_status = 2"
+			// for down interfaces, "WHERE speed_bps < 1e9" for sub-
+			// gigabit links).
+			Description: "Create topology_interfaces for per-node if_table state",
+			Up: `
+			CREATE TABLE IF NOT EXISTS topology_interfaces (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				node_id TEXT NOT NULL REFERENCES topology_nodes(id) ON DELETE CASCADE,
+				if_index INTEGER NOT NULL,
+				if_name TEXT,
+				if_descr TEXT,
+				if_alias TEXT,
+				if_type INTEGER,
+				if_admin_status INTEGER,
+				if_oper_status INTEGER,
+				if_phys_addr TEXT,
+				speed_bps INTEGER,
+				last_seen TEXT NOT NULL,
+				UNIQUE(node_id, if_index)
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_topology_interfaces_node ON topology_interfaces(node_id);
+			CREATE INDEX IF NOT EXISTS idx_topology_interfaces_oper ON topology_interfaces(if_oper_status);
+			CREATE INDEX IF NOT EXISTS idx_topology_interfaces_last_seen ON topology_interfaces(last_seen);
+		`,
+		},
 	}
 }
 

--- a/internal/database/repository_topology.go
+++ b/internal/database/repository_topology.go
@@ -38,7 +38,10 @@ type TopologyRepository struct {
 
 // GetByIdentityHash returns the node with the given identity hash
 // or ErrTopologyNodeNotFound when absent.
-func (r *TopologyRepository) GetByIdentityHash(ctx context.Context, hash string) (*TopologyNode, error) {
+func (r *TopologyRepository) GetByIdentityHash(
+	ctx context.Context,
+	hash string,
+) (*TopologyNode, error) {
 	row := r.db.QueryRow(ctx, `
 		SELECT id, client_id, identity_hash, display_name, device_type,
 		       chassis_id, sys_name, primary_mac, primary_ip,
@@ -59,7 +62,10 @@ var ErrTopologyNodeNotFound = errors.New("topology node not found")
 //
 // Returns the up-to-date row including any FirstSeen the existing
 // record carried.
-func (r *TopologyRepository) Upsert(ctx context.Context, node *TopologyNode) (*TopologyNode, error) {
+func (r *TopologyRepository) Upsert(
+	ctx context.Context,
+	node *TopologyNode,
+) (*TopologyNode, error) {
 	if node.IdentityHash == "" {
 		return nil, errors.New("topology_nodes: IdentityHash required")
 	}
@@ -150,7 +156,10 @@ type TopologyListOptions struct {
 }
 
 // List returns nodes matching opts ordered by LastSeen desc.
-func (r *TopologyRepository) List(ctx context.Context, opts TopologyListOptions) ([]*TopologyNode, error) {
+func (r *TopologyRepository) List(
+	ctx context.Context,
+	opts TopologyListOptions,
+) ([]*TopologyNode, error) {
 	const defaultLimit, maxLimit = 100, 5000
 
 	query, args := newListQueryBuilder(`
@@ -176,6 +185,200 @@ func toNullTime(t time.Time) sql.NullString {
 		return sql.NullString{}
 	}
 	return sql.NullString{String: t.UTC().Format(time.RFC3339Nano), Valid: true}
+}
+
+// TopologyInterface mirrors one row of topology_interfaces.
+// Reconciled from if_table observations; columns shaped so alert
+// rules can index admin/oper status and speed without parsing JSON.
+type TopologyInterface struct {
+	ID            int64
+	NodeID        string
+	IfIndex       uint32
+	IfName        string
+	IfDescr       string
+	IfAlias       string
+	IfType        uint32
+	IfAdminStatus int
+	IfOperStatus  int
+	IfPhysAddr    string
+	SpeedBps      uint64
+	LastSeen      time.Time
+}
+
+// UpsertTargetNode records the (client_id, target_id) -> node_id
+// mapping so A4.2+ reconcilers (if_table, lldp, arp, fdb, routing,
+// bgp4) can resolve their observations to the right topology node
+// without re-decoding sysinfo. The sysinfo reconciler calls this on
+// every node upsert.
+func (r *TopologyRepository) UpsertTargetNode(
+	ctx context.Context,
+	clientID, targetID, nodeID string,
+	lastSeen time.Time,
+) error {
+	if targetID == "" {
+		return errors.New("topology_target_nodes: TargetID required")
+	}
+	if nodeID == "" {
+		return errors.New("topology_target_nodes: NodeID required")
+	}
+	if clientID == "" {
+		clientID = "default"
+	}
+	if lastSeen.IsZero() {
+		lastSeen = time.Now().UTC()
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO topology_target_nodes (client_id, target_id, node_id, last_seen)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(client_id, target_id) DO UPDATE SET
+			node_id = excluded.node_id,
+			last_seen = excluded.last_seen
+	`,
+		clientID, targetID, nodeID,
+		lastSeen.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert topology_target_nodes: %w", err)
+	}
+	return nil
+}
+
+// NodeIDForTarget resolves (client_id, target_id) -> node_id. Returns
+// "" + ErrTopologyNodeNotFound when no mapping exists yet (the
+// sysinfo reconciler hasn't seen this target).
+func (r *TopologyRepository) NodeIDForTarget(
+	ctx context.Context,
+	clientID, targetID string,
+) (string, error) {
+	if clientID == "" {
+		clientID = "default"
+	}
+	row := r.db.QueryRow(ctx,
+		`SELECT node_id FROM topology_target_nodes WHERE client_id = ? AND target_id = ?`,
+		clientID, targetID,
+	)
+	var nodeID string
+	if err := row.Scan(&nodeID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrTopologyNodeNotFound
+		}
+		return "", fmt.Errorf("nodeIDForTarget: %w", err)
+	}
+	return nodeID, nil
+}
+
+// UpsertInterface inserts or updates one topology_interfaces row.
+// Reconcilers call this once per if_table row per node per poll.
+func (r *TopologyRepository) UpsertInterface(ctx context.Context, iface *TopologyInterface) error {
+	if iface.NodeID == "" {
+		return errors.New("topology_interfaces: NodeID required")
+	}
+	if iface.LastSeen.IsZero() {
+		iface.LastSeen = time.Now().UTC()
+	}
+
+	const ifaceUpsertSQL = `
+		INSERT INTO topology_interfaces
+		  (node_id, if_index, if_name, if_descr, if_alias, if_type,
+		   if_admin_status, if_oper_status, if_phys_addr, speed_bps,
+		   last_seen)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(node_id, if_index) DO UPDATE SET
+			if_name = excluded.if_name,
+			if_descr = excluded.if_descr,
+			if_alias = excluded.if_alias,
+			if_type = excluded.if_type,
+			if_admin_status = excluded.if_admin_status,
+			if_oper_status = excluded.if_oper_status,
+			if_phys_addr = excluded.if_phys_addr,
+			speed_bps = excluded.speed_bps,
+			last_seen = excluded.last_seen
+	`
+	_, err := r.db.Exec(ctx, ifaceUpsertSQL,
+		iface.NodeID, iface.IfIndex,
+		toNullString(iface.IfName), toNullString(iface.IfDescr),
+		toNullString(iface.IfAlias), iface.IfType,
+		iface.IfAdminStatus, iface.IfOperStatus,
+		toNullString(iface.IfPhysAddr),
+		iface.SpeedBps,
+		iface.LastSeen.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert topology_interface: %w", err)
+	}
+	return nil
+}
+
+// ListInterfaces returns every interface for a node ordered by
+// IfIndex ascending.
+func (r *TopologyRepository) ListInterfaces(
+	ctx context.Context,
+	nodeID string,
+) ([]*TopologyInterface, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, node_id, if_index, if_name, if_descr, if_alias,
+		       if_type, if_admin_status, if_oper_status, if_phys_addr,
+		       speed_bps, last_seen
+		FROM topology_interfaces
+		WHERE node_id = ?
+		ORDER BY if_index ASC
+	`, nodeID)
+	if err != nil {
+		return nil, fmt.Errorf("list topology_interfaces: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*TopologyInterface
+	for rows.Next() {
+		iface, scanErr := scanTopologyInterface(rows.Scan)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, iface)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("list topology_interfaces iter: %w", rowsErr)
+	}
+	return out, nil
+}
+
+func scanTopologyInterface(scan func(...any) error) (*TopologyInterface, error) {
+	var (
+		iface       TopologyInterface
+		ifName      sql.NullString
+		ifDescr     sql.NullString
+		ifAlias     sql.NullString
+		ifPhysAddr  sql.NullString
+		lastSeenStr string
+	)
+	err := scan(
+		&iface.ID, &iface.NodeID, &iface.IfIndex,
+		&ifName, &ifDescr, &ifAlias,
+		&iface.IfType, &iface.IfAdminStatus, &iface.IfOperStatus,
+		&ifPhysAddr, &iface.SpeedBps, &lastSeenStr,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrTopologyNodeNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan topology_interface: %w", err)
+	}
+	if ifName.Valid {
+		iface.IfName = ifName.String
+	}
+	if ifDescr.Valid {
+		iface.IfDescr = ifDescr.String
+	}
+	if ifAlias.Valid {
+		iface.IfAlias = ifAlias.String
+	}
+	if ifPhysAddr.Valid {
+		iface.IfPhysAddr = ifPhysAddr.String
+	}
+	if parsed, perr := time.Parse(time.RFC3339Nano, lastSeenStr); perr == nil {
+		iface.LastSeen = parsed
+	}
+	return &iface, nil
 }
 
 func scanTopologyNode(scan func(...any) error) (*TopologyNode, error) {

--- a/internal/topology/iftable_reconciler.go
+++ b/internal/topology/iftable_reconciler.go
@@ -1,0 +1,272 @@
+package topology
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// IfTableReconcilerName is the engine identifier.
+const IfTableReconcilerName = "topology-iftable-reconciler"
+
+// ifTableHighWaterKey is the settings key holding the latest
+// ObservedAt this reconciler has already processed.
+const ifTableHighWaterKey = "topology.iftable.high_water"
+
+// nodeIfaceUpserter is the narrowed surface the iftable reconciler
+// needs. The sysinfo reconciler already populated the
+// (client, target) -> node_id mapping; here we look it up + write
+// one row per interface.
+type nodeIfaceUpserter interface {
+	NodeIDForTarget(ctx context.Context, clientID, targetID string) (string, error)
+	UpsertInterface(ctx context.Context, iface *database.TopologyInterface) error
+}
+
+// IfTableReconciler turns if_table observations into
+// topology_interfaces rows attached to their parent node. Skips
+// observations whose target_id has no node mapping yet — those land
+// on the next pass after sysinfo reconciliation catches up.
+type IfTableReconciler struct {
+	obs      observationsReader
+	store    nodeIfaceUpserter
+	settings settingsKV
+	logger   *slog.Logger
+	now      func() time.Time
+	interval time.Duration
+
+	mu      sync.Mutex
+	started bool
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+// IfTableConfig wires the iftable reconciler. Mirrors Config for
+// consistency across reconcilers.
+type IfTableConfig struct {
+	Observations observationsReader
+	Store        nodeIfaceUpserter
+	Settings     settingsKV
+	Logger       *slog.Logger
+	Now          func() time.Time
+	Interval     time.Duration
+}
+
+// NewIfTableReconciler returns an unstarted iftable reconciler.
+func NewIfTableReconciler(cfg IfTableConfig) (*IfTableReconciler, error) {
+	if cfg.Observations == nil {
+		return nil, errors.New("topology: iftable Observations required")
+	}
+	if cfg.Store == nil {
+		return nil, errors.New("topology: iftable Store required")
+	}
+	if cfg.Settings == nil {
+		return nil, errors.New("topology: iftable Settings required")
+	}
+	d := applyDefaults(cfg.Logger, cfg.Now, cfg.Interval)
+	return &IfTableReconciler{
+		obs:      cfg.Observations,
+		store:    cfg.Store,
+		settings: cfg.Settings,
+		logger:   d.logger,
+		now:      d.now,
+		interval: d.interval,
+	}, nil
+}
+
+// Name implements [engine.Engine].
+func (*IfTableReconciler) Name() string { return IfTableReconcilerName }
+
+// Start kicks off the reconcile loop. Idempotent.
+func (r *IfTableReconciler) Start(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.started {
+		return nil
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	r.started = true
+	r.wg.Add(1)
+	go r.loop(loopCtx)
+	r.logger.InfoContext(ctx, "iftable reconciler started", "interval", r.interval)
+	return nil
+}
+
+// Stop terminates the reconcile loop. Honors ctx deadline.
+func (r *IfTableReconciler) Stop(ctx context.Context) error {
+	r.mu.Lock()
+	if !r.started {
+		r.mu.Unlock()
+		return nil
+	}
+	r.started = false
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.mu.Unlock()
+
+	doneCh := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	r.logger.InfoContext(ctx, "iftable reconciler stopped")
+	return nil
+}
+
+func (r *IfTableReconciler) loop(ctx context.Context) {
+	defer r.wg.Done()
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	if err := r.ReconcileOnce(ctx); err != nil {
+		r.logger.WarnContext(ctx, "iftable reconcile failed", "error", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := r.ReconcileOnce(ctx); err != nil {
+				r.logger.WarnContext(ctx, "iftable reconcile failed", "error", err)
+			}
+		}
+	}
+}
+
+// ReconcileOnce processes one batch of new if_table observations.
+func (r *IfTableReconciler) ReconcileOnce(ctx context.Context) error {
+	since, err := r.loadHighWater(ctx)
+	if err != nil {
+		return fmt.Errorf("load high-water: %w", err)
+	}
+	observations, err := r.obs.List(ctx, database.ListOptions{
+		Kind:  "if_table",
+		Since: since,
+		Limit: defaultBatchLimit,
+	})
+	if err != nil {
+		return fmt.Errorf("list if_table observations: %w", err)
+	}
+	if len(observations) == 0 {
+		return nil
+	}
+
+	var maxObservedAt time.Time
+	rowsUpserted := 0
+	for _, obs := range observations {
+		if obs.ObservedAt.After(maxObservedAt) {
+			maxObservedAt = obs.ObservedAt
+		}
+		nodeID, lookupErr := r.store.NodeIDForTarget(ctx, obs.ClientID, obs.TargetID)
+		if lookupErr != nil {
+			if errors.Is(lookupErr, database.ErrTopologyNodeNotFound) {
+				r.logger.DebugContext(ctx, "iftable: target has no node mapping yet, skipping",
+					"target_id", obs.TargetID)
+				continue
+			}
+			r.logger.WarnContext(ctx, "iftable: target -> node lookup failed",
+				"target_id", obs.TargetID, "error", lookupErr)
+			continue
+		}
+		rowsUpserted += r.applyObservation(ctx, obs, nodeID)
+	}
+	r.logger.DebugContext(ctx, "iftable reconcile pass",
+		"batch", len(observations), "rows", rowsUpserted, "max_observed_at", maxObservedAt)
+
+	if !maxObservedAt.IsZero() {
+		if saveErr := r.saveHighWater(ctx, maxObservedAt); saveErr != nil {
+			return fmt.Errorf("save high-water: %w", saveErr)
+		}
+	}
+	return nil
+}
+
+// ifTablePayload mirrors the iftable.Observation JSON shape.
+type ifTablePayload struct {
+	Rows []ifRow `json:"Rows"`
+}
+
+// ifRow mirrors the iftable.Row JSON shape — keep field names
+// aligned with internal/polling/snmp/collectors/iftable.Row.
+type ifRow struct {
+	IfIndex    uint32 `json:"IfIndex"`
+	IfDescr    string `json:"IfDescr"`
+	IfName     string `json:"IfName"`
+	IfAlias    string `json:"IfAlias"`
+	IfType     uint32 `json:"IfType"`
+	IfAdmin    int    `json:"IfAdmin"`
+	IfOper     int    `json:"IfOper"`
+	IfPhysAddr string `json:"IfPhysAddr"`
+	SpeedBps   uint64 `json:"SpeedBps"`
+}
+
+// applyObservation decodes the iftable payload and upserts one row
+// per interface. Returns the count of upserts that succeeded.
+func (r *IfTableReconciler) applyObservation(
+	ctx context.Context,
+	obs *database.SNMPObservation,
+	nodeID string,
+) int {
+	var p ifTablePayload
+	if err := json.Unmarshal([]byte(obs.PayloadJSON), &p); err != nil {
+		r.logger.WarnContext(ctx, "iftable: unmarshal payload failed",
+			"target_id", obs.TargetID, "error", err)
+		return 0
+	}
+	count := 0
+	for _, row := range p.Rows {
+		if row.IfIndex == 0 {
+			continue
+		}
+		iface := &database.TopologyInterface{
+			NodeID:        nodeID,
+			IfIndex:       row.IfIndex,
+			IfName:        row.IfName,
+			IfDescr:       row.IfDescr,
+			IfAlias:       row.IfAlias,
+			IfType:        row.IfType,
+			IfAdminStatus: row.IfAdmin,
+			IfOperStatus:  row.IfOper,
+			IfPhysAddr:    row.IfPhysAddr,
+			SpeedBps:      row.SpeedBps,
+			LastSeen:      obs.ObservedAt,
+		}
+		if upsertErr := r.store.UpsertInterface(ctx, iface); upsertErr != nil {
+			r.logger.WarnContext(ctx, "iftable: interface upsert failed",
+				"target_id", obs.TargetID, "if_index", row.IfIndex, "error", upsertErr)
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func (r *IfTableReconciler) loadHighWater(ctx context.Context) (time.Time, error) {
+	raw, err := r.settings.GetWithDefault(ctx, ifTableHighWaterKey, "")
+	if err != nil {
+		return time.Time{}, err
+	}
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse iftable high-water %q: %w", raw, err)
+	}
+	return parsed, nil
+}
+
+func (r *IfTableReconciler) saveHighWater(ctx context.Context, t time.Time) error {
+	return r.settings.Set(ctx, ifTableHighWaterKey, t.UTC().Format(time.RFC3339Nano))
+}

--- a/internal/topology/iftable_reconciler_test.go
+++ b/internal/topology/iftable_reconciler_test.go
@@ -1,0 +1,281 @@
+package topology_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/topology"
+)
+
+type fakeIfStore struct {
+	mu        sync.Mutex
+	nodeFor   map[string]string // (client|target) -> nodeID
+	lookupErr error
+	upserts   []*database.TopologyInterface
+	upsertErr error
+}
+
+func newFakeIfStore() *fakeIfStore {
+	return &fakeIfStore{nodeFor: make(map[string]string)}
+}
+
+func (f *fakeIfStore) NodeIDForTarget(_ context.Context, clientID, targetID string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.lookupErr != nil {
+		return "", f.lookupErr
+	}
+	id, ok := f.nodeFor[clientID+"|"+targetID]
+	if !ok {
+		return "", database.ErrTopologyNodeNotFound
+	}
+	return id, nil
+}
+
+func (f *fakeIfStore) UpsertInterface(_ context.Context, iface *database.TopologyInterface) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.upserts = append(f.upserts, iface)
+	return nil
+}
+
+func ifPayload(rows ...map[string]any) string {
+	b, _ := json.Marshal(map[string]any{"Rows": rows})
+	return string(b)
+}
+
+func ifObs(client, target string, observed time.Time, rows ...map[string]any) *database.SNMPObservation {
+	return &database.SNMPObservation{
+		ClientID:    client,
+		TargetID:    target,
+		Kind:        "if_table",
+		ObservedAt:  observed,
+		PayloadJSON: ifPayload(rows...),
+	}
+}
+
+func TestNewIfTableReconciler_RejectsMissingDeps(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cfg  topology.IfTableConfig
+	}{
+		{"missing Observations", topology.IfTableConfig{Store: newFakeIfStore(), Settings: newFakeSettings()}},
+		{"missing Store", topology.IfTableConfig{Observations: &fakeObservations{}, Settings: newFakeSettings()}},
+		{"missing Settings", topology.IfTableConfig{Observations: &fakeObservations{}, Store: newFakeIfStore()}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := topology.NewIfTableReconciler(tt.cfg); err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestIfTableReconcileOnce_UpsertsOneRowPerInterface(t *testing.T) {
+	t.Parallel()
+	store := newFakeIfStore()
+	store.nodeFor["client-a|t-1"] = "node-abc"
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		ifObs("client-a", "t-1", at(),
+			map[string]any{
+				"IfIndex": 1, "IfName": "Gi0/0", "IfAdmin": 1, "IfOper": 1, "SpeedBps": 1000000000,
+			},
+			map[string]any{
+				"IfIndex": 2, "IfName": "Gi0/1", "IfAdmin": 1, "IfOper": 2, "SpeedBps": 1000000000,
+			},
+		),
+	}}
+	r, _ := topology.NewIfTableReconciler(topology.IfTableConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if len(store.upserts) != 2 {
+		t.Fatalf("upserts = %d, want 2", len(store.upserts))
+	}
+	if store.upserts[0].NodeID != "node-abc" {
+		t.Errorf("NodeID = %q, want node-abc", store.upserts[0].NodeID)
+	}
+	if store.upserts[0].IfName != "Gi0/0" {
+		t.Errorf("IfName = %q", store.upserts[0].IfName)
+	}
+}
+
+func TestIfTableReconcileOnce_SkipsObservationsWithoutNodeMapping(t *testing.T) {
+	t.Parallel()
+	store := newFakeIfStore() // empty mapping
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		ifObs("c", "t-orphan", at(),
+			map[string]any{"IfIndex": 1, "IfName": "eth0"},
+		),
+	}}
+	settings := newFakeSettings()
+	r, _ := topology.NewIfTableReconciler(topology.IfTableConfig{
+		Observations: o, Store: store, Settings: settings,
+		Logger: silentLogger(), Now: at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if len(store.upserts) != 0 {
+		t.Errorf("expected zero upserts for orphan target, got %d", len(store.upserts))
+	}
+	// High-water still advances so we don't reprocess every poll
+	// forever waiting for sysinfo to catch up.
+	hw, _ := settings.GetWithDefault(context.Background(), "topology.iftable.high_water", "")
+	if hw == "" {
+		t.Error("high-water should advance even when target has no node mapping")
+	}
+}
+
+func TestIfTableReconcileOnce_PersistsMaxObservedAt(t *testing.T) {
+	t.Parallel()
+	store := newFakeIfStore()
+	store.nodeFor["c|t-1"] = "node-1"
+	store.nodeFor["c|t-2"] = "node-2"
+
+	old := at().Add(-time.Hour)
+	newer := at()
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		ifObs("c", "t-1", newer, map[string]any{"IfIndex": 1, "IfName": "e0"}),
+		ifObs("c", "t-2", old, map[string]any{"IfIndex": 1, "IfName": "e0"}),
+	}}
+	s := newFakeSettings()
+	r, _ := topology.NewIfTableReconciler(topology.IfTableConfig{
+		Observations: o, Store: store, Settings: s,
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	hw, _ := s.GetWithDefault(context.Background(), "topology.iftable.high_water", "")
+	parsed, perr := time.Parse(time.RFC3339Nano, hw)
+	if perr != nil {
+		t.Fatalf("parse high water: %v", perr)
+	}
+	if !parsed.Equal(newer) {
+		t.Errorf("high-water = %v, want %v", parsed, newer)
+	}
+}
+
+func TestIfTableReconcileOnce_MalformedPayloadSkipsObservation(t *testing.T) {
+	t.Parallel()
+	store := newFakeIfStore()
+	store.nodeFor["c|t-1"] = "node-1"
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		{
+			ClientID: "c", TargetID: "t-1", Kind: "if_table",
+			ObservedAt: at(), PayloadJSON: "{not valid json",
+		},
+	}}
+	r, _ := topology.NewIfTableReconciler(topology.IfTableConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("malformed should not abort batch; got %v", err)
+	}
+	if len(store.upserts) != 0 {
+		t.Errorf("malformed payload should yield zero upserts, got %d", len(store.upserts))
+	}
+}
+
+func TestIfTableReconcileOnce_ZeroIfIndexSkipped(t *testing.T) {
+	t.Parallel()
+	store := newFakeIfStore()
+	store.nodeFor["c|t-1"] = "node-1"
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		ifObs("c", "t-1", at(),
+			map[string]any{"IfIndex": 0, "IfName": "invalid"},
+			map[string]any{"IfIndex": 1, "IfName": "ok"},
+		),
+	}}
+	r, _ := topology.NewIfTableReconciler(topology.IfTableConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+	if len(store.upserts) != 1 || store.upserts[0].IfName != "ok" {
+		t.Errorf("ifIndex 0 should be skipped, got upserts = %+v", store.upserts)
+	}
+}
+
+func TestIfTableReconcileOnce_LookupErrorContinuesBatch(t *testing.T) {
+	t.Parallel()
+	store := newFakeIfStore()
+	store.lookupErr = errors.New("db down")
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		ifObs("c", "t-1", at(), map[string]any{"IfIndex": 1, "IfName": "e0"}),
+	}}
+	r, _ := topology.NewIfTableReconciler(topology.IfTableConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Errorf("lookup error should not abort batch, got %v", err)
+	}
+}
+
+func TestIfTableReconcileOnce_ListErrorPropagates(t *testing.T) {
+	t.Parallel()
+	r, _ := topology.NewIfTableReconciler(topology.IfTableConfig{
+		Observations: &fakeObservations{listErr: errors.New("db down")},
+		Store:        newFakeIfStore(),
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err == nil {
+		t.Error("expected list error to propagate")
+	}
+}
+
+func TestIfTableStartStop_Idempotent(t *testing.T) {
+	t.Parallel()
+	r, _ := topology.NewIfTableReconciler(topology.IfTableConfig{
+		Observations: &fakeObservations{},
+		Store:        newFakeIfStore(),
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+		Interval:     500 * time.Millisecond,
+	})
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := r.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestIfTableReconciler_EngineName(t *testing.T) {
+	t.Parallel()
+	r, _ := topology.NewIfTableReconciler(topology.IfTableConfig{
+		Observations: &fakeObservations{},
+		Store:        newFakeIfStore(),
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+	})
+	if r.Name() != topology.IfTableReconcilerName {
+		t.Errorf("Name() = %q, want %q", r.Name(), topology.IfTableReconcilerName)
+	}
+}

--- a/internal/topology/reconciler_base.go
+++ b/internal/topology/reconciler_base.go
@@ -1,0 +1,36 @@
+package topology
+
+import (
+	"log/slog"
+	"time"
+)
+
+// reconcilerDefaults holds the per-reconciler tunables every
+// implementation (sysinfo, iftable, lldp, arp, ...) needs.
+// Extracted so the Logger/Now/Interval defaulting logic isn't
+// duplicated per-reconciler — keeps constructors short and
+// satisfies the dupl linter when adding the 3rd+ reconciler.
+type reconcilerDefaults struct {
+	logger   *slog.Logger
+	now      func() time.Time
+	interval time.Duration
+}
+
+// applyDefaults fills nil Logger/Now and clamps Interval. Returns
+// the canonical values so callers can copy them into their own
+// struct.
+func applyDefaults(logger *slog.Logger, now func() time.Time, interval time.Duration) reconcilerDefaults {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+	if interval < minPollInterval {
+		interval = minPollInterval
+	}
+	return reconcilerDefaults{logger: logger, now: now, interval: interval}
+}

--- a/internal/topology/sysinfo_reconciler.go
+++ b/internal/topology/sysinfo_reconciler.go
@@ -54,8 +54,17 @@ type observationsReader interface {
 }
 
 // nodeUpserter is the narrowed surface for topology_nodes writes.
+// UpsertTargetNode records the (client, target) -> node mapping so
+// downstream reconcilers (if_table, lldp, arp, fdb, routing, bgp4)
+// can resolve their observations to the right node without re-
+// decoding sysinfo on every pass.
 type nodeUpserter interface {
 	Upsert(ctx context.Context, node *database.TopologyNode) (*database.TopologyNode, error)
+	UpsertTargetNode(
+		ctx context.Context,
+		clientID, targetID, nodeID string,
+		lastSeen time.Time,
+	) error
 }
 
 // settingsKV is the high-water-mark store.
@@ -101,25 +110,14 @@ func NewSysInfoReconciler(cfg Config) (*SysInfoReconciler, error) {
 	if cfg.Settings == nil {
 		return nil, errors.New("topology: Settings required")
 	}
-	if cfg.Logger == nil {
-		cfg.Logger = slog.Default()
-	}
-	if cfg.Now == nil {
-		cfg.Now = func() time.Time { return time.Now().UTC() }
-	}
-	if cfg.Interval <= 0 {
-		cfg.Interval = defaultPollInterval
-	}
-	if cfg.Interval < minPollInterval {
-		cfg.Interval = minPollInterval
-	}
+	d := applyDefaults(cfg.Logger, cfg.Now, cfg.Interval)
 	return &SysInfoReconciler{
 		obs:      cfg.Observations,
 		nodes:    cfg.Nodes,
 		settings: cfg.Settings,
-		logger:   cfg.Logger,
-		now:      cfg.Now,
-		interval: cfg.Interval,
+		logger:   d.logger,
+		now:      d.now,
+		interval: d.interval,
 	}, nil
 }
 
@@ -224,10 +222,20 @@ func (r *SysInfoReconciler) ReconcileOnce(ctx context.Context) error {
 				"target_id", obs.TargetID, "error", buildErr)
 			continue
 		}
-		if _, upsertErr := r.nodes.Upsert(ctx, node); upsertErr != nil {
+		stored, upsertErr := r.nodes.Upsert(ctx, node)
+		if upsertErr != nil {
 			r.logger.WarnContext(ctx, "upsert topology_node failed",
 				"target_id", obs.TargetID, "identity", node.IdentityHash, "error", upsertErr)
 			continue
+		}
+		// Persist (client, target) -> node so A4.2+ reconcilers can
+		// look up the node by target_id without re-decoding sysinfo.
+		mapErr := r.nodes.UpsertTargetNode(
+			ctx, obs.ClientID, obs.TargetID, stored.ID, obs.ObservedAt,
+		)
+		if mapErr != nil {
+			r.logger.WarnContext(ctx, "upsert target_node mapping failed",
+				"target_id", obs.TargetID, "node_id", stored.ID, "error", mapErr)
 		}
 		upserted++
 	}
@@ -260,7 +268,9 @@ type sysInfoPayload struct {
 
 // buildNode decodes the observation payload into a TopologyNode
 // ready for upsert.
-func (r *SysInfoReconciler) buildNode(obs *database.SNMPObservation) (*database.TopologyNode, error) {
+func (r *SysInfoReconciler) buildNode(
+	obs *database.SNMPObservation,
+) (*database.TopologyNode, error) {
 	var p sysInfoPayload
 	if err := json.Unmarshal([]byte(obs.PayloadJSON), &p); err != nil {
 		return nil, fmt.Errorf("unmarshal sysinfo payload: %w", err)

--- a/internal/topology/sysinfo_reconciler_test.go
+++ b/internal/topology/sysinfo_reconciler_test.go
@@ -22,7 +22,10 @@ type fakeObservations struct {
 	listErr error
 }
 
-func (f *fakeObservations) List(_ context.Context, _ database.ListOptions) ([]*database.SNMPObservation, error) {
+func (f *fakeObservations) List(
+	_ context.Context,
+	_ database.ListOptions,
+) ([]*database.SNMPObservation, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.listErr != nil {
@@ -36,10 +39,19 @@ func (f *fakeObservations) List(_ context.Context, _ database.ListOptions) ([]*d
 type fakeNodes struct {
 	mu        sync.Mutex
 	upserts   []*database.TopologyNode
+	mappings  []targetNodeMapping
 	upsertErr error
 }
 
-func (f *fakeNodes) Upsert(_ context.Context, node *database.TopologyNode) (*database.TopologyNode, error) {
+type targetNodeMapping struct {
+	clientID, targetID, nodeID string
+	lastSeen                   time.Time
+}
+
+func (f *fakeNodes) Upsert(
+	_ context.Context,
+	node *database.TopologyNode,
+) (*database.TopologyNode, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.upsertErr != nil {
@@ -47,6 +59,19 @@ func (f *fakeNodes) Upsert(_ context.Context, node *database.TopologyNode) (*dat
 	}
 	f.upserts = append(f.upserts, node)
 	return node, nil
+}
+
+func (f *fakeNodes) UpsertTargetNode(
+	_ context.Context,
+	clientID, targetID, nodeID string,
+	lastSeen time.Time,
+) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mappings = append(f.mappings, targetNodeMapping{
+		clientID: clientID, targetID: targetID, nodeID: nodeID, lastSeen: lastSeen,
+	})
+	return nil
 }
 
 type fakeSettings struct {
@@ -86,7 +111,10 @@ func payload(client, target, sysName, sysObjectID string) string {
 	return string(b)
 }
 
-func obs(client, target, sysName, sysObjectID string, observed time.Time) *database.SNMPObservation {
+func obs(
+	client, target, sysName, sysObjectID string,
+	observed time.Time,
+) *database.SNMPObservation {
 	return &database.SNMPObservation{
 		ClientID:    client,
 		TargetID:    target,
@@ -103,8 +131,14 @@ func TestNew_RejectsMissingDeps(t *testing.T) {
 		cfg  topology.Config
 	}{
 		{"missing Observations", topology.Config{Nodes: &fakeNodes{}, Settings: newFakeSettings()}},
-		{"missing Nodes", topology.Config{Observations: &fakeObservations{}, Settings: newFakeSettings()}},
-		{"missing Settings", topology.Config{Observations: &fakeObservations{}, Nodes: &fakeNodes{}}},
+		{
+			"missing Nodes",
+			topology.Config{Observations: &fakeObservations{}, Settings: newFakeSettings()},
+		},
+		{
+			"missing Settings",
+			topology.Config{Observations: &fakeObservations{}, Nodes: &fakeNodes{}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
Stage A4.2 — second topology reconciler. Consumes `if_table`
observations and writes one `topology_interfaces` row per node
interface. Introduces the `(client, target) -> node_id` mapping
table that A4.3+ reconcilers (lldp/cdp/fdp/arp/fdb/routing/bgp4)
will all join through.

## Changes
- **Migration**: `topology_target_nodes` mapping (PK on `(client_id, target_id)`)
- **Migration**: `topology_interfaces` (unique `(node_id, if_index)`; admin/oper status + speed_bps as indexed columns, not JSON, so alert rules query cheaply)
- **`TopologyRepository.UpsertTargetNode` / `NodeIDForTarget`** — O(1) lookup at poll rate
- **`TopologyRepository.UpsertInterface` / `ListInterfaces`**
- **`SysInfoReconciler`** now calls `UpsertTargetNode` after every successful node upsert
- **`internal/topology/reconciler_base.go`** — shared `applyDefaults` helper for Logger/Now/Interval defaulting, removing dupl between constructors
- **`IfTableReconciler`** — new engine; orphan targets (no node mapping yet) skipped with high-water still advancing so we don't reprocess forever
- 10 unit tests

## Validation
- `go test ./internal/topology/... ./internal/database/...` → green
- `golangci-lint run` → 0 issues

## Next
A4.3 — lldp/cdp/fdp edge reconciler upserts `topology_links` from neighbor observations