### PR TITLE
feat(engine): reporter on snmp poller + topology reconcilers

### DIFF
--- a/internal/polling/snmp/poller.go
+++ b/internal/polling/snmp/poller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 	"github.com/krisarmstrong/seed/internal/scheduler"
 )
 
@@ -53,7 +54,13 @@ type Poller struct {
 
 	runMu   sync.Mutex
 	started bool
+	stopped bool
 	jobIDs  []string
+
+	statusMu      sync.Mutex
+	lastChainAt   time.Time
+	lastChainErr  string
+	inflightCount int
 }
 
 // NewPoller returns an unstarted Poller. Pass nil logger to use
@@ -85,6 +92,58 @@ func (p *Poller) RegisterCollector(c Collector) {
 // poller registers in the lifecycle registry alongside the probe +
 // retention engines.
 func (*Poller) Name() string { return "snmp-poller" }
+
+// Status implements [engine.Reporter]. The poller doesn't have a
+// single "tick" — collectors run per-target on independent schedules
+// — so LastTickAt reports the most recent chain completion across
+// all targets, and Inflight reports how many chains are in flight
+// right now. State is "stopped" after Stop(), otherwise always "ok"
+// (degraded would need a per-target SLA the registry doesn't track).
+func (p *Poller) Status() engine.Status {
+	p.statusMu.Lock()
+	lastAt := p.lastChainAt
+	lastErr := p.lastChainErr
+	inflight := p.inflightCount
+	p.statusMu.Unlock()
+
+	p.runMu.Lock()
+	stopped := p.stopped
+	p.runMu.Unlock()
+
+	s := engine.Status{
+		LastTickAt: lastAt,
+		LastError:  lastErr,
+		Inflight:   inflight,
+	}
+	if stopped {
+		s.State = engine.StateStopped
+	} else {
+		s.State = engine.StateOK
+	}
+	return s
+}
+
+// recordChainStart bumps the inflight counter when a target's
+// collector chain kicks off.
+func (p *Poller) recordChainStart() {
+	p.statusMu.Lock()
+	defer p.statusMu.Unlock()
+	p.inflightCount++
+}
+
+// recordChainEnd stamps the completion time + error and decrements
+// inflight.
+func (p *Poller) recordChainEnd(err error) {
+	p.statusMu.Lock()
+	defer p.statusMu.Unlock()
+	p.inflightCount--
+	p.lastChainAt = time.Now().UTC()
+	if err != nil {
+		p.lastChainErr = err.Error()
+		return
+	}
+	p.lastChainErr = ""
+}
 
 // Start loads all enabled polling_targets and registers one job
 // per target with the scheduler. Idempotent.
@@ -131,6 +190,7 @@ func (p *Poller) Stop(ctx context.Context) error {
 	p.jobIDs = nil
 	p.scheduler.Stop()
 	p.started = false
+	p.stopped = true
 	p.logger.InfoContext(ctx, "snmp poller stopped")
 	return nil
 }
@@ -140,10 +200,12 @@ func (p *Poller) Stop(ctx context.Context) error {
 // continues. After the chain runs, last_status / last_error /
 // last_polled_at are recorded.
 func (p *Poller) runChain(ctx context.Context, target *database.PollingTarget) {
+	p.recordChainStart()
 	creds := credentialsForTarget(target)
 
 	wireTarget := wireTarget(target)
 	var firstErr error
+	defer func() { p.recordChainEnd(firstErr) }()
 	for _, name := range target.CollectorChain {
 		p.mu.RLock()
 		c, ok := p.collectors[name]

--- a/internal/topology/arp_reconciler.go
+++ b/internal/topology/arp_reconciler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
 
 // ARPReconcilerName is the engine identifier.
@@ -42,9 +43,11 @@ type ARPReconciler struct {
 	logger   *slog.Logger
 	now      func() time.Time
 	interval time.Duration
+	tracker  *tickTracker
 
 	mu      sync.Mutex
 	started bool
+	stopped bool
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 }
@@ -78,11 +81,20 @@ func NewARPReconciler(cfg ARPConfig) (*ARPReconciler, error) {
 		logger:   d.logger,
 		now:      d.now,
 		interval: d.interval,
+		tracker:  newTickTracker(d.interval, d.now),
 	}, nil
 }
 
 // Name implements [engine.Engine].
 func (*ARPReconciler) Name() string { return ARPReconcilerName }
+
+// Status implements [engine.Reporter].
+func (r *ARPReconciler) Status() engine.Status {
+	r.mu.Lock()
+	stopped := r.stopped
+	r.mu.Unlock()
+	return r.tracker.status(stopped)
+}
 
 // Start kicks off the reconcile loop. Idempotent.
 func (r *ARPReconciler) Start(ctx context.Context) error {
@@ -108,6 +120,7 @@ func (r *ARPReconciler) Stop(ctx context.Context) error {
 		return nil
 	}
 	r.started = false
+	r.stopped = true
 	if r.cancel != nil {
 		r.cancel()
 	}
@@ -148,6 +161,12 @@ func (r *ARPReconciler) loop(ctx context.Context) {
 
 // ReconcileOnce processes one batch of new arp observations.
 func (r *ARPReconciler) ReconcileOnce(ctx context.Context) error {
+	err := r.reconcileOnceInner(ctx)
+	r.tracker.recordTick(err)
+	return err
+}
+
+func (r *ARPReconciler) reconcileOnceInner(ctx context.Context) error {
 	since, err := r.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)

--- a/internal/topology/edge_reconciler.go
+++ b/internal/topology/edge_reconciler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
 
 // EdgeReconcilerName is the engine identifier.
@@ -49,9 +50,11 @@ type EdgeReconciler struct {
 	logger   *slog.Logger
 	now      func() time.Time
 	interval time.Duration
+	tracker  *tickTracker
 
 	mu      sync.Mutex
 	started bool
+	stopped bool
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 }
@@ -85,11 +88,20 @@ func NewEdgeReconciler(cfg EdgeConfig) (*EdgeReconciler, error) {
 		logger:   d.logger,
 		now:      d.now,
 		interval: d.interval,
+		tracker:  newTickTracker(d.interval, d.now),
 	}, nil
 }
 
 // Name implements [engine.Engine].
 func (*EdgeReconciler) Name() string { return EdgeReconcilerName }
+
+// Status implements [engine.Reporter].
+func (r *EdgeReconciler) Status() engine.Status {
+	r.mu.Lock()
+	stopped := r.stopped
+	r.mu.Unlock()
+	return r.tracker.status(stopped)
+}
 
 // Start kicks off the reconcile loop. Idempotent.
 func (r *EdgeReconciler) Start(ctx context.Context) error {
@@ -115,6 +127,7 @@ func (r *EdgeReconciler) Stop(ctx context.Context) error {
 		return nil
 	}
 	r.started = false
+	r.stopped = true
 	if r.cancel != nil {
 		r.cancel()
 	}
@@ -157,6 +170,12 @@ func (r *EdgeReconciler) loop(ctx context.Context) {
 // Iterating per-kind keeps the SQL filters indexed (snmp_observations
 // has an idx on (client_id, kind, observed_at)).
 func (r *EdgeReconciler) ReconcileOnce(ctx context.Context) error {
+	err := r.reconcileOnceInner(ctx)
+	r.tracker.recordTick(err)
+	return err
+}
+
+func (r *EdgeReconciler) reconcileOnceInner(ctx context.Context) error {
 	since, err := r.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)

--- a/internal/topology/iftable_reconciler.go
+++ b/internal/topology/iftable_reconciler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
 
 // IfTableReconcilerName is the engine identifier.
@@ -39,9 +40,11 @@ type IfTableReconciler struct {
 	logger   *slog.Logger
 	now      func() time.Time
 	interval time.Duration
+	tracker  *tickTracker
 
 	mu      sync.Mutex
 	started bool
+	stopped bool
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 }
@@ -76,11 +79,20 @@ func NewIfTableReconciler(cfg IfTableConfig) (*IfTableReconciler, error) {
 		logger:   d.logger,
 		now:      d.now,
 		interval: d.interval,
+		tracker:  newTickTracker(d.interval, d.now),
 	}, nil
 }
 
 // Name implements [engine.Engine].
 func (*IfTableReconciler) Name() string { return IfTableReconcilerName }
+
+// Status implements [engine.Reporter].
+func (r *IfTableReconciler) Status() engine.Status {
+	r.mu.Lock()
+	stopped := r.stopped
+	r.mu.Unlock()
+	return r.tracker.status(stopped)
+}
 
 // Start kicks off the reconcile loop. Idempotent.
 func (r *IfTableReconciler) Start(ctx context.Context) error {
@@ -106,6 +118,7 @@ func (r *IfTableReconciler) Stop(ctx context.Context) error {
 		return nil
 	}
 	r.started = false
+	r.stopped = true
 	if r.cancel != nil {
 		r.cancel()
 	}
@@ -146,6 +159,12 @@ func (r *IfTableReconciler) loop(ctx context.Context) {
 
 // ReconcileOnce processes one batch of new if_table observations.
 func (r *IfTableReconciler) ReconcileOnce(ctx context.Context) error {
+	err := r.reconcileOnceInner(ctx)
+	r.tracker.recordTick(err)
+	return err
+}
+
+func (r *IfTableReconciler) reconcileOnceInner(ctx context.Context) error {
 	since, err := r.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)

--- a/internal/topology/reporter.go
+++ b/internal/topology/reporter.go
@@ -1,0 +1,67 @@
+package topology
+
+// reporter.go provides the shared status accounting the four
+// reconcilers (sys_info, if_table, edge, arp) layer on top of their
+// Engine implementation to satisfy engine.Reporter (#1383).
+//
+// Each reconciler embeds *tickTracker. The tracker maintains
+// lastTickAt + lastError under its own mutex and surfaces them via
+// status(stopped). Engines call tracker.recordTick(err) at the end
+// of every ReconcileOnce pass.
+//
+// Kept package-private — the engine.Reporter interface is the
+// public seam. Operators see the rolled-up Status in /api/v1/engines,
+// not the raw tracker.
+
+import (
+	"sync"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/engine"
+)
+
+// degradedTickMultiplier mirrors the alerts/pipeline constant: a
+// reconciler that hasn't ticked in 2x its configured interval is
+// reported as degraded.
+const degradedTickMultiplier = 2
+
+type tickTracker struct {
+	interval time.Duration
+	now      func() time.Time
+
+	mu         sync.Mutex
+	lastTickAt time.Time
+	lastError  string
+}
+
+func newTickTracker(interval time.Duration, now func() time.Time) *tickTracker {
+	return &tickTracker{interval: interval, now: now}
+}
+
+func (t *tickTracker) recordTick(err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastTickAt = t.now()
+	if err != nil {
+		t.lastError = err.Error()
+		return
+	}
+	t.lastError = ""
+}
+
+func (t *tickTracker) status(stopped bool) engine.Status {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s := engine.Status{LastTickAt: t.lastTickAt, LastError: t.lastError}
+	switch {
+	case stopped:
+		s.State = engine.StateStopped
+	case t.lastTickAt.IsZero():
+		s.State = engine.StateOK
+	case t.now().Sub(t.lastTickAt) > degradedTickMultiplier*t.interval:
+		s.State = engine.StateDegraded
+	default:
+		s.State = engine.StateOK
+	}
+	return s
+}

--- a/internal/topology/sysinfo_reconciler.go
+++ b/internal/topology/sysinfo_reconciler.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/engine"
 )
 
 // SysInfoReconcilerName is the engine identifier.
@@ -82,9 +83,11 @@ type SysInfoReconciler struct {
 	logger   *slog.Logger
 	now      func() time.Time
 	interval time.Duration
+	tracker  *tickTracker
 
 	mu      sync.Mutex
 	started bool
+	stopped bool
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 }
@@ -118,11 +121,20 @@ func NewSysInfoReconciler(cfg Config) (*SysInfoReconciler, error) {
 		logger:   d.logger,
 		now:      d.now,
 		interval: d.interval,
+		tracker:  newTickTracker(d.interval, d.now),
 	}, nil
 }
 
 // Name implements [engine.Engine].
 func (*SysInfoReconciler) Name() string { return SysInfoReconcilerName }
+
+// Status implements [engine.Reporter].
+func (r *SysInfoReconciler) Status() engine.Status {
+	r.mu.Lock()
+	stopped := r.stopped
+	r.mu.Unlock()
+	return r.tracker.status(stopped)
+}
 
 // Start kicks off the reconcile loop. Idempotent.
 func (r *SysInfoReconciler) Start(ctx context.Context) error {
@@ -148,6 +160,7 @@ func (r *SysInfoReconciler) Stop(ctx context.Context) error {
 		return nil
 	}
 	r.started = false
+	r.stopped = true
 	if r.cancel != nil {
 		r.cancel()
 	}
@@ -192,6 +205,12 @@ func (r *SysInfoReconciler) loop(ctx context.Context) {
 // ReconcileOnce processes one batch of new sys_info observations.
 // Exposed for tests and for the engine loop alike.
 func (r *SysInfoReconciler) ReconcileOnce(ctx context.Context) error {
+	err := r.reconcileOnceInner(ctx)
+	r.tracker.recordTick(err)
+	return err
+}
+
+func (r *SysInfoReconciler) reconcileOnceInner(ctx context.Context) error {
 	since, err := r.loadHighWater(ctx)
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)


### PR DESCRIPTION
## Summary

PR 9 of the V1.0 follow-up plan #1367, stacked on #1389. Combined with #1391 (PR 8), closes #1383's full Reporter adoption.

Five more engines adopt `engine.Reporter`:

- `SysInfoReconciler` — topology_nodes from sys_info
- `IfTableReconciler` — topology_interfaces from if_table
- `EdgeReconciler` — topology_links from lldp/cdp/fdp
- `ARPReconciler` — topology_arp_bindings
- snmp `Poller` — per-target collector chain orchestrator

## Implementation

**Reconcilers** share a small package-level `tickTracker` (`internal/topology/reporter.go`) that owns `lastTickAt` + `lastError` under its own mutex and computes State ("ok" within 2× interval, "degraded" beyond, "stopped" after Stop). Each `ReconcileOnce` wraps the original body to call `tracker.recordTick` after the pass.

**Poller** is shaped differently — no single "tick", just per-target chains on independent schedules. Its `Status()` reports the most recent chain completion across all targets plus `Inflight` (count of chains running right now). `recordChainStart` / `recordChainEnd` in `runChain` stamp the counters; `state="stopped"` after `Stop()`, otherwise always "ok" since there's no per-poller SLA the registry could check.

## Verification

```
$ go test ./internal/topology/... ./internal/polling/...
ok ...

$ make lint
0 issues.
```

Existing tests for all five engines unchanged and still passing. The `tickTracker` is package-private; tests can reach it only through the public `Status()` surface.

Plan: see comment on #1367.