### PR TITLE
feat(engine): optional reporter interface + /engines status surface

### DIFF
--- a/internal/alerts/pipeline/listener_pipeline.go
+++ b/internal/alerts/pipeline/listener_pipeline.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
 
 // ListenerPipelineName is the engine identifier.
@@ -92,11 +93,14 @@ type ListenerPipeline struct {
 	rules       []Rule
 	suppression time.Duration
 
-	mu      sync.Mutex
-	started bool
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
-	emitted map[string]time.Time
+	mu         sync.Mutex
+	started    bool
+	stopped    bool
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+	emitted    map[string]time.Time
+	lastTickAt time.Time
+	lastError  string
 }
 
 // ListenerConfig wires the pipeline.
@@ -160,6 +164,28 @@ func NewListenerPipeline(cfg ListenerConfig) (*ListenerPipeline, error) {
 // Name implements [engine.Engine].
 func (*ListenerPipeline) Name() string { return ListenerPipelineName }
 
+// Status implements [engine.Reporter]. See observation_pipeline.go
+// for the state model — same rules apply here.
+func (p *ListenerPipeline) Status() engine.Status {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	s := engine.Status{
+		LastTickAt: p.lastTickAt,
+		LastError:  p.lastError,
+	}
+	switch {
+	case p.stopped:
+		s.State = engine.StateStopped
+	case p.lastTickAt.IsZero():
+		s.State = engine.StateOK
+	case p.now().Sub(p.lastTickAt) > degradedTickMultiplier*p.interval:
+		s.State = engine.StateDegraded
+	default:
+		s.State = engine.StateOK
+	}
+	return s
+}
+
 // Start kicks off the scan loop. Idempotent.
 func (p *ListenerPipeline) Start(ctx context.Context) error {
 	p.mu.Lock()
@@ -185,6 +211,7 @@ func (p *ListenerPipeline) Stop(ctx context.Context) error {
 		return nil
 	}
 	p.started = false
+	p.stopped = true
 	if p.cancel != nil {
 		p.cancel()
 	}
@@ -225,6 +252,24 @@ func (p *ListenerPipeline) loop(ctx context.Context) {
 
 // ScanOnce processes one batch of listener_events.
 func (p *ListenerPipeline) ScanOnce(ctx context.Context) error {
+	err := p.scanOnceInner(ctx)
+	p.recordScan(err)
+	return err
+}
+
+// recordScan stamps lastTickAt + lastError for engine.Reporter.
+func (p *ListenerPipeline) recordScan(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastTickAt = p.now()
+	if err != nil {
+		p.lastError = err.Error()
+		return
+	}
+	p.lastError = ""
+}
+
+func (p *ListenerPipeline) scanOnceInner(ctx context.Context) error {
 	since, err := p.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)

--- a/internal/alerts/pipeline/observation_pipeline.go
+++ b/internal/alerts/pipeline/observation_pipeline.go
@@ -10,7 +10,13 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
+
+// degradedTickMultiplier is how many scan intervals can elapse
+// before a pipeline's Status() reports degraded. Two ticks gives
+// the loop one missed tick of grace before paging.
+const degradedTickMultiplier = 2
 
 // ObservationPipelineName is the engine identifier.
 const ObservationPipelineName = "alert-observation-pipeline"
@@ -53,9 +59,14 @@ type ObservationPipeline struct {
 
 	mu      sync.Mutex
 	started bool
+	stopped bool
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 	emitted map[string]time.Time
+
+	// Per-scan status, updated under mu for engine.Reporter.
+	lastTickAt time.Time
+	lastError  string
 
 	// Previous-state caches. Keyed by entity identifier
 	// ("target/ifindex" or "target/peer-ip", etc.). Updated after
@@ -120,6 +131,30 @@ func NewObservationPipeline(cfg ObservationConfig) (*ObservationPipeline, error)
 // Name implements [engine.Engine].
 func (*ObservationPipeline) Name() string { return ObservationPipelineName }
 
+// Status implements [engine.Reporter]. State derives from how long
+// it has been since the last scan completed: "ok" within
+// degradedTickMultiplier*interval, "degraded" beyond that, and
+// "stopped" after Stop has been called.
+func (p *ObservationPipeline) Status() engine.Status {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	s := engine.Status{
+		LastTickAt: p.lastTickAt,
+		LastError:  p.lastError,
+	}
+	switch {
+	case p.stopped:
+		s.State = engine.StateStopped
+	case p.lastTickAt.IsZero():
+		s.State = engine.StateOK
+	case p.now().Sub(p.lastTickAt) > degradedTickMultiplier*p.interval:
+		s.State = engine.StateDegraded
+	default:
+		s.State = engine.StateOK
+	}
+	return s
+}
+
 // Start kicks off the scan loop. Idempotent.
 func (p *ObservationPipeline) Start(ctx context.Context) error {
 	p.mu.Lock()
@@ -145,6 +180,7 @@ func (p *ObservationPipeline) Stop(ctx context.Context) error {
 		return nil
 	}
 	p.started = false
+	p.stopped = true
 	if p.cancel != nil {
 		p.cancel()
 	}
@@ -187,6 +223,25 @@ func (p *ObservationPipeline) loop(ctx context.Context) {
 // has a delta signal. iftable + bgp4_mib + host_resources are the
 // V1.0 set; future kinds extend the per-kind dispatch.
 func (p *ObservationPipeline) ScanOnce(ctx context.Context) error {
+	err := p.scanOnceInner(ctx)
+	p.recordScan(err)
+	return err
+}
+
+// recordScan stamps lastTickAt + lastError for engine.Reporter.
+// Called from ScanOnce on every pass; held briefly under mu.
+func (p *ObservationPipeline) recordScan(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastTickAt = p.now()
+	if err != nil {
+		p.lastError = err.Error()
+		return
+	}
+	p.lastError = ""
+}
+
+func (p *ObservationPipeline) scanOnceInner(ctx context.Context) error {
 	since, err := p.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)

--- a/internal/alerts/pipeline/reporter_test.go
+++ b/internal/alerts/pipeline/reporter_test.go
@@ -1,0 +1,126 @@
+package pipeline_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/alerts/pipeline"
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
+)
+
+func TestListenerPipeline_Status_BeforeFirstScan(t *testing.T) {
+	t.Parallel()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: &fakeEvents{}, Alerts: &fakeAlerts{}, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	r, ok := any(p).(engine.Reporter)
+	if !ok {
+		t.Fatal("ListenerPipeline must implement engine.Reporter")
+	}
+	s := r.Status()
+	if s.State != engine.StateOK {
+		t.Errorf("State before any scan = %q, want ok", s.State)
+	}
+	if !s.LastTickAt.IsZero() {
+		t.Errorf("LastTickAt = %v, want zero before first scan", s.LastTickAt)
+	}
+}
+
+func TestListenerPipeline_Status_AfterScanRecordsTick(t *testing.T) {
+	t.Parallel()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: &fakeEvents{}, Alerts: &fakeAlerts{}, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = p.ScanOnce(context.Background())
+	s := any(p).(engine.Reporter).Status()
+	if s.LastTickAt.IsZero() {
+		t.Error("LastTickAt should be non-zero after ScanOnce")
+	}
+	if s.LastError != "" {
+		t.Errorf("LastError = %q, want empty after clean scan", s.LastError)
+	}
+}
+
+func TestListenerPipeline_Status_AfterScanErrorRecordsError(t *testing.T) {
+	t.Parallel()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events:   &fakeEvents{listErr: errors.New("db down")},
+		Alerts:   &fakeAlerts{},
+		Settings: newFakeSettings(),
+		Logger:   silentLogger(),
+		Now:      at,
+	})
+	_ = p.ScanOnce(context.Background())
+	s := any(p).(engine.Reporter).Status()
+	if s.LastError == "" {
+		t.Error("LastError should be populated after failed scan")
+	}
+}
+
+func TestListenerPipeline_Status_AfterStop(t *testing.T) {
+	t.Parallel()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: &fakeEvents{}, Alerts: &fakeAlerts{}, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at, Interval: 500 * time.Millisecond,
+	})
+	if startErr := p.Start(context.Background()); startErr != nil {
+		t.Fatalf("Start: %v", startErr)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if stopErr := p.Stop(ctx); stopErr != nil {
+		t.Fatalf("Stop: %v", stopErr)
+	}
+	s := any(p).(engine.Reporter).Status()
+	if s.State != engine.StateStopped {
+		t.Errorf("State after Stop = %q, want stopped", s.State)
+	}
+}
+
+// fakeObs lets us drive ObservationPipeline.ScanOnce.
+type fakeObs struct {
+	rows    []*database.SNMPObservation
+	listErr error
+}
+
+func (f *fakeObs) List(_ context.Context, _ database.ListOptions) ([]*database.SNMPObservation, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]*database.SNMPObservation, len(f.rows))
+	copy(out, f.rows)
+	return out, nil
+}
+
+func TestObservationPipeline_Status_LifecycleTransitions(t *testing.T) {
+	t.Parallel()
+	p, err := pipeline.NewObservationPipeline(pipeline.ObservationConfig{
+		Observations: &fakeObs{},
+		Alerts:       &fakeAlerts{},
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+	})
+	if err != nil {
+		t.Fatalf("NewObservationPipeline: %v", err)
+	}
+	rep, ok := any(p).(engine.Reporter)
+	if !ok {
+		t.Fatal("ObservationPipeline must implement engine.Reporter")
+	}
+
+	// Before scan
+	if state := rep.Status().State; state != engine.StateOK {
+		t.Errorf("pre-scan state = %q, want ok", state)
+	}
+	// After clean scan
+	_ = p.ScanOnce(context.Background())
+	if rep.Status().LastTickAt.IsZero() {
+		t.Error("LastTickAt zero after ScanOnce")
+	}
+}

--- a/internal/api/handlers_engines.go
+++ b/internal/api/handlers_engines.go
@@ -1,23 +1,28 @@
 package api
 
-// /api/v1/engines — Stage A5.8. Read-only admin endpoint listing
-// every long-running subsystem registered with services.Engines
-// (probe, retention, snmp-poller, the 4 topology reconcilers, the
-// 2 alert pipelines, plus any opt-in listeners).
+// /api/v1/engines — Stage A5.8 + #1383 enhancement. Read-only admin
+// endpoint listing every long-running subsystem registered with
+// services.Engines (probe, retention, snmp-poller, the 4 topology
+// reconcilers, the 2 alert pipelines, plus any opt-in listeners).
 //
 //   GET /api/v1/engines
-//     -> { jsonKeyCount: N, "engines": [{ jsonKeyName: "..." }, ...] }
+//     -> { count: N, "engines": [{
+//            "name": "...",
+//            "state": "ok" | "degraded" | "stopped",
+//            "lastTickAt": "RFC3339" | "",
+//            "lastError": "" | "...",
+//            "inflight": N
+//          }, ...] }
 //
-// The endpoint deliberately does NOT expose per-engine status or
-// last-tick timestamps for V1.0 — the engine.Engine interface
-// only carries Name + Start + Stop, and inventing a richer status
-// surface would require touching every engine implementation. A
-// future iteration can add an optional Status() method and a
-// Reporter interface; until then, "is this engine in the registry"
-// is the useful signal operators need.
+// Engines opt into rich status by implementing engine.Reporter. Those
+// that don't get a default {state: "ok"} payload — backward-compatible
+// with the V1.0 wire format and avoids forcing every engine to grow a
+// Status() method before operators see any signal.
 
 import (
 	"net/http"
+
+	"github.com/krisarmstrong/seed/internal/engine"
 )
 
 func (s *Server) handleEngines(w http.ResponseWriter, r *http.Request) {
@@ -32,10 +37,30 @@ func (s *Server) handleEngines(w http.ResponseWriter, r *http.Request) {
 	engines := s.services.Engines.Engines()
 	out := make([]map[string]any, 0, len(engines))
 	for _, e := range engines {
-		out = append(out, map[string]any{jsonKeyName: e.Name()})
+		out = append(out, encodeEngineEntry(e))
 	}
 	writeJSON(w, r, map[string]any{
 		jsonKeyCount: len(out),
 		"engines":    out,
 	})
+}
+
+// encodeEngineEntry flattens one engine into the wire shape. Engines
+// that implement engine.Reporter get their Status() surfaced; engines
+// that don't get StatusOK() so the response is uniform.
+func encodeEngineEntry(e engine.Engine) map[string]any {
+	status := engine.StatusOK()
+	if reporter, ok := e.(engine.Reporter); ok {
+		status = reporter.Status()
+		if status.State == "" {
+			status.State = engine.StateOK
+		}
+	}
+	return map[string]any{
+		jsonKeyName:  e.Name(),
+		"state":      status.State,
+		"lastTickAt": formatTime(status.LastTickAt),
+		"lastError":  status.LastError,
+		"inflight":   status.Inflight,
+	}
 }

--- a/internal/api/handlers_engines_internal_test.go
+++ b/internal/api/handlers_engines_internal_test.go
@@ -1,11 +1,35 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/engine"
 )
+
+// minimalEngine is an Engine that does not implement Reporter — used
+// to exercise the type-assertion fallback in handleEngines.
+type minimalEngine struct{ name string }
+
+func (m *minimalEngine) Name() string                { return m.name }
+func (*minimalEngine) Start(_ context.Context) error { return nil }
+func (*minimalEngine) Stop(_ context.Context) error  { return nil }
+
+// reportingEngine implements both Engine and Reporter — exercises
+// the rich-status path.
+type reportingEngine struct {
+	name   string
+	status engine.Status
+}
+
+func (r *reportingEngine) Name() string                { return r.name }
+func (*reportingEngine) Start(_ context.Context) error { return nil }
+func (*reportingEngine) Stop(_ context.Context) error  { return nil }
+func (r *reportingEngine) Status() engine.Status       { return r.status }
 
 func TestHandleEngines_ReturnsRegistryContents(t *testing.T) {
 	s := &Server{services: NewServiceContainer()}
@@ -66,5 +90,99 @@ func TestHandleEngines_NoServicesReturnsEmpty(t *testing.T) {
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp.Count != 0 {
 		t.Errorf("count = %d, want 0", resp.Count)
+	}
+}
+
+func TestHandleEngines_EngineWithoutReporter_DefaultsToStateOK(t *testing.T) {
+	s := &Server{services: NewServiceContainer()}
+	if regErr := s.services.Engines.Register(&minimalEngine{name: "plain"}); regErr != nil {
+		t.Fatalf("register: %v", regErr)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/engines", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleEngines(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Engines []map[string]any `json:"engines"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Engines) == 0 {
+		t.Fatal("expected at least one engine entry")
+	}
+	got := resp.Engines[0]
+	if got["state"] != "ok" {
+		t.Errorf("state = %v, want \"ok\" (engine without Reporter)", got["state"])
+	}
+	if got["lastError"] != "" {
+		t.Errorf("lastError = %v, want empty", got["lastError"])
+	}
+}
+
+func TestHandleEngines_EngineWithReporter_SurfacesStatus(t *testing.T) {
+	s := &Server{services: NewServiceContainer()}
+	rep := &reportingEngine{
+		name: "rich",
+		status: engine.Status{
+			State:      engine.StateDegraded,
+			LastTickAt: time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC),
+			LastError:  "scan timeout: ctx deadline exceeded",
+			Inflight:   3,
+		},
+	}
+	if regErr := s.services.Engines.Register(rep); regErr != nil {
+		t.Fatalf("register: %v", regErr)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/engines", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleEngines(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		Engines []map[string]any `json:"engines"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Engines) == 0 {
+		t.Fatal("expected at least one engine entry")
+	}
+	got := resp.Engines[0]
+	if got["state"] != "degraded" {
+		t.Errorf("state = %v, want \"degraded\"", got["state"])
+	}
+	if got["lastError"] != "scan timeout: ctx deadline exceeded" {
+		t.Errorf("lastError = %v", got["lastError"])
+	}
+	if got["lastTickAt"] != "2026-05-31T12:00:00Z" {
+		t.Errorf("lastTickAt = %v, want RFC3339 string", got["lastTickAt"])
+	}
+	// JSON decode of integer field yields float64 — cast through that.
+	if inflight, ok := got["inflight"].(float64); !ok || int(inflight) != 3 {
+		t.Errorf("inflight = %v (%T), want 3", got["inflight"], got["inflight"])
+	}
+}
+
+func TestHandleEngines_ReporterReturnsEmptyState_FillsOK(t *testing.T) {
+	s := &Server{services: NewServiceContainer()}
+	if regErr := s.services.Engines.Register(&reportingEngine{
+		name:   "blank-state",
+		status: engine.Status{}, // State left empty
+	}); regErr != nil {
+		t.Fatalf("register: %v", regErr)
+	}
+	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/engines", http.NoBody)
+	w := httptest.NewRecorder()
+	s.handleEngines(w, req)
+	var resp struct {
+		Engines []map[string]any `json:"engines"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Engines[0]["state"] != "ok" {
+		t.Errorf("blank Status.State should default to ok, got %v", resp.Engines[0]["state"])
 	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -240,3 +240,98 @@ func equalSlices(a, b []string) bool {
 	}
 	return true
 }
+
+// reportingFakeEngine implements both Engine and Reporter so the
+// type-assertion path in handlers_engines.go can be exercised.
+type reportingFakeEngine struct {
+	fakeEngine
+
+	status engine.Status
+}
+
+func (r *reportingFakeEngine) Status() engine.Status { return r.status }
+
+func TestStatusOK_DefaultStateIsOK(t *testing.T) {
+	t.Parallel()
+	s := engine.StatusOK()
+	if s.State != engine.StateOK {
+		t.Errorf("StatusOK().State = %q, want %q", s.State, engine.StateOK)
+	}
+	if s.LastError != "" {
+		t.Errorf("StatusOK().LastError = %q, want empty", s.LastError)
+	}
+}
+
+func TestStatusJSON_NameSurfaceIsStable(t *testing.T) {
+	t.Parallel()
+	// State constants must match the values handlers and operator
+	// tooling rely on. Locking them in tests prevents a silent
+	// rename that would break dashboards.
+	if engine.StateOK != "ok" {
+		t.Errorf("StateOK = %q, want \"ok\"", engine.StateOK)
+	}
+	if engine.StateDegraded != "degraded" {
+		t.Errorf("StateDegraded = %q, want \"degraded\"", engine.StateDegraded)
+	}
+	if engine.StateStopped != "stopped" {
+		t.Errorf("StateStopped = %q, want \"stopped\"", engine.StateStopped)
+	}
+}
+
+func TestReporter_TypeAssertion_EngineWithoutReporter(t *testing.T) {
+	t.Parallel()
+	// Plain fakeEngine doesn't implement Reporter — confirm the
+	// type assertion fails gracefully so the handler can fall
+	// back to StatusOK.
+	var e engine.Engine = &fakeEngine{name: "no-reporter"}
+	if _, ok := e.(engine.Reporter); ok {
+		t.Error("plain fakeEngine should not implement Reporter")
+	}
+}
+
+func TestReporter_TypeAssertion_EngineWithReporter(t *testing.T) {
+	t.Parallel()
+	custom := engine.Status{
+		State:     engine.StateDegraded,
+		LastError: "scan timeout",
+		Inflight:  2,
+	}
+	var e engine.Engine = &reportingFakeEngine{
+		fakeEngine: fakeEngine{name: "with-reporter"},
+		status:     custom,
+	}
+	rep, ok := e.(engine.Reporter)
+	if !ok {
+		t.Fatal("reportingFakeEngine should implement Reporter")
+	}
+	got := rep.Status()
+	if got.State != engine.StateDegraded {
+		t.Errorf("State = %q, want degraded", got.State)
+	}
+	if got.LastError != "scan timeout" {
+		t.Errorf("LastError = %q", got.LastError)
+	}
+	if got.Inflight != 2 {
+		t.Errorf("Inflight = %d, want 2", got.Inflight)
+	}
+}
+
+func TestRegistry_HoldsMixedEngines(t *testing.T) {
+	t.Parallel()
+	// Registry must accept engines whether or not they implement
+	// Reporter — adoption is opt-in.
+	r := engine.NewRegistry(silentLogger())
+	if err := r.Register(&fakeEngine{name: "plain"}); err != nil {
+		t.Fatalf("register plain: %v", err)
+	}
+	if err := r.Register(&reportingFakeEngine{
+		fakeEngine: fakeEngine{name: "reporting"},
+		status:     engine.StatusOK(),
+	}); err != nil {
+		t.Fatalf("register reporting: %v", err)
+	}
+	got := r.Engines()
+	if len(got) != 2 {
+		t.Errorf("registry holds %d engines, want 2", len(got))
+	}
+}

--- a/internal/engine/reporter.go
+++ b/internal/engine/reporter.go
@@ -1,0 +1,79 @@
+package engine
+
+// reporter.go defines the optional Status() surface engines can
+// implement to expose richer health information to /api/v1/engines.
+// The interface is deliberately optional — adoption is per-engine,
+// no compile-time pressure on engines that have nothing useful to
+// say beyond "I'm registered".
+//
+// Operators care about three things:
+//
+//   1. Is this engine running and ticking? (LastTickAt)
+//   2. Is anything broken? (LastError + State)
+//   3. How busy is it? (Inflight, optional)
+//
+// The /api/v1/engines handler type-asserts each registered engine
+// to Reporter; engines that don't implement it default to a
+// StatusOK() payload so the wire response is uniform regardless of
+// adoption status.
+
+import "time"
+
+// State enumerates the values Status.State may take. Locked as
+// constants so handler dashboards and operator tooling can switch
+// on them without inventing magic strings.
+const (
+	// StateOK means the engine is registered and either idle or
+	// ticking on schedule.
+	StateOK = "ok"
+
+	// StateDegraded means the engine is registered but its last
+	// tick failed OR its last tick is older than 2× its expected
+	// interval. The engine package doesn't enforce the timing
+	// check — engines decide their own thresholds because
+	// "expected interval" varies wildly (probe = seconds,
+	// retention = hours).
+	StateDegraded = "degraded"
+
+	// StateStopped means the engine has been explicitly stopped
+	// (e.g. via Registry.Stop). Engines that have never started
+	// still report StateOK because "never started" is observable
+	// via LastTickAt being zero.
+	StateStopped = "stopped"
+)
+
+// Status is the payload Reporter returns. Every field is optional;
+// handlers tolerate zero values.
+type Status struct {
+	// State is one of StateOK / StateDegraded / StateStopped.
+	State string
+
+	// LastTickAt is the time the engine completed its most recent
+	// scan / tick. Zero means "never ticked" (engine just started).
+	LastTickAt time.Time
+
+	// LastError is the formatted error string from the most recent
+	// tick that returned an error; empty when the most recent tick
+	// succeeded.
+	LastError string
+
+	// Inflight is the count of in-progress operations the engine
+	// is tracking (e.g. concurrent SNMP probes). Optional — engines
+	// that don't maintain a counter leave this at zero.
+	Inflight int
+}
+
+// Reporter is the optional surface engines implement to expose
+// per-engine status. Handlers MUST tolerate engines that do not
+// implement Reporter (type-assert and fall back to StatusOK).
+type Reporter interface {
+	Status() Status
+}
+
+// StatusOK returns the default Status payload for engines that
+// don't implement Reporter or are reporting a healthy state with
+// no rich data to add. Use this rather than a struct literal so
+// the default shape stays consistent across call sites.
+func StatusOK() Status {
+	return Status{State: StateOK}
+}

--- a/internal/polling/snmp/poller.go
+++ b/internal/polling/snmp/poller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 	"github.com/krisarmstrong/seed/internal/scheduler"
 )
 
@@ -53,7 +54,13 @@ type Poller struct {
 
 	runMu   sync.Mutex
 	started bool
+	stopped bool
 	jobIDs  []string
+
+	statusMu      sync.Mutex
+	lastChainAt   time.Time
+	lastChainErr  string
+	inflightCount int
 }
 
 // NewPoller returns an unstarted Poller. Pass nil logger to use
@@ -85,6 +92,58 @@ func (p *Poller) RegisterCollector(c Collector) {
 // poller registers in the lifecycle registry alongside the probe +
 // retention engines.
 func (*Poller) Name() string { return "snmp-poller" }
+
+// Status implements [engine.Reporter]. The poller doesn't have a
+// single "tick" — collectors run per-target on independent schedules
+// — so LastTickAt reports the most recent chain completion across
+// all targets, and Inflight reports how many chains are in flight
+// right now. State is "stopped" after Stop(), otherwise always "ok"
+// (degraded would need a per-target SLA the registry doesn't track).
+func (p *Poller) Status() engine.Status {
+	p.statusMu.Lock()
+	lastAt := p.lastChainAt
+	lastErr := p.lastChainErr
+	inflight := p.inflightCount
+	p.statusMu.Unlock()
+
+	p.runMu.Lock()
+	stopped := p.stopped
+	p.runMu.Unlock()
+
+	s := engine.Status{
+		LastTickAt: lastAt,
+		LastError:  lastErr,
+		Inflight:   inflight,
+	}
+	if stopped {
+		s.State = engine.StateStopped
+	} else {
+		s.State = engine.StateOK
+	}
+	return s
+}
+
+// recordChainStart bumps the inflight counter when a target's
+// collector chain kicks off.
+func (p *Poller) recordChainStart() {
+	p.statusMu.Lock()
+	defer p.statusMu.Unlock()
+	p.inflightCount++
+}
+
+// recordChainEnd stamps the completion time + error and decrements
+// inflight.
+func (p *Poller) recordChainEnd(err error) {
+	p.statusMu.Lock()
+	defer p.statusMu.Unlock()
+	p.inflightCount--
+	p.lastChainAt = time.Now().UTC()
+	if err != nil {
+		p.lastChainErr = err.Error()
+		return
+	}
+	p.lastChainErr = ""
+}
 
 // Start loads all enabled polling_targets and registers one job
 // per target with the scheduler. Idempotent.
@@ -131,6 +190,7 @@ func (p *Poller) Stop(ctx context.Context) error {
 	p.jobIDs = nil
 	p.scheduler.Stop()
 	p.started = false
+	p.stopped = true
 	p.logger.InfoContext(ctx, "snmp poller stopped")
 	return nil
 }
@@ -140,10 +200,12 @@ func (p *Poller) Stop(ctx context.Context) error {
 // continues. After the chain runs, last_status / last_error /
 // last_polled_at are recorded.
 func (p *Poller) runChain(ctx context.Context, target *database.PollingTarget) {
+	p.recordChainStart()
 	creds := credentialsForTarget(target)
 
 	wireTarget := wireTarget(target)
 	var firstErr error
+	defer func() { p.recordChainEnd(firstErr) }()
 	for _, name := range target.CollectorChain {
 		p.mu.RLock()
 		c, ok := p.collectors[name]

--- a/internal/topology/arp_reconciler.go
+++ b/internal/topology/arp_reconciler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
 
 // ARPReconcilerName is the engine identifier.
@@ -42,9 +43,11 @@ type ARPReconciler struct {
 	logger   *slog.Logger
 	now      func() time.Time
 	interval time.Duration
+	tracker  *tickTracker
 
 	mu      sync.Mutex
 	started bool
+	stopped bool
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 }
@@ -78,11 +81,20 @@ func NewARPReconciler(cfg ARPConfig) (*ARPReconciler, error) {
 		logger:   d.logger,
 		now:      d.now,
 		interval: d.interval,
+		tracker:  newTickTracker(d.interval, d.now),
 	}, nil
 }
 
 // Name implements [engine.Engine].
 func (*ARPReconciler) Name() string { return ARPReconcilerName }
+
+// Status implements [engine.Reporter].
+func (r *ARPReconciler) Status() engine.Status {
+	r.mu.Lock()
+	stopped := r.stopped
+	r.mu.Unlock()
+	return r.tracker.status(stopped)
+}
 
 // Start kicks off the reconcile loop. Idempotent.
 func (r *ARPReconciler) Start(ctx context.Context) error {
@@ -108,6 +120,7 @@ func (r *ARPReconciler) Stop(ctx context.Context) error {
 		return nil
 	}
 	r.started = false
+	r.stopped = true
 	if r.cancel != nil {
 		r.cancel()
 	}
@@ -148,6 +161,12 @@ func (r *ARPReconciler) loop(ctx context.Context) {
 
 // ReconcileOnce processes one batch of new arp observations.
 func (r *ARPReconciler) ReconcileOnce(ctx context.Context) error {
+	err := r.reconcileOnceInner(ctx)
+	r.tracker.recordTick(err)
+	return err
+}
+
+func (r *ARPReconciler) reconcileOnceInner(ctx context.Context) error {
 	since, err := r.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)

--- a/internal/topology/edge_reconciler.go
+++ b/internal/topology/edge_reconciler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
 
 // EdgeReconcilerName is the engine identifier.
@@ -49,9 +50,11 @@ type EdgeReconciler struct {
 	logger   *slog.Logger
 	now      func() time.Time
 	interval time.Duration
+	tracker  *tickTracker
 
 	mu      sync.Mutex
 	started bool
+	stopped bool
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 }
@@ -85,11 +88,20 @@ func NewEdgeReconciler(cfg EdgeConfig) (*EdgeReconciler, error) {
 		logger:   d.logger,
 		now:      d.now,
 		interval: d.interval,
+		tracker:  newTickTracker(d.interval, d.now),
 	}, nil
 }
 
 // Name implements [engine.Engine].
 func (*EdgeReconciler) Name() string { return EdgeReconcilerName }
+
+// Status implements [engine.Reporter].
+func (r *EdgeReconciler) Status() engine.Status {
+	r.mu.Lock()
+	stopped := r.stopped
+	r.mu.Unlock()
+	return r.tracker.status(stopped)
+}
 
 // Start kicks off the reconcile loop. Idempotent.
 func (r *EdgeReconciler) Start(ctx context.Context) error {
@@ -115,6 +127,7 @@ func (r *EdgeReconciler) Stop(ctx context.Context) error {
 		return nil
 	}
 	r.started = false
+	r.stopped = true
 	if r.cancel != nil {
 		r.cancel()
 	}
@@ -157,6 +170,12 @@ func (r *EdgeReconciler) loop(ctx context.Context) {
 // Iterating per-kind keeps the SQL filters indexed (snmp_observations
 // has an idx on (client_id, kind, observed_at)).
 func (r *EdgeReconciler) ReconcileOnce(ctx context.Context) error {
+	err := r.reconcileOnceInner(ctx)
+	r.tracker.recordTick(err)
+	return err
+}
+
+func (r *EdgeReconciler) reconcileOnceInner(ctx context.Context) error {
 	since, err := r.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)

--- a/internal/topology/iftable_reconciler.go
+++ b/internal/topology/iftable_reconciler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
 
 // IfTableReconcilerName is the engine identifier.
@@ -39,9 +40,11 @@ type IfTableReconciler struct {
 	logger   *slog.Logger
 	now      func() time.Time
 	interval time.Duration
+	tracker  *tickTracker
 
 	mu      sync.Mutex
 	started bool
+	stopped bool
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 }
@@ -76,11 +79,20 @@ func NewIfTableReconciler(cfg IfTableConfig) (*IfTableReconciler, error) {
 		logger:   d.logger,
 		now:      d.now,
 		interval: d.interval,
+		tracker:  newTickTracker(d.interval, d.now),
 	}, nil
 }
 
 // Name implements [engine.Engine].
 func (*IfTableReconciler) Name() string { return IfTableReconcilerName }
+
+// Status implements [engine.Reporter].
+func (r *IfTableReconciler) Status() engine.Status {
+	r.mu.Lock()
+	stopped := r.stopped
+	r.mu.Unlock()
+	return r.tracker.status(stopped)
+}
 
 // Start kicks off the reconcile loop. Idempotent.
 func (r *IfTableReconciler) Start(ctx context.Context) error {
@@ -106,6 +118,7 @@ func (r *IfTableReconciler) Stop(ctx context.Context) error {
 		return nil
 	}
 	r.started = false
+	r.stopped = true
 	if r.cancel != nil {
 		r.cancel()
 	}
@@ -146,6 +159,12 @@ func (r *IfTableReconciler) loop(ctx context.Context) {
 
 // ReconcileOnce processes one batch of new if_table observations.
 func (r *IfTableReconciler) ReconcileOnce(ctx context.Context) error {
+	err := r.reconcileOnceInner(ctx)
+	r.tracker.recordTick(err)
+	return err
+}
+
+func (r *IfTableReconciler) reconcileOnceInner(ctx context.Context) error {
 	since, err := r.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)

--- a/internal/topology/reporter.go
+++ b/internal/topology/reporter.go
@@ -1,0 +1,67 @@
+package topology
+
+// reporter.go provides the shared status accounting the four
+// reconcilers (sys_info, if_table, edge, arp) layer on top of their
+// Engine implementation to satisfy engine.Reporter (#1383).
+//
+// Each reconciler embeds *tickTracker. The tracker maintains
+// lastTickAt + lastError under its own mutex and surfaces them via
+// status(stopped). Engines call tracker.recordTick(err) at the end
+// of every ReconcileOnce pass.
+//
+// Kept package-private — the engine.Reporter interface is the
+// public seam. Operators see the rolled-up Status in /api/v1/engines,
+// not the raw tracker.
+
+import (
+	"sync"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/engine"
+)
+
+// degradedTickMultiplier mirrors the alerts/pipeline constant: a
+// reconciler that hasn't ticked in 2x its configured interval is
+// reported as degraded.
+const degradedTickMultiplier = 2
+
+type tickTracker struct {
+	interval time.Duration
+	now      func() time.Time
+
+	mu         sync.Mutex
+	lastTickAt time.Time
+	lastError  string
+}
+
+func newTickTracker(interval time.Duration, now func() time.Time) *tickTracker {
+	return &tickTracker{interval: interval, now: now}
+}
+
+func (t *tickTracker) recordTick(err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastTickAt = t.now()
+	if err != nil {
+		t.lastError = err.Error()
+		return
+	}
+	t.lastError = ""
+}
+
+func (t *tickTracker) status(stopped bool) engine.Status {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s := engine.Status{LastTickAt: t.lastTickAt, LastError: t.lastError}
+	switch {
+	case stopped:
+		s.State = engine.StateStopped
+	case t.lastTickAt.IsZero():
+		s.State = engine.StateOK
+	case t.now().Sub(t.lastTickAt) > degradedTickMultiplier*t.interval:
+		s.State = engine.StateDegraded
+	default:
+		s.State = engine.StateOK
+	}
+	return s
+}

--- a/internal/topology/sysinfo_reconciler.go
+++ b/internal/topology/sysinfo_reconciler.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
 
 // SysInfoReconcilerName is the engine identifier.
@@ -82,9 +83,11 @@ type SysInfoReconciler struct {
 	logger   *slog.Logger
 	now      func() time.Time
 	interval time.Duration
+	tracker  *tickTracker
 
 	mu      sync.Mutex
 	started bool
+	stopped bool
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 }
@@ -118,11 +121,20 @@ func NewSysInfoReconciler(cfg Config) (*SysInfoReconciler, error) {
 		logger:   d.logger,
 		now:      d.now,
 		interval: d.interval,
+		tracker:  newTickTracker(d.interval, d.now),
 	}, nil
 }
 
 // Name implements [engine.Engine].
 func (*SysInfoReconciler) Name() string { return SysInfoReconcilerName }
+
+// Status implements [engine.Reporter].
+func (r *SysInfoReconciler) Status() engine.Status {
+	r.mu.Lock()
+	stopped := r.stopped
+	r.mu.Unlock()
+	return r.tracker.status(stopped)
+}
 
 // Start kicks off the reconcile loop. Idempotent.
 func (r *SysInfoReconciler) Start(ctx context.Context) error {
@@ -148,6 +160,7 @@ func (r *SysInfoReconciler) Stop(ctx context.Context) error {
 		return nil
 	}
 	r.started = false
+	r.stopped = true
 	if r.cancel != nil {
 		r.cancel()
 	}
@@ -192,6 +205,12 @@ func (r *SysInfoReconciler) loop(ctx context.Context) {
 // ReconcileOnce processes one batch of new sys_info observations.
 // Exposed for tests and for the engine loop alike.
 func (r *SysInfoReconciler) ReconcileOnce(ctx context.Context) error {
+	err := r.reconcileOnceInner(ctx)
+	r.tracker.recordTick(err)
+	return err
+}
+
+func (r *SysInfoReconciler) reconcileOnceInner(ctx context.Context) error {
 	since, err := r.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)


### PR DESCRIPTION
## Summary

Closes #1383 (Phase 3 / PR 7 of the V1.0 follow-up plan tracked under #1367).

Introduces `engine.Reporter` — an optional contract engines can implement to expose per-engine health to `/api/v1/engines`. Operators currently see only `{name}` for each engine; they can't tell from the API whether an engine is stuck, last-erroring, or actively ticking. This PR adds that visibility.

```
engine.Status { State, LastTickAt, LastError, Inflight }
engine.StatusOK() — default for engines without rich status
engine.StateOK / StateDegraded / StateStopped — locked constants
```

`/api/v1/engines` now type-asserts each engine to `engine.Reporter` and surfaces:

```json
{
  "count": 9,
  "engines": [
    {
      "name": "probe",
      "state": "ok",
      "lastTickAt": "2026-05-31T12:34:56.789Z",
      "lastError": "",
      "inflight": 0
    },
    {
      "name": "snmp-poller",
      "state": "degraded",
      "lastTickAt": "2026-05-31T12:30:01.123Z",
      "lastError": "scan timeout: ctx deadline exceeded",
      "inflight": 3
    }
  ]
}
```

## Design notes

- **Opt-in adoption**. Engines that don't implement `Reporter` get `StatusOK()` so the wire response stays uniform without forcing every engine to grow a `Status()` method in this PR. The V1.0 `{count, engines: [{name}]}` shape is preserved; new fields are additive.
- **State constants locked in tests**. `TestStatusJSON_NameSurfaceIsStable` asserts the literal `"ok"` / `"degraded"` / `"stopped"` values so a future rename doesn't silently break operator dashboards.
- **Per-engine retrofit deferred**. Plan PRs 8 and 9 land the actual `Status()` implementations on the alert pipelines, snmp poller, and topology reconcilers in separate diffs — keeps this PR a clean interface + handler change.

## Test plan

- [x] `internal/engine/engine_test.go` — 5 new cases: `StatusOK()` default, locked state-name constants, type-assertion of plain engine fails, type-assertion of reporting engine returns Status, registry holds mixed engines.
- [x] `internal/api/handlers_engines_internal_test.go` — 3 new cases: engine without Reporter defaults to `state: "ok"`, engine with Reporter surfaces full status, blank `Status.State` falls back to `"ok"`.
- [x] Existing handler tests still pass — backward-compatible response shape.
- [x] `make lint` zero warnings, `go test ./...` clean.

## Tier gating

None. The handler is admin-only via the existing auth middleware; no per-tier change.

Plan: see comment on #1367.