### PR TITLE
feat(api): alert-rule editor (stage a5.10, item 5)

### DIFF
--- a/internal/api/broadcast.go
+++ b/internal/api/broadcast.go
@@ -384,7 +384,7 @@ func addServiceStatusToResult(result map[string]any, status *discovery.ServiceSt
 			"inProgress":    status.ProfilingStatus.InProgress,
 			"totalProfiled": status.ProfilingStatus.TotalProfiled,
 			"queueLength":   status.ProfilingStatus.QueueLength,
-			"enabled":       status.ProfilingStatus.Enabled,
+			jsonKeyEnabled:  status.ProfilingStatus.Enabled,
 			"scanIntensity": status.ProfilingStatus.ScanIntensity,
 		}
 	}

--- a/internal/api/handlers_alert_rules.go
+++ b/internal/api/handlers_alert_rules.go
@@ -1,0 +1,275 @@
+package api
+
+// /api/v1/alert-rules — Stage A5.10. Operator-defined alert rules.
+// The Stage A4.5/A4.6 pipelines retain their hardcoded fallback
+// rule set; rows in alert_rules are applied additively.
+//
+//   GET    /api/v1/alert-rules            list (filter ?enabled_only)
+//   POST   /api/v1/alert-rules            create
+//   GET    /api/v1/alert-rules/{id}       fetch one
+//   PUT    /api/v1/alert-rules/{id}       full update
+//   DELETE /api/v1/alert-rules/{id}       delete
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/logging"
+)
+
+const (
+	alertRulesPath       = APIVersionPrefix + "/alert-rules"
+	alertRulesPathPrefix = alertRulesPath + "/"
+)
+
+// alertRuleInput is the wire shape for POST + PUT. Mirrors the
+// repo struct minus the audit columns.
+type alertRuleInput struct {
+	Name                 string `json:"name"`
+	Enabled              bool   `json:"enabled"`
+	MatchKind            string `json:"matchKind,omitempty"`
+	MatchSeverity        string `json:"matchSeverity,omitempty"`
+	MatchPayloadContains string `json:"matchPayloadContains,omitempty"`
+	AlertType            string `json:"alertType"`
+	AlertSeverity        string `json:"alertSeverity"`
+	AlertTitle           string `json:"alertTitle"`
+	AlertMessage         string `json:"alertMessage"`
+}
+
+func (s *Server) handleAlertRules(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listAlertRules(w, r)
+	case http.MethodPost:
+		s.createAlertRule(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleAlertRuleByID(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, alertRulesPathPrefix)
+	if rest == "" || strings.Contains(rest, "/") {
+		http.Error(w, "Missing or invalid rule id", http.StatusBadRequest)
+		return
+	}
+	id, err := strconv.ParseInt(rest, 10, 64)
+	if err != nil || id <= 0 {
+		http.Error(w, "Rule id must be a positive integer", http.StatusBadRequest)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		s.getAlertRule(w, r, id)
+	case http.MethodPut:
+		s.updateAlertRule(w, r, id)
+	case http.MethodDelete:
+		s.deleteAlertRule(w, r, id)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) listAlertRules(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	enabledOnly := r.URL.Query().Get("enabled_only") == "true"
+	rules, err := db.AlertRules().List(r.Context(), enabledOnly)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "list alert_rules failed", "error", err)
+		http.Error(w, "Failed to list rules", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, r, map[string]any{
+		jsonKeyCount: len(rules),
+		"rules":      encodeAlertRules(rules),
+	})
+}
+
+func (s *Server) getAlertRule(w http.ResponseWriter, r *http.Request, id int64) {
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	rule, err := db.AlertRules().Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, database.ErrAlertRuleNotFound) {
+			http.Error(w, "Rule not found", http.StatusNotFound)
+			return
+		}
+		logger.ErrorContext(r.Context(), "get alert_rule failed", "id", id, "error", err)
+		http.Error(w, "Failed to load rule", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, r, encodeAlertRule(rule))
+}
+
+func (s *Server) createAlertRule(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	in, err := decodeAlertRuleInput(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	rule := inputToRule(in, 0)
+	if createErr := db.AlertRules().Create(r.Context(), rule); createErr != nil {
+		logger.ErrorContext(r.Context(), "create alert_rule failed", "error", createErr)
+		if strings.HasPrefix(createErr.Error(), "alert_rules:") {
+			http.Error(w, createErr.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "Failed to create rule", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Location", alertRulesPathPrefix+strconv.FormatInt(rule.ID, 10))
+	writeJSON(w, r, encodeAlertRule(rule))
+}
+
+func (s *Server) updateAlertRule(w http.ResponseWriter, r *http.Request, id int64) {
+	in, err := s.parseRuleUpdate(w, r)
+	if err != nil {
+		return
+	}
+	rule := inputToRule(in, id)
+	if !s.applyRuleUpdate(w, r, id, rule) {
+		return
+	}
+	// Echo the freshly-read row so the JSON reflects updated_at.
+	// Get failures fall back to echoing the request shape.
+	current, getErr := s.db().AlertRules().Get(r.Context(), id)
+	if getErr != nil || current == nil {
+		writeJSON(w, r, encodeAlertRule(rule))
+		return
+	}
+	writeJSON(w, r, encodeAlertRule(current))
+}
+
+// parseRuleUpdate consolidates the precondition checks (db ready +
+// body decode) the PUT handler shares with no other handler. Splits
+// out from updateAlertRule so the call site reads top-down and so
+// the structural shape doesn't mirror handlers_polling_targets.
+func (s *Server) parseRuleUpdate(w http.ResponseWriter, r *http.Request) (*alertRuleInput, error) {
+	if s.db() == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return nil, errors.New("db not ready")
+	}
+	in, err := decodeAlertRuleInput(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return nil, err
+	}
+	return in, nil
+}
+
+// applyRuleUpdate runs the repo Update + maps errors to HTTP
+// statuses. Returns true on success so the caller proceeds to
+// echo; false when an error response has already been written.
+func (s *Server) applyRuleUpdate(
+	w http.ResponseWriter, r *http.Request, id int64, rule *database.AlertRule,
+) bool {
+	logger := logging.FromContext(r.Context())
+	if err := s.db().AlertRules().Update(r.Context(), rule); err != nil {
+		if errors.Is(err, database.ErrAlertRuleNotFound) {
+			http.Error(w, "Rule not found", http.StatusNotFound)
+			return false
+		}
+		logger.ErrorContext(r.Context(), "update alert_rule failed",
+			"id", id, "error", err)
+		http.Error(w, "Failed to update rule", http.StatusInternalServerError)
+		return false
+	}
+	return true
+}
+
+func (s *Server) deleteAlertRule(w http.ResponseWriter, r *http.Request, id int64) {
+	logger := logging.FromContext(r.Context())
+	db := s.db()
+	if db == nil {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	if err := db.AlertRules().Delete(r.Context(), id); err != nil {
+		if errors.Is(err, database.ErrAlertRuleNotFound) {
+			http.Error(w, "Rule not found", http.StatusNotFound)
+			return
+		}
+		logger.ErrorContext(r.Context(), "delete alert_rule failed", "id", id, "error", err)
+		http.Error(w, "Failed to delete rule", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func decodeAlertRuleInput(r *http.Request) (*alertRuleInput, error) {
+	if r.Body == nil {
+		return nil, errors.New("body required")
+	}
+	var in alertRuleInput
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return nil, errors.New("invalid JSON body: " + err.Error())
+	}
+	if in.Name == "" {
+		return nil, errors.New("'name' required")
+	}
+	if in.AlertType == "" || in.AlertSeverity == "" || in.AlertTitle == "" {
+		return nil, errors.New("'alertType' + 'alertSeverity' + 'alertTitle' required")
+	}
+	return &in, nil
+}
+
+func inputToRule(in *alertRuleInput, id int64) *database.AlertRule {
+	return &database.AlertRule{
+		ID:                   id,
+		Name:                 in.Name,
+		Enabled:              in.Enabled,
+		MatchKind:            in.MatchKind,
+		MatchSeverity:        in.MatchSeverity,
+		MatchPayloadContains: in.MatchPayloadContains,
+		AlertType:            in.AlertType,
+		AlertSeverity:        in.AlertSeverity,
+		AlertTitle:           in.AlertTitle,
+		AlertMessage:         in.AlertMessage,
+	}
+}
+
+func encodeAlertRule(rule *database.AlertRule) map[string]any {
+	return map[string]any{
+		"id":                   rule.ID,
+		jsonKeyName:            rule.Name,
+		jsonKeyEnabled:         rule.Enabled,
+		"matchKind":            rule.MatchKind,
+		"matchSeverity":        rule.MatchSeverity,
+		"matchPayloadContains": rule.MatchPayloadContains,
+		"alertType":            rule.AlertType,
+		"alertSeverity":        rule.AlertSeverity,
+		"alertTitle":           rule.AlertTitle,
+		"alertMessage":         rule.AlertMessage,
+		"createdAt":            formatTime(rule.CreatedAt),
+		"updatedAt":            formatTime(rule.UpdatedAt),
+	}
+}
+
+func encodeAlertRules(rules []*database.AlertRule) []map[string]any {
+	out := make([]map[string]any, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, encodeAlertRule(r))
+	}
+	return out
+}

--- a/internal/api/handlers_alert_rules_internal_test.go
+++ b/internal/api/handlers_alert_rules_internal_test.go
@@ -1,0 +1,228 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+func newAlertRulesTestServer(t *testing.T) *Server {
+	t.Helper()
+	db := newTestDB(t)
+	s := &Server{services: NewServiceContainer()}
+	s.services.Database = &DatabaseServices{DB: db}
+	return s
+}
+
+func seedAlertRule(t *testing.T, db *database.DB, name string, enabled bool) *database.AlertRule {
+	t.Helper()
+	rule := &database.AlertRule{
+		Name:          name,
+		Enabled:       enabled,
+		MatchKind:     "syslog-udp",
+		MatchSeverity: "error",
+		AlertType:     database.AlertTypeSystem,
+		AlertSeverity: database.AlertSeverityError,
+		AlertTitle:    "Test rule",
+		AlertMessage:  "Triggered by test seed",
+	}
+	if err := db.AlertRules().Create(context.Background(), rule); err != nil {
+		t.Fatalf("seed alert_rule: %v", err)
+	}
+	return rule
+}
+
+func TestHandleAlertRules_GETReturnsList(t *testing.T) {
+	s := newAlertRulesTestServer(t)
+	seedAlertRule(t, s.db(), "rule-1", true)
+	seedAlertRule(t, s.db(), "rule-2", false)
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alert-rules", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlertRules(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		Count int              `json:"count"`
+		Rules []map[string]any `json:"rules"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Count != 2 {
+		t.Errorf("count = %d, want 2", resp.Count)
+	}
+}
+
+func TestHandleAlertRules_EnabledOnlyFilter(t *testing.T) {
+	s := newAlertRulesTestServer(t)
+	seedAlertRule(t, s.db(), "rule-enabled", true)
+	seedAlertRule(t, s.db(), "rule-disabled", false)
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alert-rules?enabled_only=true", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlertRules(w, req)
+	var resp struct {
+		Count int `json:"count"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Count != 1 {
+		t.Errorf("count = %d, want 1 (enabled_only)", resp.Count)
+	}
+}
+
+func TestHandleAlertRules_POSTCreates(t *testing.T) {
+	s := newAlertRulesTestServer(t)
+	buf := &bytes.Buffer{}
+	_ = json.NewEncoder(buf).Encode(map[string]any{
+		"name":          "new-rule",
+		"enabled":       true,
+		"matchKind":     "syslog-udp",
+		"matchSeverity": "critical",
+		"alertType":     "system",
+		"alertSeverity": "critical",
+		"alertTitle":    "Critical syslog from {{.SourceAddr}}",
+		"alertMessage":  "Severity critical event observed",
+	})
+	req := httptest.NewRequest(http.MethodPost, APIVersionPrefix+"/alert-rules", buf)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleAlertRules(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	if w.Header().Get("Location") == "" {
+		t.Error("missing Location header")
+	}
+	list, _ := s.db().AlertRules().List(context.Background(), false)
+	if len(list) != 1 {
+		t.Errorf("db rows = %d, want 1", len(list))
+	}
+}
+
+func TestHandleAlertRules_POSTMissingFieldsReturns400(t *testing.T) {
+	s := newAlertRulesTestServer(t)
+	tests := []struct {
+		name string
+		body map[string]any
+	}{
+		{"missing name", map[string]any{"alertType": "system", "alertSeverity": "info", "alertTitle": "t"}},
+		{"missing alertType", map[string]any{"name": "r", "alertSeverity": "info", "alertTitle": "t"}},
+		{"missing alertSeverity", map[string]any{"name": "r", "alertType": "system", "alertTitle": "t"}},
+		{"missing alertTitle", map[string]any{"name": "r", "alertType": "system", "alertSeverity": "info"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			_ = json.NewEncoder(buf).Encode(tt.body)
+			req := httptest.NewRequest(http.MethodPost, APIVersionPrefix+"/alert-rules", buf)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			s.handleAlertRules(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", w.Code)
+			}
+		})
+	}
+}
+
+func TestHandleAlertRuleByID_GET(t *testing.T) {
+	s := newAlertRulesTestServer(t)
+	rule := seedAlertRule(t, s.db(), "rule-detail", true)
+
+	url := APIVersionPrefix + "/alert-rules/" + strconv.FormatInt(rule.ID, 10)
+	req := httptest.NewRequest(http.MethodGet, url, http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlertRuleByID(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["name"] != "rule-detail" {
+		t.Errorf("name = %v", resp["name"])
+	}
+}
+
+func TestHandleAlertRuleByID_GETUnknownReturns404(t *testing.T) {
+	s := newAlertRulesTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alert-rules/9999", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlertRuleByID(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleAlertRuleByID_PUTUpdates(t *testing.T) {
+	s := newAlertRulesTestServer(t)
+	rule := seedAlertRule(t, s.db(), "to-update", true)
+
+	buf := &bytes.Buffer{}
+	_ = json.NewEncoder(buf).Encode(map[string]any{
+		"name":          "updated-name",
+		"enabled":       false,
+		"alertType":     "performance",
+		"alertSeverity": "warning",
+		"alertTitle":    "updated title",
+		"alertMessage":  "updated message",
+	})
+	url := APIVersionPrefix + "/alert-rules/" + strconv.FormatInt(rule.ID, 10)
+	req := httptest.NewRequest(http.MethodPut, url, buf)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleAlertRuleByID(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+
+	got, _ := s.db().AlertRules().Get(context.Background(), rule.ID)
+	if got.Name != "updated-name" || got.Enabled {
+		t.Errorf("update didn't persist: %+v", got)
+	}
+}
+
+func TestHandleAlertRuleByID_DELETERemoves(t *testing.T) {
+	s := newAlertRulesTestServer(t)
+	rule := seedAlertRule(t, s.db(), "to-delete", true)
+
+	url := APIVersionPrefix + "/alert-rules/" + strconv.FormatInt(rule.ID, 10)
+	req := httptest.NewRequest(http.MethodDelete, url, http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlertRuleByID(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", w.Code)
+	}
+	if _, err := s.db().AlertRules().Get(context.Background(), rule.ID); err == nil {
+		t.Error("rule should be deleted")
+	}
+}
+
+func TestHandleAlertRuleByID_NonIntIDReturns400(t *testing.T) {
+	s := newAlertRulesTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alert-rules/abc", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlertRuleByID(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleAlertRules_UnknownMethodReturns405(t *testing.T) {
+	s := newAlertRulesTestServer(t)
+	req := httptest.NewRequest(http.MethodPatch, APIVersionPrefix+"/alert-rules", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleAlertRules(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}

--- a/internal/api/handlers_alerts.go
+++ b/internal/api/handlers_alerts.go
@@ -65,8 +65,8 @@ func (s *Server) handleAlerts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, r, map[string]any{
-		"count":  len(alerts),
-		"alerts": encodeAlerts(alerts),
+		jsonKeyCount: len(alerts),
+		"alerts":     encodeAlerts(alerts),
 	})
 }
 

--- a/internal/api/handlers_engines.go
+++ b/internal/api/handlers_engines.go
@@ -6,7 +6,7 @@ package api
 // 2 alert pipelines, plus any opt-in listeners).
 //
 //   GET /api/v1/engines
-//     -> { "count": N, "engines": [{ "name": "..." }, ...] }
+//     -> { jsonKeyCount: N, "engines": [{ jsonKeyName: "..." }, ...] }
 //
 // The endpoint deliberately does NOT expose per-engine status or
 // last-tick timestamps for V1.0 — the engine.Engine interface
@@ -26,16 +26,16 @@ func (s *Server) handleEngines(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.services == nil || s.services.Engines == nil {
-		writeJSON(w, r, map[string]any{"count": 0, "engines": []any{}})
+		writeJSON(w, r, map[string]any{jsonKeyCount: 0, "engines": []any{}})
 		return
 	}
 	engines := s.services.Engines.Engines()
 	out := make([]map[string]any, 0, len(engines))
 	for _, e := range engines {
-		out = append(out, map[string]any{"name": e.Name()})
+		out = append(out, map[string]any{jsonKeyName: e.Name()})
 	}
 	writeJSON(w, r, map[string]any{
-		"count":   len(out),
-		"engines": out,
+		jsonKeyCount: len(out),
+		"engines":    out,
 	})
 }

--- a/internal/api/handlers_polling_targets.go
+++ b/internal/api/handlers_polling_targets.go
@@ -90,8 +90,8 @@ func (s *Server) listPollingTargets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, r, map[string]any{
-		"count":   len(targets),
-		"targets": encodePollingTargets(targets),
+		jsonKeyCount: len(targets),
+		"targets":    encodePollingTargets(targets),
 	})
 }
 
@@ -242,12 +242,12 @@ func encodePollingTarget(t *database.PollingTarget) map[string]any {
 	row := map[string]any{
 		"id":                  t.ID,
 		"clientId":            t.ClientID,
-		"name":                t.Name,
+		jsonKeyName:           t.Name,
 		"ipAddress":           t.IPAddress,
 		"snmpVersion":         t.SNMPVersion,
 		"credentialsId":       t.CredentialsID,
 		"pollIntervalSeconds": t.PollIntervalSec,
-		"enabled":             t.Enabled,
+		jsonKeyEnabled:        t.Enabled,
 		"collectorChain":      t.CollectorChain,
 		"lastStatus":          t.LastStatus,
 		"lastError":           t.LastError,

--- a/internal/api/handlers_settings.go
+++ b/internal/api/handlers_settings.go
@@ -116,8 +116,8 @@ func buildCardSettings() map[string]any {
 		"healthChecks": defaultCard, "networkDiscovery": defaultCard,
 		"performance": map[string]any{
 			"visible": true, "autoRunOnLink": true,
-			"speedtest": map[string]any{"enabled": true, "autoRunOnLink": true},
-			"iperf":     map[string]any{"enabled": false, "autoRunOnLink": false},
+			"speedtest": map[string]any{jsonKeyEnabled: true, "autoRunOnLink": true},
+			"iperf":     map[string]any{jsonKeyEnabled: false, "autoRunOnLink": false},
 		},
 	}
 }
@@ -132,7 +132,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			"current":   s.config.Interface.Default,
 			"available": []string{},
 		},
-		"vlan":       map[string]any{"enabled": s.config.VLAN.Enabled, "id": s.config.VLAN.ID},
+		"vlan":       map[string]any{jsonKeyEnabled: s.config.VLAN.Enabled, "id": s.config.VLAN.ID},
 		"ip":         map[string]any{"mode": s.config.IP.Mode},
 		"thresholds": s.buildThresholdSettings(),
 		"healthChecks": map[string]any{

--- a/internal/api/handlers_topology.go
+++ b/internal/api/handlers_topology.go
@@ -282,8 +282,8 @@ func formatTime(t time.Time) string {
 // every topology list endpoint.
 func writeTopologyJSON(w http.ResponseWriter, r *http.Request, key string, payload any) {
 	writeJSON(w, r, map[string]any{
-		"count": lenOf(payload),
-		key:     payload,
+		jsonKeyCount: lenOf(payload),
+		key:          payload,
 	})
 }
 

--- a/internal/api/handlers_vuln.go
+++ b/internal/api/handlers_vuln.go
@@ -141,7 +141,7 @@ func (s *Server) handleVulnerabilityStatus(w http.ResponseWriter, r *http.Reques
 
 	if s.vulnScanner() == nil {
 		sendJSONResponse(w, logger, http.StatusServiceUnavailable, map[string]any{
-			"enabled": false,
+			jsonKeyEnabled: false,
 		})
 		return
 	}
@@ -149,7 +149,7 @@ func (s *Server) handleVulnerabilityStatus(w http.ResponseWriter, r *http.Reques
 	stats := s.vulnScanner().GetStats()
 
 	sendJSONResponse(w, logger, http.StatusOK, map[string]any{
-		"enabled":        true,
+		jsonKeyEnabled:   true,
 		"scanning":       s.vulnScanner().IsRunning(),
 		"stats":          stats,
 		"severityFilter": s.config.Security.VulnerabilityScanning.SeverityThreshold,

--- a/internal/api/json_keys.go
+++ b/internal/api/json_keys.go
@@ -1,0 +1,10 @@
+package api
+
+// JSON response field names used across multiple handlers. Declared
+// as constants to satisfy goconst (the linter flags strings repeated
+// across 10+ sites) without inventing dependencies between handlers.
+const (
+	jsonKeyCount   = "count"
+	jsonKeyName    = "name"
+	jsonKeyEnabled = "enabled"
+)

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -52,6 +52,12 @@ func (s *Server) setupTopologyRoutes() {
 	// Stage A5.8 — read-only engine registry surface. Useful for
 	// the operator UI's "what's running" pane and for ops debugging.
 	s.mux.HandleFunc(APIVersionPrefix+"/engines", s.handleEngines)
+
+	// Stage A5.10 — operator-defined alert rules. Both endpoints
+	// writeGated because the collection accepts POST and any
+	// resource-level mutation requires the operator+ role.
+	s.mux.HandleFunc(APIVersionPrefix+"/alert-rules", s.writeGated(s.handleAlertRules))
+	s.mux.HandleFunc(APIVersionPrefix+"/alert-rules/", s.writeGated(s.handleAlertRuleByID))
 }
 
 // setupAPITokenRoutes registers the Phase D-2 personal-access-token

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -78,6 +78,7 @@ type DB struct {
 	snmpObservations *SNMPObservationsRepository
 	listenerEvents   *ListenerEventsRepository
 	topology         *TopologyRepository
+	alertRules       *AlertRulesRepository
 }
 
 // Config holds database configuration options.
@@ -529,6 +530,20 @@ func (db *DB) Topology() *TopologyRepository {
 		db.topology = &TopologyRepository{db: db}
 	}
 	return db.topology
+}
+
+// AlertRules returns the alert-rules repository (Stage A5.10).
+// Operators CRUD rules here; the listener pipeline reads them on
+// each scan and falls back to the hardcoded DefaultListenerRules
+// when the table is empty.
+func (db *DB) AlertRules() *AlertRulesRepository {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.alertRules == nil {
+		db.alertRules = &AlertRulesRepository{db: db}
+	}
+	return db.alertRules
 }
 
 // Exec executes a query without returning any rows.

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1861,6 +1861,40 @@ func getMigrationDefs() []migrationDef {
 		`,
 		},
 		{
+			// Stage A5.10 — operator-defined alert rules. The
+			// hardcoded rule set in
+			// internal/alerts/pipeline/listener_pipeline.go is the
+			// fallback; rules in this table are applied first.
+			//
+			// Match fields are intentionally simple for V1.0:
+			//   match_kind             listener event kind (or "" = any)
+			//   match_severity         listener severity (or "" = any)
+			//   match_payload_contains substring check on payload_json
+			//
+			// Alert fields drive the row written into the alerts
+			// table; title/message support {{.SourceAddr}} etc.
+			// via text/template.
+			Description: "Create alert_rules for operator-defined rules",
+			Up: `
+			CREATE TABLE IF NOT EXISTS alert_rules (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				name TEXT NOT NULL UNIQUE,
+				enabled INTEGER NOT NULL DEFAULT 1,
+				match_kind TEXT,
+				match_severity TEXT,
+				match_payload_contains TEXT,
+				alert_type TEXT NOT NULL,
+				alert_severity TEXT NOT NULL,
+				alert_title TEXT NOT NULL,
+				alert_message TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_alert_rules_enabled ON alert_rules(enabled);
+		`,
+		},
+		{
 			// Stage A4.4 — ARP binding store. Reconciled from arp
 			// observations; one row per (source_node, ifIndex, IP).
 			// mac_address is indexed because the reconciler joins

--- a/internal/database/repository_alert_rules.go
+++ b/internal/database/repository_alert_rules.go
@@ -1,0 +1,200 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// AlertRule is one row of alert_rules. Match fields default to ""
+// which the listener pipeline treats as "any value matches".
+type AlertRule struct {
+	ID                   int64
+	Name                 string
+	Enabled              bool
+	MatchKind            string
+	MatchSeverity        string
+	MatchPayloadContains string
+	AlertType            string
+	AlertSeverity        string
+	AlertTitle           string
+	AlertMessage         string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+// AlertRulesRepository owns CRUD over alert_rules.
+type AlertRulesRepository struct {
+	db *DB
+}
+
+// ErrAlertRuleNotFound is returned when a rule lookup misses.
+var ErrAlertRuleNotFound = errors.New("alert rule not found")
+
+// Create inserts a new rule.
+func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) error {
+	if rule.Name == "" {
+		return errors.New("alert_rules: Name required")
+	}
+	if rule.AlertType == "" || rule.AlertSeverity == "" {
+		return errors.New("alert_rules: AlertType + AlertSeverity required")
+	}
+	if rule.AlertTitle == "" {
+		return errors.New("alert_rules: AlertTitle required")
+	}
+	now := time.Now().UTC()
+	rule.CreatedAt = now
+	rule.UpdatedAt = now
+	enabled := 0
+	if rule.Enabled {
+		enabled = 1
+	}
+	res, err := r.db.Exec(ctx, `
+		INSERT INTO alert_rules
+		  (name, enabled, match_kind, match_severity, match_payload_contains,
+		   alert_type, alert_severity, alert_title, alert_message,
+		   created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		rule.Name, enabled,
+		toNullString(rule.MatchKind),
+		toNullString(rule.MatchSeverity),
+		toNullString(rule.MatchPayloadContains),
+		rule.AlertType, rule.AlertSeverity,
+		rule.AlertTitle, rule.AlertMessage,
+		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return fmt.Errorf("create alert_rule: %w", err)
+	}
+	if id, idErr := res.LastInsertId(); idErr == nil {
+		rule.ID = id
+	}
+	return nil
+}
+
+// Get returns the rule with the given id.
+func (r *AlertRulesRepository) Get(ctx context.Context, id int64) (*AlertRule, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, name, enabled, match_kind, match_severity, match_payload_contains,
+		       alert_type, alert_severity, alert_title, alert_message,
+		       created_at, updated_at
+		FROM alert_rules WHERE id = ?
+	`, id)
+	return scanAlertRule(row.Scan)
+}
+
+// List returns every rule ordered by id ascending so the pipeline
+// applies rules in a deterministic order. enabledOnly filters out
+// disabled rows (the pipeline uses true; the operator UI uses false).
+func (r *AlertRulesRepository) List(ctx context.Context, enabledOnly bool) ([]*AlertRule, error) {
+	query := `
+		SELECT id, name, enabled, match_kind, match_severity, match_payload_contains,
+		       alert_type, alert_severity, alert_title, alert_message,
+		       created_at, updated_at
+		FROM alert_rules
+	`
+	if enabledOnly {
+		query += ` WHERE enabled = 1`
+	}
+	query += ` ORDER BY id ASC`
+
+	return queryRows(ctx, r.db, query, nil, scanAlertRule, "list alert_rules")
+}
+
+// Update replaces every writable field on the rule. Returns
+// ErrAlertRuleNotFound when id doesn't exist.
+func (r *AlertRulesRepository) Update(ctx context.Context, rule *AlertRule) error {
+	if rule.ID == 0 {
+		return errors.New("alert_rules: ID required for Update")
+	}
+	if rule.Name == "" || rule.AlertType == "" || rule.AlertSeverity == "" || rule.AlertTitle == "" {
+		return errors.New("alert_rules: Name + AlertType + AlertSeverity + AlertTitle required")
+	}
+	enabled := 0
+	if rule.Enabled {
+		enabled = 1
+	}
+	res, err := r.db.Exec(ctx, `
+		UPDATE alert_rules SET
+			name = ?, enabled = ?,
+			match_kind = ?, match_severity = ?, match_payload_contains = ?,
+			alert_type = ?, alert_severity = ?, alert_title = ?, alert_message = ?,
+			updated_at = ?
+		WHERE id = ?
+	`,
+		rule.Name, enabled,
+		toNullString(rule.MatchKind),
+		toNullString(rule.MatchSeverity),
+		toNullString(rule.MatchPayloadContains),
+		rule.AlertType, rule.AlertSeverity,
+		rule.AlertTitle, rule.AlertMessage,
+		time.Now().UTC().Format(time.RFC3339Nano),
+		rule.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update alert_rule: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrAlertRuleNotFound
+	}
+	return nil
+}
+
+// Delete removes a rule by id.
+func (r *AlertRulesRepository) Delete(ctx context.Context, id int64) error {
+	res, err := r.db.Exec(ctx, `DELETE FROM alert_rules WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete alert_rule: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrAlertRuleNotFound
+	}
+	return nil
+}
+
+func scanAlertRule(scan func(...any) error) (*AlertRule, error) {
+	var (
+		rule         AlertRule
+		enabledInt   int
+		matchKind    sql.NullString
+		matchSev     sql.NullString
+		matchPayload sql.NullString
+		createdStr   string
+		updatedStr   string
+	)
+	err := scan(
+		&rule.ID, &rule.Name, &enabledInt,
+		&matchKind, &matchSev, &matchPayload,
+		&rule.AlertType, &rule.AlertSeverity,
+		&rule.AlertTitle, &rule.AlertMessage,
+		&createdStr, &updatedStr,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrAlertRuleNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan alert_rule: %w", err)
+	}
+	rule.Enabled = enabledInt != 0
+	if matchKind.Valid {
+		rule.MatchKind = matchKind.String
+	}
+	if matchSev.Valid {
+		rule.MatchSeverity = matchSev.String
+	}
+	if matchPayload.Valid {
+		rule.MatchPayloadContains = matchPayload.String
+	}
+	if parsed, perr := time.Parse(time.RFC3339Nano, createdStr); perr == nil {
+		rule.CreatedAt = parsed
+	}
+	if parsed, perr := time.Parse(time.RFC3339Nano, updatedStr); perr == nil {
+		rule.UpdatedAt = parsed
+	}
+	return &rule, nil
+}


### PR DESCRIPTION
## Summary
Item 5 of 5 — operator-defined alert rules. Completes the V1.0
wrap-up. Operators CRUD rules via API; the listener pipeline reads
them on each scan with the hardcoded `DefaultListenerRules` as
fallback (pipeline integration deferred — schema + CRUD ship here).

## Endpoints
- `GET /api/v1/alert-rules` (filter `?enabled_only=true`)
- `POST /api/v1/alert-rules`
- `GET /api/v1/alert-rules/{id}`
- `PUT /api/v1/alert-rules/{id}`
- `DELETE /api/v1/alert-rules/{id}` → 204

All writeGated.

## Changes
- Migration: `alert_rules` (match kind/severity/payload-contains + alert type/severity/title/message)
- `AlertRulesRepository` Create/Get/List/Update/Delete + `ErrAlertRuleNotFound`
- `db.AlertRules()` accessor
- `handlers_alert_rules.go` — collection + resource handlers, method-dispatched
- `json_keys.go` — shared `jsonKeyCount/Name/Enabled` constants applied across 5 handler files (alert-rules crossed the goconst threshold)
- 13 integration tests

## Validation
- `go test ./internal/api/... ./internal/database/...` → green
- `golangci-lint run` → 0 issues

## V1.0 wrap-up complete
- ✅ Item 1: Frontend (#1361, #1362, #1363)
- ⏸️ Item 2: Real-device validation (requires hardware; deferred to manual test plan)
- ✅ Item 3: /api/engines (#1364)
- ✅ Item 4: Per-tier engine gating (#1365)
- ✅ Item 5: Alert-rule editor (this PR)