### PR TITLE
feat(api): /api/v1/engines admin endpoint (stage a5.8, item 3)

### DIFF
--- a/internal/api/handlers_engines.go
+++ b/internal/api/handlers_engines.go
@@ -1,0 +1,41 @@
+package api
+
+// /api/v1/engines — Stage A5.8. Read-only admin endpoint listing
+// every long-running subsystem registered with services.Engines
+// (probe, retention, snmp-poller, the 4 topology reconcilers, the
+// 2 alert pipelines, plus any opt-in listeners).
+//
+//   GET /api/v1/engines
+//     -> { "count": N, "engines": [{ "name": "..." }, ...] }
+//
+// The endpoint deliberately does NOT expose per-engine status or
+// last-tick timestamps for V1.0 — the engine.Engine interface
+// only carries Name + Start + Stop, and inventing a richer status
+// surface would require touching every engine implementation. A
+// future iteration can add an optional Status() method and a
+// Reporter interface; until then, "is this engine in the registry"
+// is the useful signal operators need.
+
+import (
+	"net/http"
+)
+
+func (s *Server) handleEngines(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.services == nil || s.services.Engines == nil {
+		writeJSON(w, r, map[string]any{"count": 0, "engines": []any{}})
+		return
+	}
+	engines := s.services.Engines.Engines()
+	out := make([]map[string]any, 0, len(engines))
+	for _, e := range engines {
+		out = append(out, map[string]any{"name": e.Name()})
+	}
+	writeJSON(w, r, map[string]any{
+		"count":   len(out),
+		"engines": out,
+	})
+}

--- a/internal/api/handlers_engines_internal_test.go
+++ b/internal/api/handlers_engines_internal_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleEngines_ReturnsRegistryContents(t *testing.T) {
+	s := &Server{services: NewServiceContainer()}
+	initDatabaseDependentServices(s.services, newTestDB(t))
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/engines", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleEngines(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Count   int              `json:"count"`
+		Engines []map[string]any `json:"engines"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// 9 engines from initDatabaseDependentServices (verified by
+	// the wire-up test in server_a4_engines_internal_test.go).
+	const wantCount = 9
+	if resp.Count != wantCount {
+		t.Errorf("count = %d, want %d", resp.Count, wantCount)
+	}
+	names := map[string]bool{}
+	for _, e := range resp.Engines {
+		if n, ok := e["name"].(string); ok {
+			names[n] = true
+		}
+	}
+	for _, expected := range []string{
+		"probe", "retention", "snmp-poller",
+		"topology-sysinfo-reconciler", "alert-listener-pipeline",
+	} {
+		if !names[expected] {
+			t.Errorf("missing engine %q in response", expected)
+		}
+	}
+}
+
+func TestHandleEngines_RejectsNonGET(t *testing.T) {
+	s := &Server{services: NewServiceContainer()}
+	req := httptest.NewRequest(http.MethodPost, APIVersionPrefix+"/engines", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleEngines(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleEngines_NoServicesReturnsEmpty(t *testing.T) {
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/engines", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleEngines(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		Count int `json:"count"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Count != 0 {
+		t.Errorf("count = %d, want 0", resp.Count)
+	}
+}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -48,6 +48,10 @@ func (s *Server) setupTopologyRoutes() {
 	// requires the operator+ role.
 	s.mux.HandleFunc(APIVersionPrefix+"/polling-targets", s.writeGated(s.handlePollingTargets))
 	s.mux.HandleFunc(APIVersionPrefix+"/polling-targets/", s.writeGated(s.handlePollingTargetByID))
+
+	// Stage A5.8 — read-only engine registry surface. Useful for
+	// the operator UI's "what's running" pane and for ops debugging.
+	s.mux.HandleFunc(APIVersionPrefix+"/engines", s.handleEngines)
 }
 
 // setupAPITokenRoutes registers the Phase D-2 personal-access-token


### PR DESCRIPTION
## Summary
Item 3 of 5 — read-only admin endpoint listing every long-running
subsystem registered with `services.Engines`. Useful for the
operator UI's "what's running" pane and ops debugging.

  GET /api/v1/engines → { "count": N, "engines": [{"name": "..."}, ...] }

## Validation
- `go test ./internal/api/...` → green
- `golangci-lint run` → 0 issues