### PR TITLE
feat(api): polling targets crud (stage a5.3)

### DIFF
--- a/internal/api/handlers_polling_targets.go
+++ b/internal/api/handlers_polling_targets.go
@@ -1,0 +1,269 @@
+package api
+
+// /api/v1/polling-targets endpoints — Stage A5.3. Operators add
+// devices to poll here; the SNMP poller picks them up on the next
+// tick (Enabled=true) and the chain reconcilers fold the resulting
+// observations into the topology graph.
+//
+//   GET    /api/v1/polling-targets         list (filter by ?client_id)
+//   POST   /api/v1/polling-targets         create
+//   GET    /api/v1/polling-targets/{id}    fetch one
+//   PUT    /api/v1/polling-targets/{id}    full update
+//   DELETE /api/v1/polling-targets/{id}    delete
+//
+// List is read-only; the mutating routes go through writeGated so
+// only operator+ roles can add/edit/remove devices to poll.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/logging"
+)
+
+const (
+	pollingTargetsPath       = APIVersionPrefix + "/polling-targets"
+	pollingTargetsPathPrefix = pollingTargetsPath + "/"
+)
+
+// pollingTargetInput is the request body for POST + PUT. Mirrors the
+// repo struct minus the audit columns the server fills in.
+type pollingTargetInput struct {
+	ClientID        string   `json:"clientId,omitempty"`
+	Name            string   `json:"name"`
+	IPAddress       string   `json:"ipAddress"`
+	SNMPVersion     string   `json:"snmpVersion,omitempty"`
+	CredentialsID   string   `json:"credentialsId,omitempty"`
+	PollIntervalSec int      `json:"pollIntervalSeconds,omitempty"`
+	Enabled         bool     `json:"enabled"`
+	CollectorChain  []string `json:"collectorChain,omitempty"`
+}
+
+// handlePollingTargets routes the collection-level endpoint
+// (GET list / POST create) — both share the same path so the mux
+// dispatches by method here.
+func (s *Server) handlePollingTargets(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listPollingTargets(w, r)
+	case http.MethodPost:
+		s.createPollingTarget(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handlePollingTargetByID routes the resource-level endpoint
+// (GET / PUT / DELETE).
+func (s *Server) handlePollingTargetByID(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, pollingTargetsPathPrefix)
+	if id == "" || strings.Contains(id, "/") {
+		http.Error(w, "Missing or invalid target id", http.StatusBadRequest)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		s.getPollingTarget(w, r, id)
+	case http.MethodPut:
+		s.updatePollingTarget(w, r, id)
+	case http.MethodDelete:
+		s.deletePollingTarget(w, r, id)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) listPollingTargets(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	targets, err := db.PollingTargets().List(r.Context(), r.URL.Query().Get("client_id"))
+	if err != nil {
+		logger.ErrorContext(r.Context(), "list polling_targets failed", "error", err)
+		http.Error(w, "Failed to list polling targets", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, r, map[string]any{
+		"count":   len(targets),
+		"targets": encodePollingTargets(targets),
+	})
+}
+
+func (s *Server) getPollingTarget(w http.ResponseWriter, r *http.Request, id string) {
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	target, err := db.PollingTargets().Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, database.ErrPollingTargetNotFound) {
+			http.Error(w, "Target not found", http.StatusNotFound)
+			return
+		}
+		logger.ErrorContext(r.Context(), "get polling_target failed", "id", id, "error", err)
+		http.Error(w, "Failed to load target", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, r, encodePollingTarget(target))
+}
+
+func (s *Server) createPollingTarget(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	in, err := decodePollingTargetInput(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	target := inputToTarget(in, "")
+	if createErr := db.PollingTargets().Create(r.Context(), target); createErr != nil {
+		logger.ErrorContext(r.Context(), "create polling_target failed", "error", createErr)
+		// Validation errors from the repo are user input; everything
+		// else is a server problem. The repo signals validation via
+		// errors that don't wrap an underlying sql error — pragmatic
+		// classification by prefix keeps us from inventing a typed
+		// error hierarchy for one endpoint.
+		if strings.HasPrefix(createErr.Error(), "polling_targets:") {
+			http.Error(w, createErr.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "Failed to create target", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Location", pollingTargetsPathPrefix+target.ID)
+	writeJSON(w, r, encodePollingTarget(target))
+}
+
+func (s *Server) updatePollingTarget(w http.ResponseWriter, r *http.Request, id string) {
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	in, err := decodePollingTargetInput(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	target := inputToTarget(in, id)
+	if updErr := db.PollingTargets().Update(r.Context(), target); updErr != nil {
+		if errors.Is(updErr, database.ErrPollingTargetNotFound) {
+			http.Error(w, "Target not found", http.StatusNotFound)
+			return
+		}
+		logger.ErrorContext(r.Context(), "update polling_target failed", "id", id, "error", updErr)
+		http.Error(w, "Failed to update target", http.StatusInternalServerError)
+		return
+	}
+	// Echo the freshly-read row so the client sees the audit columns
+	// (updated_at) the repo refreshed.
+	current, _ := db.PollingTargets().Get(r.Context(), id)
+	if current == nil {
+		writeJSON(w, r, encodePollingTarget(target))
+		return
+	}
+	writeJSON(w, r, encodePollingTarget(current))
+}
+
+func (s *Server) deletePollingTarget(w http.ResponseWriter, r *http.Request, id string) {
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	if err := db.PollingTargets().Delete(r.Context(), id); err != nil {
+		if errors.Is(err, database.ErrPollingTargetNotFound) {
+			http.Error(w, "Target not found", http.StatusNotFound)
+			return
+		}
+		logger.ErrorContext(r.Context(), "delete polling_target failed", "id", id, "error", err)
+		http.Error(w, "Failed to delete target", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// decodePollingTargetInput parses the JSON body. Returns a 400-
+// shaped error for malformed payloads.
+func decodePollingTargetInput(r *http.Request) (*pollingTargetInput, error) {
+	var in pollingTargetInput
+	if r.Body == nil {
+		return nil, errors.New("body required")
+	}
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return nil, errors.New("invalid JSON body: " + err.Error())
+	}
+	if in.Name == "" {
+		return nil, errors.New("'name' required")
+	}
+	if in.IPAddress == "" {
+		return nil, errors.New("'ipAddress' required")
+	}
+	return &in, nil
+}
+
+// inputToTarget maps the wire shape into the repo struct. id ==
+// "" means "let the repo generate one" (Create); a non-empty id is
+// used for Update.
+func inputToTarget(in *pollingTargetInput, id string) *database.PollingTarget {
+	return &database.PollingTarget{
+		ID:              id,
+		ClientID:        in.ClientID,
+		Name:            in.Name,
+		IPAddress:       in.IPAddress,
+		SNMPVersion:     in.SNMPVersion,
+		CredentialsID:   in.CredentialsID,
+		PollIntervalSec: in.PollIntervalSec,
+		Enabled:         in.Enabled,
+		CollectorChain:  in.CollectorChain,
+	}
+}
+
+// encodePollingTarget shapes the repo row into JSON. Done
+// explicitly so the wire format stays stable when DB columns
+// evolve.
+func encodePollingTarget(t *database.PollingTarget) map[string]any {
+	row := map[string]any{
+		"id":                  t.ID,
+		"clientId":            t.ClientID,
+		"name":                t.Name,
+		"ipAddress":           t.IPAddress,
+		"snmpVersion":         t.SNMPVersion,
+		"credentialsId":       t.CredentialsID,
+		"pollIntervalSeconds": t.PollIntervalSec,
+		"enabled":             t.Enabled,
+		"collectorChain":      t.CollectorChain,
+		"lastStatus":          t.LastStatus,
+		"lastError":           t.LastError,
+		"createdAt":           formatTime(t.CreatedAt),
+		"updatedAt":           formatTime(t.UpdatedAt),
+	}
+	if !t.LastPolledAt.IsZero() {
+		row["lastPolledAt"] = formatTime(t.LastPolledAt)
+	}
+	return row
+}
+
+func encodePollingTargets(targets []*database.PollingTarget) []map[string]any {
+	out := make([]map[string]any, 0, len(targets))
+	for _, t := range targets {
+		out = append(out, encodePollingTarget(t))
+	}
+	return out
+}

--- a/internal/api/handlers_polling_targets_internal_test.go
+++ b/internal/api/handlers_polling_targets_internal_test.go
@@ -1,0 +1,270 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// newPollingTargetsTestServer returns a Server with only the bits
+// the polling-targets handlers touch.
+func newPollingTargetsTestServer(t *testing.T) *Server {
+	t.Helper()
+	db := newTestDB(t)
+	s := &Server{services: NewServiceContainer()}
+	s.services.Database = &DatabaseServices{DB: db}
+	return s
+}
+
+// seedTarget inserts a polling target via the repo and returns it.
+func seedTarget(t *testing.T, db *database.DB, name string) *database.PollingTarget {
+	t.Helper()
+	target := &database.PollingTarget{
+		Name:            name,
+		IPAddress:       "10.0.0.1",
+		SNMPVersion:     "v2c",
+		PollIntervalSec: 60,
+		Enabled:         true,
+		CollectorChain:  []string{"sys_info"},
+	}
+	if err := db.PollingTargets().Create(context.Background(), target); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	return target
+}
+
+func postJSON(t *testing.T, body any) *http.Request {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	if err := json.NewEncoder(buf).Encode(body); err != nil {
+		t.Fatalf("encode body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, APIVersionPrefix+"/polling-targets", buf)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestHandlePollingTargets_GETReturnsList(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	seedTarget(t, s.db(), "router-1")
+	seedTarget(t, s.db(), "router-2")
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/polling-targets", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handlePollingTargets(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Count   int              `json:"count"`
+		Targets []map[string]any `json:"targets"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Count != 2 {
+		t.Errorf("count = %d, want 2", resp.Count)
+	}
+}
+
+func TestHandlePollingTargets_POSTCreates(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	req := postJSON(t, map[string]any{
+		"name":                "router-1",
+		"ipAddress":           "10.0.0.1",
+		"snmpVersion":         "v2c",
+		"pollIntervalSeconds": 60,
+		"enabled":             true,
+	})
+	w := httptest.NewRecorder()
+	s.handlePollingTargets(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); loc == "" {
+		t.Error("missing Location header on create")
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["name"] != "router-1" || resp["ipAddress"] != "10.0.0.1" {
+		t.Errorf("response = %+v", resp)
+	}
+	// Confirm the row landed in the DB.
+	list, _ := s.db().PollingTargets().List(context.Background(), "")
+	if len(list) != 1 {
+		t.Errorf("db rows = %d, want 1", len(list))
+	}
+}
+
+func TestHandlePollingTargets_POSTMissingNameReturns400(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	req := postJSON(t, map[string]any{"ipAddress": "10.0.0.1"})
+	w := httptest.NewRecorder()
+	s.handlePollingTargets(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandlePollingTargets_POSTMissingIPReturns400(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	req := postJSON(t, map[string]any{"name": "router-1"})
+	w := httptest.NewRecorder()
+	s.handlePollingTargets(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandlePollingTargets_POSTUnknownFieldsReturns400(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	// "extra" isn't a known input field; the disallow-unknown-fields
+	// decoder rejects the request.
+	body := []byte(`{"name":"r","ipAddress":"10.0.0.1","extra":true}`)
+	req := httptest.NewRequest(http.MethodPost, APIVersionPrefix+"/polling-targets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handlePollingTargets(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandlePollingTargets_UnknownMethodReturns405(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	req := httptest.NewRequest(http.MethodPatch, APIVersionPrefix+"/polling-targets", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handlePollingTargets(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandlePollingTargetByID_GET(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	target := seedTarget(t, s.db(), "router-1")
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/polling-targets/"+target.ID, http.NoBody)
+	w := httptest.NewRecorder()
+	s.handlePollingTargetByID(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["id"] != target.ID {
+		t.Errorf("id = %v, want %v", resp["id"], target.ID)
+	}
+}
+
+func TestHandlePollingTargetByID_GETUnknownReturns404(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/polling-targets/no-such-id", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handlePollingTargetByID(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandlePollingTargetByID_PUTUpdates(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	target := seedTarget(t, s.db(), "old-name")
+
+	buf := &bytes.Buffer{}
+	_ = json.NewEncoder(buf).Encode(map[string]any{
+		"name":                "new-name",
+		"ipAddress":           "10.0.0.99",
+		"snmpVersion":         "v2c",
+		"pollIntervalSeconds": 120,
+		"enabled":             false,
+		"collectorChain":      []string{"sys_info", "if_table"},
+	})
+	req := httptest.NewRequest(http.MethodPut, APIVersionPrefix+"/polling-targets/"+target.ID, buf)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handlePollingTargetByID(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	// Re-fetch from DB to confirm.
+	got, _ := s.db().PollingTargets().Get(context.Background(), target.ID)
+	if got.Name != "new-name" || got.IPAddress != "10.0.0.99" {
+		t.Errorf("update didn't persist: %+v", got)
+	}
+	if got.Enabled {
+		t.Error("Enabled should be false after update")
+	}
+}
+
+func TestHandlePollingTargetByID_PUTUnknownReturns404(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	buf := &bytes.Buffer{}
+	_ = json.NewEncoder(buf).Encode(map[string]any{
+		"name":      "x",
+		"ipAddress": "10.0.0.1",
+	})
+	req := httptest.NewRequest(http.MethodPut, APIVersionPrefix+"/polling-targets/no-such-id", buf)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handlePollingTargetByID(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandlePollingTargetByID_DELETERemoves(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	target := seedTarget(t, s.db(), "to-delete")
+
+	req := httptest.NewRequest(http.MethodDelete, APIVersionPrefix+"/polling-targets/"+target.ID, http.NoBody)
+	w := httptest.NewRecorder()
+	s.handlePollingTargetByID(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", w.Code)
+	}
+
+	if _, err := s.db().PollingTargets().Get(context.Background(), target.ID); err == nil {
+		t.Error("target should be deleted from DB")
+	}
+}
+
+func TestHandlePollingTargetByID_DELETEUnknownReturns404(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	req := httptest.NewRequest(http.MethodDelete, APIVersionPrefix+"/polling-targets/no-such-id", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handlePollingTargetByID(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandlePollingTargetByID_BadPathReturns400(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	// trailing-slash-only path = empty id.
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/polling-targets/", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handlePollingTargetByID(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandlePollingTargetByID_PATCHRejected(t *testing.T) {
+	s := newPollingTargetsTestServer(t)
+	target := seedTarget(t, s.db(), "r-1")
+	req := httptest.NewRequest(http.MethodPatch, APIVersionPrefix+"/polling-targets/"+target.ID, http.NoBody)
+	w := httptest.NewRecorder()
+	s.handlePollingTargetByID(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -39,6 +39,15 @@ func (s *Server) setupTopologyRoutes() {
 	// is writeGated so only operator+ can ack/resolve.
 	s.mux.HandleFunc(APIVersionPrefix+"/alerts", s.handleAlerts)
 	s.mux.HandleFunc(APIVersionPrefix+"/alerts/", s.writeGated(s.handleAlertAction))
+
+	// Stage A5.3 — polling targets CRUD. Collection-level routes
+	// (GET list, POST create) are method-dispatched in
+	// handlePollingTargets; resource-level (GET, PUT, DELETE) in
+	// handlePollingTargetByID. Both are writeGated because the
+	// collection handler accepts POST and any mutating method
+	// requires the operator+ role.
+	s.mux.HandleFunc(APIVersionPrefix+"/polling-targets", s.writeGated(s.handlePollingTargets))
+	s.mux.HandleFunc(APIVersionPrefix+"/polling-targets/", s.writeGated(s.handlePollingTargetByID))
 }
 
 // setupAPITokenRoutes registers the Phase D-2 personal-access-token

--- a/internal/database/repository_polling_targets.go
+++ b/internal/database/repository_polling_targets.go
@@ -2,7 +2,9 @@ package database
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -86,6 +88,126 @@ func (r *PollingTargetRepository) Get(ctx context.Context, id string) (*PollingT
 		FROM polling_targets WHERE id = ?
 	`, id)
 	return scanPollingTarget(row.Scan)
+}
+
+// Create inserts a new polling target. ID + timestamps are stamped
+// here if zero; the caller is expected to populate the remaining
+// fields (Name, IPAddress, SNMPVersion, CollectorChain, etc.).
+// Default poll interval is 300s when caller passes 0.
+func (r *PollingTargetRepository) Create(ctx context.Context, t *PollingTarget) error {
+	if t.IPAddress == "" {
+		return errors.New("polling_targets: IPAddress required")
+	}
+	if t.Name == "" {
+		return errors.New("polling_targets: Name required")
+	}
+	if t.ID == "" {
+		t.ID = "tgt-" + randomID()
+	}
+	if t.ClientID == "" {
+		t.ClientID = "default"
+	}
+	if t.SNMPVersion == "" {
+		t.SNMPVersion = "v2c"
+	}
+	if t.PollIntervalSec == 0 {
+		t.PollIntervalSec = 300
+	}
+	chainJSON, _ := json.Marshal(t.CollectorChain)
+	if len(t.CollectorChain) == 0 {
+		// Default chain matches the migration default so a freshly
+		// added target picks up the same set the migration would
+		// have populated.
+		chainJSON = []byte(`["sys_info","if_table","lldp","arp","fdb"]`)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	t.CreatedAt = time.Now().UTC()
+	t.UpdatedAt = t.CreatedAt
+	enabled := 0
+	if t.Enabled {
+		enabled = 1
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO polling_targets
+		  (id, client_id, name, ip_address, snmp_version, credentials_id,
+		   poll_interval_seconds, enabled, collector_chain,
+		   created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		t.ID, t.ClientID, t.Name, t.IPAddress, t.SNMPVersion,
+		toNullString(t.CredentialsID),
+		t.PollIntervalSec, enabled, string(chainJSON),
+		now, now,
+	)
+	if err != nil {
+		return fmt.Errorf("create polling_target: %w", err)
+	}
+	return nil
+}
+
+// Update modifies the writable fields (name, ip, snmp version, poll
+// interval, enabled, collector chain, credentials_id). Read-only
+// audit columns (created_at, last_polled_at, last_status, last_error)
+// stay untouched. Returns [ErrPollingTargetNotFound] when id is
+// absent — distinguishes a missing target from a SQL-level
+// [sql.ErrNoRows] surface so handlers can map it to HTTP 404.
+func (r *PollingTargetRepository) Update(ctx context.Context, t *PollingTarget) error {
+	if t.ID == "" {
+		return errors.New("polling_targets: ID required for Update")
+	}
+	chainJSON, _ := json.Marshal(t.CollectorChain)
+	enabled := 0
+	if t.Enabled {
+		enabled = 1
+	}
+	res, err := r.db.Exec(ctx, `
+		UPDATE polling_targets SET
+			name = ?, ip_address = ?, snmp_version = ?,
+			credentials_id = ?, poll_interval_seconds = ?, enabled = ?,
+			collector_chain = ?, updated_at = ?
+		WHERE id = ?
+	`,
+		t.Name, t.IPAddress, t.SNMPVersion,
+		toNullString(t.CredentialsID),
+		t.PollIntervalSec, enabled, string(chainJSON),
+		time.Now().UTC().Format(time.RFC3339Nano),
+		t.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update polling_target: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrPollingTargetNotFound
+	}
+	return nil
+}
+
+// Delete removes a polling target by id. Cascades via foreign-key
+// chain on dependent rows (none today). Returns
+// ErrPollingTargetNotFound when no row matched.
+func (r *PollingTargetRepository) Delete(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("polling_targets: ID required for Delete")
+	}
+	res, err := r.db.Exec(ctx, `DELETE FROM polling_targets WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete polling_target: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrPollingTargetNotFound
+	}
+	return nil
+}
+
+// randomID returns a 12-char hex string suitable for non-secret IDs.
+// crypto/rand is overkill for primary keys; we keep it for the
+// uniform-distribution guarantee under contention.
+func randomID() string {
+	var b [6]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
 }
 
 // UpdateLastPoll records the outcome of the most recent poll attempt.


### PR DESCRIPTION
## Summary
Stage A5.3 — closes the operator-facing pieces of the operator UX
work. The SNMP poller now has an API surface for adding/editing/
removing devices.

## Endpoints (writeGated — operator+)
- `GET /api/v1/polling-targets` — list (filter by `?client_id`)
- `POST /api/v1/polling-targets` — create; returns `Location: /api/v1/polling-targets/{id}`
- `GET /api/v1/polling-targets/{id}` — fetch one
- `PUT /api/v1/polling-targets/{id}` — full update; echoes the freshly-read row
- `DELETE /api/v1/polling-targets/{id}` — 204 No Content

## Changes
- **Repository**: `Create` / `Update` / `Delete` + `randomID` helper; defaults SNMPv2c, 300s poll interval, standard collector chain when omitted
- **`pollingTargetInput`** + `inputToTarget` + `encodePollingTarget` — stable wire shape distinct from the DB struct so columns can evolve
- `decodePollingTargetInput` uses `DisallowUnknownFields` so typos like `{"ipaddres":…}` return 400 instead of silently dropping
- Repo validation errors (`polling_targets:` prefix) → HTTP 400; everything else → 500
- 13 integration tests

## Validation
- `go test ./internal/api/... ./internal/database/...` → green
- `golangci-lint run` → 0 issues

## Next
A5.4 — wire `snmp.Poller` + orchestrator into `services.Engines` so the new targets actually get polled. Final piece of the end-to-end loop.