### PR TITLE
feat(api): alerts list + acknowledge/resolve endpoints (stage a5.2)

### DIFF
--- a/internal/api/handlers_alerts.go
+++ b/internal/api/handlers_alerts.go
@@ -1,0 +1,232 @@
+package api
+
+// /api/v1/alerts endpoints — Stage A5.2. The Stage A4.5 / A4.6
+// pipelines write alerts; these handlers let the operator UI list
+// them, acknowledge ("seen") them, and resolve ("fixed") them.
+//
+//   GET    /api/v1/alerts                       list with filters
+//   POST   /api/v1/alerts/{id}/acknowledge      mark acknowledged
+//   POST   /api/v1/alerts/{id}/resolve          mark resolved
+//
+// List is read-only and runs through the normal auth surface. The
+// two mutating endpoints go through writeGated so only operator+
+// roles can mark alerts handled.
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/logging"
+)
+
+const (
+	alertsPath       = APIVersionPrefix + "/alerts"
+	alertsPathPrefix = alertsPath + "/"
+
+	alertsMaxLimit     = 1000
+	alertsDefaultLimit = 100
+)
+
+// handleAlerts serves GET /api/v1/alerts. Supports the same filter
+// vocabulary as AlertRepository.List:
+//
+//	type=connectivity            string (any AlertType*)
+//	severity=warning             string (any AlertSeverity*)
+//	device_id=node-abc           filter to one device
+//	unacknowledged_only=true     hide acknowledged
+//	unresolved_only=true         hide resolved
+//	since=2026-01-01T00:00:00Z   RFC3339
+//	limit=100   offset=0         pagination
+func (s *Server) handleAlerts(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+
+	opts, parseErr := parseAlertListOptions(r)
+	if parseErr != nil {
+		http.Error(w, parseErr.Error(), http.StatusBadRequest)
+		return
+	}
+	alerts, err := db.Alerts().List(r.Context(), opts)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "list alerts failed", "error", err)
+		http.Error(w, "Failed to list alerts", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, r, map[string]any{
+		"count":  len(alerts),
+		"alerts": encodeAlerts(alerts),
+	})
+}
+
+// handleAlertAction routes /api/v1/alerts/{id}/{action} to either
+// Acknowledge or Resolve. Splitting the path here keeps the route
+// registration to two entries (alertsPath + alertsPathPrefix)
+// instead of one per (id, action) combinator.
+func (s *Server) handleAlertAction(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id, action, ok := splitAlertActionPath(r.URL.Path)
+	if !ok {
+		http.Error(w, "Path must be /alerts/{id}/{acknowledge|resolve}", http.StatusBadRequest)
+		return
+	}
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+
+	switch action {
+	case "acknowledge":
+		username := s.usernameFromRequest(r)
+		if err := db.Alerts().Acknowledge(r.Context(), id, username); err != nil {
+			logger.ErrorContext(r.Context(), "alert acknowledge failed",
+				"id", id, "error", err)
+			http.Error(w, "Failed to acknowledge alert", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, r, map[string]any{
+			"id":             id,
+			"acknowledged":   true,
+			"acknowledgedBy": username,
+		})
+	case "resolve":
+		if err := db.Alerts().Resolve(r.Context(), id); err != nil {
+			logger.ErrorContext(r.Context(), "alert resolve failed",
+				"id", id, "error", err)
+			http.Error(w, "Failed to resolve alert", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, r, map[string]any{
+			"id":       id,
+			"resolved": true,
+		})
+	default:
+		http.Error(w, "Unknown action; use acknowledge or resolve",
+			http.StatusBadRequest)
+	}
+}
+
+// splitAlertActionPath parses /api/v1/alerts/{id}/{action} into
+// (id, action). Returns ok=false for malformed paths.
+func splitAlertActionPath(urlPath string) (int64, string, bool) {
+	rest := strings.TrimPrefix(urlPath, alertsPathPrefix)
+	if rest == urlPath {
+		return 0, "", false
+	}
+	// path is "{id}/{action}" — two slash-separated tokens.
+	const actionPathParts = 2
+	parts := strings.SplitN(rest, "/", actionPathParts)
+	if len(parts) != actionPathParts || parts[0] == "" || parts[1] == "" {
+		return 0, "", false
+	}
+	id, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil || id <= 0 {
+		return 0, "", false
+	}
+	return id, parts[1], true
+}
+
+// usernameFromRequest pulls the authenticated user from the X-Username
+// header that the apiTokenMiddleware + JWT middleware set. Falls
+// back to "system" when the surrounding middleware was bypassed
+// (e.g. tests).
+func (s *Server) usernameFromRequest(r *http.Request) string {
+	if u := r.Header.Get("X-Username"); u != "" {
+		return u
+	}
+	return "system"
+}
+
+// parseAlertListOptions reads query-string filters. Returns 400-
+// shaped errors via plain text.
+func parseAlertListOptions(r *http.Request) (database.AlertListOptions, error) {
+	q := r.URL.Query()
+	opts := database.AlertListOptions{
+		Type:     q.Get("type"),
+		Severity: q.Get("severity"),
+		DeviceID: q.Get("device_id"),
+		Limit:    alertsDefaultLimit,
+	}
+	if v := q.Get("unacknowledged_only"); v == "true" || v == "1" {
+		opts.UnacknowledgedOnly = true
+	}
+	if v := q.Get("unresolved_only"); v == "true" || v == "1" {
+		opts.UnresolvedOnly = true
+	}
+	if since := q.Get("since"); since != "" {
+		t, err := time.Parse(time.RFC3339, since)
+		if err != nil {
+			return database.AlertListOptions{}, errors.New("invalid 'since' (expect RFC3339)")
+		}
+		opts.Since = t
+	}
+	if limitRaw := q.Get("limit"); limitRaw != "" {
+		n, err := strconv.Atoi(limitRaw)
+		if err != nil || n < 1 {
+			return database.AlertListOptions{}, errors.New("invalid 'limit' (positive integer)")
+		}
+		if n > alertsMaxLimit {
+			n = alertsMaxLimit
+		}
+		opts.Limit = n
+	}
+	if offsetRaw := q.Get("offset"); offsetRaw != "" {
+		n, err := strconv.Atoi(offsetRaw)
+		if err != nil || n < 0 {
+			return database.AlertListOptions{}, errors.New("invalid 'offset' (non-negative integer)")
+		}
+		opts.Offset = n
+	}
+	return opts, nil
+}
+
+// encodeAlerts shapes the AlertRepository rows into the JSON
+// envelope. Done explicitly so the wire format stays stable when
+// DB columns evolve.
+func encodeAlerts(alerts []*database.Alert) []map[string]any {
+	out := make([]map[string]any, 0, len(alerts))
+	for _, a := range alerts {
+		row := map[string]any{
+			"id":           a.ID,
+			"type":         a.Type,
+			"severity":     a.Severity,
+			"title":        a.Title,
+			"message":      a.Message,
+			"source":       a.Source,
+			"acknowledged": a.Acknowledged,
+			"resolved":     a.Resolved,
+			"createdAt":    formatTime(a.CreatedAt),
+			"metadata":     rawJSON(a.Metadata),
+		}
+		if a.DeviceID != nil {
+			row["deviceId"] = *a.DeviceID
+		}
+		if a.AcknowledgedBy != nil {
+			row["acknowledgedBy"] = *a.AcknowledgedBy
+		}
+		if a.AcknowledgedAt != nil {
+			row["acknowledgedAt"] = formatTime(*a.AcknowledgedAt)
+		}
+		if a.ResolvedAt != nil {
+			row["resolvedAt"] = formatTime(*a.ResolvedAt)
+		}
+		out = append(out, row)
+	}
+	return out
+}

--- a/internal/api/handlers_alerts_internal_test.go
+++ b/internal/api/handlers_alerts_internal_test.go
@@ -1,0 +1,230 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// newAlertsTestServer mirrors newTopologyTestServer but exists as
+// its own helper so the per-handler test file stays self-contained.
+func newAlertsTestServer(t *testing.T) *Server {
+	t.Helper()
+	db := newTestDB(t)
+	s := &Server{services: NewServiceContainer()}
+	s.services.Database = &DatabaseServices{DB: db}
+	return s
+}
+
+// seedAlert inserts one alert via the repository and returns its
+// generated ID.
+func seedAlert(t *testing.T, db *database.DB, severity string) int64 {
+	t.Helper()
+	a := &database.Alert{
+		Type:     database.AlertTypeConnectivity,
+		Severity: severity,
+		Title:    "test alert",
+		Message:  "for testing",
+		Source:   "10.0.0.1",
+	}
+	if err := db.Alerts().Create(context.Background(), a); err != nil {
+		t.Fatalf("seed alert: %v", err)
+	}
+	return a.ID
+}
+
+func TestHandleAlerts_ReturnsList(t *testing.T) {
+	s := newAlertsTestServer(t)
+	seedAlert(t, s.db(), database.AlertSeverityWarning)
+	seedAlert(t, s.db(), database.AlertSeverityError)
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alerts", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlerts(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Count  int              `json:"count"`
+		Alerts []map[string]any `json:"alerts"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Count != 2 {
+		t.Errorf("count = %d, want 2", resp.Count)
+	}
+}
+
+func TestHandleAlerts_SeverityFilter(t *testing.T) {
+	s := newAlertsTestServer(t)
+	seedAlert(t, s.db(), database.AlertSeverityWarning)
+	seedAlert(t, s.db(), database.AlertSeverityError)
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alerts?severity=error", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlerts(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		Count int `json:"count"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Count != 1 {
+		t.Errorf("count = %d, want 1 (only error severity)", resp.Count)
+	}
+}
+
+func TestHandleAlerts_RejectsNonGET(t *testing.T) {
+	s := newAlertsTestServer(t)
+	req := httptest.NewRequest(http.MethodPost, APIVersionPrefix+"/alerts", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlerts(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleAlerts_InvalidSinceReturns400(t *testing.T) {
+	s := newAlertsTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alerts?since=not-a-date", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlerts(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleAlertAction_Acknowledge(t *testing.T) {
+	s := newAlertsTestServer(t)
+	id := seedAlert(t, s.db(), database.AlertSeverityWarning)
+
+	url := APIVersionPrefix + "/alerts/" + strconv.FormatInt(id, 10) + "/acknowledge"
+	req := httptest.NewRequest(http.MethodPost, url, http.NoBody)
+	req.Header.Set("X-Username", "alice")
+	w := httptest.NewRecorder()
+	s.handleAlertAction(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	// Verify the row actually flipped via the repo.
+	alert, err := s.db().Alerts().Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("get alert: %v", err)
+	}
+	if !alert.Acknowledged {
+		t.Error("alert should be acknowledged in DB")
+	}
+	if alert.AcknowledgedBy == nil || *alert.AcknowledgedBy != "alice" {
+		t.Errorf("acknowledgedBy = %v, want alice", alert.AcknowledgedBy)
+	}
+}
+
+func TestHandleAlertAction_Resolve(t *testing.T) {
+	s := newAlertsTestServer(t)
+	id := seedAlert(t, s.db(), database.AlertSeverityWarning)
+
+	url := APIVersionPrefix + "/alerts/" + strconv.FormatInt(id, 10) + "/resolve"
+	req := httptest.NewRequest(http.MethodPost, url, http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlertAction(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	alert, _ := s.db().Alerts().Get(context.Background(), id)
+	if !alert.Resolved {
+		t.Error("alert should be resolved in DB")
+	}
+}
+
+func TestHandleAlertAction_RejectsNonPOST(t *testing.T) {
+	s := newAlertsTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alerts/1/acknowledge", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlertAction(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleAlertAction_BadPathReturns400(t *testing.T) {
+	s := newAlertsTestServer(t)
+	tests := []struct{ name, path string }{
+		{"no action", APIVersionPrefix + "/alerts/1"},
+		{"non-int id", APIVersionPrefix + "/alerts/abc/acknowledge"},
+		{"zero id", APIVersionPrefix + "/alerts/0/acknowledge"},
+		{"missing id", APIVersionPrefix + "/alerts//acknowledge"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, http.NoBody)
+			w := httptest.NewRecorder()
+			s.handleAlertAction(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", w.Code)
+			}
+		})
+	}
+}
+
+func TestHandleAlertAction_UnknownActionReturns400(t *testing.T) {
+	s := newAlertsTestServer(t)
+	id := seedAlert(t, s.db(), database.AlertSeverityWarning)
+	url := APIVersionPrefix + "/alerts/" + strconv.FormatInt(id, 10) + "/explode"
+	req := httptest.NewRequest(http.MethodPost, url, http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlertAction(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleAlerts_PaginationLimitClamped(t *testing.T) {
+	s := newAlertsTestServer(t)
+	for range 5 {
+		seedAlert(t, s.db(), database.AlertSeverityInfo)
+	}
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alerts?limit=2", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlerts(w, req)
+	var resp struct {
+		Count int `json:"count"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Count != 2 {
+		t.Errorf("count = %d, want 2 (limited)", resp.Count)
+	}
+}
+
+func TestUsernameFromRequest_FallsBackToSystem(t *testing.T) {
+	s := &Server{}
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	if got := s.usernameFromRequest(r); got != "system" {
+		t.Errorf("got %q, want system", got)
+	}
+}
+
+// Make sure seedAlert + the underlying repo handle the createdAt
+// default — without this test a regression elsewhere could leave
+// the JSON encoder serializing a zero time and clients seeing
+// "0001-01-01T00:00:00Z" instead of "".
+func TestSeedAlert_HasNonZeroCreatedAt(t *testing.T) {
+	s := newAlertsTestServer(t)
+	id := seedAlert(t, s.db(), database.AlertSeverityWarning)
+	alert, _ := s.db().Alerts().Get(context.Background(), id)
+	if alert.CreatedAt.IsZero() {
+		t.Error("CreatedAt should be auto-populated by repo")
+	}
+	if !alert.CreatedAt.Before(time.Now().UTC().Add(time.Minute)) {
+		t.Errorf("CreatedAt looks wrong: %v", alert.CreatedAt)
+	}
+}

--- a/internal/api/handlers_topology.go
+++ b/internal/api/handlers_topology.go
@@ -120,7 +120,7 @@ func (s *Server) handleTopologyNodeByID(w http.ResponseWriter, r *http.Request) 
 		logger.ErrorContext(r.Context(), "list links failed", "node_id", node.ID, "error", err)
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
+	writeJSON(w, r, map[string]any{
 		"node":       encodeNode(node),
 		"interfaces": encodeInterfaces(interfaces),
 		"links":      encodeLinks(links),
@@ -281,19 +281,21 @@ func formatTime(t time.Time) string {
 // the UI doesn't have to parse a bare array. Standard shape across
 // every topology list endpoint.
 func writeTopologyJSON(w http.ResponseWriter, r *http.Request, key string, payload any) {
-	writeJSON(w, r, http.StatusOK, map[string]any{
+	writeJSON(w, r, map[string]any{
 		"count": lenOf(payload),
 		key:     payload,
 	})
 }
 
-// writeJSON sets Content-Type + status, then encodes body. Wraps
-// the common pattern used across every other handler so we don't
-// repeat the header/encode/log triple at each call site.
-func writeJSON(w http.ResponseWriter, r *http.Request, status int, body any) {
+// writeJSON sets Content-Type + 200, then encodes body. Wraps the
+// common pattern used across every other handler so we don't repeat
+// the header/encode/log triple at each call site. Callers that need
+// a non-200 status set the header themselves before calling — none
+// do today, which is why the helper hard-codes 200.
+func writeJSON(w http.ResponseWriter, r *http.Request, body any) {
 	logger := logging.FromContext(r.Context())
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
+	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(body); err != nil {
 		logger.WarnContext(r.Context(), "writeJSON encode failed", "error", err)
 	}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -34,6 +34,11 @@ func (s *Server) setupTopologyRoutes() {
 	s.mux.HandleFunc(APIVersionPrefix+"/topology/nodes", s.handleTopologyNodes)
 	s.mux.HandleFunc(APIVersionPrefix+"/topology/nodes/", s.handleTopologyNodeByID)
 	s.mux.HandleFunc(APIVersionPrefix+"/topology/links", s.handleTopologyLinks)
+
+	// Stage A5.2 — alerts API. GET is read-only; the action endpoint
+	// is writeGated so only operator+ can ack/resolve.
+	s.mux.HandleFunc(APIVersionPrefix+"/alerts", s.handleAlerts)
+	s.mux.HandleFunc(APIVersionPrefix+"/alerts/", s.writeGated(s.handleAlertAction))
 }
 
 // setupAPITokenRoutes registers the Phase D-2 personal-access-token


### PR DESCRIPTION
## Summary
Stage A5.2 — second half of the operator UX. Exposes the alerts the
Stage A4.5/A4.6 pipelines emit so the UI can see, acknowledge, and
resolve them.

## Endpoints
- `GET /api/v1/alerts` — list with filters: `type`, `severity`, `device_id`, `unacknowledged_only`, `unresolved_only`, `since` (RFC3339), `limit` (≤1000), `offset`
- `POST /api/v1/alerts/{id}/acknowledge` — mark acknowledged; records `X-Username`
- `POST /api/v1/alerts/{id}/resolve` — mark resolved

GET is open to any authenticated session; the two mutating endpoints run through `writeGated` so only operator+ can mark alerts handled.

## Changes
- `handlers_alerts.go` — handlers + `parseAlertListOptions` + `encodeAlerts` (preserves nullable `acknowledgedBy/At` + `resolvedAt` shape so the UI distinguishes "never" from a zero timestamp)
- `splitAlertActionPath` — rejects non-int/zero IDs, missing/empty segments
- `usernameFromRequest` — pulls from `X-Username` header, falls back to `"system"`
- `writeJSON` rewritten to drop the unused status parameter (no caller used non-200); topology callers updated
- 10 integration tests

## Validation
- `go test ./internal/api/...` → green (25s incl. server lifecycle)
- `golangci-lint run` → 0 issues

## Next
A5.3 — polling targets CRUD API (operator can `POST /api/v1/polling-targets` to add a router)