### PR TITLE
feat(alerts): load listener rules from db with hot reload

### DIFF
--- a/internal/alerts/pipeline/listener_pipeline.go
+++ b/internal/alerts/pipeline/listener_pipeline.go
@@ -96,12 +96,12 @@ type ListenerPipeline struct {
 	defaults       []Rule
 	suppression    time.Duration
 
-	mu      sync.Mutex
-	started bool
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
-	emitted map[string]time.Time
-	rules   []Rule
+	mu       sync.Mutex
+	started  bool
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	suppress suppressionStore
+	rules    []Rule
 }
 
 // ListenerConfig wires the pipeline.
@@ -131,6 +131,13 @@ type ListenerConfig struct {
 	// When nil and AlertRules is also nil, DefaultListenerRules() is
 	// used permanently.
 	Rules []Rule
+
+	// Suppressions is the persistence backend for the per-(rule, entity)
+	// "don't re-fire within the window" check. When nil, an in-memory
+	// store is used (legacy — restart loses state). Production wires
+	// NewDBSuppressionStore(db.AlertSuppressions()) for restart-safety
+	// (#1380).
+	Suppressions suppressionStore
 }
 
 // NewListenerPipeline returns an unstarted pipeline.
@@ -171,6 +178,10 @@ func NewListenerPipeline(cfg ListenerConfig) (*ListenerPipeline, error) {
 	if initial == nil {
 		initial = defaults
 	}
+	suppress := cfg.Suppressions
+	if suppress == nil {
+		suppress = newInMemorySuppressionStore()
+	}
 	p := &ListenerPipeline{
 		events:         cfg.Events,
 		alerts:         cfg.Alerts,
@@ -184,7 +195,7 @@ func NewListenerPipeline(cfg ListenerConfig) (*ListenerPipeline, error) {
 		defaults:       defaults,
 		suppression:    cfg.Suppression,
 		rules:          initial,
-		emitted:        make(map[string]time.Time),
+		suppress:       suppress,
 	}
 	// Prime ruleset from the DB before returning so a caller that
 	// jumps straight to ScanOnce (tests, single-shot use) sees the
@@ -394,7 +405,12 @@ func (p *ListenerPipeline) evaluate(ctx context.Context, evt *database.ListenerE
 			continue
 		}
 		fingerprint := fingerprintFor(rule.ID, evt.SourceAddr, evt.Kind)
-		if p.suppressed(fingerprint, now) {
+		suppressed, suppErr := p.suppress.IsSuppressed(ctx, fingerprint, now)
+		if suppErr != nil {
+			p.logger.WarnContext(ctx, "suppression check failed",
+				"rule", rule.ID, "error", suppErr)
+		}
+		if suppressed {
 			continue
 		}
 		alert := rule.Build(evt)
@@ -406,7 +422,13 @@ func (p *ListenerPipeline) evaluate(ctx context.Context, evt *database.ListenerE
 				"rule", rule.ID, "source", evt.SourceAddr, "error", writeErr)
 			continue
 		}
-		p.markEmitted(fingerprint, now)
+		markErr := p.suppress.Mark(
+			ctx, fingerprint, rule.ID, evt.SourceAddr, now.Add(p.suppression),
+		)
+		if markErr != nil {
+			p.logger.WarnContext(ctx, "suppression mark failed",
+				"rule", rule.ID, "error", markErr)
+		}
 		count++
 	}
 	return count
@@ -421,38 +443,6 @@ func fingerprintFor(ruleID, source, kind string) string {
 	h.Write([]byte{0x00})
 	h.Write([]byte(kind))
 	return hex.EncodeToString(h.Sum(nil))[:24]
-}
-
-// suppressed returns true when this fingerprint has fired within the
-// suppression window.
-func (p *ListenerPipeline) suppressed(fingerprint string, now time.Time) bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	last, ok := p.emitted[fingerprint]
-	if !ok {
-		return false
-	}
-	return now.Sub(last) < p.suppression
-}
-
-// markEmitted records the fire time for a fingerprint. Old entries
-// (>2x suppression window) are evicted lazily to keep the map
-// bounded.
-func (p *ListenerPipeline) markEmitted(fingerprint string, now time.Time) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.emitted[fingerprint] = now
-	// Lazy eviction: walk the map only when it gets noticeably big.
-	const evictThreshold = 4096
-	if len(p.emitted) <= evictThreshold {
-		return
-	}
-	cutoff := now.Add(-2 * p.suppression)
-	for k, v := range p.emitted {
-		if v.Before(cutoff) {
-			delete(p.emitted, k)
-		}
-	}
 }
 
 func (p *ListenerPipeline) loadHighWater(ctx context.Context) (time.Time, error) {

--- a/internal/alerts/pipeline/listener_pipeline.go
+++ b/internal/alerts/pipeline/listener_pipeline.go
@@ -37,10 +37,11 @@ const listenerHighWaterKey = "alerts.listener.high_water"
 
 // Tunables — production defaults.
 const (
-	defaultBatch       = 500
-	defaultInterval    = 15 * time.Second
-	minInterval        = 100 * time.Millisecond
-	defaultSuppression = 5 * time.Minute
+	defaultBatch          = 500
+	defaultInterval       = 15 * time.Second
+	minInterval           = 100 * time.Millisecond
+	defaultSuppression    = 5 * time.Minute
+	defaultReloadInterval = 60 * time.Second
 )
 
 // listenerReader is the narrowed surface the listener pipeline
@@ -83,20 +84,24 @@ type Rule struct {
 // for every event matching any built-in rule. Suppression dedupes
 // repeated alerts for the same (rule, source) within the window.
 type ListenerPipeline struct {
-	events      listenerReader
-	alerts      alertWriter
-	settings    settingsKV
-	logger      *slog.Logger
-	now         func() time.Time
-	interval    time.Duration
-	rules       []Rule
-	suppression time.Duration
+	events         listenerReader
+	alerts         alertWriter
+	settings       settingsKV
+	alertRules     alertRulesReader
+	logger         *slog.Logger
+	now            func() time.Time
+	interval       time.Duration
+	reloadInterval time.Duration
+	staticRules    bool // true when Config.Rules was supplied; reloading disabled
+	defaults       []Rule
+	suppression    time.Duration
 
 	mu      sync.Mutex
 	started bool
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 	emitted map[string]time.Time
+	rules   []Rule
 }
 
 // ListenerConfig wires the pipeline.
@@ -109,8 +114,22 @@ type ListenerConfig struct {
 	Interval    time.Duration
 	Suppression time.Duration
 
-	// Rules override the built-in set; when nil, DefaultListenerRules
-	// is used.
+	// AlertRules pulls operator-configured rows from alert_rules.
+	// When set, the pipeline reloads rules from the table on each
+	// ReloadInterval tick and falls back to DefaultListenerRules
+	// only when the table is empty / has no enabled rows.
+	// Ignored when Rules is also set (Rules wins for static-config
+	// tests).
+	AlertRules alertRulesReader
+
+	// ReloadInterval controls how often AlertRules is re-queried.
+	// Defaults to 60s; floored at 1s.
+	ReloadInterval time.Duration
+
+	// Rules override every other source; when set, the pipeline uses
+	// exactly these rules and never reloads. Primary use is tests.
+	// When nil and AlertRules is also nil, DefaultListenerRules() is
+	// used permanently.
 	Rules []Rule
 }
 
@@ -140,21 +159,45 @@ func NewListenerPipeline(cfg ListenerConfig) (*ListenerPipeline, error) {
 	if cfg.Suppression <= 0 {
 		cfg.Suppression = defaultSuppression
 	}
-	rules := cfg.Rules
-	if rules == nil {
-		rules = DefaultListenerRules()
+	if cfg.ReloadInterval <= 0 {
+		cfg.ReloadInterval = defaultReloadInterval
 	}
-	return &ListenerPipeline{
-		events:      cfg.Events,
-		alerts:      cfg.Alerts,
-		settings:    cfg.Settings,
-		logger:      cfg.Logger,
-		now:         cfg.Now,
-		interval:    cfg.Interval,
-		suppression: cfg.Suppression,
-		rules:       rules,
-		emitted:     make(map[string]time.Time),
-	}, nil
+	if cfg.ReloadInterval < time.Second {
+		cfg.ReloadInterval = time.Second
+	}
+	defaults := DefaultListenerRules()
+	staticRules := cfg.Rules != nil
+	initial := cfg.Rules
+	if initial == nil {
+		initial = defaults
+	}
+	p := &ListenerPipeline{
+		events:         cfg.Events,
+		alerts:         cfg.Alerts,
+		settings:       cfg.Settings,
+		alertRules:     cfg.AlertRules,
+		logger:         cfg.Logger,
+		now:            cfg.Now,
+		interval:       cfg.Interval,
+		reloadInterval: cfg.ReloadInterval,
+		staticRules:    staticRules,
+		defaults:       defaults,
+		suppression:    cfg.Suppression,
+		rules:          initial,
+		emitted:        make(map[string]time.Time),
+	}
+	// Prime ruleset from the DB before returning so a caller that
+	// jumps straight to ScanOnce (tests, single-shot use) sees the
+	// operator's configured rules rather than DefaultListenerRules.
+	// Failure here is non-fatal — the pipeline retains DefaultListenerRules
+	// and the next reload tick gets another chance.
+	if !staticRules && cfg.AlertRules != nil {
+		if reloadErr := p.ReloadRules(context.Background()); reloadErr != nil {
+			cfg.Logger.Warn("initial alert_rules load failed; using defaults",
+				"error", reloadErr)
+		}
+	}
+	return p, nil
 }
 
 // Name implements [engine.Engine].
@@ -162,6 +205,18 @@ func (*ListenerPipeline) Name() string { return ListenerPipelineName }
 
 // Start kicks off the scan loop. Idempotent.
 func (p *ListenerPipeline) Start(ctx context.Context) error {
+	// Prime the ruleset from DB before announcing started, so the
+	// first scan reflects operator config rather than the default
+	// rules for the first reload interval. A reload failure here is
+	// non-fatal — the pipeline retains DefaultListenerRules until a
+	// later reload succeeds.
+	if !p.staticRulesView() {
+		if reloadErr := p.ReloadRules(ctx); reloadErr != nil {
+			p.logger.WarnContext(ctx, "initial alert_rules reload failed; using defaults",
+				"error", reloadErr)
+		}
+	}
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.started {
@@ -172,9 +227,77 @@ func (p *ListenerPipeline) Start(ctx context.Context) error {
 	p.started = true
 	p.wg.Add(1)
 	go p.loop(loopCtx)
+	if !p.staticRules && p.alertRules != nil {
+		p.wg.Add(1)
+		go p.reloadLoop(loopCtx)
+	}
 	p.logger.InfoContext(ctx, "listener alert pipeline started",
-		"interval", p.interval, "rules", len(p.rules))
+		"interval", p.interval, "rules", len(p.rules),
+		"reload_interval", p.reloadInterval, "db_rules_active", p.alertRules != nil && !p.staticRules)
 	return nil
+}
+
+// staticRulesView reads p.staticRules without taking the mutex — safe
+// because it's set once at construction and never mutated.
+func (p *ListenerPipeline) staticRulesView() bool { return p.staticRules || p.alertRules == nil }
+
+// reloadLoop ticks every reloadInterval and pulls the latest enabled
+// rules from alertRules into the pipeline's ruleset.
+func (p *ListenerPipeline) reloadLoop(ctx context.Context) {
+	defer p.wg.Done()
+	t := time.NewTicker(p.reloadInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := p.ReloadRules(ctx); err != nil {
+				p.logger.WarnContext(ctx, "alert_rules reload failed; keeping previous ruleset",
+					"error", err)
+			}
+		}
+	}
+}
+
+// ReloadRules pulls every enabled alert_rules row, compiles them into
+// runtime rules, and swaps them in atomically. Falls back to
+// DefaultListenerRules when the DB has no enabled rows. Returns the
+// list error from the repo unchanged so callers can decide to log /
+// retry. Safe to call concurrently with ScanOnce.
+func (p *ListenerPipeline) ReloadRules(ctx context.Context) error {
+	if p.alertRules == nil || p.staticRules {
+		return nil
+	}
+	rows, err := p.alertRules.List(ctx, true)
+	if err != nil {
+		return err
+	}
+	compiled := CompileRulesFromDB(rows)
+	var next []Rule
+	var usingDefaults bool
+	if len(compiled) == 0 {
+		next = p.defaults
+		usingDefaults = true
+	} else {
+		next = compiled
+	}
+	p.mu.Lock()
+	p.rules = next
+	p.mu.Unlock()
+	p.logger.DebugContext(ctx, "alert_rules reloaded",
+		"db_rows", len(rows), "compiled", len(compiled),
+		"active_rules", len(next), "defaults_fallback", usingDefaults)
+	return nil
+}
+
+// snapshotRules returns the current ruleset under p.mu so concurrent
+// reloads can't observe a torn iteration. The slice is shared, not
+// cloned, because Rule entries are immutable after compilation.
+func (p *ListenerPipeline) snapshotRules() []Rule {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.rules
 }
 
 // Stop terminates the scan loop. Honors ctx deadline.
@@ -265,7 +388,8 @@ func (p *ListenerPipeline) ScanOnce(ctx context.Context) error {
 func (p *ListenerPipeline) evaluate(ctx context.Context, evt *database.ListenerEvent) int {
 	now := p.now()
 	count := 0
-	for _, rule := range p.rules {
+	rules := p.snapshotRules()
+	for _, rule := range rules {
 		if !rule.Match(evt) {
 			continue
 		}

--- a/internal/alerts/pipeline/listener_rules_loader.go
+++ b/internal/alerts/pipeline/listener_rules_loader.go
@@ -11,17 +11,48 @@ package pipeline
 // was rejected because it makes "why did this fire twice?" harder to
 // answer than "my rules win or yours do".
 //
-// V1.0 keeps titles and messages as literal strings. Template support
-// lands in #1378 by extending CompileRulesFromDB to parse AlertTitle/
-// AlertMessage as text/template before returning the Rule.
+// Template support (#1378): AlertTitle / AlertMessage are parsed as
+// text/template at compile time. The runtime context (exposed to
+// templates) is the ListenerEventContext struct below — operators
+// can interpolate SourceAddr, Kind, Severity, ReceivedAt, MatchedRuleName,
+// and the decoded payload map via .Payload.<field>. Strings without
+// template syntax take a fast path that skips template execution
+// entirely (zero allocs). A broken template (parse error) is logged
+// elsewhere and falls back to the literal string so a typo never
+// drops a rule from rotation.
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"strconv"
 	"strings"
+	"text/template"
+	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
 )
+
+// ListenerEventContext is the data passed to AlertTitle / AlertMessage
+// templates. Fields mirror the event the pipeline matched, plus the
+// rule's own name so templates can self-identify.
+//
+// Operators interpolate via the standard text/template syntax:
+//
+//	{{.SourceAddr}}             - "10.0.0.1:514"
+//	{{.Severity}}               - "error"
+//	{{.Kind}}                   - "syslog-udp"
+//	{{.ReceivedAt}}             - the event ObservedAt timestamp
+//	{{.MatchedRuleName}}        - the rule's Name column
+//	{{.Payload.message}}        - decoded JSON payload fields
+type ListenerEventContext struct {
+	SourceAddr      string
+	Kind            string
+	Severity        string
+	ReceivedAt      time.Time
+	Payload         map[string]any
+	MatchedRuleName string
+}
 
 // CompileRulesFromDB converts every enabled alert_rules row into a
 // runtime Rule. Disabled rows are dropped. Returns an empty slice
@@ -47,8 +78,10 @@ func compileOne(row *database.AlertRule) Rule {
 	// that doesn't accidentally pick up a future row mutation.
 	alertType := row.AlertType
 	alertSeverity := row.AlertSeverity
-	alertTitle := row.AlertTitle
-	alertMessage := row.AlertMessage
+	ruleName := row.Name
+
+	titleRenderer := compileTemplate(row.AlertTitle)
+	messageRenderer := compileTemplate(row.AlertMessage)
 
 	return Rule{
 		ID: "db." + strconv.FormatInt(row.ID, 10),
@@ -65,15 +98,63 @@ func compileOne(row *database.AlertRule) Rule {
 			return true
 		},
 		Build: func(evt *database.ListenerEvent) *database.Alert {
+			ctx := buildEventContext(evt, ruleName)
 			return &database.Alert{
 				Type:     alertType,
 				Severity: alertSeverity,
-				Title:    alertTitle,
-				Message:  alertMessage,
+				Title:    titleRenderer(ctx),
+				Message:  messageRenderer(ctx),
 				Source:   evt.SourceAddr,
 				Metadata: evt.PayloadJSON,
 			}
 		},
+	}
+}
+
+// templateRenderer is a closure that takes the event context and
+// returns the rendered string. Literal-string rules use a no-op
+// closure that just returns the original.
+type templateRenderer func(ListenerEventContext) string
+
+// compileTemplate returns a renderer for s. When s contains no
+// template syntax ("{{"), the renderer is a fast literal-pass-
+// through that allocates nothing. When s parses cleanly, the
+// renderer executes the template against the event context. A
+// parse failure leaves the literal in place so a typo never drops
+// a rule.
+func compileTemplate(s string) templateRenderer {
+	if !strings.Contains(s, "{{") {
+		return func(ListenerEventContext) string { return s }
+	}
+	tmpl, err := template.New("alert").Parse(s)
+	if err != nil {
+		return func(ListenerEventContext) string { return s }
+	}
+	return func(ctx ListenerEventContext) string {
+		var buf bytes.Buffer
+		if execErr := tmpl.Execute(&buf, ctx); execErr != nil {
+			return s
+		}
+		return buf.String()
+	}
+}
+
+// buildEventContext converts a ListenerEvent into the template-
+// visible struct. Payload JSON is best-effort decoded into a map
+// so templates can reach inside it via .Payload.<field>; a bad
+// payload renders as an empty map.
+func buildEventContext(evt *database.ListenerEvent, ruleName string) ListenerEventContext {
+	payload := map[string]any{}
+	if evt.PayloadJSON != "" {
+		_ = json.Unmarshal([]byte(evt.PayloadJSON), &payload)
+	}
+	return ListenerEventContext{
+		SourceAddr:      evt.SourceAddr,
+		Kind:            evt.Kind,
+		Severity:        evt.Severity,
+		ReceivedAt:      evt.ObservedAt,
+		Payload:         payload,
+		MatchedRuleName: ruleName,
 	}
 }
 

--- a/internal/alerts/pipeline/listener_rules_loader.go
+++ b/internal/alerts/pipeline/listener_rules_loader.go
@@ -1,0 +1,85 @@
+package pipeline
+
+// listener_rules_loader compiles operator-configured alert_rules rows
+// into the engine.Rule shape the listener pipeline already consumes.
+//
+// Semantics (#1377): when alert_rules has at least one enabled row,
+// the DB ruleset replaces DefaultListenerRules entirely. When the
+// table is empty (or every row is disabled), the pipeline falls back
+// to DefaultListenerRules so a fresh install keeps emitting alerts
+// without any operator action. Mixing the two ("additive merging")
+// was rejected because it makes "why did this fire twice?" harder to
+// answer than "my rules win or yours do".
+//
+// V1.0 keeps titles and messages as literal strings. Template support
+// lands in #1378 by extending CompileRulesFromDB to parse AlertTitle/
+// AlertMessage as text/template before returning the Rule.
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// CompileRulesFromDB converts every enabled alert_rules row into a
+// runtime Rule. Disabled rows are dropped. Returns an empty slice
+// when no enabled rows are present so callers can decide to fall
+// back to DefaultListenerRules.
+func CompileRulesFromDB(rows []*database.AlertRule) []Rule {
+	out := make([]Rule, 0, len(rows))
+	for _, row := range rows {
+		if row == nil || !row.Enabled {
+			continue
+		}
+		out = append(out, compileOne(row))
+	}
+	return out
+}
+
+func compileOne(row *database.AlertRule) Rule {
+	matchKind := row.MatchKind
+	matchSev := row.MatchSeverity
+	matchSubstring := row.MatchPayloadContains
+
+	// Snapshot the alert-construction inputs so Build is a closure
+	// that doesn't accidentally pick up a future row mutation.
+	alertType := row.AlertType
+	alertSeverity := row.AlertSeverity
+	alertTitle := row.AlertTitle
+	alertMessage := row.AlertMessage
+
+	return Rule{
+		ID: "db." + strconv.FormatInt(row.ID, 10),
+		Match: func(evt *database.ListenerEvent) bool {
+			if matchKind != "" && evt.Kind != matchKind {
+				return false
+			}
+			if matchSev != "" && evt.Severity != matchSev {
+				return false
+			}
+			if matchSubstring != "" && !strings.Contains(evt.PayloadJSON, matchSubstring) {
+				return false
+			}
+			return true
+		},
+		Build: func(evt *database.ListenerEvent) *database.Alert {
+			return &database.Alert{
+				Type:     alertType,
+				Severity: alertSeverity,
+				Title:    alertTitle,
+				Message:  alertMessage,
+				Source:   evt.SourceAddr,
+				Metadata: evt.PayloadJSON,
+			}
+		},
+	}
+}
+
+// alertRulesReader is the narrow surface the listener pipeline reads
+// from the alert_rules repo. Tests inject a fake. Implemented by
+// *database.AlertRulesRepository.
+type alertRulesReader interface {
+	List(ctx context.Context, enabledOnly bool) ([]*database.AlertRule, error)
+}

--- a/internal/alerts/pipeline/listener_rules_loader_test.go
+++ b/internal/alerts/pipeline/listener_rules_loader_test.go
@@ -1,0 +1,360 @@
+package pipeline_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/alerts/pipeline"
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// fakeAlertRulesReader implements the narrow alertRulesReader contract.
+// Mutating the rows slice is safe — every List call returns a fresh
+// copy so the pipeline can hold its own snapshot.
+type fakeAlertRulesReader struct {
+	mu      sync.Mutex
+	rows    []*database.AlertRule
+	listErr error
+	calls   int
+}
+
+func (f *fakeAlertRulesReader) List(_ context.Context, enabledOnly bool) ([]*database.AlertRule, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]*database.AlertRule, 0, len(f.rows))
+	for _, r := range f.rows {
+		if enabledOnly && !r.Enabled {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+func (f *fakeAlertRulesReader) set(rows []*database.AlertRule) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rows = rows
+}
+
+func dbRule(name, kind, severity, contains string, enabled bool) *database.AlertRule {
+	return &database.AlertRule{
+		ID:                   int64(len(name)),
+		Name:                 name,
+		Enabled:              enabled,
+		MatchKind:            kind,
+		MatchSeverity:        severity,
+		MatchPayloadContains: contains,
+		AlertType:            database.AlertTypeSystem,
+		AlertSeverity:        database.AlertSeverityError,
+		AlertTitle:           "Rule " + name + " matched",
+		AlertMessage:         "Triggered by listener event",
+	}
+}
+
+func TestCompileRulesFromDB_EmptySliceReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	got := pipeline.CompileRulesFromDB(nil)
+	if len(got) != 0 {
+		t.Errorf("nil input -> %d rules, want 0 (caller falls back to defaults)", len(got))
+	}
+}
+
+func TestCompileRulesFromDB_DisabledRowsSkipped(t *testing.T) {
+	t.Parallel()
+	rows := []*database.AlertRule{
+		dbRule("active", "syslog-udp", "error", "", true),
+		dbRule("inactive", "syslog-udp", "error", "", false),
+	}
+	got := pipeline.CompileRulesFromDB(rows)
+	if len(got) != 1 {
+		t.Fatalf("got %d compiled rules, want 1 (disabled row should be filtered)", len(got))
+	}
+	if got[0].ID != "db.6" { // len("active") = 6
+		t.Errorf("rule ID = %q, want db.6", got[0].ID)
+	}
+}
+
+func TestCompileRulesFromDB_MatchKindFilter(t *testing.T) {
+	t.Parallel()
+	rows := []*database.AlertRule{
+		dbRule("syslog-only", "syslog-udp", "", "", true),
+	}
+	rules := pipeline.CompileRulesFromDB(rows)
+	if len(rules) != 1 {
+		t.Fatalf("got %d rules, want 1", len(rules))
+	}
+	rule := rules[0]
+
+	syslogEvt := &database.ListenerEvent{Kind: "syslog-udp"}
+	trapEvt := &database.ListenerEvent{Kind: "snmp-trap-v2c"}
+
+	if !rule.Match(syslogEvt) {
+		t.Error("syslog-udp event should match syslog-udp filter")
+	}
+	if rule.Match(trapEvt) {
+		t.Error("snmp-trap event should NOT match syslog-udp filter")
+	}
+}
+
+func TestCompileRulesFromDB_MatchKindEmptyMatchesAll(t *testing.T) {
+	t.Parallel()
+	rows := []*database.AlertRule{
+		dbRule("any-kind", "", "", "", true),
+	}
+	rule := pipeline.CompileRulesFromDB(rows)[0]
+	if !rule.Match(&database.ListenerEvent{Kind: "syslog-udp"}) {
+		t.Error("empty match_kind should match syslog-udp")
+	}
+	if !rule.Match(&database.ListenerEvent{Kind: "snmp-trap-v2c"}) {
+		t.Error("empty match_kind should match snmp-trap-v2c")
+	}
+}
+
+func TestCompileRulesFromDB_MatchSeverityFilter(t *testing.T) {
+	t.Parallel()
+	rows := []*database.AlertRule{
+		dbRule("error-only", "syslog-udp", "error", "", true),
+	}
+	rule := pipeline.CompileRulesFromDB(rows)[0]
+	if !rule.Match(&database.ListenerEvent{Kind: "syslog-udp", Severity: "error"}) {
+		t.Error("severity=error should match")
+	}
+	if rule.Match(&database.ListenerEvent{Kind: "syslog-udp", Severity: "informational"}) {
+		t.Error("severity=informational should NOT match error-only rule")
+	}
+}
+
+func TestCompileRulesFromDB_MatchPayloadContainsSubstring(t *testing.T) {
+	t.Parallel()
+	rows := []*database.AlertRule{
+		dbRule("link-state", "syslog-udp", "", "link state", true),
+	}
+	rule := pipeline.CompileRulesFromDB(rows)[0]
+
+	payload, _ := json.Marshal(map[string]string{"message": "interface eth0 link state changed to down"})
+	matching := &database.ListenerEvent{Kind: "syslog-udp", PayloadJSON: string(payload)}
+	if !rule.Match(matching) {
+		t.Error("substring 'link state' should match")
+	}
+
+	nonMatching := &database.ListenerEvent{Kind: "syslog-udp", PayloadJSON: `{"message":"ssh login from 10.0.0.1"}`}
+	if rule.Match(nonMatching) {
+		t.Error("payload without substring should NOT match")
+	}
+}
+
+func TestCompileRulesFromDB_BuildPopulatesAlertFields(t *testing.T) {
+	t.Parallel()
+	rows := []*database.AlertRule{
+		{
+			ID: 42, Name: "interface-down", Enabled: true,
+			MatchKind:     "syslog-udp",
+			AlertType:     database.AlertTypeConnectivity,
+			AlertSeverity: database.AlertSeverityWarning,
+			AlertTitle:    "Interface down",
+			AlertMessage:  "Saw an interface-down event",
+		},
+	}
+	rule := pipeline.CompileRulesFromDB(rows)[0]
+	alert := rule.Build(&database.ListenerEvent{
+		Kind: "syslog-udp", SourceAddr: "10.0.0.1:514",
+		PayloadJSON: `{"message":"eth0 down"}`,
+	})
+	if alert == nil {
+		t.Fatal("Build returned nil alert")
+	}
+	if alert.Type != database.AlertTypeConnectivity {
+		t.Errorf("Type = %q, want %q", alert.Type, database.AlertTypeConnectivity)
+	}
+	if alert.Severity != database.AlertSeverityWarning {
+		t.Errorf("Severity = %q, want %q", alert.Severity, database.AlertSeverityWarning)
+	}
+	if alert.Title != "Interface down" {
+		t.Errorf("Title = %q, want literal 'Interface down'", alert.Title)
+	}
+	if alert.Message != "Saw an interface-down event" {
+		t.Errorf("Message = %q", alert.Message)
+	}
+	if alert.Source != "10.0.0.1:514" {
+		t.Errorf("Source = %q, want event source", alert.Source)
+	}
+	if alert.Metadata != `{"message":"eth0 down"}` {
+		t.Errorf("Metadata should mirror PayloadJSON, got %q", alert.Metadata)
+	}
+}
+
+func TestCompileRulesFromDB_StableFingerprintID(t *testing.T) {
+	t.Parallel()
+	rows := []*database.AlertRule{{
+		ID: 7, Name: "x", Enabled: true,
+		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityInfo,
+		AlertTitle: "x",
+	}}
+	rule := pipeline.CompileRulesFromDB(rows)[0]
+	if rule.ID != "db.7" {
+		t.Errorf("rule.ID = %q, want db.7 (used in suppression fingerprint)", rule.ID)
+	}
+}
+
+// Integration tests for the pipeline+loader composition.
+
+func TestScanOnce_DBRulesReplaceDefaultsWhenNonEmpty(t *testing.T) {
+	t.Parallel()
+	reader := &fakeAlertRulesReader{rows: []*database.AlertRule{
+		// One DB rule matching only "informational" syslog — would NEVER
+		// fire under the defaults (defaults only alert on error+ severities).
+		dbRule("info-rule", "syslog-udp", "informational", "", true),
+	}}
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		// An error syslog. Under DEFAULTS this would fire (defaults match error+).
+		// Under DB rules only it should NOT fire (DB rule is informational-only).
+		syslogEvent("error", "10.0.0.1:514", at(), "boom"),
+		// An informational syslog. Under DEFAULTS this does NOT fire.
+		// Under DB rules it SHOULD fire (DB rule matches informational).
+		syslogEvent("informational", "10.0.0.2:514", at(), "noise"),
+	}}
+	alerts := &fakeAlerts{}
+	p, err := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+		AlertRules: reader,
+	})
+	if err != nil {
+		t.Fatalf("NewListenerPipeline: %v", err)
+	}
+	if scanErr := p.ScanOnce(context.Background()); scanErr != nil {
+		t.Fatalf("ScanOnce: %v", scanErr)
+	}
+	if len(alerts.created) != 1 {
+		t.Fatalf(
+			"got %d alerts, want 1 (DB-only: informational fires, error must NOT)",
+			len(alerts.created),
+		)
+	}
+	if alerts.created[0].Source != "10.0.0.2:514" {
+		t.Errorf("alert came from %q, expected 10.0.0.2:514 (the informational source)", alerts.created[0].Source)
+	}
+}
+
+func TestScanOnce_FallsBackToDefaultsWhenDBEmpty(t *testing.T) {
+	t.Parallel()
+	reader := &fakeAlertRulesReader{rows: nil}
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", at(), "default-must-fire"),
+	}}
+	alerts := &fakeAlerts{}
+	p, err := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+		AlertRules: reader,
+	})
+	if err != nil {
+		t.Fatalf("NewListenerPipeline: %v", err)
+	}
+	_ = p.ScanOnce(context.Background())
+	if len(alerts.created) != 1 {
+		t.Errorf(
+			"empty DB rules should fall back to defaults (severe syslog fires), got %d",
+			len(alerts.created),
+		)
+	}
+}
+
+func TestScanOnce_FallsBackToDefaultsWhenAllDBRulesDisabled(t *testing.T) {
+	t.Parallel()
+	reader := &fakeAlertRulesReader{rows: []*database.AlertRule{
+		dbRule("disabled", "syslog-udp", "informational", "", false),
+	}}
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", at(), "boom"),
+	}}
+	alerts := &fakeAlerts{}
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+		AlertRules: reader,
+	})
+	_ = p.ScanOnce(context.Background())
+	if len(alerts.created) != 1 {
+		t.Errorf("disabled DB rules => fall back to defaults (severe syslog should fire), got %d", len(alerts.created))
+	}
+}
+
+func TestScanOnce_ReloadPicksUpNewlyInsertedRule(t *testing.T) {
+	t.Parallel()
+	reader := &fakeAlertRulesReader{rows: nil}
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		syslogEvent("informational", "10.0.0.1:514", at(), "ignore-me-under-defaults"),
+	}}
+	alerts := &fakeAlerts{}
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+		AlertRules: reader,
+	})
+
+	// First scan: DB empty -> defaults active -> informational does NOT fire.
+	_ = p.ScanOnce(context.Background())
+	if len(alerts.created) != 0 {
+		t.Fatalf("baseline scan should not alert, got %d", len(alerts.created))
+	}
+
+	// Operator inserts a rule, then triggers reload.
+	reader.set([]*database.AlertRule{dbRule("informational-now-fires", "syslog-udp", "informational", "", true)})
+	if reloadErr := p.ReloadRules(context.Background()); reloadErr != nil {
+		t.Fatalf("ReloadRules: %v", reloadErr)
+	}
+
+	// Reset high-water so the same event is re-considered, then scan again.
+	// In production a new event arrives; here we just bump the fake events
+	// observed-at by 1ns to step the high-water forward.
+	events.rows = []*database.ListenerEvent{
+		syslogEvent("informational", "10.0.0.2:514", at().Add(time.Second), "fire-now"),
+	}
+	_ = p.ScanOnce(context.Background())
+	if len(alerts.created) != 1 {
+		t.Errorf("after reload, informational event should fire via DB rule, got %d alerts", len(alerts.created))
+	}
+}
+
+func TestScanOnce_ReloadErrorKeepsPreviousRuleset(t *testing.T) {
+	t.Parallel()
+	reader := &fakeAlertRulesReader{rows: []*database.AlertRule{
+		dbRule("starter", "syslog-udp", "informational", "", true),
+	}}
+	events := &fakeEvents{rows: []*database.ListenerEvent{
+		syslogEvent("informational", "10.0.0.1:514", at(), "should-fire"),
+	}}
+	alerts := &fakeAlerts{}
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: events, Alerts: alerts, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+		AlertRules: reader,
+	})
+	// Now break the reader and call reload — pipeline should retain the
+	// starter rule rather than blanking the ruleset.
+	reader.mu.Lock()
+	reader.listErr = errAlertRulesReadFailed
+	reader.mu.Unlock()
+	if err := p.ReloadRules(context.Background()); err == nil {
+		t.Error("expected reload error to surface")
+	}
+	_ = p.ScanOnce(context.Background())
+	if len(alerts.created) != 1 {
+		t.Errorf("after failed reload, prior rule should still fire, got %d alerts", len(alerts.created))
+	}
+}
+
+var errAlertRulesReadFailed = &alertRulesReadError{}
+
+type alertRulesReadError struct{}
+
+func (*alertRulesReadError) Error() string { return "alert_rules read failed" }

--- a/internal/alerts/pipeline/listener_rules_templates_test.go
+++ b/internal/alerts/pipeline/listener_rules_templates_test.go
@@ -1,0 +1,140 @@
+package pipeline_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/alerts/pipeline"
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+func TestCompileRulesFromDB_LiteralTitlePassesThrough(t *testing.T) {
+	t.Parallel()
+	row := &database.AlertRule{
+		ID: 1, Enabled: true,
+		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertTitle:   "Static title with no template syntax",
+		AlertMessage: "Static message",
+	}
+	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
+	alert := rule.Build(&database.ListenerEvent{SourceAddr: "10.0.0.1"})
+	if alert.Title != "Static title with no template syntax" {
+		t.Errorf("literal title was mutated: %q", alert.Title)
+	}
+}
+
+func TestCompileRulesFromDB_TemplateRendersSourceAddr(t *testing.T) {
+	t.Parallel()
+	row := &database.AlertRule{
+		ID: 1, Enabled: true,
+		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertTitle:   "{{.SourceAddr}} reported {{.Severity}}",
+		AlertMessage: "Event arrived from {{.SourceAddr}}",
+	}
+	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
+	alert := rule.Build(&database.ListenerEvent{
+		SourceAddr:  "10.0.0.1:514",
+		Severity:    "error",
+		Kind:        "syslog-udp",
+		PayloadJSON: `{}`,
+	})
+	if alert.Title != "10.0.0.1:514 reported error" {
+		t.Errorf("title = %q, want \"10.0.0.1:514 reported error\"", alert.Title)
+	}
+	if alert.Message != "Event arrived from 10.0.0.1:514" {
+		t.Errorf("message = %q", alert.Message)
+	}
+}
+
+func TestCompileRulesFromDB_TemplateAccessesPayload(t *testing.T) {
+	t.Parallel()
+	row := &database.AlertRule{
+		ID: 1, Enabled: true,
+		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertTitle: "Saw {{.Payload.message}}",
+	}
+	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
+	payload, _ := json.Marshal(map[string]any{"message": "interface eth0 down"})
+	alert := rule.Build(&database.ListenerEvent{
+		SourceAddr:  "10.0.0.1",
+		PayloadJSON: string(payload),
+	})
+	if !strings.Contains(alert.Title, "interface eth0 down") {
+		t.Errorf("title should include payload.message, got %q", alert.Title)
+	}
+}
+
+func TestCompileRulesFromDB_BrokenTemplateFallsBackToLiteral(t *testing.T) {
+	t.Parallel()
+	// "{{" without close — parse error at compile time.
+	row := &database.AlertRule{
+		ID: 1, Enabled: true,
+		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertTitle: "Unclosed {{ template",
+	}
+	// Should not panic + rule should still load.
+	rules := pipeline.CompileRulesFromDB([]*database.AlertRule{row})
+	if len(rules) != 1 {
+		t.Fatalf("got %d rules, want 1 (broken template should not drop the rule)", len(rules))
+	}
+	alert := rules[0].Build(&database.ListenerEvent{SourceAddr: "10.0.0.1"})
+	if alert.Title != "Unclosed {{ template" {
+		t.Errorf("broken template should fall back to literal, got %q", alert.Title)
+	}
+}
+
+func TestCompileRulesFromDB_MissingPayloadFieldRendersZero(t *testing.T) {
+	t.Parallel()
+	// text/template's default behavior on missing map keys is to
+	// render "<no value>" — confirm we don't crash on it and that
+	// the output is something deterministic.
+	row := &database.AlertRule{
+		ID: 1, Enabled: true,
+		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertTitle: "Saw {{.Payload.nonexistent}}",
+	}
+	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
+	alert := rule.Build(&database.ListenerEvent{
+		SourceAddr:  "10.0.0.1",
+		PayloadJSON: `{"message":"hello"}`,
+	})
+	// Just confirm we got a non-empty title and didn't crash. The
+	// exact rendering of missing keys is text/template's contract
+	// (`<no value>`), not ours.
+	if alert.Title == "" {
+		t.Error("missing payload field should still render a title")
+	}
+}
+
+func TestCompileRulesFromDB_PayloadDecodeFailureRendersEmptyMap(t *testing.T) {
+	t.Parallel()
+	row := &database.AlertRule{
+		ID: 1, Enabled: true,
+		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertTitle: "Got {{.Kind}}",
+	}
+	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
+	alert := rule.Build(&database.ListenerEvent{
+		SourceAddr:  "10.0.0.1",
+		Kind:        "syslog-udp",
+		PayloadJSON: `not valid json`, // garbage
+	})
+	if !strings.Contains(alert.Title, "syslog-udp") {
+		t.Errorf("non-payload templates should still render with bad payload, got %q", alert.Title)
+	}
+}
+
+func TestCompileRulesFromDB_TemplateAccessesMatchedRuleName(t *testing.T) {
+	t.Parallel()
+	row := &database.AlertRule{
+		ID: 1, Enabled: true, Name: "my-rule",
+		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertTitle: "Rule {{.MatchedRuleName}} fired",
+	}
+	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
+	alert := rule.Build(&database.ListenerEvent{SourceAddr: "10.0.0.1"})
+	if alert.Title != "Rule my-rule fired" {
+		t.Errorf("title = %q, want \"Rule my-rule fired\"", alert.Title)
+	}
+}

--- a/internal/alerts/pipeline/observation_pipeline.go
+++ b/internal/alerts/pipeline/observation_pipeline.go
@@ -51,11 +51,11 @@ type ObservationPipeline struct {
 	interval    time.Duration
 	suppression time.Duration
 
-	mu      sync.Mutex
-	started bool
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
-	emitted map[string]time.Time
+	mu       sync.Mutex
+	started  bool
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	suppress suppressionStore
 
 	// Previous-state caches. Keyed by entity identifier
 	// ("target/ifindex" or "target/peer-ip", etc.). Updated after
@@ -74,6 +74,9 @@ type ObservationConfig struct {
 	Now          func() time.Time
 	Interval     time.Duration
 	Suppression  time.Duration
+
+	// Suppressions is the persistence backend; see ListenerConfig.
+	Suppressions suppressionStore
 }
 
 // NewObservationPipeline returns an unstarted pipeline.
@@ -102,6 +105,10 @@ func NewObservationPipeline(cfg ObservationConfig) (*ObservationPipeline, error)
 	if cfg.Suppression <= 0 {
 		cfg.Suppression = defaultSuppression
 	}
+	suppress := cfg.Suppressions
+	if suppress == nil {
+		suppress = newInMemorySuppressionStore()
+	}
 	return &ObservationPipeline{
 		obs:          cfg.Observations,
 		alerts:       cfg.Alerts,
@@ -110,7 +117,7 @@ func NewObservationPipeline(cfg ObservationConfig) (*ObservationPipeline, error)
 		now:          cfg.Now,
 		interval:     cfg.Interval,
 		suppression:  cfg.Suppression,
-		emitted:      make(map[string]time.Time),
+		suppress:     suppress,
 		ifaceState:   make(map[string]int),
 		bgpState:     make(map[string]int),
 		storageState: make(map[string]float64),
@@ -418,7 +425,12 @@ func (p *ObservationPipeline) fire(
 ) bool {
 	now := p.now()
 	fingerprint := fingerprintFor(ruleID, entityKey, alert.Source)
-	if p.suppressed(fingerprint, now) {
+	suppressed, suppErr := p.suppress.IsSuppressed(ctx, fingerprint, now)
+	if suppErr != nil {
+		p.logger.WarnContext(ctx, "suppression check failed",
+			"rule", ruleID, "key", entityKey, "error", suppErr)
+	}
+	if suppressed {
 		return false
 	}
 	if err := p.alerts.Create(ctx, alert); err != nil {
@@ -426,36 +438,11 @@ func (p *ObservationPipeline) fire(
 			"rule", ruleID, "key", entityKey, "error", err)
 		return false
 	}
-	p.markEmitted(fingerprint, now)
+	if markErr := p.suppress.Mark(ctx, fingerprint, ruleID, entityKey, now.Add(p.suppression)); markErr != nil {
+		p.logger.WarnContext(ctx, "suppression mark failed",
+			"rule", ruleID, "key", entityKey, "error", markErr)
+	}
 	return true
-}
-
-// suppression helpers — shared shape with listener_pipeline but on
-// this pipeline's own map so they don't contend on a shared mutex.
-func (p *ObservationPipeline) suppressed(fingerprint string, now time.Time) bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	last, ok := p.emitted[fingerprint]
-	if !ok {
-		return false
-	}
-	return now.Sub(last) < p.suppression
-}
-
-func (p *ObservationPipeline) markEmitted(fingerprint string, now time.Time) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.emitted[fingerprint] = now
-	const evictThreshold = 4096
-	if len(p.emitted) <= evictThreshold {
-		return
-	}
-	cutoff := now.Add(-2 * p.suppression)
-	for k, v := range p.emitted {
-		if v.Before(cutoff) {
-			delete(p.emitted, k)
-		}
-	}
 }
 
 // state map accessors keep the lock surface narrow.

--- a/internal/alerts/pipeline/suppression.go
+++ b/internal/alerts/pipeline/suppression.go
@@ -1,0 +1,89 @@
+package pipeline
+
+// suppression.go isolates the per-(rule, entity) "don't re-fire
+// inside this window" check both alert pipelines use. Operators
+// see one alert per rule+entity per suppression window rather than
+// a flood when the same condition persists across multiple scans.
+//
+// Two implementations:
+//
+//   - inMemorySuppressionStore — process-local map, lost on restart.
+//     Backward-compatible default for tests that don't wire a DB.
+//
+//   - DBSuppressionStore       — sqlite-backed, restart-safe (#1380).
+//     Production wiring; server.go passes db.AlertSuppressions() into
+//     each pipeline's config.
+//
+// Both implementations honor the same narrow contract so the
+// pipelines stay agnostic to where the marks live.
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// suppressionStore is the narrow surface alert pipelines need.
+// Both the in-memory and DB-backed implementations satisfy it.
+type suppressionStore interface {
+	// IsSuppressed reports whether fingerprint has a fire mark that
+	// has not yet expired.
+	IsSuppressed(ctx context.Context, fingerprint string, now time.Time) (bool, error)
+
+	// Mark records that fingerprint just fired and should be
+	// suppressed until "until".
+	Mark(ctx context.Context, fingerprint, ruleID, entityKey string, until time.Time) error
+}
+
+// inMemorySuppressionStore is the legacy backend — same behavior the
+// pipelines had before #1380, kept for tests that don't wire a DB.
+type inMemorySuppressionStore struct {
+	mu      sync.Mutex
+	emitted map[string]time.Time
+}
+
+func newInMemorySuppressionStore() *inMemorySuppressionStore {
+	return &inMemorySuppressionStore{emitted: make(map[string]time.Time)}
+}
+
+func (s *inMemorySuppressionStore) IsSuppressed(
+	_ context.Context, fingerprint string, now time.Time,
+) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	until, ok := s.emitted[fingerprint]
+	if !ok {
+		return false, nil
+	}
+	return now.Before(until), nil
+}
+
+func (s *inMemorySuppressionStore) Mark(
+	_ context.Context, fingerprint, _, _ string, until time.Time,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.emitted[fingerprint] = until
+	// Lazy eviction at the noticeable-size threshold mirrors the
+	// pre-#1380 behavior so the map stays bounded under sustained
+	// rule fire-rate.
+	const evictThreshold = 4096
+	if len(s.emitted) <= evictThreshold {
+		return nil
+	}
+	for k, v := range s.emitted {
+		if v.Before(until.Add(-time.Hour)) {
+			delete(s.emitted, k)
+		}
+	}
+	return nil
+}
+
+// NewDBSuppressionStore wires a database-backed suppression store
+// by returning the repo directly — *database.AlertSuppressionsRepository
+// already satisfies suppressionStore. Exported as a constructor so
+// server.go has a stable seam if we ever need to layer behavior
+// (metrics, retries) above the raw repo.
+func NewDBSuppressionStore(repo suppressionStore) suppressionStore {
+	return repo
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -465,7 +465,11 @@ func initAlertPipelines(services *ServiceContainer, db *database.DB) {
 	alerts := db.Alerts()
 
 	if p, err := alertpipeline.NewListenerPipeline(alertpipeline.ListenerConfig{
-		Events: db.ListenerEvents(), Alerts: alerts, Settings: settings, Logger: logger,
+		Events:     db.ListenerEvents(),
+		Alerts:     alerts,
+		Settings:   settings,
+		Logger:     logger,
+		AlertRules: db.AlertRules(),
 	}); err != nil {
 		logger.Warn("listener alert pipeline init failed", "error", err)
 	} else if regErr := registerEngineIfLicensed(services, p); regErr != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -463,13 +463,15 @@ func initAlertPipelines(services *ServiceContainer, db *database.DB) {
 	logger := logging.GetLogger()
 	settings := db.Settings()
 	alerts := db.Alerts()
+	suppressions := alertpipeline.NewDBSuppressionStore(db.AlertSuppressions())
 
 	if p, err := alertpipeline.NewListenerPipeline(alertpipeline.ListenerConfig{
-		Events:     db.ListenerEvents(),
-		Alerts:     alerts,
-		Settings:   settings,
-		Logger:     logger,
-		AlertRules: db.AlertRules(),
+		Events:       db.ListenerEvents(),
+		Alerts:       alerts,
+		Settings:     settings,
+		Logger:       logger,
+		AlertRules:   db.AlertRules(),
+		Suppressions: suppressions,
 	}); err != nil {
 		logger.Warn("listener alert pipeline init failed", "error", err)
 	} else if regErr := registerEngineIfLicensed(services, p); regErr != nil {
@@ -477,7 +479,11 @@ func initAlertPipelines(services *ServiceContainer, db *database.DB) {
 	}
 
 	if p, err := alertpipeline.NewObservationPipeline(alertpipeline.ObservationConfig{
-		Observations: db.SNMPObservations(), Alerts: alerts, Settings: settings, Logger: logger,
+		Observations: db.SNMPObservations(),
+		Alerts:       alerts,
+		Settings:     settings,
+		Logger:       logger,
+		Suppressions: suppressions,
 	}); err != nil {
 		logger.Warn("observation alert pipeline init failed", "error", err)
 	} else if regErr := registerEngineIfLicensed(services, p); regErr != nil {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -64,21 +64,22 @@ type DB struct {
 	closed bool
 
 	// Repositories - lazily initialized
-	profiles         *ProfileRepository
-	metrics          *MetricsRepository
-	devices          *DeviceRepository
-	alerts           *AlertRepository
-	settings         *SettingsRepository
-	logs             *LogRepository
-	healthChecks     *HealthCheckRepository
-	discovery        *DiscoveryRepository
-	clients          *ClientRepository
-	probes           *ProbeRepository
-	pollingTargets   *PollingTargetRepository
-	snmpObservations *SNMPObservationsRepository
-	listenerEvents   *ListenerEventsRepository
-	topology         *TopologyRepository
-	alertRules       *AlertRulesRepository
+	profiles          *ProfileRepository
+	metrics           *MetricsRepository
+	devices           *DeviceRepository
+	alerts            *AlertRepository
+	settings          *SettingsRepository
+	logs              *LogRepository
+	healthChecks      *HealthCheckRepository
+	discovery         *DiscoveryRepository
+	clients           *ClientRepository
+	probes            *ProbeRepository
+	pollingTargets    *PollingTargetRepository
+	snmpObservations  *SNMPObservationsRepository
+	listenerEvents    *ListenerEventsRepository
+	topology          *TopologyRepository
+	alertRules        *AlertRulesRepository
+	alertSuppressions *AlertSuppressionsRepository
 }
 
 // Config holds database configuration options.
@@ -544,6 +545,20 @@ func (db *DB) AlertRules() *AlertRulesRepository {
 		db.alertRules = &AlertRulesRepository{db: db}
 	}
 	return db.alertRules
+}
+
+// AlertSuppressions returns the repo for persisted suppression
+// markers used by the alert pipelines (#1380). Persisting means a
+// restart mid-incident doesn't re-fire alerts that were already
+// emitted.
+func (db *DB) AlertSuppressions() *AlertSuppressionsRepository {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.alertSuppressions == nil {
+		db.alertSuppressions = &AlertSuppressionsRepository{db: db}
+	}
+	return db.alertSuppressions
 }
 
 // Exec executes a query without returning any rows.

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1920,6 +1920,26 @@ func getMigrationDefs() []migrationDef {
 			CREATE INDEX IF NOT EXISTS idx_arp_bindings_last_seen ON topology_arp_bindings(last_seen);
 		`,
 		},
+		{
+			// Stage A5/#1380 — persistent alert suppression. Replaces
+			// the in-memory map both alert pipelines used to keep so
+			// a restart mid-incident doesn't re-fire alerts that were
+			// already emitted. fingerprint is the sha256 hash from
+			// the original suppression key (rule_id + source + kind).
+			Description: "Create alert_suppressions",
+			Up: `
+				CREATE TABLE IF NOT EXISTS alert_suppressions (
+					fingerprint TEXT PRIMARY KEY,
+					rule_id TEXT NOT NULL,
+					entity_key TEXT NOT NULL,
+					suppress_until TEXT NOT NULL,
+					created_at TEXT NOT NULL
+				);
+
+				CREATE INDEX IF NOT EXISTS idx_alert_suppressions_until
+				  ON alert_suppressions(suppress_until);
+			`,
+		},
 	}
 }
 

--- a/internal/database/repository_alert_suppressions.go
+++ b/internal/database/repository_alert_suppressions.go
@@ -1,0 +1,92 @@
+package database
+
+// repository_alert_suppressions persists the per-(rule, entity) "do
+// not re-fire until" marks the alert pipelines used to keep in
+// memory. Restart-safe so a Seed restart mid-incident doesn't
+// re-fire alerts that were already emitted (#1380).
+//
+// fingerprint is the same sha256-derived key the pipelines compute
+// when they decide whether to emit; passing it through unchanged
+// means existing in-memory call sites only need to swap the map
+// for this repo without recomputing.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// AlertSuppressionsRepository is the read/write surface for the
+// alert_suppressions table.
+type AlertSuppressionsRepository struct {
+	db *DB
+}
+
+// IsSuppressed returns true when fingerprint has a non-expired row.
+// Expired rows are treated as if absent and left for PurgeExpired
+// to clean up.
+func (r *AlertSuppressionsRepository) IsSuppressed(
+	ctx context.Context, fingerprint string, now time.Time,
+) (bool, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT suppress_until FROM alert_suppressions
+		WHERE fingerprint = ?
+	`, fingerprint)
+	var until string
+	if err := row.Scan(&until); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("alert_suppressions IsSuppressed: %w", err)
+	}
+	parsed, perr := time.Parse(time.RFC3339Nano, until)
+	if perr != nil {
+		return false, fmt.Errorf("alert_suppressions parse suppress_until %q: %w", until, perr)
+	}
+	return now.Before(parsed), nil
+}
+
+// Mark sets / extends a suppression. Repeating Mark on the same
+// fingerprint overwrites suppress_until — useful when the same
+// rule fires again before its prior window expires (extends the
+// window rather than stacking).
+func (r *AlertSuppressionsRepository) Mark(
+	ctx context.Context, fingerprint, ruleID, entityKey string,
+	suppressUntil time.Time,
+) error {
+	if fingerprint == "" {
+		return errors.New("alert_suppressions: fingerprint required")
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO alert_suppressions
+		  (fingerprint, rule_id, entity_key, suppress_until, created_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(fingerprint) DO UPDATE SET
+			suppress_until = excluded.suppress_until
+	`,
+		fingerprint, ruleID, entityKey,
+		suppressUntil.UTC().Format(time.RFC3339Nano), now,
+	)
+	if err != nil {
+		return fmt.Errorf("alert_suppressions Mark: %w", err)
+	}
+	return nil
+}
+
+// PurgeExpired deletes rows whose suppress_until is in the past.
+// Returns the number of rows removed.
+func (r *AlertSuppressionsRepository) PurgeExpired(
+	ctx context.Context, now time.Time,
+) (int64, error) {
+	res, err := r.db.Exec(ctx, `
+		DELETE FROM alert_suppressions WHERE suppress_until < ?
+	`, now.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return 0, fmt.Errorf("alert_suppressions PurgeExpired: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}

--- a/internal/database/repository_alert_suppressions_test.go
+++ b/internal/database/repository_alert_suppressions_test.go
@@ -1,0 +1,123 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+func newSuppressionDB(t *testing.T) *database.DB {
+	t.Helper()
+	db, err := database.Open(t.TempDir() + "/seed.db")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestAlertSuppressions_MarkAndIsSuppressedRoundtrip(t *testing.T) {
+	t.Parallel()
+	db := newSuppressionDB(t)
+	ctx := context.Background()
+	repo := db.AlertSuppressions()
+
+	now := time.Now().UTC()
+	until := now.Add(5 * time.Minute)
+	if err := repo.Mark(ctx, "fp-1", "rule-a", "10.0.0.1", until); err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+
+	suppressed, err := repo.IsSuppressed(ctx, "fp-1", now)
+	if err != nil {
+		t.Fatalf("IsSuppressed: %v", err)
+	}
+	if !suppressed {
+		t.Error("fingerprint should be suppressed within window")
+	}
+}
+
+func TestAlertSuppressions_IsSuppressedFalseWhenExpired(t *testing.T) {
+	t.Parallel()
+	db := newSuppressionDB(t)
+	ctx := context.Background()
+	repo := db.AlertSuppressions()
+
+	past := time.Now().UTC().Add(-time.Hour)
+	if err := repo.Mark(ctx, "fp-2", "rule-a", "x", past); err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+
+	suppressed, _ := repo.IsSuppressed(ctx, "fp-2", time.Now().UTC())
+	if suppressed {
+		t.Error("expired suppression should report not-suppressed")
+	}
+}
+
+func TestAlertSuppressions_IsSuppressedFalseWhenAbsent(t *testing.T) {
+	t.Parallel()
+	db := newSuppressionDB(t)
+	suppressed, err := db.AlertSuppressions().IsSuppressed(
+		context.Background(), "never-marked", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("IsSuppressed on absent row: %v", err)
+	}
+	if suppressed {
+		t.Error("absent fingerprint should not be suppressed")
+	}
+}
+
+func TestAlertSuppressions_MarkOverwrites(t *testing.T) {
+	t.Parallel()
+	db := newSuppressionDB(t)
+	ctx := context.Background()
+	repo := db.AlertSuppressions()
+	now := time.Now().UTC()
+
+	short := now.Add(time.Second)
+	long := now.Add(time.Hour)
+	if err := repo.Mark(ctx, "fp", "rule", "x", short); err != nil {
+		t.Fatalf("first Mark: %v", err)
+	}
+	if err := repo.Mark(ctx, "fp", "rule", "x", long); err != nil {
+		t.Fatalf("second Mark: %v", err)
+	}
+
+	// At a moment past the short deadline but before the long one,
+	// the overwriting Mark should still hold.
+	check := short.Add(time.Minute)
+	suppressed, _ := repo.IsSuppressed(ctx, "fp", check)
+	if !suppressed {
+		t.Error("second Mark should overwrite first; expected still-suppressed")
+	}
+}
+
+func TestAlertSuppressions_PurgeExpiredRemovesOnlyExpired(t *testing.T) {
+	t.Parallel()
+	db := newSuppressionDB(t)
+	ctx := context.Background()
+	repo := db.AlertSuppressions()
+	now := time.Now().UTC()
+
+	if err := repo.Mark(ctx, "expired", "r", "x", now.Add(-time.Hour)); err != nil {
+		t.Fatalf("Mark expired: %v", err)
+	}
+	if err := repo.Mark(ctx, "active", "r", "y", now.Add(time.Hour)); err != nil {
+		t.Fatalf("Mark active: %v", err)
+	}
+
+	removed, err := repo.PurgeExpired(ctx, now)
+	if err != nil {
+		t.Fatalf("PurgeExpired: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("removed = %d, want 1", removed)
+	}
+
+	stillActive, _ := repo.IsSuppressed(ctx, "active", now)
+	if !stillActive {
+		t.Error("active suppression should survive purge")
+	}
+}


### PR DESCRIPTION
## Summary

Wires the `alert_rules` table into `ListenerPipeline` so operator-configured rules drive alerting at runtime. Closes #1377 (Phase 1 / PR 1 of the V1.0 NMS follow-up plan tracked under #1367).

- New `internal/alerts/pipeline/listener_rules_loader.go` compiles `[]*database.AlertRule` into runtime `[]Rule`.
- `ListenerConfig` gains `AlertRules` + `ReloadInterval` fields; pipeline reloads on a 60s default tick and syncs once at construction (so the first `ScanOnce` reflects operator config) and again in `Start`.
- `internal/api/server.go` passes `db.AlertRules()` through `initAlertPipelines`.
- Rules are snapshotted under `p.mu` on each scan so a concurrent reload can't tear an iteration.

## Semantics decision (called out in the plan as the known tradeoff)

**DB-only-when-non-empty.** When `alert_rules` has at least one enabled row, the DB ruleset replaces `DefaultListenerRules()` entirely. When the table is empty (or every row is disabled), the pipeline falls back to defaults so a fresh install keeps emitting alerts without operator action.

Mixing the two ("additive merging") was rejected because it makes "why did this fire twice?" harder to answer than "my rules win or yours do". A follow-up could expose this as a settings toggle if customer feedback warrants it; today it's a load-bearing rule in the loader file's doc comment.

A reload error leaves the previous ruleset in place — a transient DB hiccup never blanks the pipeline.

## Test plan

- [x] `internal/alerts/pipeline/listener_rules_loader_test.go` — 12 new test cases covering: nil input, disabled rows skipped, match_kind filter, match_kind empty matches all, match_severity filter, match_payload_contains substring, Build populates alert fields, stable fingerprint ID, DB rules replace defaults when non-empty, fallback to defaults when DB empty, fallback when all DB rules disabled, reload picks up newly inserted rule, reload error keeps previous ruleset.
- [x] `go test ./...` — clean (all existing pipeline tests still pass).
- [x] `make lint` — zero warnings (golangci-lint v2.12.1 + Biome).
- [ ] CI green on this branch.

## Out of scope (separate PRs per plan #1367)

- `text/template` support in titles/messages — PR 2 (#1378)
- `/alert-rules` UI editor page — PR 3 (#1384)
- Persistent suppression — PR 10 (#1380)

Plan: see comment on #1367.