### PR TITLE
feat(api): register stage a4 engines via services.engines (wire-up)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"time"
 
+	alertpipeline "github.com/krisarmstrong/seed/internal/alerts/pipeline"
 	"github.com/krisarmstrong/seed/internal/auth"
 	"github.com/krisarmstrong/seed/internal/canopy/survey"
 	"github.com/krisarmstrong/seed/internal/canopy/wifi"
@@ -41,6 +42,7 @@ import (
 	"github.com/krisarmstrong/seed/internal/services/speedtest"
 	"github.com/krisarmstrong/seed/internal/services/vlan"
 	"github.com/krisarmstrong/seed/internal/timeseries/retention"
+	"github.com/krisarmstrong/seed/internal/topology"
 )
 
 // indexHTMLPath is the path to the SPA entry point.
@@ -262,6 +264,8 @@ func initDatabaseDependentServices(services *ServiceContainer, db *database.DB) 
 	initProbeEngine(services, db)
 	initRetentionEngine(services, db)
 	initListeners(services, db)
+	initTopologyReconcilers(services, db)
+	initAlertPipelines(services, db)
 }
 
 // initLicenseAndAPITokens wires the Phase D-2 license manager + API
@@ -353,6 +357,82 @@ func initListeners(services *ServiceContainer, db *database.DB) {
 		} else if regErr := services.Engines.Register(l); regErr != nil {
 			logger.Warn("snmp trap listener registry registration failed", "error", regErr)
 		}
+	}
+}
+
+// initTopologyReconcilers wires the four Stage A4 reconcilers
+// (sysinfo, iftable, edge, arp) into the engine registry. They
+// consume snmp_observations on a tick and maintain the fat-Node
+// topology graph in topology_nodes / topology_interfaces /
+// topology_links / topology_arp_bindings.
+//
+// V1.0 NMS expansion — Stage A4 wire-up.
+func initTopologyReconcilers(services *ServiceContainer, db *database.DB) {
+	logger := logging.GetLogger()
+	obs := db.SNMPObservations()
+	topo := db.Topology()
+	settings := db.Settings()
+
+	if r, err := topology.NewSysInfoReconciler(topology.Config{
+		Observations: obs, Nodes: topo, Settings: settings, Logger: logger,
+	}); err != nil {
+		logger.Warn("sysinfo reconciler init failed", "error", err)
+	} else if regErr := services.Engines.Register(r); regErr != nil {
+		logger.Warn("sysinfo reconciler registry registration failed", "error", regErr)
+	}
+
+	if r, err := topology.NewIfTableReconciler(topology.IfTableConfig{
+		Observations: obs, Store: topo, Settings: settings, Logger: logger,
+	}); err != nil {
+		logger.Warn("iftable reconciler init failed", "error", err)
+	} else if regErr := services.Engines.Register(r); regErr != nil {
+		logger.Warn("iftable reconciler registry registration failed", "error", regErr)
+	}
+
+	if r, err := topology.NewEdgeReconciler(topology.EdgeConfig{
+		Observations: obs, Store: topo, Settings: settings, Logger: logger,
+	}); err != nil {
+		logger.Warn("edge reconciler init failed", "error", err)
+	} else if regErr := services.Engines.Register(r); regErr != nil {
+		logger.Warn("edge reconciler registry registration failed", "error", regErr)
+	}
+
+	if r, err := topology.NewARPReconciler(topology.ARPConfig{
+		Observations: obs, Store: topo, Settings: settings, Logger: logger,
+	}); err != nil {
+		logger.Warn("arp reconciler init failed", "error", err)
+	} else if regErr := services.Engines.Register(r); regErr != nil {
+		logger.Warn("arp reconciler registry registration failed", "error", regErr)
+	}
+}
+
+// initAlertPipelines wires the two Stage A4.5 / A4.6 alert
+// pipelines into the engine registry. The listener pipeline scans
+// listener_events for severe syslog + traps; the observation
+// pipeline scans snmp_observations for state transitions
+// (iface down, BGP flap, storage thresholds). Both write into the
+// existing alerts table via the same Alert repository.
+//
+// V1.0 NMS expansion — Stage A4 wire-up.
+func initAlertPipelines(services *ServiceContainer, db *database.DB) {
+	logger := logging.GetLogger()
+	settings := db.Settings()
+	alerts := db.Alerts()
+
+	if p, err := alertpipeline.NewListenerPipeline(alertpipeline.ListenerConfig{
+		Events: db.ListenerEvents(), Alerts: alerts, Settings: settings, Logger: logger,
+	}); err != nil {
+		logger.Warn("listener alert pipeline init failed", "error", err)
+	} else if regErr := services.Engines.Register(p); regErr != nil {
+		logger.Warn("listener alert pipeline registry registration failed", "error", regErr)
+	}
+
+	if p, err := alertpipeline.NewObservationPipeline(alertpipeline.ObservationConfig{
+		Observations: db.SNMPObservations(), Alerts: alerts, Settings: settings, Logger: logger,
+	}); err != nil {
+		logger.Warn("observation alert pipeline init failed", "error", err)
+	} else if regErr := services.Engines.Register(p); regErr != nil {
+		logger.Warn("observation alert pipeline registry registration failed", "error", regErr)
 	}
 }
 

--- a/internal/api/server_a4_engines_internal_test.go
+++ b/internal/api/server_a4_engines_internal_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestInitTopologyReconcilers_RegistersFourEngines(t *testing.T) {
+	services := NewServiceContainer()
+	initTopologyReconcilers(services, newTestDB(t))
+
+	names := make(map[string]bool)
+	for _, e := range services.Engines.Engines() {
+		names[e.Name()] = true
+	}
+	want := []string{
+		"topology-sysinfo-reconciler",
+		"topology-iftable-reconciler",
+		"topology-edge-reconciler",
+		"topology-arp-reconciler",
+	}
+	for _, n := range want {
+		if !names[n] {
+			t.Errorf("topology engine %q not registered; got %v", n, names)
+		}
+	}
+}
+
+func TestInitAlertPipelines_RegistersBothPipelines(t *testing.T) {
+	services := NewServiceContainer()
+	initAlertPipelines(services, newTestDB(t))
+
+	names := make(map[string]bool)
+	for _, e := range services.Engines.Engines() {
+		names[e.Name()] = true
+	}
+	want := []string{
+		"alert-listener-pipeline",
+		"alert-observation-pipeline",
+	}
+	for _, n := range want {
+		if !names[n] {
+			t.Errorf("alert pipeline %q not registered; got %v", n, names)
+		}
+	}
+}
+
+func TestInitDatabaseDependentServices_RegistersAllStageAEngines(t *testing.T) {
+	services := NewServiceContainer()
+	initDatabaseDependentServices(services, newTestDB(t))
+
+	names := make(map[string]bool)
+	for _, e := range services.Engines.Engines() {
+		names[e.Name()] = true
+	}
+	// Probe + retention from earlier stages, plus the four
+	// topology reconcilers and two alert pipelines from A4.
+	want := []string{
+		"probe",
+		"retention",
+		"topology-sysinfo-reconciler",
+		"topology-iftable-reconciler",
+		"topology-edge-reconciler",
+		"topology-arp-reconciler",
+		"alert-listener-pipeline",
+		"alert-observation-pipeline",
+	}
+	for _, n := range want {
+		if !names[n] {
+			t.Errorf("engine %q not registered after full init; got %v", n, names)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Closes the V1.0 unified observation architecture. The six Stage A4
engines — four topology reconcilers + two alert pipelines — now
register with `services.Engines` on startup. One `Server.Start`
brings the whole stack up; one `Server.Shutdown` takes it back down
in reverse registration order.

## Changes
- **`initTopologyReconcilers(services, db)`** — registers `topology-{sysinfo,iftable,edge,arp}-reconciler`
- **`initAlertPipelines(services, db)`** — registers `alert-listener-pipeline` + `alert-observation-pipeline`
- `initDatabaseDependentServices` calls both after the existing probe + retention + listener wire-up
- 3 integration tests covering each helper independently + the full end-to-end registry

## Validation
- `go test ./internal/api/... ./internal/topology/... ./internal/alerts/... ./internal/engine/... ./internal/database/...` → green (full integration suite incl. 20s server lifecycle)
- `golangci-lint run` → 0 issues

## Engine registry after this PR
| Engine | Purpose |
|---|---|
| `probe` | Active probe scheduler + checkers |
| `retention` | Tier-aware rollup + purge |
| `topology-sysinfo-reconciler` | sys_info → `topology_nodes` |
| `topology-iftable-reconciler` | if_table → `topology_interfaces` |
| `topology-edge-reconciler` | lldp/cdp/fdp → `topology_links` |
| `topology-arp-reconciler` | arp → IP/MAC bindings |
| `alert-listener-pipeline` | listener_events → alerts |
| `alert-observation-pipeline` | observation deltas → alerts |

Plus the env-gated `syslog-udp` + `snmp-trap-v2c` listeners.

## Deferred (post-V1.0)
- `snmp-poller` registration once the orchestrator has a real gosnmp factory + non-empty `polling_targets`
- `/api/engines` admin endpoint
- Per-tier engine gating
- Persistent alert state across restarts
- Alert-rule editor UI