### PR TITLE
feat(ui): topology page — nodes list + node detail (stage a5.6)

### DIFF
--- a/ui/src/hooks/useTopology.ts
+++ b/ui/src/hooks/useTopology.ts
@@ -1,0 +1,93 @@
+/**
+ * Hooks for /api/v1/topology/* — list view + node detail view.
+ *
+ * Two hooks rather than one so the list page doesn't accidentally
+ * fetch the much heavier detail payload, and so the detail page
+ * stays mounted across list refreshes when the user clicks back.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '../api/client';
+import type {
+  TopologyNode,
+  TopologyNodeDetailResponse,
+  TopologyNodesResponse,
+} from '../types/topology';
+
+const ENDPOINT = '/api/v1/topology';
+
+export interface UseTopologyNodesResult {
+  nodes: TopologyNode[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+/** useTopologyNodes lists every node visible to the current session.
+ * The endpoint supports filtering (device_type, since, limit); none
+ * of those are exposed in this hook yet — the page just renders
+ * everything. Filters land when the operator UX needs them. */
+export function useTopologyNodes(): UseTopologyNodesResult {
+  const [nodes, setNodes] = useState<TopologyNode[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await api.get<TopologyNodesResponse>(`${ENDPOINT}/nodes`);
+      setNodes(resp.nodes ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load topology');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { nodes, loading, error, refresh };
+}
+
+export interface UseTopologyNodeResult {
+  detail: TopologyNodeDetailResponse | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+/** useTopologyNode loads one node plus its interfaces and links in
+ * one HTTP call (the handler returns the bundled payload). Pass an
+ * empty id to render an empty-state without firing a request. */
+export function useTopologyNode(id: string): UseTopologyNodeResult {
+  const [detail, setDetail] = useState<TopologyNodeDetailResponse | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (!id) {
+      setDetail(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await api.get<TopologyNodeDetailResponse>(`${ENDPOINT}/nodes/${id}`);
+      setDetail(resp);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load node');
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { detail, loading, error, refresh };
+}

--- a/ui/src/pageRegistry.tsx
+++ b/ui/src/pageRegistry.tsx
@@ -40,6 +40,9 @@ const LogsPage = lazy(() => import('./pages/LogsPage').then((m) => ({ default: m
 const PollingTargetsPage = lazy(() =>
   import('./pages/PollingTargetsPage').then((m) => ({ default: m.PollingTargetsPage })),
 );
+const TopologyPage = lazy(() =>
+  import('./pages/TopologyPage').then((m) => ({ default: m.TopologyPage })),
+);
 
 export interface PageConfig {
   path: string;
@@ -122,5 +125,13 @@ export const pages: PageConfig[] = [
     description: 'SNMP-polled devices and their collector chains.',
     icon: ServerCog,
     component: PollingTargetsPage,
+  },
+  {
+    path: '/topology',
+    label: 'Topology',
+    title: 'Topology',
+    description: 'Fat-Node graph reconciled from SNMP observations.',
+    icon: Network,
+    component: TopologyPage,
   },
 ];

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -1,0 +1,307 @@
+/**
+ * TopologyPage
+ *
+ * Renders the fat-Node graph the Stage A4 reconcilers maintain.
+ * Two views in one route — when no node is selected, the page shows
+ * the list of every node visible to this session; clicking a node
+ * loads /topology/nodes/{id} for the detail panel (interfaces +
+ * links). State lives in this component (no router-state because
+ * the rest of the app uses path-based navigation; node detail
+ * is in-page state to avoid pushing a new route per click).
+ */
+
+import { Activity, Cable, Network, RefreshCw } from 'lucide-react';
+import { type JSX, useState } from 'react';
+import { useTopologyNode, useTopologyNodes } from '../hooks/useTopology';
+import type { TopologyInterface, TopologyLink, TopologyNode } from '../types/topology';
+import { Breadcrumbs } from '../ui/Breadcrumbs';
+import { PageHeader } from '../ui/PageHeader';
+
+export function TopologyPage(): JSX.Element {
+  const [selectedID, setSelectedID] = useState<string>('');
+
+  return (
+    <section className="stack-xl">
+      <Breadcrumbs />
+      <PageHeader
+        icon={Network}
+        title="Topology"
+        description="Devices polled and edges learned from LLDP/CDP/FDP neighbor discovery."
+        iconColorClass="text-module-shell"
+      />
+
+      <div className="grid gap-4 lg:grid-cols-[1fr_2fr]">
+        <NodeList selectedID={selectedID} onSelect={setSelectedID} />
+        <NodeDetail id={selectedID} onClear={(): void => setSelectedID('')} />
+      </div>
+    </section>
+  );
+}
+
+interface NodeListProps {
+  selectedID: string;
+  onSelect: (id: string) => void;
+}
+
+function NodeList({ selectedID, onSelect }: NodeListProps): JSX.Element {
+  const { nodes, loading, error, refresh } = useTopologyNodes();
+
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/30">
+      <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-zinc-400">
+          {loading ? 'Loading…' : `${nodes.length} node${nodes.length === 1 ? '' : 's'}`}
+        </span>
+        <button
+          type="button"
+          onClick={(): void => {
+            void refresh();
+          }}
+          className="text-zinc-400 hover:text-zinc-200"
+          aria-label="Refresh"
+        >
+          <RefreshCw className="h-4 w-4" />
+        </button>
+      </div>
+      {error ? (
+        <div className="p-3 text-sm text-rose-300">{error}</div>
+      ) : nodes.length === 0 ? (
+        <div className="p-4 text-sm text-zinc-500">
+          No nodes yet. Add a polling target and wait a poll cycle.
+        </div>
+      ) : (
+        <ul className="divide-y divide-zinc-800">
+          {nodes.map((n) => (
+            <li key={n.id}>
+              <button
+                type="button"
+                onClick={(): void => onSelect(n.id)}
+                data-testid={`node-row-${n.id}`}
+                className={`flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm transition hover:bg-zinc-800/50 ${
+                  selectedID === n.id ? 'bg-zinc-800/70' : ''
+                }`}
+              >
+                <span className="flex-1 truncate">
+                  <span className="font-medium text-zinc-100">{n.displayName || n.sysName}</span>
+                  {n.primaryIp ? (
+                    <span className="ml-2 font-mono text-xs text-zinc-500">{n.primaryIp}</span>
+                  ) : null}
+                </span>
+                <DeviceTypeBadge type={n.deviceType} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function DeviceTypeBadge({ type }: { type: string }): JSX.Element {
+  // Coarse color hints for at-a-glance scanning — matches the
+  // device_type values produced by topology.deviceTypeFromObjectID
+  // (cisco / juniper / arista / linux / mikrotik / unknown).
+  const palette: Record<string, string> = {
+    cisco: 'bg-sky-500/20 text-sky-300',
+    juniper: 'bg-emerald-500/20 text-emerald-300',
+    arista: 'bg-orange-500/20 text-orange-300',
+    linux: 'bg-zinc-500/20 text-zinc-300',
+    mikrotik: 'bg-violet-500/20 text-violet-300',
+  };
+  const cls = palette[type] ?? 'bg-zinc-700 text-zinc-400';
+  return (
+    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${cls}`}>{type || 'n/a'}</span>
+  );
+}
+
+interface NodeDetailProps {
+  id: string;
+  onClear: () => void;
+}
+
+function NodeDetail({ id, onClear }: NodeDetailProps): JSX.Element {
+  const { detail, loading, error } = useTopologyNode(id);
+
+  if (!id) {
+    return (
+      <div className="flex min-h-[300px] items-center justify-center rounded-lg border border-zinc-800 bg-zinc-900/30 text-sm text-zinc-500">
+        Select a node to see interfaces and links.
+      </div>
+    );
+  }
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-zinc-800 bg-zinc-900/30 p-6 text-sm text-zinc-500">
+        Loading node…
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="rounded-lg border border-rose-500/40 bg-rose-500/10 p-6 text-sm text-rose-300">
+        {error}
+      </div>
+    );
+  }
+  if (!detail) {
+    return (
+      <div className="rounded-lg border border-zinc-800 bg-zinc-900/30 p-6 text-sm text-zinc-500">
+        Node not found.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <NodeSummary node={detail.node} onClear={onClear} />
+      <InterfacesPanel interfaces={detail.interfaces} />
+      <LinksPanel links={detail.links} nodeID={detail.node.id} />
+    </div>
+  );
+}
+
+function NodeSummary({ node, onClear }: { node: TopologyNode; onClear: () => void }): JSX.Element {
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/30 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-zinc-100">
+            {node.displayName || node.sysName}
+          </h2>
+          <p className="text-xs text-zinc-500">{node.id}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-xs text-zinc-400 hover:text-zinc-200"
+        >
+          Clear
+        </button>
+      </div>
+      <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1 text-sm text-zinc-300">
+        <SummaryRow label="Device type" value={node.deviceType || 'n/a'} />
+        <SummaryRow label="Sys name" value={node.sysName || 'n/a'} />
+        <SummaryRow label="Primary MAC" value={node.primaryMac || 'n/a'} mono />
+        <SummaryRow label="Primary IP" value={node.primaryIp || 'n/a'} mono />
+        <SummaryRow label="First seen" value={fmtTime(node.firstSeen)} />
+        <SummaryRow label="Last seen" value={fmtTime(node.lastSeen)} />
+      </dl>
+    </div>
+  );
+}
+
+function SummaryRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}): JSX.Element {
+  return (
+    <>
+      <dt className="text-xs uppercase tracking-wide text-zinc-500">{label}</dt>
+      <dd className={mono ? 'font-mono text-zinc-200' : 'text-zinc-200'}>{value}</dd>
+    </>
+  );
+}
+
+function InterfacesPanel({ interfaces }: { interfaces: TopologyInterface[] }): JSX.Element {
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/30">
+      <div className="flex items-center gap-2 border-b border-zinc-800 px-4 py-2">
+        <Activity className="h-4 w-4 text-emerald-400" />
+        <span className="text-sm font-medium text-zinc-100">Interfaces ({interfaces.length})</span>
+      </div>
+      {interfaces.length === 0 ? (
+        <div className="p-4 text-sm text-zinc-500">
+          No interface data yet. The if_table reconciler folds these in on the next poll.
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead className="text-left text-xs uppercase tracking-wide text-zinc-500">
+            <tr>
+              <th className="px-4 py-2">Index</th>
+              <th className="px-4 py-2">Name</th>
+              <th className="px-4 py-2">Admin / Oper</th>
+              <th className="px-4 py-2">Speed</th>
+              <th className="px-4 py-2">MAC</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-800">
+            {interfaces.map((i) => (
+              <tr key={i.id}>
+                <td className="px-4 py-2 text-zinc-400">{i.ifIndex}</td>
+                <td className="px-4 py-2 text-zinc-100">{i.ifName || i.ifDescr}</td>
+                <td className="px-4 py-2">
+                  <IfStatusPair admin={i.ifAdminStatus} oper={i.ifOperStatus} />
+                </td>
+                <td className="px-4 py-2 text-zinc-300">{fmtSpeed(i.speedBps)}</td>
+                <td className="px-4 py-2 font-mono text-xs text-zinc-400">{i.ifPhysAddr || '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function IfStatusPair({ admin, oper }: { admin: number; oper: number }): JSX.Element {
+  // RFC 2233 values — 1=up, 2=down, anything else lands in the
+  // catch-all dim color.
+  return (
+    <span className="flex items-center gap-1 text-xs">
+      <span className={admin === 1 ? 'text-emerald-400' : 'text-zinc-500'}>admin</span>
+      <span className="text-zinc-600">/</span>
+      <span
+        className={oper === 1 ? 'text-emerald-400' : oper === 2 ? 'text-rose-400' : 'text-zinc-500'}
+      >
+        oper
+      </span>
+    </span>
+  );
+}
+
+function LinksPanel({ links, nodeID }: { links: TopologyLink[]; nodeID: string }): JSX.Element {
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/30">
+      <div className="flex items-center gap-2 border-b border-zinc-800 px-4 py-2">
+        <Cable className="h-4 w-4 text-sky-400" />
+        <span className="text-sm font-medium text-zinc-100">Neighbor links ({links.length})</span>
+      </div>
+      {links.length === 0 ? (
+        <div className="p-4 text-sm text-zinc-500">
+          No edges yet. LLDP/CDP/FDP needs both endpoints to be known nodes.
+        </div>
+      ) : (
+        <ul className="divide-y divide-zinc-800">
+          {links.map((l) => {
+            const otherEnd = l.sourceNodeId === nodeID ? l.targetNodeId : l.sourceNodeId;
+            return (
+              <li key={l.id} className="flex items-center justify-between px-4 py-2 text-sm">
+                <span className="text-zinc-100">↔ {otherEnd}</span>
+                <span className="text-xs text-zinc-500">
+                  {l.linkType} · {fmtTime(l.lastSeen)}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function fmtTime(iso: string): string {
+  if (!iso) return 'never';
+  return new Date(iso).toLocaleString();
+}
+
+function fmtSpeed(bps: number): string {
+  if (!bps) return '—';
+  if (bps >= 1_000_000_000) return `${(bps / 1_000_000_000).toFixed(1)} Gbps`;
+  if (bps >= 1_000_000) return `${(bps / 1_000_000).toFixed(0)} Mbps`;
+  return `${bps} bps`;
+}

--- a/ui/src/types/topology.ts
+++ b/ui/src/types/topology.ts
@@ -1,0 +1,60 @@
+/**
+ * Topology wire shapes mirroring /api/v1/topology/*. Keep field
+ * names aligned with internal/api/handlers_topology.go encoders.
+ */
+
+export interface TopologyNode {
+  id: string;
+  clientId: string;
+  identityHash: string;
+  displayName: string;
+  deviceType: string;
+  chassisId: string;
+  sysName: string;
+  primaryMac: string;
+  primaryIp: string;
+  firstSeen: string;
+  lastSeen: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface TopologyInterface {
+  id: number;
+  nodeId: string;
+  ifIndex: number;
+  ifName: string;
+  ifDescr: string;
+  ifAlias: string;
+  ifType: number;
+  ifAdminStatus: number;
+  ifOperStatus: number;
+  ifPhysAddr: string;
+  speedBps: number;
+  lastSeen: string;
+}
+
+export interface TopologyLink {
+  id: string;
+  sourceNodeId: string;
+  targetNodeId: string;
+  sourceInterface: string;
+  targetInterface: string;
+  linkType: string;
+  status: string;
+  speedMbps: number;
+  utilizationPct: number;
+  firstSeen: string;
+  lastSeen: string;
+  evidence: Record<string, unknown>;
+}
+
+export interface TopologyNodesResponse {
+  count: number;
+  nodes: TopologyNode[];
+}
+
+export interface TopologyNodeDetailResponse {
+  node: TopologyNode;
+  interfaces: TopologyInterface[];
+  links: TopologyLink[];
+}


### PR DESCRIPTION
## Summary
Stage A5.6 — operators see the fat-Node graph the Stage A4 reconcilers maintain.

## Changes
- `types/topology.ts` — list + detail wire shapes
- `hooks/useTopology.ts` — `useTopologyNodes` (list) + `useTopologyNode(id)` (detail); two hooks so the list page doesn't fetch heavy payloads
- `pages/TopologyPage.tsx` — two-column layout: list with color-coded device-type badges + detail with summary, interfaces table (RFC 2233 admin/oper as green/red), and neighbor links
- `pageRegistry.tsx` — `/topology` with `Network` icon, lazy-loaded

## Validation
- `npx tsc --noEmit` → clean
- `npx biome check` → 0 issues
- `npx vite build` → green

## Next
A5.7 — `/alerts` (list + acknowledge + resolve)