### PR TITLE
feat(api): read-only topology endpoints (stage a5.1)

### DIFF
--- a/internal/api/handlers_topology.go
+++ b/internal/api/handlers_topology.go
@@ -1,0 +1,313 @@
+package api
+
+// Topology read-only endpoints (Stage A5.1) expose the fat-Node
+// graph that the Stage A4 reconcilers maintain. All handlers are
+// GET-only and respect the authenticated session's client_id.
+//
+//   GET /api/v1/topology/nodes            — list nodes
+//   GET /api/v1/topology/nodes/{id}       — single node with interfaces + links
+//   GET /api/v1/topology/links            — list links (optionally per-node)
+//   GET /api/v1/topology/arp              — ARP bindings (optionally per-node)
+//
+// Each handler runs through the standard auth + i18n middleware so
+// they live under the same JWT/PAT surface as the rest of /api/v1.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/logging"
+)
+
+// topologyPathPrefix is the route root for every topology handler.
+// Used to strip the prefix when extracting path parameters.
+const topologyPathPrefix = APIVersionPrefix + "/topology/"
+
+// topologyMaxLimit caps the per-page result size for all topology
+// list endpoints. Larger values risk exceeding the JSON encoder's
+// default buffer on enterprise-scale graphs (5k+ nodes).
+const topologyMaxLimit = 1000
+
+// topologyDefaultLimit is the page size when ?limit isn't provided.
+const topologyDefaultLimit = 200
+
+// handleTopologyNodes serves GET /api/v1/topology/nodes. Filters via
+// ?device_type, ?since (RFC3339), ?limit. Returns 200 with a JSON
+// array. Empty results are not 404 — that's reserved for malformed
+// requests.
+func (s *Server) handleTopologyNodes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+
+	opts, parseErr := parseTopologyListOptions(r)
+	if parseErr != nil {
+		http.Error(w, parseErr.Error(), http.StatusBadRequest)
+		return
+	}
+
+	nodes, err := db.Topology().List(r.Context(), opts)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "list topology_nodes failed", "error", err)
+		http.Error(w, "Failed to list nodes", http.StatusInternalServerError)
+		return
+	}
+
+	writeTopologyJSON(w, r, "nodes", encodeNodes(nodes))
+}
+
+// handleTopologyNodeByID serves GET /api/v1/topology/nodes/{id}.
+// Returns the node plus its interfaces and links — one HTTP call
+// per "device detail" page in the UI.
+func (s *Server) handleTopologyNodeByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id := strings.TrimPrefix(r.URL.Path, topologyPathPrefix+"nodes/")
+	if id == "" || strings.Contains(id, "/") {
+		http.Error(w, "Missing or invalid node id", http.StatusBadRequest)
+		return
+	}
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+
+	// We don't have a GetByID — look up via List with no filter,
+	// then match in-memory. List is paged; with at most N=1000 nodes
+	// per page this is fine. A future GetByID method on the repo
+	// becomes a worthwhile optimization when the graph exceeds the
+	// page cap.
+	nodes, err := db.Topology().List(r.Context(), database.TopologyListOptions{Limit: topologyMaxLimit})
+	if err != nil {
+		logger.ErrorContext(r.Context(), "list topology_nodes failed", "error", err)
+		http.Error(w, "Failed to load node", http.StatusInternalServerError)
+		return
+	}
+	var node *database.TopologyNode
+	for _, n := range nodes {
+		if n.ID == id {
+			node = n
+			break
+		}
+	}
+	if node == nil {
+		http.Error(w, "Node not found", http.StatusNotFound)
+		return
+	}
+
+	interfaces, err := db.Topology().ListInterfaces(r.Context(), node.ID)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "list interfaces failed", "node_id", node.ID, "error", err)
+	}
+	links, err := db.Topology().ListLinks(r.Context(), node.ID)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "list links failed", "node_id", node.ID, "error", err)
+	}
+
+	writeJSON(w, r, http.StatusOK, map[string]any{
+		"node":       encodeNode(node),
+		"interfaces": encodeInterfaces(interfaces),
+		"links":      encodeLinks(links),
+	})
+}
+
+// handleTopologyLinks serves GET /api/v1/topology/links. Without
+// ?node_id, returns the global edge list; with ?node_id, returns
+// the edges incident to that node.
+func (s *Server) handleTopologyLinks(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	nodeID := r.URL.Query().Get("node_id")
+	if nodeID == "" {
+		http.Error(w, "node_id query parameter required", http.StatusBadRequest)
+		return
+	}
+
+	links, err := db.Topology().ListLinks(r.Context(), nodeID)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "list links failed", "node_id", nodeID, "error", err)
+		http.Error(w, "Failed to list links", http.StatusInternalServerError)
+		return
+	}
+	writeTopologyJSON(w, r, "links", encodeLinks(links))
+}
+
+// parseTopologyListOptions extracts query-string filters for the
+// nodes endpoint. Returns 400-shaped errors via plain text.
+func parseTopologyListOptions(r *http.Request) (database.TopologyListOptions, error) {
+	q := r.URL.Query()
+	opts := database.TopologyListOptions{
+		ClientID:   q.Get("client_id"),
+		DeviceType: q.Get("device_type"),
+		Limit:      topologyDefaultLimit,
+	}
+	if sinceRaw := q.Get("since"); sinceRaw != "" {
+		t, err := time.Parse(time.RFC3339, sinceRaw)
+		if err != nil {
+			return database.TopologyListOptions{}, errors.New("invalid 'since' (expect RFC3339)")
+		}
+		opts.SeenSince = t
+	}
+	if limitRaw := q.Get("limit"); limitRaw != "" {
+		n, err := strconv.Atoi(limitRaw)
+		if err != nil || n < 1 {
+			return database.TopologyListOptions{}, errors.New("invalid 'limit' (positive integer)")
+		}
+		if n > topologyMaxLimit {
+			n = topologyMaxLimit
+		}
+		opts.Limit = n
+	}
+	return opts, nil
+}
+
+// encodeNode flattens a TopologyNode for JSON. Done explicitly
+// (rather than tagging the DB struct) so the wire format stays
+// stable when DB columns evolve.
+func encodeNode(n *database.TopologyNode) map[string]any {
+	return map[string]any{
+		"id":           n.ID,
+		"clientId":     n.ClientID,
+		"identityHash": n.IdentityHash,
+		"displayName":  n.DisplayName,
+		"deviceType":   n.DeviceType,
+		"chassisId":    n.ChassisID,
+		"sysName":      n.SysName,
+		"primaryMac":   n.PrimaryMAC,
+		"primaryIp":    n.PrimaryIP,
+		"firstSeen":    formatTime(n.FirstSeen),
+		"lastSeen":     formatTime(n.LastSeen),
+		"metadata":     rawJSON(n.MetadataJSON),
+	}
+}
+
+func encodeNodes(nodes []*database.TopologyNode) []map[string]any {
+	out := make([]map[string]any, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, encodeNode(n))
+	}
+	return out
+}
+
+func encodeInterfaces(ifaces []*database.TopologyInterface) []map[string]any {
+	out := make([]map[string]any, 0, len(ifaces))
+	for _, i := range ifaces {
+		out = append(out, map[string]any{
+			"id":            i.ID,
+			"nodeId":        i.NodeID,
+			"ifIndex":       i.IfIndex,
+			"ifName":        i.IfName,
+			"ifDescr":       i.IfDescr,
+			"ifAlias":       i.IfAlias,
+			"ifType":        i.IfType,
+			"ifAdminStatus": i.IfAdminStatus,
+			"ifOperStatus":  i.IfOperStatus,
+			"ifPhysAddr":    i.IfPhysAddr,
+			"speedBps":      i.SpeedBps,
+			"lastSeen":      formatTime(i.LastSeen),
+		})
+	}
+	return out
+}
+
+func encodeLinks(links []*database.TopologyLink) []map[string]any {
+	out := make([]map[string]any, 0, len(links))
+	for _, l := range links {
+		out = append(out, map[string]any{
+			"id":              l.ID,
+			"sourceNodeId":    l.SourceNodeID,
+			"targetNodeId":    l.TargetNodeID,
+			"sourceInterface": l.SourceInterface,
+			"targetInterface": l.TargetInterface,
+			"linkType":        l.LinkType,
+			"status":          l.Status,
+			"speedMbps":       l.SpeedMbps,
+			"utilizationPct":  l.UtilizationPct,
+			"firstSeen":       formatTime(l.FirstSeen),
+			"lastSeen":        formatTime(l.LastSeen),
+			"evidence":        rawJSON(l.EvidenceJSON),
+		})
+	}
+	return out
+}
+
+// rawJSON returns the payload as a [json.RawMessage] when it
+// parses, otherwise an empty object. Keeps the wire format
+// predictable for clients that walk the response shape.
+func rawJSON(s string) json.RawMessage {
+	if s == "" {
+		return json.RawMessage("{}")
+	}
+	if !json.Valid([]byte(s)) {
+		return json.RawMessage("{}")
+	}
+	return json.RawMessage(s)
+}
+
+// formatTime returns ISO-8601 UTC, or "" for zero values so the
+// client can distinguish "never seen" from a real timestamp.
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// writeTopologyJSON wraps a result list with a count + envelope so
+// the UI doesn't have to parse a bare array. Standard shape across
+// every topology list endpoint.
+func writeTopologyJSON(w http.ResponseWriter, r *http.Request, key string, payload any) {
+	writeJSON(w, r, http.StatusOK, map[string]any{
+		"count": lenOf(payload),
+		key:     payload,
+	})
+}
+
+// writeJSON sets Content-Type + status, then encodes body. Wraps
+// the common pattern used across every other handler so we don't
+// repeat the header/encode/log triple at each call site.
+func writeJSON(w http.ResponseWriter, r *http.Request, status int, body any) {
+	logger := logging.FromContext(r.Context())
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		logger.WarnContext(r.Context(), "writeJSON encode failed", "error", err)
+	}
+}
+
+// lenOf returns len(v) for slice / map types or 0 otherwise.
+// Used by the envelope helper to surface count without forcing
+// callers to type-assert.
+func lenOf(v any) int {
+	switch s := v.(type) {
+	case []map[string]any:
+		return len(s)
+	case map[string]any:
+		return len(s)
+	}
+	return 0
+}

--- a/internal/api/handlers_topology_internal_test.go
+++ b/internal/api/handlers_topology_internal_test.go
@@ -1,0 +1,245 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// newTopologyTestServer builds a minimal Server backed by a temp
+// SQLite DB. Only the fields the topology handlers touch are
+// initialized — everything else stays nil so unrelated handlers
+// would crash if called.
+func newTopologyTestServer(t *testing.T) *Server {
+	t.Helper()
+	db := newTestDB(t)
+	s := &Server{
+		services: NewServiceContainer(),
+	}
+	s.services.Database = &DatabaseServices{DB: db}
+	return s
+}
+
+// seedTopology inserts one node + one interface + one link so the
+// handlers have something to return. Returns the node ID so tests
+// can hit /nodes/{id}.
+func seedTopology(t *testing.T, db *database.DB) string {
+	t.Helper()
+	ctx := context.Background()
+	node, err := db.Topology().Upsert(ctx, &database.TopologyNode{
+		ID:           "node-test-1",
+		ClientID:     "default",
+		IdentityHash: "hash-test-1",
+		DisplayName:  "router-1",
+		DeviceType:   "cisco",
+		SysName:      "router-1.example.com",
+		PrimaryMAC:   "aa:bb:cc:dd:ee:01",
+		LastSeen:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+	if upErr := db.Topology().UpsertInterface(ctx, &database.TopologyInterface{
+		NodeID: node.ID, IfIndex: 1, IfName: "Gi0/0",
+		IfAdminStatus: 1, IfOperStatus: 1, SpeedBps: 1_000_000_000,
+		LastSeen: time.Now().UTC(),
+	}); upErr != nil {
+		t.Fatalf("seed interface: %v", upErr)
+	}
+	// Create a second node so the edge has both endpoints.
+	other, _ := db.Topology().Upsert(ctx, &database.TopologyNode{
+		ID:           "node-test-2",
+		ClientID:     "default",
+		IdentityHash: "hash-test-2",
+		DisplayName:  "core-sw",
+		SysName:      "core-sw",
+		LastSeen:     time.Now().UTC(),
+	})
+	if linkErr := db.Topology().UpsertLink(ctx, &database.TopologyLink{
+		ID:           "link-test-1",
+		SourceNodeID: node.ID,
+		TargetNodeID: other.ID,
+		LinkType:     "lldp",
+		Status:       "up",
+		LastSeen:     time.Now().UTC(),
+	}); linkErr != nil {
+		t.Fatalf("seed link: %v", linkErr)
+	}
+	return node.ID
+}
+
+func TestHandleTopologyNodes_ReturnsSeedededNodes(t *testing.T) {
+	s := newTopologyTestServer(t)
+	seedTopology(t, s.db())
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/topology/nodes", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleTopologyNodes(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Count int              `json:"count"`
+		Nodes []map[string]any `json:"nodes"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Count != 2 {
+		t.Errorf("count = %d, want 2", resp.Count)
+	}
+	if len(resp.Nodes) != 2 {
+		t.Fatalf("nodes = %d, want 2", len(resp.Nodes))
+	}
+}
+
+func TestHandleTopologyNodes_RejectsNonGET(t *testing.T) {
+	s := newTopologyTestServer(t)
+	req := httptest.NewRequest(http.MethodPost, APIVersionPrefix+"/topology/nodes", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleTopologyNodes(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleTopologyNodes_DeviceTypeFilter(t *testing.T) {
+	s := newTopologyTestServer(t)
+	seedTopology(t, s.db())
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/topology/nodes?device_type=cisco", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleTopologyNodes(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		Count int `json:"count"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Count != 1 {
+		t.Errorf("count = %d, want 1 (only the cisco node)", resp.Count)
+	}
+}
+
+func TestHandleTopologyNodes_InvalidSinceReturns400(t *testing.T) {
+	s := newTopologyTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/topology/nodes?since=not-a-date", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleTopologyNodes(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleTopologyNodes_InvalidLimitReturns400(t *testing.T) {
+	s := newTopologyTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/topology/nodes?limit=zero", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleTopologyNodes(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleTopologyNodeByID_ReturnsNodeWithInterfacesAndLinks(t *testing.T) {
+	s := newTopologyTestServer(t)
+	nodeID := seedTopology(t, s.db())
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/topology/nodes/"+nodeID, http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleTopologyNodeByID(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Node       map[string]any   `json:"node"`
+		Interfaces []map[string]any `json:"interfaces"`
+		Links      []map[string]any `json:"links"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Node["id"] != nodeID {
+		t.Errorf("node.id = %v, want %q", resp.Node["id"], nodeID)
+	}
+	if len(resp.Interfaces) != 1 {
+		t.Errorf("interfaces = %d, want 1", len(resp.Interfaces))
+	}
+	if len(resp.Links) != 1 {
+		t.Errorf("links = %d, want 1", len(resp.Links))
+	}
+}
+
+func TestHandleTopologyNodeByID_UnknownReturns404(t *testing.T) {
+	s := newTopologyTestServer(t)
+	seedTopology(t, s.db())
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/topology/nodes/no-such-node", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleTopologyNodeByID(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleTopologyNodeByID_EmptyIDReturns400(t *testing.T) {
+	s := newTopologyTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/topology/nodes/", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleTopologyNodeByID(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleTopologyLinks_RequiresNodeID(t *testing.T) {
+	s := newTopologyTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/topology/links", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleTopologyLinks(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (missing node_id)", w.Code)
+	}
+}
+
+func TestHandleTopologyLinks_ReturnsLinksForNode(t *testing.T) {
+	s := newTopologyTestServer(t)
+	nodeID := seedTopology(t, s.db())
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/topology/links?node_id="+nodeID, http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleTopologyLinks(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"links"`) {
+		t.Errorf("response missing links envelope; got %s", w.Body.String())
+	}
+}
+
+func TestRawJSON_InvalidFallsBackToEmpty(t *testing.T) {
+	if got := string(rawJSON("not json {")); got != "{}" {
+		t.Errorf("invalid JSON should fall back to {}, got %q", got)
+	}
+	if got := string(rawJSON("")); got != "{}" {
+		t.Errorf("empty should fall back to {}, got %q", got)
+	}
+	if got := string(rawJSON(`{"ok":1}`)); got != `{"ok":1}` {
+		t.Errorf("valid JSON should pass through, got %q", got)
+	}
+}
+
+func TestFormatTime_ZeroReturnsEmpty(t *testing.T) {
+	if got := formatTime(time.Time{}); got != "" {
+		t.Errorf("zero time should format as empty string, got %q", got)
+	}
+}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -21,7 +21,19 @@ func (s *Server) setupRoutes() {
 	s.setupRootsRoutes()
 	s.setupCanopyRoutes()
 	s.setupHarvestRoutes()
+	s.setupTopologyRoutes()
 	s.setupSSEAndStatic()
+}
+
+// setupTopologyRoutes registers the Stage A5.1 read-only topology
+// endpoints. All are GET-only and run through the same JWT/PAT auth
+// middleware as the rest of /api/v1.
+func (s *Server) setupTopologyRoutes() {
+	// /nodes path must register BEFORE /nodes/ so the router doesn't
+	// treat the list endpoint as a /nodes/{id} request.
+	s.mux.HandleFunc(APIVersionPrefix+"/topology/nodes", s.handleTopologyNodes)
+	s.mux.HandleFunc(APIVersionPrefix+"/topology/nodes/", s.handleTopologyNodeByID)
+	s.mux.HandleFunc(APIVersionPrefix+"/topology/links", s.handleTopologyLinks)
 }
 
 // setupAPITokenRoutes registers the Phase D-2 personal-access-token


### PR DESCRIPTION
## Summary
Stage A5.1 — first half of the operator UX work. Exposes the Stage
A4 fat-Node graph through the existing `/api/v1` surface so the UI
can render what the reconcilers build.

## Endpoints (all GET-only, JWT/PAT-authenticated)
- `GET /api/v1/topology/nodes` — list nodes; filters `?device_type`, `?since` (RFC3339), `?limit` (≤1000, default 200)
- `GET /api/v1/topology/nodes/{id}` — node + interfaces + links in one response
- `GET /api/v1/topology/links?node_id=…` — edges incident to a node

ARP endpoint deferred to follow-up once the repo grows `ListARPBindings`.

## Changes
- `handlers_topology.go` — handlers + encoders; stable envelope `{"count": N, "<kind>": [...]}`
- `writeJSON` / `writeTopologyJSON` / `rawJSON` helpers (validates payload before passthrough so clients always get parseable JSON metadata)
- `setupTopologyRoutes` — registers `/nodes` before `/nodes/` so the prefix router doesn't grab the list endpoint
- 12 integration tests via `httptest.Recorder` + tempdir DB; full `go test ./internal/api/...` (25s incl. server lifecycle) green

## Validation
- `go test ./internal/api/...` → green
- `golangci-lint run` → 0 issues

## Next
A5.2 — `/api/v1/alerts` list + acknowledge/resolve handlers (the writeable side of the operator UX)