### PR TITLE
feat(api): wire snmp poller into services.engines (stage a5.4)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -31,6 +31,8 @@ import (
 	"github.com/krisarmstrong/seed/internal/oauth"
 	"github.com/krisarmstrong/seed/internal/paths"
 	"github.com/krisarmstrong/seed/internal/pipeline/publicip"
+	snmporchestrator "github.com/krisarmstrong/seed/internal/polling/snmp/orchestrator"
+	"github.com/krisarmstrong/seed/internal/polling/snmp/snmpclient"
 	"github.com/krisarmstrong/seed/internal/probe"
 	"github.com/krisarmstrong/seed/internal/probe/checkers"
 	"github.com/krisarmstrong/seed/internal/scheduler"
@@ -266,6 +268,7 @@ func initDatabaseDependentServices(services *ServiceContainer, db *database.DB) 
 	initListeners(services, db)
 	initTopologyReconcilers(services, db)
 	initAlertPipelines(services, db)
+	initSNMPPoller(services, db)
 }
 
 // initLicenseAndAPITokens wires the Phase D-2 license manager + API
@@ -357,6 +360,48 @@ func initListeners(services *ServiceContainer, db *database.DB) {
 		} else if regErr := services.Engines.Register(l); regErr != nil {
 			logger.Warn("snmp trap listener registry registration failed", "error", regErr)
 		}
+	}
+}
+
+// snmpPollerSchedulerTick is the cadence the snmp.Poller's
+// scheduler wakes up at to dispatch due target jobs. The actual
+// per-target cadence comes from polling_targets.poll_interval_seconds
+// (default 300s); a 5s tick gives 1% scheduling-grain overhead on
+// the default-cadence targets and is plenty fast for the 60s
+// cadence operators typically use on high-priority devices.
+const snmpPollerSchedulerTick = 5 * time.Second
+
+// initSNMPPoller wires the orchestrator-built [*snmp.Poller] into
+// the engine registry. Three things have to be true for the poller
+// to do useful work:
+//
+//  1. The orchestrator needs a [snmp.ClientFactory] — we supply
+//     the production gosnmp-backed one from internal/polling/snmp/
+//     snmpclient.
+//  2. There needs to be at least one row in polling_targets —
+//     V1.0 operators populate this via the A5.3 CRUD API. With
+//     zero rows the poller still starts (idempotent) but does
+//     no work.
+//  3. The scheduler needs a tick interval; snmpPollerSchedulerTick
+//     defaults to 5s — see the doc comment for the rationale.
+//
+// V1.0 NMS expansion — Stage A5.4.
+func initSNMPPoller(services *ServiceContainer, db *database.DB) {
+	logger := logging.GetLogger()
+	sched := scheduler.New(snmpPollerSchedulerTick)
+	factory := snmpclient.NewFactory(snmpclient.Options{})
+	poller, err := snmporchestrator.Build(snmporchestrator.Config{
+		DB:            db,
+		Scheduler:     sched,
+		ClientFactory: factory,
+		Logger:        logger,
+	})
+	if err != nil {
+		logger.Warn("snmp poller init failed", "error", err)
+		return
+	}
+	if regErr := services.Engines.Register(poller); regErr != nil {
+		logger.Warn("snmp poller registry registration failed", "error", regErr)
 	}
 }
 

--- a/internal/api/server_snmp_poller_internal_test.go
+++ b/internal/api/server_snmp_poller_internal_test.go
@@ -1,0 +1,46 @@
+package api
+
+import "testing"
+
+func TestInitSNMPPoller_RegistersEngine(t *testing.T) {
+	services := NewServiceContainer()
+	initSNMPPoller(services, newTestDB(t))
+
+	names := make(map[string]bool)
+	for _, e := range services.Engines.Engines() {
+		names[e.Name()] = true
+	}
+	if !names["snmp-poller"] {
+		t.Errorf("snmp-poller not registered; got engines = %v", names)
+	}
+}
+
+// TestInitDatabaseDependentServices_RegistersEverythingIncludingPoller
+// verifies the full server init lands all 9 expected engines in the
+// registry: probe, retention, 4 topology reconcilers, 2 alert
+// pipelines, and the snmp poller.
+func TestInitDatabaseDependentServices_RegistersEverythingIncludingPoller(t *testing.T) {
+	services := NewServiceContainer()
+	initDatabaseDependentServices(services, newTestDB(t))
+
+	names := make(map[string]bool)
+	for _, e := range services.Engines.Engines() {
+		names[e.Name()] = true
+	}
+	want := []string{
+		"probe",
+		"retention",
+		"topology-sysinfo-reconciler",
+		"topology-iftable-reconciler",
+		"topology-edge-reconciler",
+		"topology-arp-reconciler",
+		"alert-listener-pipeline",
+		"alert-observation-pipeline",
+		"snmp-poller",
+	}
+	for _, n := range want {
+		if !names[n] {
+			t.Errorf("engine %q not registered after full init; got %v", n, names)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Stage A5.4 — closes the end-to-end loop. An operator POSTs to
`/api/v1/polling-targets`, the SNMP poller picks the row up on its
next 5s tick, the 11 collectors emit observations, the 4
reconcilers fold them into the topology graph, the alert pipelines
fire on transitions, and operators see the result through
`/api/v1/topology` + `/api/v1/alerts`.

## Changes
- **`initSNMPPoller(services, db)`** — wires production
  `snmpclient.NewFactory`, a 5s-tick scheduler, and
  `orchestrator.Build`; registers the `*snmp.Poller` via
  `services.Engines.Register`
- `snmpPollerSchedulerTick = 5 * time.Second`
- 2 integration tests:
  - `initSNMPPoller` registers exactly the `snmp-poller` engine
  - Full `initDatabaseDependentServices` produces all 9 expected engines

## Validation
- `go test ./internal/api/...` → green (25s incl. server lifecycle)
- `golangci-lint run` → 0 issues

## V1.0 unified observation architecture — engines at startup
| Engine | Purpose |
|---|---|
| `probe` | Active probe scheduler + checkers |
| `retention` | Tier-aware rollup + purge |
| `snmp-poller` | Per-target collector chain dispatch |
| `topology-sysinfo-reconciler` | sys_info → topology_nodes |
| `topology-iftable-reconciler` | if_table → topology_interfaces |
| `topology-edge-reconciler` | lldp/cdp/fdp → topology_links |
| `topology-arp-reconciler` | arp → IP/MAC bindings |
| `alert-listener-pipeline` | listener_events → alerts |
| `alert-observation-pipeline` | snmp_observations deltas → alerts |

Plus opt-in (`SEED_SYSLOG_BIND` / `SEED_SNMP_TRAP_BIND`) listeners.

## Stage A closes here
Follow-ups in subsequent stages:
- `/api/v1/topology/arp` (needs `ListARPBindings` repo method)
- Per-tier engine gating (Free vs Starter vs Pro)
- `/api/engines` admin endpoint
- Persistent alert state across restarts
- Alert-rule editor UI
- Time-windowed rules (CPU > 80% for > 5min)