### PR TITLE
feat(alerts): reporter on listener + observation pipelines

### DIFF
--- a/internal/alerts/pipeline/listener_pipeline.go
+++ b/internal/alerts/pipeline/listener_pipeline.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
 
 // ListenerPipelineName is the engine identifier.
@@ -92,11 +93,14 @@ type ListenerPipeline struct {
 	rules       []Rule
 	suppression time.Duration
 
-	mu      sync.Mutex
-	started bool
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
-	emitted map[string]time.Time
+	mu         sync.Mutex
+	started    bool
+	stopped    bool
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+	emitted    map[string]time.Time
+	lastTickAt time.Time
+	lastError  string
 }
 
 // ListenerConfig wires the pipeline.
@@ -160,6 +164,28 @@ func NewListenerPipeline(cfg ListenerConfig) (*ListenerPipeline, error) {
 // Name implements [engine.Engine].
 func (*ListenerPipeline) Name() string { return ListenerPipelineName }
 
+// Status implements [engine.Reporter]. See observation_pipeline.go
+// for the state model — same rules apply here.
+func (p *ListenerPipeline) Status() engine.Status {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	s := engine.Status{
+		LastTickAt: p.lastTickAt,
+		LastError:  p.lastError,
+	}
+	switch {
+	case p.stopped:
+		s.State = engine.StateStopped
+	case p.lastTickAt.IsZero():
+		s.State = engine.StateOK
+	case p.now().Sub(p.lastTickAt) > degradedTickMultiplier*p.interval:
+		s.State = engine.StateDegraded
+	default:
+		s.State = engine.StateOK
+	}
+	return s
+}
+
 // Start kicks off the scan loop. Idempotent.
 func (p *ListenerPipeline) Start(ctx context.Context) error {
 	p.mu.Lock()
@@ -185,6 +211,7 @@ func (p *ListenerPipeline) Stop(ctx context.Context) error {
 		return nil
 	}
 	p.started = false
+	p.stopped = true
 	if p.cancel != nil {
 		p.cancel()
 	}
@@ -225,6 +252,24 @@ func (p *ListenerPipeline) loop(ctx context.Context) {
 
 // ScanOnce processes one batch of listener_events.
 func (p *ListenerPipeline) ScanOnce(ctx context.Context) error {
+	err := p.scanOnceInner(ctx)
+	p.recordScan(err)
+	return err
+}
+
+// recordScan stamps lastTickAt + lastError for engine.Reporter.
+func (p *ListenerPipeline) recordScan(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastTickAt = p.now()
+	if err != nil {
+		p.lastError = err.Error()
+		return
+	}
+	p.lastError = ""
+}
+
+func (p *ListenerPipeline) scanOnceInner(ctx context.Context) error {
 	since, err := p.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)

--- a/internal/alerts/pipeline/observation_pipeline.go
+++ b/internal/alerts/pipeline/observation_pipeline.go
@@ -10,7 +10,13 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
+
+// degradedTickMultiplier is how many scan intervals can elapse
+// before a pipeline's Status() reports degraded. Two ticks gives
+// the loop one missed tick of grace before paging.
+const degradedTickMultiplier = 2
 
 // ObservationPipelineName is the engine identifier.
 const ObservationPipelineName = "alert-observation-pipeline"
@@ -53,9 +59,14 @@ type ObservationPipeline struct {
 
 	mu      sync.Mutex
 	started bool
+	stopped bool
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 	emitted map[string]time.Time
+
+	// Per-scan status, updated under mu for engine.Reporter.
+	lastTickAt time.Time
+	lastError  string
 
 	// Previous-state caches. Keyed by entity identifier
 	// ("target/ifindex" or "target/peer-ip", etc.). Updated after
@@ -120,6 +131,30 @@ func NewObservationPipeline(cfg ObservationConfig) (*ObservationPipeline, error)
 // Name implements [engine.Engine].
 func (*ObservationPipeline) Name() string { return ObservationPipelineName }
 
+// Status implements [engine.Reporter]. State derives from how long
+// it has been since the last scan completed: "ok" within
+// degradedTickMultiplier*interval, "degraded" beyond that, and
+// "stopped" after Stop has been called.
+func (p *ObservationPipeline) Status() engine.Status {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	s := engine.Status{
+		LastTickAt: p.lastTickAt,
+		LastError:  p.lastError,
+	}
+	switch {
+	case p.stopped:
+		s.State = engine.StateStopped
+	case p.lastTickAt.IsZero():
+		s.State = engine.StateOK
+	case p.now().Sub(p.lastTickAt) > degradedTickMultiplier*p.interval:
+		s.State = engine.StateDegraded
+	default:
+		s.State = engine.StateOK
+	}
+	return s
+}
+
 // Start kicks off the scan loop. Idempotent.
 func (p *ObservationPipeline) Start(ctx context.Context) error {
 	p.mu.Lock()
@@ -145,6 +180,7 @@ func (p *ObservationPipeline) Stop(ctx context.Context) error {
 		return nil
 	}
 	p.started = false
+	p.stopped = true
 	if p.cancel != nil {
 		p.cancel()
 	}
@@ -187,6 +223,25 @@ func (p *ObservationPipeline) loop(ctx context.Context) {
 // has a delta signal. iftable + bgp4_mib + host_resources are the
 // V1.0 set; future kinds extend the per-kind dispatch.
 func (p *ObservationPipeline) ScanOnce(ctx context.Context) error {
+	err := p.scanOnceInner(ctx)
+	p.recordScan(err)
+	return err
+}
+
+// recordScan stamps lastTickAt + lastError for engine.Reporter.
+// Called from ScanOnce on every pass; held briefly under mu.
+func (p *ObservationPipeline) recordScan(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastTickAt = p.now()
+	if err != nil {
+		p.lastError = err.Error()
+		return
+	}
+	p.lastError = ""
+}
+
+func (p *ObservationPipeline) scanOnceInner(ctx context.Context) error {
 	since, err := p.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)

--- a/internal/alerts/pipeline/reporter_test.go
+++ b/internal/alerts/pipeline/reporter_test.go
@@ -1,0 +1,126 @@
+package pipeline_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/alerts/pipeline"
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
+)
+
+func TestListenerPipeline_Status_BeforeFirstScan(t *testing.T) {
+	t.Parallel()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: &fakeEvents{}, Alerts: &fakeAlerts{}, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	r, ok := any(p).(engine.Reporter)
+	if !ok {
+		t.Fatal("ListenerPipeline must implement engine.Reporter")
+	}
+	s := r.Status()
+	if s.State != engine.StateOK {
+		t.Errorf("State before any scan = %q, want ok", s.State)
+	}
+	if !s.LastTickAt.IsZero() {
+		t.Errorf("LastTickAt = %v, want zero before first scan", s.LastTickAt)
+	}
+}
+
+func TestListenerPipeline_Status_AfterScanRecordsTick(t *testing.T) {
+	t.Parallel()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: &fakeEvents{}, Alerts: &fakeAlerts{}, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at,
+	})
+	_ = p.ScanOnce(context.Background())
+	s := any(p).(engine.Reporter).Status()
+	if s.LastTickAt.IsZero() {
+		t.Error("LastTickAt should be non-zero after ScanOnce")
+	}
+	if s.LastError != "" {
+		t.Errorf("LastError = %q, want empty after clean scan", s.LastError)
+	}
+}
+
+func TestListenerPipeline_Status_AfterScanErrorRecordsError(t *testing.T) {
+	t.Parallel()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events:   &fakeEvents{listErr: errors.New("db down")},
+		Alerts:   &fakeAlerts{},
+		Settings: newFakeSettings(),
+		Logger:   silentLogger(),
+		Now:      at,
+	})
+	_ = p.ScanOnce(context.Background())
+	s := any(p).(engine.Reporter).Status()
+	if s.LastError == "" {
+		t.Error("LastError should be populated after failed scan")
+	}
+}
+
+func TestListenerPipeline_Status_AfterStop(t *testing.T) {
+	t.Parallel()
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events: &fakeEvents{}, Alerts: &fakeAlerts{}, Settings: newFakeSettings(),
+		Logger: silentLogger(), Now: at, Interval: 500 * time.Millisecond,
+	})
+	if startErr := p.Start(context.Background()); startErr != nil {
+		t.Fatalf("Start: %v", startErr)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if stopErr := p.Stop(ctx); stopErr != nil {
+		t.Fatalf("Stop: %v", stopErr)
+	}
+	s := any(p).(engine.Reporter).Status()
+	if s.State != engine.StateStopped {
+		t.Errorf("State after Stop = %q, want stopped", s.State)
+	}
+}
+
+// fakeObs lets us drive ObservationPipeline.ScanOnce.
+type fakeObs struct {
+	rows    []*database.SNMPObservation
+	listErr error
+}
+
+func (f *fakeObs) List(_ context.Context, _ database.ListOptions) ([]*database.SNMPObservation, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]*database.SNMPObservation, len(f.rows))
+	copy(out, f.rows)
+	return out, nil
+}
+
+func TestObservationPipeline_Status_LifecycleTransitions(t *testing.T) {
+	t.Parallel()
+	p, err := pipeline.NewObservationPipeline(pipeline.ObservationConfig{
+		Observations: &fakeObs{},
+		Alerts:       &fakeAlerts{},
+		Settings:     newFakeSettings(),
+		Logger:       silentLogger(),
+		Now:          at,
+	})
+	if err != nil {
+		t.Fatalf("NewObservationPipeline: %v", err)
+	}
+	rep, ok := any(p).(engine.Reporter)
+	if !ok {
+		t.Fatal("ObservationPipeline must implement engine.Reporter")
+	}
+
+	// Before scan
+	if state := rep.Status().State; state != engine.StateOK {
+		t.Errorf("pre-scan state = %q, want ok", state)
+	}
+	// After clean scan
+	_ = p.ScanOnce(context.Background())
+	if rep.Status().LastTickAt.IsZero() {
+		t.Error("LastTickAt zero after ScanOnce")
+	}
+}


### PR DESCRIPTION
## Summary

PR 8 of the V1.0 follow-up plan #1367, stacked on #1389. First adopter of the `engine.Reporter` interface.

Both alert pipelines now implement `engine.Reporter`, exposing `LastTickAt` / `LastError` to `/api/v1/engines`. State derives from elapsed time since the last completed scan:

- **ok** — within `2 × interval` (or never ticked yet)
- **degraded** — older than `2 × interval`
- **stopped** — `Stop()` has been called

## Implementation

- `ScanOnce` wraps the original logic and stamps `lastTickAt` + `lastError` under `p.mu` at the end of every pass. `recordScan(err)` is the single update site so success + failure paths share one record.
- `Stop` sets `stopped = true` so post-shutdown probes see the correct state.
- `Status()` returns a snapshot under the same mutex so concurrent scans can't tear the read.
- `degradedTickMultiplier = 2` is the only new tunable — captured at package scope with a doc comment so a future operator-facing setting has an obvious home.

## Tests

`internal/alerts/pipeline/reporter_test.go` — 5 cases: ListenerPipeline before scan (state=ok, LastTickAt zero), after clean scan (LastTickAt non-zero), after failed scan (LastError populated), after Stop (state=stopped), ObservationPipeline lifecycle round-trip.

`make lint` zero, `go test ./...` clean.

Closes part of #1383 (PRs 8 + 9 split per plan).