### PR TITLE
feat(topology): edge reconciler upserts topology_links (stage a4.3)

### DIFF
--- a/internal/database/repository_topology.go
+++ b/internal/database/repository_topology.go
@@ -187,6 +187,212 @@ func toNullTime(t time.Time) sql.NullString {
 	return sql.NullString{String: t.UTC().Format(time.RFC3339Nano), Valid: true}
 }
 
+// TopologyLink mirrors one row of topology_links. Edges are
+// identity-merged the same way nodes are — the link ID is derived
+// from (source_node, source_interface, target_node, target_interface)
+// so re-observations of the same physical cable upsert rather than
+// duplicate.
+type TopologyLink struct {
+	ID              string
+	SourceNodeID    string
+	TargetNodeID    string
+	SourceInterface string
+	TargetInterface string
+	LinkType        string // "lldp", "cdp", "fdp"
+	Status          string // "up", "down", "unknown"
+	SpeedMbps       uint32
+	UtilizationPct  float64
+	FirstSeen       time.Time
+	LastSeen        time.Time
+	EvidenceJSON    string
+}
+
+// NodeIDForSysName resolves a sys_name back to its node_id by
+// looking up topology_nodes. Used by the edge reconciler to map
+// an LLDP/CDP neighbor's reported hostname to a known node.
+// Returns ErrTopologyNodeNotFound when no node has that sys_name.
+func (r *TopologyRepository) NodeIDForSysName(ctx context.Context, clientID, sysName string) (string, error) {
+	if clientID == "" {
+		clientID = "default"
+	}
+	if sysName == "" {
+		return "", ErrTopologyNodeNotFound
+	}
+	row := r.db.QueryRow(ctx, `
+		SELECT id FROM topology_nodes
+		WHERE client_id = ? AND sys_name = ?
+		ORDER BY last_seen DESC
+		LIMIT 1
+	`, clientID, sysName)
+	var id string
+	if err := row.Scan(&id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrTopologyNodeNotFound
+		}
+		return "", fmt.Errorf("nodeIDForSysName: %w", err)
+	}
+	return id, nil
+}
+
+// UpsertLink inserts or updates a topology_links row. The link's
+// ID is the merge key — the edge reconciler computes it
+// deterministically from (source_node, source_interface,
+// target_node, target_interface) so two LLDP polls of the same
+// physical cable update one row instead of inserting two.
+func (r *TopologyRepository) UpsertLink(ctx context.Context, link *TopologyLink) error {
+	if link.ID == "" {
+		return errors.New("topology_links: ID required")
+	}
+	if link.SourceNodeID == "" || link.TargetNodeID == "" {
+		return errors.New("topology_links: SourceNodeID + TargetNodeID required")
+	}
+	if link.LinkType == "" {
+		link.LinkType = "unknown"
+	}
+	if link.Status == "" {
+		link.Status = "up"
+	}
+	if link.LastSeen.IsZero() {
+		link.LastSeen = time.Now().UTC()
+	}
+	if link.FirstSeen.IsZero() {
+		link.FirstSeen = link.LastSeen
+	}
+
+	// ON CONFLICT preserves first_seen; everything else refreshes
+	// from the new observation.
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO topology_links
+		  (id, source_node_id, target_node_id, source_interface, target_interface,
+		   link_type, status, speed_mbps, utilization_pct,
+		   first_seen, last_seen, evidence_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			source_interface = excluded.source_interface,
+			target_interface = excluded.target_interface,
+			link_type = excluded.link_type,
+			status = excluded.status,
+			speed_mbps = excluded.speed_mbps,
+			utilization_pct = excluded.utilization_pct,
+			last_seen = excluded.last_seen,
+			evidence_json = excluded.evidence_json
+	`,
+		link.ID, link.SourceNodeID, link.TargetNodeID,
+		toNullString(link.SourceInterface), toNullString(link.TargetInterface),
+		link.LinkType, link.Status,
+		nullableUint32(link.SpeedMbps),
+		nullableFloat(link.UtilizationPct),
+		link.FirstSeen.UTC().Format(time.RFC3339Nano),
+		link.LastSeen.UTC().Format(time.RFC3339Nano),
+		toNullString(link.EvidenceJSON),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert topology_link: %w", err)
+	}
+	return nil
+}
+
+// ListLinks returns every link involving nodeID (either source or
+// target) ordered by LastSeen desc.
+func (r *TopologyRepository) ListLinks(ctx context.Context, nodeID string) ([]*TopologyLink, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, source_node_id, target_node_id, source_interface, target_interface,
+		       link_type, status, speed_mbps, utilization_pct,
+		       first_seen, last_seen, evidence_json
+		FROM topology_links
+		WHERE source_node_id = ? OR target_node_id = ?
+		ORDER BY last_seen DESC
+	`, nodeID, nodeID)
+	if err != nil {
+		return nil, fmt.Errorf("list topology_links: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*TopologyLink
+	for rows.Next() {
+		link, scanErr := scanTopologyLink(rows.Scan)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, link)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("list topology_links iter: %w", rowsErr)
+	}
+	return out, nil
+}
+
+// nullableUint32 returns [sql.NullInt32] with valid=false when v == 0.
+// SpeedMbps + UtilizationPct are nullable in the schema so the UI
+// can distinguish "no measurement yet" from "0 Mbps". Values above
+// [math.MaxInt32] clamp down — SQLite stores INTEGER as int64 in
+// the driver but the NullInt32 wrapper is signed, so clamping keeps
+// the conversion well-defined for the (rare) terabit-per-second link.
+func nullableUint32(v uint32) sql.NullInt32 {
+	if v == 0 {
+		return sql.NullInt32{}
+	}
+	const maxInt32 uint32 = 1<<31 - 1
+	if v > maxInt32 {
+		v = maxInt32
+	}
+	return sql.NullInt32{Int32: int32(v), Valid: true}
+}
+
+func nullableFloat(v float64) sql.NullFloat64 {
+	if v == 0 {
+		return sql.NullFloat64{}
+	}
+	return sql.NullFloat64{Float64: v, Valid: true}
+}
+
+func scanTopologyLink(scan func(...any) error) (*TopologyLink, error) {
+	var (
+		link         TopologyLink
+		srcIface     sql.NullString
+		tgtIface     sql.NullString
+		speedMbps    sql.NullInt32
+		utilization  sql.NullFloat64
+		evidenceJSON sql.NullString
+		firstSeenStr string
+		lastSeenStr  string
+	)
+	err := scan(
+		&link.ID, &link.SourceNodeID, &link.TargetNodeID,
+		&srcIface, &tgtIface, &link.LinkType, &link.Status,
+		&speedMbps, &utilization,
+		&firstSeenStr, &lastSeenStr, &evidenceJSON,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrTopologyNodeNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan topology_link: %w", err)
+	}
+	if srcIface.Valid {
+		link.SourceInterface = srcIface.String
+	}
+	if tgtIface.Valid {
+		link.TargetInterface = tgtIface.String
+	}
+	if speedMbps.Valid && speedMbps.Int32 >= 0 {
+		link.SpeedMbps = uint32(speedMbps.Int32)
+	}
+	if utilization.Valid {
+		link.UtilizationPct = utilization.Float64
+	}
+	if evidenceJSON.Valid {
+		link.EvidenceJSON = evidenceJSON.String
+	}
+	if parsed, perr := time.Parse(time.RFC3339Nano, firstSeenStr); perr == nil {
+		link.FirstSeen = parsed
+	}
+	if parsed, perr := time.Parse(time.RFC3339Nano, lastSeenStr); perr == nil {
+		link.LastSeen = parsed
+	}
+	return &link, nil
+}
+
 // TopologyInterface mirrors one row of topology_interfaces.
 // Reconciled from if_table observations; columns shaped so alert
 // rules can index admin/oper status and speed without parsing JSON.

--- a/internal/topology/edge_reconciler.go
+++ b/internal/topology/edge_reconciler.go
@@ -1,0 +1,392 @@
+package topology
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// EdgeReconcilerName is the engine identifier.
+const EdgeReconcilerName = "topology-edge-reconciler"
+
+// edgeHighWaterKey is the settings key holding the latest ObservedAt
+// the edge reconciler has already processed across all neighbor kinds.
+const edgeHighWaterKey = "topology.edge.high_water"
+
+// neighborKinds enumerates every observation kind the edge
+// reconciler consumes. lldp/cdp/fdp are wire-distinct discovery
+// protocols that all converge on the same edge graph; reconciling
+// across all three in one engine keeps the high-water mark coherent.
+// Declared as a function (rather than a package var) so the linter
+// doesn't flag a global; the caller pattern is `for _, k := range neighborKinds()`.
+func neighborKinds() []string { return []string{"lldp", "cdp", "fdp"} }
+
+// edgeStore is the narrowed repo surface the edge reconciler uses.
+type edgeStore interface {
+	NodeIDForTarget(ctx context.Context, clientID, targetID string) (string, error)
+	NodeIDForSysName(ctx context.Context, clientID, sysName string) (string, error)
+	UpsertLink(ctx context.Context, link *database.TopologyLink) error
+}
+
+// EdgeReconciler turns lldp/cdp/fdp observations into
+// topology_links. Only emits edges when both endpoints map to a
+// known topology node — orphan neighbors (where the remote isn't
+// polled) are skipped with a debug log. Stage B may introduce
+// "ghost" nodes for orphan neighbors once the operator UI needs
+// them.
+type EdgeReconciler struct {
+	obs      observationsReader
+	store    edgeStore
+	settings settingsKV
+	logger   *slog.Logger
+	now      func() time.Time
+	interval time.Duration
+
+	mu      sync.Mutex
+	started bool
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+// EdgeConfig wires the edge reconciler.
+type EdgeConfig struct {
+	Observations observationsReader
+	Store        edgeStore
+	Settings     settingsKV
+	Logger       *slog.Logger
+	Now          func() time.Time
+	Interval     time.Duration
+}
+
+// NewEdgeReconciler returns an unstarted reconciler.
+func NewEdgeReconciler(cfg EdgeConfig) (*EdgeReconciler, error) {
+	if cfg.Observations == nil {
+		return nil, errors.New("topology: edge Observations required")
+	}
+	if cfg.Store == nil {
+		return nil, errors.New("topology: edge Store required")
+	}
+	if cfg.Settings == nil {
+		return nil, errors.New("topology: edge Settings required")
+	}
+	d := applyDefaults(cfg.Logger, cfg.Now, cfg.Interval)
+	return &EdgeReconciler{
+		obs:      cfg.Observations,
+		store:    cfg.Store,
+		settings: cfg.Settings,
+		logger:   d.logger,
+		now:      d.now,
+		interval: d.interval,
+	}, nil
+}
+
+// Name implements [engine.Engine].
+func (*EdgeReconciler) Name() string { return EdgeReconcilerName }
+
+// Start kicks off the reconcile loop. Idempotent.
+func (r *EdgeReconciler) Start(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.started {
+		return nil
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	r.started = true
+	r.wg.Add(1)
+	go r.loop(loopCtx)
+	r.logger.InfoContext(ctx, "edge reconciler started", "interval", r.interval)
+	return nil
+}
+
+// Stop terminates the reconcile loop. Honors ctx deadline.
+func (r *EdgeReconciler) Stop(ctx context.Context) error {
+	r.mu.Lock()
+	if !r.started {
+		r.mu.Unlock()
+		return nil
+	}
+	r.started = false
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.mu.Unlock()
+
+	doneCh := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	r.logger.InfoContext(ctx, "edge reconciler stopped")
+	return nil
+}
+
+func (r *EdgeReconciler) loop(ctx context.Context) {
+	defer r.wg.Done()
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	if err := r.ReconcileOnce(ctx); err != nil {
+		r.logger.WarnContext(ctx, "edge reconcile failed", "error", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := r.ReconcileOnce(ctx); err != nil {
+				r.logger.WarnContext(ctx, "edge reconcile failed", "error", err)
+			}
+		}
+	}
+}
+
+// ReconcileOnce processes one batch across all neighbor kinds.
+// Iterating per-kind keeps the SQL filters indexed (snmp_observations
+// has an idx on (client_id, kind, observed_at)).
+func (r *EdgeReconciler) ReconcileOnce(ctx context.Context) error {
+	since, err := r.loadHighWater(ctx)
+	if err != nil {
+		return fmt.Errorf("load high-water: %w", err)
+	}
+
+	var maxObservedAt time.Time
+	totalLinks := 0
+	for _, kind := range neighborKinds() {
+		count, kindMax, kindErr := r.reconcileKind(ctx, kind, since)
+		if kindErr != nil {
+			r.logger.WarnContext(ctx, "edge reconcile kind failed",
+				"kind", kind, "error", kindErr)
+			continue
+		}
+		totalLinks += count
+		if kindMax.After(maxObservedAt) {
+			maxObservedAt = kindMax
+		}
+	}
+	r.logger.DebugContext(ctx, "edge reconcile pass",
+		"links", totalLinks, "max_observed_at", maxObservedAt)
+
+	if !maxObservedAt.IsZero() {
+		if saveErr := r.saveHighWater(ctx, maxObservedAt); saveErr != nil {
+			return fmt.Errorf("save high-water: %w", saveErr)
+		}
+	}
+	return nil
+}
+
+// reconcileKind processes one observation kind. Returns the link
+// count and the newest ObservedAt across the batch.
+func (r *EdgeReconciler) reconcileKind(
+	ctx context.Context,
+	kind string,
+	since time.Time,
+) (int, time.Time, error) {
+	observations, err := r.obs.List(ctx, database.ListOptions{
+		Kind:  kind,
+		Since: since,
+		Limit: defaultBatchLimit,
+	})
+	if err != nil {
+		return 0, time.Time{}, fmt.Errorf("list %s observations: %w", kind, err)
+	}
+
+	var maxAt time.Time
+	count := 0
+	for _, obs := range observations {
+		if obs.ObservedAt.After(maxAt) {
+			maxAt = obs.ObservedAt
+		}
+		sourceNodeID, lookupErr := r.store.NodeIDForTarget(ctx, obs.ClientID, obs.TargetID)
+		if lookupErr != nil {
+			if errors.Is(lookupErr, database.ErrTopologyNodeNotFound) {
+				continue
+			}
+			r.logger.WarnContext(ctx, "edge: source node lookup failed",
+				"kind", kind, "target_id", obs.TargetID, "error", lookupErr)
+			continue
+		}
+		count += r.applyObservation(ctx, obs, kind, sourceNodeID)
+	}
+	return count, maxAt, nil
+}
+
+// neighborRecord captures the fields needed to materialize one edge.
+// Common to lldp + cdp + fdp; the per-kind decoder fills it in.
+type neighborRecord struct {
+	localInterface  string
+	remoteName      string
+	remoteInterface string
+}
+
+// applyObservation decodes the observation payload, resolves each
+// neighbor's node, and upserts an edge. Returns the count of edges
+// that landed.
+func (r *EdgeReconciler) applyObservation(
+	ctx context.Context,
+	obs *database.SNMPObservation,
+	kind string,
+	sourceNodeID string,
+) int {
+	neighbors, decodeErr := decodeNeighbors(kind, obs.PayloadJSON)
+	if decodeErr != nil {
+		r.logger.WarnContext(ctx, "edge: decode payload failed",
+			"kind", kind, "target_id", obs.TargetID, "error", decodeErr)
+		return 0
+	}
+	count := 0
+	for _, n := range neighbors {
+		if n.remoteName == "" {
+			continue
+		}
+		remoteNodeID, lookupErr := r.store.NodeIDForSysName(ctx, obs.ClientID, n.remoteName)
+		if lookupErr != nil {
+			// Skip orphan neighbors. A future stage may introduce
+			// ghost nodes; V1.0 needs both endpoints already known.
+			continue
+		}
+		linkID := linkIDFor(sourceNodeID, n.localInterface, remoteNodeID, n.remoteInterface)
+		evidence, _ := json.Marshal(map[string]string{
+			"kind":          kind,
+			"source_target": obs.TargetID,
+			"remote_name":   n.remoteName,
+		})
+		link := &database.TopologyLink{
+			ID:              linkID,
+			SourceNodeID:    sourceNodeID,
+			TargetNodeID:    remoteNodeID,
+			SourceInterface: n.localInterface,
+			TargetInterface: n.remoteInterface,
+			LinkType:        kind,
+			Status:          "up",
+			LastSeen:        obs.ObservedAt,
+			EvidenceJSON:    string(evidence),
+		}
+		if upsertErr := r.store.UpsertLink(ctx, link); upsertErr != nil {
+			r.logger.WarnContext(ctx, "edge: link upsert failed",
+				"kind", kind, "link_id", linkID, "error", upsertErr)
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// linkIDFor derives a stable ID from the sorted node-pair so that
+// observations from either side of the cable upsert to the same
+// row. Interfaces are intentionally NOT part of the ID — LLDP/CDP
+// report local-port labels (ifIndex, descriptor, alias) differently
+// across vendors, and two observations of the same physical cable
+// often disagree on which label to use. Keying by node-pair only
+// has the side-effect that parallel cables between the same two
+// nodes collapse into one row; refinement to per-port granularity
+// is tracked for Stage A4-bis once iftable-derived port identity
+// is reliable across vendors.
+func linkIDFor(sourceNodeID, _, remoteNodeID, _ string) string {
+	a, b := sourceNodeID, remoteNodeID
+	if a > b {
+		a, b = b, a
+	}
+	h := sha256.New()
+	h.Write([]byte(a))
+	h.Write([]byte{0x00})
+	h.Write([]byte(b))
+	return "link-" + hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// lldpPayload mirrors the lldp.Observation JSON shape.
+type lldpPayload struct {
+	Neighbors []struct {
+		LocalPortNum    uint32 `json:"LocalPortNum"`
+		PortID          string `json:"PortID"`
+		PortDescription string `json:"PortDescription"`
+		SysName         string `json:"SysName"`
+	} `json:"Neighbors"`
+}
+
+// cdpPayload mirrors the cdp.Observation JSON shape (also used for fdp).
+type cdpPayload struct {
+	Neighbors []struct {
+		LocalIfIndex uint32 `json:"LocalIfIndex"`
+		DeviceID     string `json:"DeviceID"`
+		DevicePort   string `json:"DevicePort"`
+	} `json:"Neighbors"`
+}
+
+// decodeNeighbors extracts the per-kind payload and returns a
+// uniform slice of neighborRecord. Unknown kinds yield an error
+// because the reconciler should only see kinds it advertised.
+func decodeNeighbors(kind, raw string) ([]neighborRecord, error) {
+	switch kind {
+	case "lldp":
+		var p lldpPayload
+		if err := json.Unmarshal([]byte(raw), &p); err != nil {
+			return nil, err
+		}
+		out := make([]neighborRecord, 0, len(p.Neighbors))
+		for _, n := range p.Neighbors {
+			out = append(out, neighborRecord{
+				localInterface:  fmt.Sprintf("ifIndex-%d", n.LocalPortNum),
+				remoteName:      n.SysName,
+				remoteInterface: firstNonEmpty(n.PortDescription, n.PortID),
+			})
+		}
+		return out, nil
+	case "cdp", "fdp":
+		var p cdpPayload
+		if err := json.Unmarshal([]byte(raw), &p); err != nil {
+			return nil, err
+		}
+		out := make([]neighborRecord, 0, len(p.Neighbors))
+		for _, n := range p.Neighbors {
+			out = append(out, neighborRecord{
+				localInterface:  fmt.Sprintf("ifIndex-%d", n.LocalIfIndex),
+				remoteName:      n.DeviceID,
+				remoteInterface: n.DevicePort,
+			})
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("edge reconciler: unknown kind %q", kind)
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func (r *EdgeReconciler) loadHighWater(ctx context.Context) (time.Time, error) {
+	raw, err := r.settings.GetWithDefault(ctx, edgeHighWaterKey, "")
+	if err != nil {
+		return time.Time{}, err
+	}
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse edge high-water %q: %w", raw, err)
+	}
+	return parsed, nil
+}
+
+func (r *EdgeReconciler) saveHighWater(ctx context.Context, t time.Time) error {
+	return r.settings.Set(ctx, edgeHighWaterKey, t.UTC().Format(time.RFC3339Nano))
+}

--- a/internal/topology/edge_reconciler_test.go
+++ b/internal/topology/edge_reconciler_test.go
@@ -1,0 +1,380 @@
+package topology_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/topology"
+)
+
+type fakeEdgeStore struct {
+	mu sync.Mutex
+
+	// (client|target) -> node_id for sysinfo-resolved sources.
+	targetMap map[string]string
+	// sys_name -> node_id for remote-neighbor resolution.
+	sysNameMap map[string]string
+
+	links     []*database.TopologyLink
+	upsertErr error
+}
+
+func newFakeEdgeStore() *fakeEdgeStore {
+	return &fakeEdgeStore{
+		targetMap:  map[string]string{},
+		sysNameMap: map[string]string{},
+	}
+}
+
+func (f *fakeEdgeStore) NodeIDForTarget(_ context.Context, clientID, targetID string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	id, ok := f.targetMap[clientID+"|"+targetID]
+	if !ok {
+		return "", database.ErrTopologyNodeNotFound
+	}
+	return id, nil
+}
+
+func (f *fakeEdgeStore) NodeIDForSysName(_ context.Context, _, sysName string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	id, ok := f.sysNameMap[sysName]
+	if !ok {
+		return "", database.ErrTopologyNodeNotFound
+	}
+	return id, nil
+}
+
+func (f *fakeEdgeStore) UpsertLink(_ context.Context, link *database.TopologyLink) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.links = append(f.links, link)
+	return nil
+}
+
+// All edge tests use client "c" for simplicity; multi-client
+// isolation is covered by the sysinfo reconciler tests where the
+// client_id matters for identity merging.
+const edgeTestClient = "c"
+
+func lldpObs(target string, observed time.Time, neighbors []map[string]any) *database.SNMPObservation {
+	b, _ := json.Marshal(map[string]any{"Neighbors": neighbors})
+	return &database.SNMPObservation{
+		ClientID: edgeTestClient, TargetID: target, Kind: "lldp",
+		ObservedAt: observed, PayloadJSON: string(b),
+	}
+}
+
+func cdpObs(target, kind string, observed time.Time, neighbors []map[string]any) *database.SNMPObservation {
+	b, _ := json.Marshal(map[string]any{"Neighbors": neighbors})
+	return &database.SNMPObservation{
+		ClientID: edgeTestClient, TargetID: target, Kind: kind,
+		ObservedAt: observed, PayloadJSON: string(b),
+	}
+}
+
+func TestNewEdgeReconciler_RejectsMissingDeps(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cfg  topology.EdgeConfig
+	}{
+		{"missing Observations", topology.EdgeConfig{Store: newFakeEdgeStore(), Settings: newFakeSettings()}},
+		{"missing Store", topology.EdgeConfig{Observations: &fakeObservations{}, Settings: newFakeSettings()}},
+		{"missing Settings", topology.EdgeConfig{Observations: &fakeObservations{}, Store: newFakeEdgeStore()}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := topology.NewEdgeReconciler(tt.cfg); err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestEdgeReconcileOnce_LLDPEmitsOneLinkPerNeighbor(t *testing.T) {
+	t.Parallel()
+	store := newFakeEdgeStore()
+	store.targetMap["c|t-source"] = "node-A"
+	store.sysNameMap["core-sw"] = "node-B"
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		lldpObs("t-source", at(), []map[string]any{
+			{"LocalPortNum": 24, "PortID": "Gi0/24", "SysName": "core-sw"},
+		}),
+	}}
+	r, _ := topology.NewEdgeReconciler(topology.EdgeConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if len(store.links) != 1 {
+		t.Fatalf("links = %d, want 1", len(store.links))
+	}
+	link := store.links[0]
+	if link.LinkType != "lldp" {
+		t.Errorf("LinkType = %q", link.LinkType)
+	}
+	// Either endpoint order acceptable as long as both nodes are present.
+	if (link.SourceNodeID != "node-A" || link.TargetNodeID != "node-B") &&
+		(link.SourceNodeID != "node-B" || link.TargetNodeID != "node-A") {
+		t.Errorf("endpoints = (%s, %s)", link.SourceNodeID, link.TargetNodeID)
+	}
+}
+
+func TestEdgeReconcileOnce_OrphanNeighborSkipped(t *testing.T) {
+	t.Parallel()
+	store := newFakeEdgeStore()
+	store.targetMap["c|t-source"] = "node-A"
+	// sysNameMap deliberately empty — remote unknown.
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		lldpObs("t-source", at(), []map[string]any{
+			{"LocalPortNum": 1, "SysName": "unknown-edge"},
+		}),
+	}}
+	r, _ := topology.NewEdgeReconciler(topology.EdgeConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	if len(store.links) != 0 {
+		t.Errorf("orphan remote should be skipped, got %d links", len(store.links))
+	}
+}
+
+func TestEdgeReconcileOnce_SameLinkFromBothSidesMergesToOneRow(t *testing.T) {
+	t.Parallel()
+	store := newFakeEdgeStore()
+	store.targetMap["c|t-A"] = "node-A"
+	store.targetMap["c|t-B"] = "node-B"
+	store.sysNameMap["sw-A"] = "node-A"
+	store.sysNameMap["sw-B"] = "node-B"
+
+	// Two observations describing the same cable from each end.
+	// Source A sees B as neighbor on local port 24; source B sees
+	// A as neighbor on local port 12.
+	// Because linkIDFor sorts endpoints lexicographically, both
+	// upserts must hit the same ID — but interfaces differ between
+	// the two views, so the resulting row will reflect whichever
+	// arrived last (deterministic given high-water ordering).
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		lldpObs("t-A", at(), []map[string]any{
+			{"LocalPortNum": 24, "PortID": "Gi0/12", "SysName": "sw-B"},
+		}),
+		lldpObs("t-B", at(), []map[string]any{
+			{"LocalPortNum": 12, "PortID": "Gi0/24", "SysName": "sw-A"},
+		}),
+	}}
+	r, _ := topology.NewEdgeReconciler(topology.EdgeConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	if len(store.links) != 2 {
+		t.Fatalf("expected 2 upserts (one per side), got %d", len(store.links))
+	}
+	// Both upserts must share the same canonical link ID — that's
+	// how the database upsert collapses them in production.
+	if store.links[0].ID != store.links[1].ID {
+		t.Errorf("two observations of the same cable should produce the same link ID; got %q vs %q",
+			store.links[0].ID, store.links[1].ID)
+	}
+	if !strings.HasPrefix(store.links[0].ID, "link-") {
+		t.Errorf("link ID should be prefixed link-, got %q", store.links[0].ID)
+	}
+}
+
+func TestEdgeReconcileOnce_CDPAlsoCreatesLinks(t *testing.T) {
+	t.Parallel()
+	store := newFakeEdgeStore()
+	store.targetMap["c|t-A"] = "node-A"
+	store.sysNameMap["fqdn-core-sw"] = "node-B"
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		cdpObs("t-A", "cdp", at(), []map[string]any{
+			{"LocalIfIndex": 5, "DeviceID": "fqdn-core-sw", "DevicePort": "Gi1/0/24"},
+		}),
+	}}
+	r, _ := topology.NewEdgeReconciler(topology.EdgeConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	if len(store.links) != 1 {
+		t.Fatalf("expected 1 link from cdp, got %d", len(store.links))
+	}
+	if store.links[0].LinkType != "cdp" {
+		t.Errorf("LinkType = %q, want cdp", store.links[0].LinkType)
+	}
+}
+
+func TestEdgeReconcileOnce_FDPRoutedThroughCDPPayloadShape(t *testing.T) {
+	t.Parallel()
+	store := newFakeEdgeStore()
+	store.targetMap["c|t-A"] = "node-A"
+	store.sysNameMap["foundry-edge"] = "node-B"
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		cdpObs("t-A", "fdp", at(), []map[string]any{
+			{"LocalIfIndex": 1, "DeviceID": "foundry-edge", "DevicePort": "ether-1"},
+		}),
+	}}
+	r, _ := topology.NewEdgeReconciler(topology.EdgeConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	if len(store.links) != 1 || store.links[0].LinkType != "fdp" {
+		t.Errorf("expected one fdp link, got %+v", store.links)
+	}
+}
+
+func TestEdgeReconcileOnce_SourceNotKnownSkips(t *testing.T) {
+	t.Parallel()
+	store := newFakeEdgeStore()
+	// targetMap empty -> source unknown.
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		lldpObs("t-A", at(), []map[string]any{
+			{"LocalPortNum": 1, "SysName": "core"},
+		}),
+	}}
+	r, _ := topology.NewEdgeReconciler(topology.EdgeConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+	if len(store.links) != 0 {
+		t.Errorf("unknown source should yield zero links, got %d", len(store.links))
+	}
+}
+
+func TestEdgeReconcileOnce_ListErrorOnOneKindContinuesOthers(t *testing.T) {
+	t.Parallel()
+	store := newFakeEdgeStore()
+	store.targetMap["c|t-A"] = "node-A"
+	store.sysNameMap["core"] = "node-B"
+
+	// fakeObservations.List ignores kind filter — so a list error
+	// kills all kinds at once. Use a per-kind capable fake.
+	pc := &perKindObservations{
+		byKind: map[string][]*database.SNMPObservation{
+			"lldp": {lldpObs("t-A", at(), []map[string]any{
+				{"LocalPortNum": 1, "SysName": "core"},
+			})},
+		},
+		errByKind: map[string]error{
+			"cdp": errors.New("cdp index dead"),
+		},
+	}
+	r, _ := topology.NewEdgeReconciler(topology.EdgeConfig{
+		Observations: pc, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("per-kind error should not abort the pass; got %v", err)
+	}
+	if len(store.links) != 1 {
+		t.Errorf("expected lldp link despite cdp failure, got %d links", len(store.links))
+	}
+}
+
+// perKindObservations is a fake that respects opts.Kind so we can
+// test the per-kind error-isolation behavior.
+type perKindObservations struct {
+	mu        sync.Mutex
+	byKind    map[string][]*database.SNMPObservation
+	errByKind map[string]error
+}
+
+func (p *perKindObservations) List(_ context.Context, opts database.ListOptions) ([]*database.SNMPObservation, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err, ok := p.errByKind[opts.Kind]; ok {
+		return nil, err
+	}
+	return p.byKind[opts.Kind], nil
+}
+
+func TestEdgeReconcileOnce_MaxObservedAtAcrossKinds(t *testing.T) {
+	t.Parallel()
+	store := newFakeEdgeStore()
+	store.targetMap["c|t-A"] = "node-A"
+	store.sysNameMap["b"] = "node-B"
+
+	older := at().Add(-time.Hour)
+	newer := at()
+	pc := &perKindObservations{byKind: map[string][]*database.SNMPObservation{
+		"lldp": {lldpObs("t-A", older, []map[string]any{{"LocalPortNum": 1, "SysName": "b"}})},
+		"cdp":  {cdpObs("t-A", "cdp", newer, []map[string]any{{"LocalIfIndex": 1, "DeviceID": "b"}})},
+	}}
+	s := newFakeSettings()
+	r, _ := topology.NewEdgeReconciler(topology.EdgeConfig{
+		Observations: pc, Store: store, Settings: s,
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	hw, _ := s.GetWithDefault(context.Background(), "topology.edge.high_water", "")
+	parsed, perr := time.Parse(time.RFC3339Nano, hw)
+	if perr != nil {
+		t.Fatalf("parse high-water: %v", perr)
+	}
+	if !parsed.Equal(newer) {
+		t.Errorf("high-water = %v, want %v (max across kinds)", parsed, newer)
+	}
+}
+
+func TestEdgeReconciler_EngineName(t *testing.T) {
+	t.Parallel()
+	r, _ := topology.NewEdgeReconciler(topology.EdgeConfig{
+		Observations: &fakeObservations{},
+		Store:        newFakeEdgeStore(),
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+	})
+	if r.Name() != topology.EdgeReconcilerName {
+		t.Errorf("Name() = %q, want %q", r.Name(), topology.EdgeReconcilerName)
+	}
+}
+
+func TestEdgeStartStop_Idempotent(t *testing.T) {
+	t.Parallel()
+	r, _ := topology.NewEdgeReconciler(topology.EdgeConfig{
+		Observations: &fakeObservations{},
+		Store:        newFakeEdgeStore(),
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+		Interval:     500 * time.Millisecond,
+	})
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := r.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}

--- a/internal/topology/sysinfo_reconciler_test.go
+++ b/internal/topology/sysinfo_reconciler_test.go
@@ -24,15 +24,22 @@ type fakeObservations struct {
 
 func (f *fakeObservations) List(
 	_ context.Context,
-	_ database.ListOptions,
+	opts database.ListOptions,
 ) ([]*database.SNMPObservation, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	out := make([]*database.SNMPObservation, len(f.rows))
-	copy(out, f.rows)
+	// Honor the kind filter so reconcilers that fan out across
+	// multiple kinds (lldp/cdp/fdp) don't see each other's rows.
+	out := make([]*database.SNMPObservation, 0, len(f.rows))
+	for _, row := range f.rows {
+		if opts.Kind != "" && row.Kind != opts.Kind {
+			continue
+		}
+		out = append(out, row)
+	}
 	return out, nil
 }
 


### PR DESCRIPTION
## Summary
Stage A4.3 — third topology reconciler. Consumes LLDP + CDP + FDP
observations across all three kinds in one engine and emits one
`topology_links` row per neighbor pair. Only emits edges when both
endpoints already exist in `topology_nodes` (Stage B may add
"ghost" nodes for orphans).

## Changes
- **Repository**: `NodeIDForSysName`, `UpsertLink` (with ON CONFLICT DO UPDATE), `ListLinks`, `nullableUint32`/`nullableFloat` helpers
- **`EdgeReconciler`**: engine.Engine that fans across `lldp`/`cdp`/`fdp` kinds in one pass; per-kind isolation so a list error on one doesn't kill the others
- **`linkIDFor`** keys edges by the sorted node-pair only — observations from either side of a cable upsert to the same row regardless of vendor-specific port labels. V1.0 trade-off: parallel cables between the same two nodes collapse to one edge. A4-bis refines this.
- **`fakeObservations`** extended to honor `opts.Kind` so multi-kind fan-out tests work without bespoke fakes
- 12 unit tests

## Validation
- `go test ./internal/topology/... ./internal/database/...` → green
- `golangci-lint run` → 0 issues

## Next
A4.4 — ARP reconciler attaches IP↔MAC bindings; sets `topology_nodes.primary_ip` for nodes whose primary MAC matches an ARP entry