### PR TITLE
feat(topology): arp reconciler + ip/mac bindings (stage a4.4)

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1860,6 +1860,32 @@ func getMigrationDefs() []migrationDef {
 			CREATE INDEX IF NOT EXISTS idx_topology_interfaces_last_seen ON topology_interfaces(last_seen);
 		`,
 		},
+		{
+			// Stage A4.4 — ARP binding store. Reconciled from arp
+			// observations; one row per (source_node, ifIndex, IP).
+			// mac_address is indexed because the reconciler joins
+			// against topology_nodes.primary_mac to backfill node
+			// identity (IP-to-MAC -> MAC matches a node's chassis ->
+			// IP becomes node.primary_ip).
+			Description: "Create topology_arp_bindings",
+			Up: `
+			CREATE TABLE IF NOT EXISTS topology_arp_bindings (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				source_node_id TEXT NOT NULL REFERENCES topology_nodes(id) ON DELETE CASCADE,
+				if_index INTEGER NOT NULL,
+				ip_address TEXT NOT NULL,
+				mac_address TEXT NOT NULL,
+				media_type INTEGER,
+				last_seen TEXT NOT NULL,
+				UNIQUE(source_node_id, if_index, ip_address)
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_arp_bindings_mac ON topology_arp_bindings(mac_address);
+			CREATE INDEX IF NOT EXISTS idx_arp_bindings_ip ON topology_arp_bindings(ip_address);
+			CREATE INDEX IF NOT EXISTS idx_arp_bindings_last_seen ON topology_arp_bindings(last_seen);
+		`,
+		},
 	}
 }
 

--- a/internal/database/repository_topology.go
+++ b/internal/database/repository_topology.go
@@ -187,6 +187,101 @@ func toNullTime(t time.Time) sql.NullString {
 	return sql.NullString{String: t.UTC().Format(time.RFC3339Nano), Valid: true}
 }
 
+// TopologyARPBinding mirrors one row of topology_arp_bindings.
+// Reconciled from arp observations; the row's MAC is the join key
+// used to backfill node.primary_ip when a binding matches a known
+// node's chassis/primary MAC.
+type TopologyARPBinding struct {
+	ID           int64
+	ClientID     string
+	SourceNodeID string
+	IfIndex      uint32
+	IPAddress    string
+	MACAddress   string
+	MediaType    int
+	LastSeen     time.Time
+}
+
+// UpsertARPBinding writes one binding row. The unique constraint
+// (source_node, if_index, ip_address) ensures repeated observations
+// of the same binding update one row.
+func (r *TopologyRepository) UpsertARPBinding(ctx context.Context, b *TopologyARPBinding) error {
+	if b.SourceNodeID == "" {
+		return errors.New("topology_arp_bindings: SourceNodeID required")
+	}
+	if b.IPAddress == "" || b.MACAddress == "" {
+		return errors.New("topology_arp_bindings: IPAddress + MACAddress required")
+	}
+	if b.ClientID == "" {
+		b.ClientID = "default"
+	}
+	if b.LastSeen.IsZero() {
+		b.LastSeen = time.Now().UTC()
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO topology_arp_bindings
+		  (client_id, source_node_id, if_index, ip_address, mac_address, media_type, last_seen)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(source_node_id, if_index, ip_address) DO UPDATE SET
+			mac_address = excluded.mac_address,
+			media_type = excluded.media_type,
+			last_seen = excluded.last_seen
+	`,
+		b.ClientID, b.SourceNodeID, b.IfIndex,
+		b.IPAddress, b.MACAddress, b.MediaType,
+		b.LastSeen.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert topology_arp_binding: %w", err)
+	}
+	return nil
+}
+
+// SetNodePrimaryIP updates a node's primary_ip column without
+// touching last_seen or first_seen. Used by the ARP reconciler to
+// backfill node identity when a binding's MAC matches the node's
+// primary MAC.
+func (r *TopologyRepository) SetNodePrimaryIP(ctx context.Context, nodeID, ip string) error {
+	if nodeID == "" {
+		return errors.New("topology_nodes: NodeID required")
+	}
+	_, err := r.db.Exec(ctx,
+		`UPDATE topology_nodes SET primary_ip = ? WHERE id = ?`,
+		toNullString(ip), nodeID,
+	)
+	if err != nil {
+		return fmt.Errorf("set primary_ip: %w", err)
+	}
+	return nil
+}
+
+// NodeIDForMAC resolves a MAC address to a node by matching against
+// topology_nodes.primary_mac. Returns ErrTopologyNodeNotFound when
+// no node has that MAC. Used by the ARP reconciler to identify
+// which (if any) node a binding's MAC corresponds to.
+func (r *TopologyRepository) NodeIDForMAC(ctx context.Context, clientID, mac string) (string, error) {
+	if clientID == "" {
+		clientID = "default"
+	}
+	if mac == "" {
+		return "", ErrTopologyNodeNotFound
+	}
+	row := r.db.QueryRow(ctx, `
+		SELECT id FROM topology_nodes
+		WHERE client_id = ? AND primary_mac = ?
+		ORDER BY last_seen DESC
+		LIMIT 1
+	`, clientID, mac)
+	var id string
+	if err := row.Scan(&id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrTopologyNodeNotFound
+		}
+		return "", fmt.Errorf("nodeIDForMAC: %w", err)
+	}
+	return id, nil
+}
+
 // TopologyLink mirrors one row of topology_links. Edges are
 // identity-merged the same way nodes are — the link ID is derived
 // from (source_node, source_interface, target_node, target_interface)

--- a/internal/topology/arp_reconciler.go
+++ b/internal/topology/arp_reconciler.go
@@ -1,0 +1,277 @@
+package topology
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// ARPReconcilerName is the engine identifier.
+const ARPReconcilerName = "topology-arp-reconciler"
+
+// arpHighWaterKey is the settings key holding the latest ObservedAt
+// the ARP reconciler has already processed.
+const arpHighWaterKey = "topology.arp.high_water"
+
+// arpStore is the narrowed repo surface the ARP reconciler uses.
+// In addition to writing bindings, the reconciler joins MAC values
+// against topology_nodes.primary_mac to backfill primary_ip on
+// nodes whose chassis MAC matches the binding — the bridge between
+// L2 and L3 identity.
+type arpStore interface {
+	NodeIDForTarget(ctx context.Context, clientID, targetID string) (string, error)
+	NodeIDForMAC(ctx context.Context, clientID, mac string) (string, error)
+	UpsertARPBinding(ctx context.Context, b *database.TopologyARPBinding) error
+	SetNodePrimaryIP(ctx context.Context, nodeID, ip string) error
+}
+
+// ARPReconciler turns arp observations into topology_arp_bindings
+// rows and backfills node.primary_ip when a binding's MAC matches
+// a known node. Two operations per binding — keep them in one
+// reconciler so the high-water mark stays coherent.
+type ARPReconciler struct {
+	obs      observationsReader
+	store    arpStore
+	settings settingsKV
+	logger   *slog.Logger
+	now      func() time.Time
+	interval time.Duration
+
+	mu      sync.Mutex
+	started bool
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+// ARPConfig wires the reconciler.
+type ARPConfig struct {
+	Observations observationsReader
+	Store        arpStore
+	Settings     settingsKV
+	Logger       *slog.Logger
+	Now          func() time.Time
+	Interval     time.Duration
+}
+
+// NewARPReconciler returns an unstarted reconciler.
+func NewARPReconciler(cfg ARPConfig) (*ARPReconciler, error) {
+	if cfg.Observations == nil {
+		return nil, errors.New("topology: arp Observations required")
+	}
+	if cfg.Store == nil {
+		return nil, errors.New("topology: arp Store required")
+	}
+	if cfg.Settings == nil {
+		return nil, errors.New("topology: arp Settings required")
+	}
+	d := applyDefaults(cfg.Logger, cfg.Now, cfg.Interval)
+	return &ARPReconciler{
+		obs:      cfg.Observations,
+		store:    cfg.Store,
+		settings: cfg.Settings,
+		logger:   d.logger,
+		now:      d.now,
+		interval: d.interval,
+	}, nil
+}
+
+// Name implements [engine.Engine].
+func (*ARPReconciler) Name() string { return ARPReconcilerName }
+
+// Start kicks off the reconcile loop. Idempotent.
+func (r *ARPReconciler) Start(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.started {
+		return nil
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	r.started = true
+	r.wg.Add(1)
+	go r.loop(loopCtx)
+	r.logger.InfoContext(ctx, "arp reconciler started", "interval", r.interval)
+	return nil
+}
+
+// Stop terminates the reconcile loop. Honors ctx deadline.
+func (r *ARPReconciler) Stop(ctx context.Context) error {
+	r.mu.Lock()
+	if !r.started {
+		r.mu.Unlock()
+		return nil
+	}
+	r.started = false
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.mu.Unlock()
+
+	doneCh := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	r.logger.InfoContext(ctx, "arp reconciler stopped")
+	return nil
+}
+
+func (r *ARPReconciler) loop(ctx context.Context) {
+	defer r.wg.Done()
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	if err := r.ReconcileOnce(ctx); err != nil {
+		r.logger.WarnContext(ctx, "arp reconcile failed", "error", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := r.ReconcileOnce(ctx); err != nil {
+				r.logger.WarnContext(ctx, "arp reconcile failed", "error", err)
+			}
+		}
+	}
+}
+
+// ReconcileOnce processes one batch of new arp observations.
+func (r *ARPReconciler) ReconcileOnce(ctx context.Context) error {
+	since, err := r.loadHighWater(ctx)
+	if err != nil {
+		return fmt.Errorf("load high-water: %w", err)
+	}
+	observations, err := r.obs.List(ctx, database.ListOptions{
+		Kind:  "arp",
+		Since: since,
+		Limit: defaultBatchLimit,
+	})
+	if err != nil {
+		return fmt.Errorf("list arp observations: %w", err)
+	}
+	if len(observations) == 0 {
+		return nil
+	}
+
+	var maxObservedAt time.Time
+	bindings := 0
+	backfills := 0
+	for _, obs := range observations {
+		if obs.ObservedAt.After(maxObservedAt) {
+			maxObservedAt = obs.ObservedAt
+		}
+		sourceNodeID, lookupErr := r.store.NodeIDForTarget(ctx, obs.ClientID, obs.TargetID)
+		if lookupErr != nil {
+			// Source not yet known — A4.1 sysinfo reconciler will
+			// fill in the mapping shortly; skip for now.
+			continue
+		}
+		b, bf := r.applyObservation(ctx, obs, sourceNodeID)
+		bindings += b
+		backfills += bf
+	}
+	r.logger.DebugContext(ctx, "arp reconcile pass",
+		"batch", len(observations), "bindings", bindings, "backfills", backfills,
+		"max_observed_at", maxObservedAt)
+
+	if !maxObservedAt.IsZero() {
+		if saveErr := r.saveHighWater(ctx, maxObservedAt); saveErr != nil {
+			return fmt.Errorf("save high-water: %w", saveErr)
+		}
+	}
+	return nil
+}
+
+// arpPayload mirrors the arp.Observation JSON.
+type arpPayload struct {
+	Entries []arpEntry `json:"Entries"`
+}
+
+type arpEntry struct {
+	IfIndex    uint32 `json:"IfIndex"`
+	IPAddress  string `json:"IPAddress"`
+	MACAddress string `json:"MACAddress"`
+	MediaType  int    `json:"MediaType"`
+}
+
+// applyObservation decodes the arp payload, upserts one binding per
+// entry, and backfills primary_ip on any node whose primary_mac
+// matches an entry's MAC. Returns (bindingCount, backfillCount).
+func (r *ARPReconciler) applyObservation(
+	ctx context.Context,
+	obs *database.SNMPObservation,
+	sourceNodeID string,
+) (int, int) {
+	var p arpPayload
+	if err := json.Unmarshal([]byte(obs.PayloadJSON), &p); err != nil {
+		r.logger.WarnContext(ctx, "arp: unmarshal payload failed",
+			"target_id", obs.TargetID, "error", err)
+		return 0, 0
+	}
+	bindings, backfills := 0, 0
+	for _, e := range p.Entries {
+		if e.IPAddress == "" || e.MACAddress == "" {
+			continue
+		}
+		binding := &database.TopologyARPBinding{
+			ClientID:     obs.ClientID,
+			SourceNodeID: sourceNodeID,
+			IfIndex:      e.IfIndex,
+			IPAddress:    e.IPAddress,
+			MACAddress:   e.MACAddress,
+			MediaType:    e.MediaType,
+			LastSeen:     obs.ObservedAt,
+		}
+		if upsertErr := r.store.UpsertARPBinding(ctx, binding); upsertErr != nil {
+			r.logger.WarnContext(ctx, "arp: binding upsert failed",
+				"target_id", obs.TargetID, "ip", e.IPAddress, "error", upsertErr)
+			continue
+		}
+		bindings++
+
+		// L2 -> L3 identity bridge: if this binding's MAC matches a
+		// node's primary_mac, that node's primary_ip is this binding's
+		// IP. The fat-Node finally has a network-layer identity.
+		matchedNodeID, lookupErr := r.store.NodeIDForMAC(ctx, obs.ClientID, e.MACAddress)
+		if lookupErr != nil {
+			continue
+		}
+		if setErr := r.store.SetNodePrimaryIP(ctx, matchedNodeID, e.IPAddress); setErr != nil {
+			r.logger.WarnContext(ctx, "arp: primary_ip backfill failed",
+				"node_id", matchedNodeID, "ip", e.IPAddress, "error", setErr)
+			continue
+		}
+		backfills++
+	}
+	return bindings, backfills
+}
+
+func (r *ARPReconciler) loadHighWater(ctx context.Context) (time.Time, error) {
+	raw, err := r.settings.GetWithDefault(ctx, arpHighWaterKey, "")
+	if err != nil {
+		return time.Time{}, err
+	}
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse arp high-water %q: %w", raw, err)
+	}
+	return parsed, nil
+}
+
+func (r *ARPReconciler) saveHighWater(ctx context.Context, t time.Time) error {
+	return r.settings.Set(ctx, arpHighWaterKey, t.UTC().Format(time.RFC3339Nano))
+}

--- a/internal/topology/arp_reconciler_test.go
+++ b/internal/topology/arp_reconciler_test.go
@@ -1,0 +1,338 @@
+package topology_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/topology"
+)
+
+type fakeARPStore struct {
+	mu sync.Mutex
+
+	targetMap map[string]string // (client|target) -> node_id
+	macMap    map[string]string // mac -> node_id
+
+	bindings   []*database.TopologyARPBinding
+	primaryIPs map[string]string // node_id -> ip
+
+	upsertErr error
+	setIPErr  error
+}
+
+func newFakeARPStore() *fakeARPStore {
+	return &fakeARPStore{
+		targetMap:  map[string]string{},
+		macMap:     map[string]string{},
+		primaryIPs: map[string]string{},
+	}
+}
+
+func (f *fakeARPStore) NodeIDForTarget(_ context.Context, clientID, targetID string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	id, ok := f.targetMap[clientID+"|"+targetID]
+	if !ok {
+		return "", database.ErrTopologyNodeNotFound
+	}
+	return id, nil
+}
+
+func (f *fakeARPStore) NodeIDForMAC(_ context.Context, _, mac string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	id, ok := f.macMap[mac]
+	if !ok {
+		return "", database.ErrTopologyNodeNotFound
+	}
+	return id, nil
+}
+
+func (f *fakeARPStore) UpsertARPBinding(_ context.Context, b *database.TopologyARPBinding) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.bindings = append(f.bindings, b)
+	return nil
+}
+
+func (f *fakeARPStore) SetNodePrimaryIP(_ context.Context, nodeID, ip string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.setIPErr != nil {
+		return f.setIPErr
+	}
+	f.primaryIPs[nodeID] = ip
+	return nil
+}
+
+func arpObs(target string, observed time.Time, entries []map[string]any) *database.SNMPObservation {
+	b, _ := json.Marshal(map[string]any{"Entries": entries})
+	return &database.SNMPObservation{
+		ClientID:    "c",
+		TargetID:    target,
+		Kind:        "arp",
+		ObservedAt:  observed,
+		PayloadJSON: string(b),
+	}
+}
+
+func TestNewARPReconciler_RejectsMissingDeps(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cfg  topology.ARPConfig
+	}{
+		{"missing Observations", topology.ARPConfig{Store: newFakeARPStore(), Settings: newFakeSettings()}},
+		{"missing Store", topology.ARPConfig{Observations: &fakeObservations{}, Settings: newFakeSettings()}},
+		{"missing Settings", topology.ARPConfig{Observations: &fakeObservations{}, Store: newFakeARPStore()}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := topology.NewARPReconciler(tt.cfg); err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestARPReconcileOnce_UpsertsOneBindingPerEntry(t *testing.T) {
+	t.Parallel()
+	store := newFakeARPStore()
+	store.targetMap["c|t-1"] = "node-source"
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		arpObs("t-1", at(), []map[string]any{
+			{"IfIndex": 1, "IPAddress": "10.0.0.1", "MACAddress": "aa:bb:cc:dd:ee:01", "MediaType": 3},
+			{"IfIndex": 1, "IPAddress": "10.0.0.2", "MACAddress": "aa:bb:cc:dd:ee:02", "MediaType": 3},
+		}),
+	}}
+	r, _ := topology.NewARPReconciler(topology.ARPConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if len(store.bindings) != 2 {
+		t.Fatalf("bindings = %d, want 2", len(store.bindings))
+	}
+	if store.bindings[0].SourceNodeID != "node-source" {
+		t.Errorf("SourceNodeID = %q", store.bindings[0].SourceNodeID)
+	}
+	if store.bindings[0].IPAddress != "10.0.0.1" {
+		t.Errorf("IPAddress = %q", store.bindings[0].IPAddress)
+	}
+}
+
+func TestARPReconcileOnce_BackfillsPrimaryIPOnMACMatch(t *testing.T) {
+	t.Parallel()
+	store := newFakeARPStore()
+	store.targetMap["c|t-1"] = "node-source"
+	// Node-B's primary MAC matches an ARP entry — its primary_ip
+	// should be backfilled.
+	store.macMap["aa:bb:cc:dd:ee:99"] = "node-B"
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		arpObs("t-1", at(), []map[string]any{
+			{"IfIndex": 1, "IPAddress": "192.0.2.10", "MACAddress": "aa:bb:cc:dd:ee:99"},
+		}),
+	}}
+	r, _ := topology.NewARPReconciler(topology.ARPConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	if got := store.primaryIPs["node-B"]; got != "192.0.2.10" {
+		t.Errorf("primary_ip[node-B] = %q, want 192.0.2.10", got)
+	}
+}
+
+func TestARPReconcileOnce_UnmatchedMACSkipsBackfill(t *testing.T) {
+	t.Parallel()
+	store := newFakeARPStore()
+	store.targetMap["c|t-1"] = "node-source"
+	// macMap deliberately empty — no node matches the binding's MAC.
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		arpObs("t-1", at(), []map[string]any{
+			{"IfIndex": 1, "IPAddress": "10.0.0.5", "MACAddress": "11:22:33:44:55:66"},
+		}),
+	}}
+	r, _ := topology.NewARPReconciler(topology.ARPConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	if len(store.primaryIPs) != 0 {
+		t.Errorf("no MAC match should mean no backfills, got %d", len(store.primaryIPs))
+	}
+	// Binding should still be written.
+	if len(store.bindings) != 1 {
+		t.Errorf("binding should still be persisted, got %d", len(store.bindings))
+	}
+}
+
+func TestARPReconcileOnce_SourceNotMappedSkips(t *testing.T) {
+	t.Parallel()
+	store := newFakeARPStore() // empty target map -> source unknown
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		arpObs("t-orphan", at(), []map[string]any{
+			{"IfIndex": 1, "IPAddress": "10.0.0.1", "MACAddress": "aa:aa:aa:aa:aa:aa"},
+		}),
+	}}
+	r, _ := topology.NewARPReconciler(topology.ARPConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	if len(store.bindings) != 0 {
+		t.Errorf("source-unknown observation should yield zero bindings, got %d",
+			len(store.bindings))
+	}
+}
+
+func TestARPReconcileOnce_EmptyIPOrMACSkipped(t *testing.T) {
+	t.Parallel()
+	store := newFakeARPStore()
+	store.targetMap["c|t-1"] = "node-source"
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		arpObs("t-1", at(), []map[string]any{
+			{"IfIndex": 1, "IPAddress": "10.0.0.1", "MACAddress": ""},                  // bad
+			{"IfIndex": 1, "IPAddress": "", "MACAddress": "aa:bb:cc:dd:ee:ff"},         // bad
+			{"IfIndex": 1, "IPAddress": "10.0.0.2", "MACAddress": "11:22:33:44:55:66"}, // good
+		}),
+	}}
+	r, _ := topology.NewARPReconciler(topology.ARPConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	if len(store.bindings) != 1 {
+		t.Errorf("empty IP/MAC rows should be skipped, got %d bindings", len(store.bindings))
+	}
+}
+
+func TestARPReconcileOnce_UpsertErrorSkipsBackfill(t *testing.T) {
+	t.Parallel()
+	store := newFakeARPStore()
+	store.targetMap["c|t-1"] = "node-source"
+	store.macMap["aa:aa:aa:aa:aa:aa"] = "node-B"
+	store.upsertErr = errors.New("constraint")
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		arpObs("t-1", at(), []map[string]any{
+			{"IfIndex": 1, "IPAddress": "10.0.0.1", "MACAddress": "aa:aa:aa:aa:aa:aa"},
+		}),
+	}}
+	r, _ := topology.NewARPReconciler(topology.ARPConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	// Backfill must not run if the binding upsert failed.
+	if _, ok := store.primaryIPs["node-B"]; ok {
+		t.Error("backfill should not happen when upsert errored")
+	}
+}
+
+func TestARPReconcileOnce_MalformedPayloadSkipsObservation(t *testing.T) {
+	t.Parallel()
+	store := newFakeARPStore()
+	store.targetMap["c|t-1"] = "node-source"
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		{
+			ClientID: "c", TargetID: "t-1", Kind: "arp",
+			ObservedAt: at(), PayloadJSON: "{not valid",
+		},
+	}}
+	r, _ := topology.NewARPReconciler(topology.ARPConfig{
+		Observations: o, Store: store, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	if err := r.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("malformed should not abort: %v", err)
+	}
+	if len(store.bindings) != 0 {
+		t.Errorf("malformed payload should yield zero bindings, got %d", len(store.bindings))
+	}
+}
+
+func TestARPReconcileOnce_PersistsHighWater(t *testing.T) {
+	t.Parallel()
+	store := newFakeARPStore()
+	store.targetMap["c|t-1"] = "node-source"
+
+	o := &fakeObservations{rows: []*database.SNMPObservation{
+		arpObs("t-1", at(), []map[string]any{
+			{"IfIndex": 1, "IPAddress": "10.0.0.1", "MACAddress": "aa:bb:cc:dd:ee:ff"},
+		}),
+	}}
+	s := newFakeSettings()
+	r, _ := topology.NewARPReconciler(topology.ARPConfig{
+		Observations: o, Store: store, Settings: s,
+		Logger: silentLogger(), Now: at,
+	})
+	_ = r.ReconcileOnce(context.Background())
+
+	hw, _ := s.GetWithDefault(context.Background(), "topology.arp.high_water", "")
+	parsed, perr := time.Parse(time.RFC3339Nano, hw)
+	if perr != nil {
+		t.Fatalf("parse high-water: %v", perr)
+	}
+	if !parsed.Equal(at()) {
+		t.Errorf("high-water = %v, want %v", parsed, at())
+	}
+}
+
+func TestARPReconciler_EngineName(t *testing.T) {
+	t.Parallel()
+	r, _ := topology.NewARPReconciler(topology.ARPConfig{
+		Observations: &fakeObservations{},
+		Store:        newFakeARPStore(),
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+	})
+	if r.Name() != topology.ARPReconcilerName {
+		t.Errorf("Name() = %q, want %q", r.Name(), topology.ARPReconcilerName)
+	}
+}
+
+func TestARPStartStop_Idempotent(t *testing.T) {
+	t.Parallel()
+	r, _ := topology.NewARPReconciler(topology.ARPConfig{
+		Observations: &fakeObservations{},
+		Store:        newFakeARPStore(),
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+		Interval:     500 * time.Millisecond,
+	})
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := r.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Stage A4.4 — fourth topology reconciler. Consumes ARP observations,
writes one `topology_arp_bindings` row per `(source_node, ifIndex, ip)`,
and **backfills `topology_nodes.primary_ip`** when a binding's MAC
matches a known node's `primary_mac`. The L2→L3 identity bridge: an
SNMP-only device gains a network-layer identity after the first ARP
poll from any adjacent node.

## Changes
- **Migration**: `topology_arp_bindings` with unique `(source_node_id, if_index, ip_address)`; mac + ip indexed for alert-rule queries
- **Repository**: `UpsertARPBinding` (ON CONFLICT DO UPDATE), `NodeIDForMAC`, `SetNodePrimaryIP`
- **`ARPReconciler`** — binding write first, backfill best-effort; a backfill failure doesn't roll back the binding
- 11 unit tests

## Validation
- `go test ./internal/topology/... ./internal/database/...` → green
- `golangci-lint run` → 0 issues

## Next
A4.5 — listener-event alert pipeline (consumes `listener_events` and `snmp_observations` deltas, emits structured alerts)