### PR TITLE
feat(alerts): listener-event alert pipeline (stage a4.5)

### DIFF
--- a/internal/alerts/pipeline/listener_pipeline.go
+++ b/internal/alerts/pipeline/listener_pipeline.go
@@ -1,0 +1,473 @@
+// Package pipeline consumes the observation + event streams that
+// Stage A3.5 emits (listener_events for syslog/traps,
+// snmp_observations for collector deltas) and emits structured
+// alerts into the existing alerts table.
+//
+// Stage A4.5 ships the listener-event pipeline (syslog + traps);
+// Stage A4.6 adds the observation-delta pipeline (interface
+// transitions, BGP peer state, storage % thresholds).
+//
+// Rules are hardcoded for V1.0 — a small built-in set covering the
+// "always alert on these" cases. User-configurable rules + a UI
+// land in a follow-up stage; the engine + suppression machinery
+// here is already shaped for that future.
+package pipeline
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// ListenerPipelineName is the engine identifier.
+const ListenerPipelineName = "alert-listener-pipeline"
+
+// listenerHighWaterKey is the settings key holding the latest
+// ObservedAt the listener alert pipeline has already processed.
+const listenerHighWaterKey = "alerts.listener.high_water"
+
+// Tunables — production defaults.
+const (
+	defaultBatch       = 500
+	defaultInterval    = 15 * time.Second
+	minInterval        = 100 * time.Millisecond
+	defaultSuppression = 5 * time.Minute
+)
+
+// listenerReader is the narrowed surface the listener pipeline
+// needs from the listener_events repo. Tests inject a fake.
+type listenerReader interface {
+	List(ctx context.Context, opts database.ListenerEventListOptions) ([]*database.ListenerEvent, error)
+}
+
+// alertWriter is the narrowed surface for writing alerts.
+type alertWriter interface {
+	Create(ctx context.Context, alert *database.Alert) error
+}
+
+// settingsKV is the high-water-mark store. Same shape as
+// internal/topology — duplicate type rather than a circular import.
+type settingsKV interface {
+	GetWithDefault(ctx context.Context, key, defaultValue string) (string, error)
+	Set(ctx context.Context, key, value string) error
+}
+
+// Rule is one alert-emitting predicate. Match returns true when the
+// event should fire an alert; Build constructs the alert payload.
+// Both functions receive the same event so Build can pull whichever
+// fields the title/message wants without re-decoding.
+type Rule struct {
+	// ID is a stable identifier used in the suppression fingerprint
+	// so two events firing the same rule against the same source
+	// don't spam (e.g. linkDown trap arriving every 30s).
+	ID string
+
+	// Match returns true when this rule applies to evt.
+	Match func(evt *database.ListenerEvent) bool
+
+	// Build returns the alert to write. The returned Source is used
+	// in the suppression fingerprint alongside the rule ID.
+	Build func(evt *database.ListenerEvent) *database.Alert
+}
+
+// ListenerPipeline scans listener_events on a tick and writes alerts
+// for every event matching any built-in rule. Suppression dedupes
+// repeated alerts for the same (rule, source) within the window.
+type ListenerPipeline struct {
+	events      listenerReader
+	alerts      alertWriter
+	settings    settingsKV
+	logger      *slog.Logger
+	now         func() time.Time
+	interval    time.Duration
+	rules       []Rule
+	suppression time.Duration
+
+	mu      sync.Mutex
+	started bool
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	emitted map[string]time.Time
+}
+
+// ListenerConfig wires the pipeline.
+type ListenerConfig struct {
+	Events      listenerReader
+	Alerts      alertWriter
+	Settings    settingsKV
+	Logger      *slog.Logger
+	Now         func() time.Time
+	Interval    time.Duration
+	Suppression time.Duration
+
+	// Rules override the built-in set; when nil, DefaultListenerRules
+	// is used.
+	Rules []Rule
+}
+
+// NewListenerPipeline returns an unstarted pipeline.
+func NewListenerPipeline(cfg ListenerConfig) (*ListenerPipeline, error) {
+	if cfg.Events == nil {
+		return nil, errors.New("alerts: listener Events required")
+	}
+	if cfg.Alerts == nil {
+		return nil, errors.New("alerts: listener Alerts writer required")
+	}
+	if cfg.Settings == nil {
+		return nil, errors.New("alerts: listener Settings required")
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.Now == nil {
+		cfg.Now = func() time.Time { return time.Now().UTC() }
+	}
+	if cfg.Interval <= 0 {
+		cfg.Interval = defaultInterval
+	}
+	if cfg.Interval < minInterval {
+		cfg.Interval = minInterval
+	}
+	if cfg.Suppression <= 0 {
+		cfg.Suppression = defaultSuppression
+	}
+	rules := cfg.Rules
+	if rules == nil {
+		rules = DefaultListenerRules()
+	}
+	return &ListenerPipeline{
+		events:      cfg.Events,
+		alerts:      cfg.Alerts,
+		settings:    cfg.Settings,
+		logger:      cfg.Logger,
+		now:         cfg.Now,
+		interval:    cfg.Interval,
+		suppression: cfg.Suppression,
+		rules:       rules,
+		emitted:     make(map[string]time.Time),
+	}, nil
+}
+
+// Name implements [engine.Engine].
+func (*ListenerPipeline) Name() string { return ListenerPipelineName }
+
+// Start kicks off the scan loop. Idempotent.
+func (p *ListenerPipeline) Start(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started {
+		return nil
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	p.cancel = cancel
+	p.started = true
+	p.wg.Add(1)
+	go p.loop(loopCtx)
+	p.logger.InfoContext(ctx, "listener alert pipeline started",
+		"interval", p.interval, "rules", len(p.rules))
+	return nil
+}
+
+// Stop terminates the scan loop. Honors ctx deadline.
+func (p *ListenerPipeline) Stop(ctx context.Context) error {
+	p.mu.Lock()
+	if !p.started {
+		p.mu.Unlock()
+		return nil
+	}
+	p.started = false
+	if p.cancel != nil {
+		p.cancel()
+	}
+	p.mu.Unlock()
+
+	doneCh := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	p.logger.InfoContext(ctx, "listener alert pipeline stopped")
+	return nil
+}
+
+func (p *ListenerPipeline) loop(ctx context.Context) {
+	defer p.wg.Done()
+	t := time.NewTicker(p.interval)
+	defer t.Stop()
+	if err := p.ScanOnce(ctx); err != nil {
+		p.logger.WarnContext(ctx, "listener alert scan failed", "error", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := p.ScanOnce(ctx); err != nil {
+				p.logger.WarnContext(ctx, "listener alert scan failed", "error", err)
+			}
+		}
+	}
+}
+
+// ScanOnce processes one batch of listener_events.
+func (p *ListenerPipeline) ScanOnce(ctx context.Context) error {
+	since, err := p.loadHighWater(ctx)
+	if err != nil {
+		return fmt.Errorf("load high-water: %w", err)
+	}
+	events, err := p.events.List(ctx, database.ListenerEventListOptions{
+		Since: since,
+		Limit: defaultBatch,
+	})
+	if err != nil {
+		return fmt.Errorf("list listener_events: %w", err)
+	}
+	if len(events) == 0 {
+		return nil
+	}
+
+	var maxObservedAt time.Time
+	alertsEmitted := 0
+	for _, evt := range events {
+		if evt.ObservedAt.After(maxObservedAt) {
+			maxObservedAt = evt.ObservedAt
+		}
+		alertsEmitted += p.evaluate(ctx, evt)
+	}
+	p.logger.DebugContext(ctx, "listener alert pass",
+		"batch", len(events), "alerts", alertsEmitted,
+		"max_observed_at", maxObservedAt)
+
+	if !maxObservedAt.IsZero() {
+		if saveErr := p.saveHighWater(ctx, maxObservedAt); saveErr != nil {
+			return fmt.Errorf("save high-water: %w", saveErr)
+		}
+	}
+	return nil
+}
+
+// evaluate applies every rule to evt and writes any alerts that
+// match + pass suppression. Returns the count of alerts emitted.
+func (p *ListenerPipeline) evaluate(ctx context.Context, evt *database.ListenerEvent) int {
+	now := p.now()
+	count := 0
+	for _, rule := range p.rules {
+		if !rule.Match(evt) {
+			continue
+		}
+		fingerprint := fingerprintFor(rule.ID, evt.SourceAddr, evt.Kind)
+		if p.suppressed(fingerprint, now) {
+			continue
+		}
+		alert := rule.Build(evt)
+		if alert == nil {
+			continue
+		}
+		if writeErr := p.alerts.Create(ctx, alert); writeErr != nil {
+			p.logger.WarnContext(ctx, "alert create failed",
+				"rule", rule.ID, "source", evt.SourceAddr, "error", writeErr)
+			continue
+		}
+		p.markEmitted(fingerprint, now)
+		count++
+	}
+	return count
+}
+
+// fingerprintFor builds the suppression key.
+func fingerprintFor(ruleID, source, kind string) string {
+	h := sha256.New()
+	h.Write([]byte(ruleID))
+	h.Write([]byte{0x00})
+	h.Write([]byte(source))
+	h.Write([]byte{0x00})
+	h.Write([]byte(kind))
+	return hex.EncodeToString(h.Sum(nil))[:24]
+}
+
+// suppressed returns true when this fingerprint has fired within the
+// suppression window.
+func (p *ListenerPipeline) suppressed(fingerprint string, now time.Time) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	last, ok := p.emitted[fingerprint]
+	if !ok {
+		return false
+	}
+	return now.Sub(last) < p.suppression
+}
+
+// markEmitted records the fire time for a fingerprint. Old entries
+// (>2x suppression window) are evicted lazily to keep the map
+// bounded.
+func (p *ListenerPipeline) markEmitted(fingerprint string, now time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.emitted[fingerprint] = now
+	// Lazy eviction: walk the map only when it gets noticeably big.
+	const evictThreshold = 4096
+	if len(p.emitted) <= evictThreshold {
+		return
+	}
+	cutoff := now.Add(-2 * p.suppression)
+	for k, v := range p.emitted {
+		if v.Before(cutoff) {
+			delete(p.emitted, k)
+		}
+	}
+}
+
+func (p *ListenerPipeline) loadHighWater(ctx context.Context) (time.Time, error) {
+	raw, err := p.settings.GetWithDefault(ctx, listenerHighWaterKey, "")
+	if err != nil {
+		return time.Time{}, err
+	}
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse high-water %q: %w", raw, err)
+	}
+	return parsed, nil
+}
+
+func (p *ListenerPipeline) saveHighWater(ctx context.Context, t time.Time) error {
+	return p.settings.Set(ctx, listenerHighWaterKey, t.UTC().Format(time.RFC3339Nano))
+}
+
+// DefaultListenerRules returns the V1.0 built-in rule set:
+//
+//   - syslog severity emergency/alert/critical/error -> alert
+//   - snmp trap linkDown -> alert (warning)
+//   - snmp trap authenticationFailure -> alert (error)
+//   - snmp trap any other event -> alert (info) when an explicit
+//     trap OID is present
+//
+// The function returns a fresh slice each call so a pipeline can
+// safely append or filter without affecting other callers.
+func DefaultListenerRules() []Rule {
+	return []Rule{
+		ruleSyslogSevereLogged(),
+		ruleTrapLinkDown(),
+		ruleTrapAuthFailure(),
+	}
+}
+
+func ruleSyslogSevereLogged() Rule {
+	severeSeverities := map[string]bool{
+		"emergency": true,
+		"alert":     true,
+		"critical":  true,
+		"error":     true,
+	}
+	return Rule{
+		ID: "syslog.severe",
+		Match: func(evt *database.ListenerEvent) bool {
+			return evt.Kind == "syslog-udp" && severeSeverities[evt.Severity]
+		},
+		Build: func(evt *database.ListenerEvent) *database.Alert {
+			return &database.Alert{
+				Type:     database.AlertTypeSystem,
+				Severity: mapSyslogSeverity(evt.Severity),
+				Title:    fmt.Sprintf("Syslog %s from %s", evt.Severity, evt.SourceAddr),
+				Message:  summarize(evt.PayloadJSON, "message"),
+				Source:   evt.SourceAddr,
+				Metadata: evt.PayloadJSON,
+			}
+		},
+	}
+}
+
+func ruleTrapLinkDown() Rule {
+	return Rule{
+		ID: "trap.linkdown",
+		Match: func(evt *database.ListenerEvent) bool {
+			if evt.Kind != "snmp-trap-v2c" {
+				return false
+			}
+			return strings.Contains(evt.PayloadJSON, `"1.3.6.1.6.3.1.1.5.3"`)
+		},
+		Build: func(evt *database.ListenerEvent) *database.Alert {
+			return &database.Alert{
+				Type:     database.AlertTypeConnectivity,
+				Severity: database.AlertSeverityWarning,
+				Title:    "Link down trap from " + evt.SourceAddr,
+				Message:  "SNMP linkDown trap received",
+				Source:   evt.SourceAddr,
+				Metadata: evt.PayloadJSON,
+			}
+		},
+	}
+}
+
+func ruleTrapAuthFailure() Rule {
+	return Rule{
+		ID: "trap.authfail",
+		Match: func(evt *database.ListenerEvent) bool {
+			if evt.Kind != "snmp-trap-v2c" {
+				return false
+			}
+			return strings.Contains(evt.PayloadJSON, `"1.3.6.1.6.3.1.1.5.5"`)
+		},
+		Build: func(evt *database.ListenerEvent) *database.Alert {
+			return &database.Alert{
+				Type:     database.AlertTypeSecurity,
+				Severity: database.AlertSeverityError,
+				Title:    "SNMP authentication failure from " + evt.SourceAddr,
+				Message:  "Repeated authentication failures may indicate a credential probe",
+				Source:   evt.SourceAddr,
+				Metadata: evt.PayloadJSON,
+			}
+		},
+	}
+}
+
+// mapSyslogSeverity bridges syslog severity names to the alerts
+// table's enum.
+func mapSyslogSeverity(s string) string {
+	switch s {
+	case "emergency", "alert", "critical":
+		return database.AlertSeverityCritical
+	case "error":
+		return database.AlertSeverityError
+	case "warning":
+		return database.AlertSeverityWarning
+	default:
+		return database.AlertSeverityInfo
+	}
+}
+
+// summarize pulls one string field out of a JSON payload without
+// fully unmarshalling. Returns "" when the field is absent or the
+// payload isn't valid JSON. Used to grab e.g. the syslog "message"
+// for an alert title without forcing a struct definition per kind.
+func summarize(payload, field string) string {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &m); err != nil {
+		return ""
+	}
+	raw, ok := m[field]
+	if !ok {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
+}

--- a/internal/alerts/pipeline/listener_pipeline_test.go
+++ b/internal/alerts/pipeline/listener_pipeline_test.go
@@ -1,0 +1,361 @@
+package pipeline_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/alerts/pipeline"
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+func silentLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+func at() time.Time              { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) }
+
+type fakeEvents struct {
+	mu      sync.Mutex
+	rows    []*database.ListenerEvent
+	listErr error
+}
+
+func (f *fakeEvents) List(_ context.Context, _ database.ListenerEventListOptions) ([]*database.ListenerEvent, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]*database.ListenerEvent, len(f.rows))
+	copy(out, f.rows)
+	return out, nil
+}
+
+type fakeAlerts struct {
+	mu        sync.Mutex
+	created   []*database.Alert
+	createErr error
+}
+
+func (f *fakeAlerts) Create(_ context.Context, alert *database.Alert) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.created = append(f.created, alert)
+	return nil
+}
+
+type fakeSettings struct {
+	mu     sync.Mutex
+	values map[string]string
+}
+
+func newFakeSettings() *fakeSettings {
+	return &fakeSettings{values: make(map[string]string)}
+}
+
+func (f *fakeSettings) GetWithDefault(_ context.Context, key, def string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.values[key]
+	if !ok {
+		return def, nil
+	}
+	return v, nil
+}
+
+func (f *fakeSettings) Set(_ context.Context, key, value string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.values[key] = value
+	return nil
+}
+
+func syslogEvent(severity, source string, observed time.Time, message string) *database.ListenerEvent {
+	payload, _ := json.Marshal(map[string]string{
+		"facility":     "3",
+		"severityName": severity,
+		"message":      message,
+	})
+	return &database.ListenerEvent{
+		Kind:        "syslog-udp",
+		ClientID:    "default",
+		SourceAddr:  source,
+		Severity:    severity,
+		ObservedAt:  observed,
+		PayloadJSON: string(payload),
+	}
+}
+
+func trapEvent(trapOID, source string, observed time.Time) *database.ListenerEvent {
+	payload, _ := json.Marshal(map[string]string{
+		"version": "v2c",
+		"trapOid": trapOID,
+	})
+	return &database.ListenerEvent{
+		Kind:        "snmp-trap-v2c",
+		ClientID:    "default",
+		SourceAddr:  source,
+		ObservedAt:  observed,
+		PayloadJSON: string(payload),
+	}
+}
+
+func TestNewListenerPipeline_RejectsMissingDeps(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cfg  pipeline.ListenerConfig
+	}{
+		{"missing Events", pipeline.ListenerConfig{Alerts: &fakeAlerts{}, Settings: newFakeSettings()}},
+		{"missing Alerts", pipeline.ListenerConfig{Events: &fakeEvents{}, Settings: newFakeSettings()}},
+		{"missing Settings", pipeline.ListenerConfig{Events: &fakeEvents{}, Alerts: &fakeAlerts{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := pipeline.NewListenerPipeline(tt.cfg); err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestScanOnce_SyslogSevereErrorEmitsAlert(t *testing.T) {
+	t.Parallel()
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", at(), "SSH login failed for user admin"),
+	}}
+	alerts := &fakeAlerts{}
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	if err := p.ScanOnce(context.Background()); err != nil {
+		t.Fatalf("ScanOnce: %v", err)
+	}
+	if len(alerts.created) != 1 {
+		t.Fatalf("alerts = %d, want 1", len(alerts.created))
+	}
+	if alerts.created[0].Severity != database.AlertSeverityError {
+		t.Errorf("severity = %q, want error", alerts.created[0].Severity)
+	}
+}
+
+func TestScanOnce_SyslogInfoDoesNotAlert(t *testing.T) {
+	t.Parallel()
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		syslogEvent("informational", "10.0.0.1:514", at(), "nightly cron run"),
+	}}
+	alerts := &fakeAlerts{}
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = p.ScanOnce(context.Background())
+	if len(alerts.created) != 0 {
+		t.Errorf("informational syslog should not alert, got %d alerts", len(alerts.created))
+	}
+}
+
+func TestScanOnce_TrapLinkDownEmitsConnectivityAlert(t *testing.T) {
+	t.Parallel()
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		trapEvent("1.3.6.1.6.3.1.1.5.3", "10.0.0.5:0", at()),
+	}}
+	alerts := &fakeAlerts{}
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = p.ScanOnce(context.Background())
+	if len(alerts.created) != 1 {
+		t.Fatalf("alerts = %d, want 1", len(alerts.created))
+	}
+	a := alerts.created[0]
+	if a.Type != database.AlertTypeConnectivity || a.Severity != database.AlertSeverityWarning {
+		t.Errorf("type/severity = %q/%q", a.Type, a.Severity)
+	}
+}
+
+func TestScanOnce_TrapAuthFailureEmitsSecurityAlert(t *testing.T) {
+	t.Parallel()
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		trapEvent("1.3.6.1.6.3.1.1.5.5", "10.0.0.5:0", at()),
+	}}
+	alerts := &fakeAlerts{}
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = p.ScanOnce(context.Background())
+	if len(alerts.created) != 1 {
+		t.Fatalf("alerts = %d, want 1", len(alerts.created))
+	}
+	a := alerts.created[0]
+	if a.Type != database.AlertTypeSecurity || a.Severity != database.AlertSeverityError {
+		t.Errorf("type/severity = %q/%q", a.Type, a.Severity)
+	}
+}
+
+func TestScanOnce_SuppressionBlocksRepeats(t *testing.T) {
+	t.Parallel()
+	// Two identical linkDown traps in the same scan -> one alert.
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		trapEvent("1.3.6.1.6.3.1.1.5.3", "10.0.0.5:0", at()),
+		trapEvent("1.3.6.1.6.3.1.1.5.3", "10.0.0.5:0", at().Add(time.Second)),
+	}}
+	alerts := &fakeAlerts{}
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at, Suppression: time.Minute,
+	})
+	_ = p.ScanOnce(context.Background())
+	if len(alerts.created) != 1 {
+		t.Errorf("suppression should collapse to 1 alert, got %d", len(alerts.created))
+	}
+}
+
+func TestScanOnce_DifferentSourcesNotSuppressed(t *testing.T) {
+	t.Parallel()
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		trapEvent("1.3.6.1.6.3.1.1.5.3", "10.0.0.5:0", at()),
+		trapEvent("1.3.6.1.6.3.1.1.5.3", "10.0.0.6:0", at()),
+	}}
+	alerts := &fakeAlerts{}
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at, Suppression: time.Minute,
+	})
+	_ = p.ScanOnce(context.Background())
+	if len(alerts.created) != 2 {
+		t.Errorf("alerts from different sources must not be suppressed, got %d", len(alerts.created))
+	}
+}
+
+func TestScanOnce_PersistsHighWater(t *testing.T) {
+	t.Parallel()
+	older := at().Add(-time.Hour)
+	newer := at()
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", older, "old"),
+		syslogEvent("error", "10.0.0.2:514", newer, "new"),
+	}}
+	settings := newFakeSettings()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: &fakeAlerts{}, Settings: settings,
+		Logger: silentLogger(), Now: at,
+	})
+	_ = p.ScanOnce(context.Background())
+
+	hw, _ := settings.GetWithDefault(context.Background(), "alerts.listener.high_water", "")
+	parsed, perr := time.Parse(time.RFC3339Nano, hw)
+	if perr != nil {
+		t.Fatalf("parse high-water: %v", perr)
+	}
+	if !parsed.Equal(newer) {
+		t.Errorf("high-water = %v, want %v", parsed, newer)
+	}
+}
+
+func TestScanOnce_ListErrorPropagates(t *testing.T) {
+	t.Parallel()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events:   &fakeEvents{listErr: errors.New("db down")},
+		Alerts:   &fakeAlerts{},
+		Settings: newFakeSettings(),
+		Logger:   silentLogger(),
+		Now:      at,
+	})
+	if err := p.ScanOnce(context.Background()); err == nil {
+		t.Error("expected list error to propagate")
+	}
+}
+
+func TestScanOnce_CreateErrorContinuesBatch(t *testing.T) {
+	t.Parallel()
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", at(), "boom"),
+	}}
+	alerts := &fakeAlerts{createErr: errors.New("constraint")}
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	if err := p.ScanOnce(context.Background()); err != nil {
+		t.Fatalf("create error should not abort scan: %v", err)
+	}
+}
+
+func TestScanOnce_CustomRulesOverrideDefaults(t *testing.T) {
+	t.Parallel()
+	hits := 0
+	custom := []pipeline.Rule{
+		{
+			ID:    "test.everything",
+			Match: func(_ *database.ListenerEvent) bool { return true },
+			Build: func(evt *database.ListenerEvent) *database.Alert {
+				hits++
+				return &database.Alert{
+					Type: "test", Severity: "info",
+					Title: "all", Message: "all", Source: evt.SourceAddr,
+				}
+			},
+		},
+	}
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		// An informational syslog would NOT trip the defaults but
+		// will trip our match-all custom rule.
+		syslogEvent("informational", "10.0.0.1:514", at(), "noise"),
+	}}
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: &fakeAlerts{}, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+		Rules: custom,
+	})
+	_ = p.ScanOnce(context.Background())
+	if hits != 1 {
+		t.Errorf("custom rule should fire once, got %d", hits)
+	}
+}
+
+func TestListenerPipeline_EngineName(t *testing.T) {
+	t.Parallel()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events:   &fakeEvents{},
+		Alerts:   &fakeAlerts{},
+		Settings: newFakeSettings(),
+		Logger:   silentLogger(),
+		Now:      at,
+	})
+	if p.Name() != pipeline.ListenerPipelineName {
+		t.Errorf("Name() = %q, want %q", p.Name(), pipeline.ListenerPipelineName)
+	}
+}
+
+func TestListenerStartStop_Idempotent(t *testing.T) {
+	t.Parallel()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events:   &fakeEvents{},
+		Alerts:   &fakeAlerts{},
+		Settings: newFakeSettings(),
+		Logger:   silentLogger(),
+		Now:      at,
+		Interval: 500 * time.Millisecond,
+	})
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := p.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Stage A4.5 — first half of the alert pipeline. Consumes
`listener_events` on a tick, applies built-in rules, emits structured
alerts into the existing `alerts` table. Rate-limit suppression
dedupes repeated alerts for `(rule, source, kind)` within the
suppression window.

## Changes
- **`internal/alerts/pipeline.ListenerPipeline`** — `engine.Engine` named `alert-listener-pipeline`
- High-water mark in `settings`; in-memory suppression map with lazy eviction at 4096 entries
- **Built-in rules (V1.0)**:
  - `syslog.severe` → any error/critical/alert/emergency syslog → mapped severity alert
  - `trap.linkdown` → SNMP linkDown trap → connectivity/warning
  - `trap.authfail` → SNMP authentication failure → security/error
- Rules injectable via `Config.Rules` so future stages plug in user-configurable rules without touching the engine
- 12 unit tests

## Validation
- `go test ./internal/alerts/...` → green
- `golangci-lint run` → 0 issues

## Next
A4.6 — observation-delta pipeline (ifOperStatus transitions, BGP peer state changes, storage % thresholds)