### PR TITLE
feat(alerts): replay observation state on startup

### DIFF
--- a/internal/alerts/pipeline/listener_pipeline.go
+++ b/internal/alerts/pipeline/listener_pipeline.go
@@ -96,12 +96,12 @@ type ListenerPipeline struct {
 	defaults       []Rule
 	suppression    time.Duration
 
-	mu      sync.Mutex
-	started bool
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
-	emitted map[string]time.Time
-	rules   []Rule
+	mu       sync.Mutex
+	started  bool
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	suppress suppressionStore
+	rules    []Rule
 }
 
 // ListenerConfig wires the pipeline.
@@ -131,6 +131,13 @@ type ListenerConfig struct {
 	// When nil and AlertRules is also nil, DefaultListenerRules() is
 	// used permanently.
 	Rules []Rule
+
+	// Suppressions is the persistence backend for the per-(rule, entity)
+	// "don't re-fire within the window" check. When nil, an in-memory
+	// store is used (legacy — restart loses state). Production wires
+	// NewDBSuppressionStore(db.AlertSuppressions()) for restart-safety
+	// (#1380).
+	Suppressions suppressionStore
 }
 
 // NewListenerPipeline returns an unstarted pipeline.
@@ -171,6 +178,10 @@ func NewListenerPipeline(cfg ListenerConfig) (*ListenerPipeline, error) {
 	if initial == nil {
 		initial = defaults
 	}
+	suppress := cfg.Suppressions
+	if suppress == nil {
+		suppress = newInMemorySuppressionStore()
+	}
 	p := &ListenerPipeline{
 		events:         cfg.Events,
 		alerts:         cfg.Alerts,
@@ -184,7 +195,7 @@ func NewListenerPipeline(cfg ListenerConfig) (*ListenerPipeline, error) {
 		defaults:       defaults,
 		suppression:    cfg.Suppression,
 		rules:          initial,
-		emitted:        make(map[string]time.Time),
+		suppress:       suppress,
 	}
 	// Prime ruleset from the DB before returning so a caller that
 	// jumps straight to ScanOnce (tests, single-shot use) sees the
@@ -394,7 +405,12 @@ func (p *ListenerPipeline) evaluate(ctx context.Context, evt *database.ListenerE
 			continue
 		}
 		fingerprint := fingerprintFor(rule.ID, evt.SourceAddr, evt.Kind)
-		if p.suppressed(fingerprint, now) {
+		suppressed, suppErr := p.suppress.IsSuppressed(ctx, fingerprint, now)
+		if suppErr != nil {
+			p.logger.WarnContext(ctx, "suppression check failed",
+				"rule", rule.ID, "error", suppErr)
+		}
+		if suppressed {
 			continue
 		}
 		alert := rule.Build(evt)
@@ -406,7 +422,13 @@ func (p *ListenerPipeline) evaluate(ctx context.Context, evt *database.ListenerE
 				"rule", rule.ID, "source", evt.SourceAddr, "error", writeErr)
 			continue
 		}
-		p.markEmitted(fingerprint, now)
+		markErr := p.suppress.Mark(
+			ctx, fingerprint, rule.ID, evt.SourceAddr, now.Add(p.suppression),
+		)
+		if markErr != nil {
+			p.logger.WarnContext(ctx, "suppression mark failed",
+				"rule", rule.ID, "error", markErr)
+		}
 		count++
 	}
 	return count
@@ -421,38 +443,6 @@ func fingerprintFor(ruleID, source, kind string) string {
 	h.Write([]byte{0x00})
 	h.Write([]byte(kind))
 	return hex.EncodeToString(h.Sum(nil))[:24]
-}
-
-// suppressed returns true when this fingerprint has fired within the
-// suppression window.
-func (p *ListenerPipeline) suppressed(fingerprint string, now time.Time) bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	last, ok := p.emitted[fingerprint]
-	if !ok {
-		return false
-	}
-	return now.Sub(last) < p.suppression
-}
-
-// markEmitted records the fire time for a fingerprint. Old entries
-// (>2x suppression window) are evicted lazily to keep the map
-// bounded.
-func (p *ListenerPipeline) markEmitted(fingerprint string, now time.Time) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.emitted[fingerprint] = now
-	// Lazy eviction: walk the map only when it gets noticeably big.
-	const evictThreshold = 4096
-	if len(p.emitted) <= evictThreshold {
-		return
-	}
-	cutoff := now.Add(-2 * p.suppression)
-	for k, v := range p.emitted {
-		if v.Before(cutoff) {
-			delete(p.emitted, k)
-		}
-	}
 }
 
 func (p *ListenerPipeline) loadHighWater(ctx context.Context) (time.Time, error) {

--- a/internal/alerts/pipeline/observation_pipeline.go
+++ b/internal/alerts/pipeline/observation_pipeline.go
@@ -51,11 +51,11 @@ type ObservationPipeline struct {
 	interval    time.Duration
 	suppression time.Duration
 
-	mu      sync.Mutex
-	started bool
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
-	emitted map[string]time.Time
+	mu       sync.Mutex
+	started  bool
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	suppress suppressionStore
 
 	// Previous-state caches. Keyed by entity identifier
 	// ("target/ifindex" or "target/peer-ip", etc.). Updated after
@@ -74,6 +74,9 @@ type ObservationConfig struct {
 	Now          func() time.Time
 	Interval     time.Duration
 	Suppression  time.Duration
+
+	// Suppressions is the persistence backend; see ListenerConfig.
+	Suppressions suppressionStore
 }
 
 // NewObservationPipeline returns an unstarted pipeline.
@@ -102,6 +105,10 @@ func NewObservationPipeline(cfg ObservationConfig) (*ObservationPipeline, error)
 	if cfg.Suppression <= 0 {
 		cfg.Suppression = defaultSuppression
 	}
+	suppress := cfg.Suppressions
+	if suppress == nil {
+		suppress = newInMemorySuppressionStore()
+	}
 	return &ObservationPipeline{
 		obs:          cfg.Observations,
 		alerts:       cfg.Alerts,
@@ -110,7 +117,7 @@ func NewObservationPipeline(cfg ObservationConfig) (*ObservationPipeline, error)
 		now:          cfg.Now,
 		interval:     cfg.Interval,
 		suppression:  cfg.Suppression,
-		emitted:      make(map[string]time.Time),
+		suppress:     suppress,
 		ifaceState:   make(map[string]int),
 		bgpState:     make(map[string]int),
 		storageState: make(map[string]float64),
@@ -418,7 +425,12 @@ func (p *ObservationPipeline) fire(
 ) bool {
 	now := p.now()
 	fingerprint := fingerprintFor(ruleID, entityKey, alert.Source)
-	if p.suppressed(fingerprint, now) {
+	suppressed, suppErr := p.suppress.IsSuppressed(ctx, fingerprint, now)
+	if suppErr != nil {
+		p.logger.WarnContext(ctx, "suppression check failed",
+			"rule", ruleID, "key", entityKey, "error", suppErr)
+	}
+	if suppressed {
 		return false
 	}
 	if err := p.alerts.Create(ctx, alert); err != nil {
@@ -426,36 +438,11 @@ func (p *ObservationPipeline) fire(
 			"rule", ruleID, "key", entityKey, "error", err)
 		return false
 	}
-	p.markEmitted(fingerprint, now)
+	if markErr := p.suppress.Mark(ctx, fingerprint, ruleID, entityKey, now.Add(p.suppression)); markErr != nil {
+		p.logger.WarnContext(ctx, "suppression mark failed",
+			"rule", ruleID, "key", entityKey, "error", markErr)
+	}
 	return true
-}
-
-// suppression helpers — shared shape with listener_pipeline but on
-// this pipeline's own map so they don't contend on a shared mutex.
-func (p *ObservationPipeline) suppressed(fingerprint string, now time.Time) bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	last, ok := p.emitted[fingerprint]
-	if !ok {
-		return false
-	}
-	return now.Sub(last) < p.suppression
-}
-
-func (p *ObservationPipeline) markEmitted(fingerprint string, now time.Time) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.emitted[fingerprint] = now
-	const evictThreshold = 4096
-	if len(p.emitted) <= evictThreshold {
-		return
-	}
-	cutoff := now.Add(-2 * p.suppression)
-	for k, v := range p.emitted {
-		if v.Before(cutoff) {
-			delete(p.emitted, k)
-		}
-	}
 }
 
 // state map accessors keep the lock surface narrow.

--- a/internal/alerts/pipeline/observation_pipeline.go
+++ b/internal/alerts/pipeline/observation_pipeline.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
@@ -50,6 +51,7 @@ type ObservationPipeline struct {
 	now         func() time.Time
 	interval    time.Duration
 	suppression time.Duration
+	replayDepth int
 
 	mu       sync.Mutex
 	started  bool
@@ -65,6 +67,12 @@ type ObservationPipeline struct {
 	storageState map[string]float64 // (target, storage_index) -> last %
 }
 
+// defaultReplayDepth is how many recent observations per kind get
+// pulled at startup to prime the state caches. Two = the previous
+// state plus the current one, which is enough to detect the most
+// recent transition without a deeper history walk.
+const defaultReplayDepth = 2
+
 // ObservationConfig wires the pipeline.
 type ObservationConfig struct {
 	Observations observationReader
@@ -77,6 +85,12 @@ type ObservationConfig struct {
 
 	// Suppressions is the persistence backend; see ListenerConfig.
 	Suppressions suppressionStore
+
+	// ReplayDepth controls how many recent observations per kind
+	// are read at Start to prime the state caches (#1381). Zero
+	// uses defaultReplayDepth (2). Set to -1 to disable replay
+	// (legacy in-memory behavior — fresh state every restart).
+	ReplayDepth int
 }
 
 // NewObservationPipeline returns an unstarted pipeline.
@@ -109,6 +123,10 @@ func NewObservationPipeline(cfg ObservationConfig) (*ObservationPipeline, error)
 	if suppress == nil {
 		suppress = newInMemorySuppressionStore()
 	}
+	replayDepth := cfg.ReplayDepth
+	if replayDepth == 0 {
+		replayDepth = defaultReplayDepth
+	}
 	return &ObservationPipeline{
 		obs:          cfg.Observations,
 		alerts:       cfg.Alerts,
@@ -118,6 +136,7 @@ func NewObservationPipeline(cfg ObservationConfig) (*ObservationPipeline, error)
 		interval:     cfg.Interval,
 		suppression:  cfg.Suppression,
 		suppress:     suppress,
+		replayDepth:  replayDepth,
 		ifaceState:   make(map[string]int),
 		bgpState:     make(map[string]int),
 		storageState: make(map[string]float64),
@@ -128,7 +147,25 @@ func NewObservationPipeline(cfg ObservationConfig) (*ObservationPipeline, error)
 func (*ObservationPipeline) Name() string { return ObservationPipelineName }
 
 // Start kicks off the scan loop. Idempotent.
+//
+// Before the loop kicks, Start primes the per-entity state caches
+// from the most recent observations in the DB (#1381). Without this,
+// a Seed restart would re-fire every "interface down" alert on the
+// first scan because the state cache starts empty and any non-up
+// reading looks like a transition. The replay is bounded by
+// replayDepth so we don't pay for unbounded history at startup.
 func (p *ObservationPipeline) Start(ctx context.Context) error {
+	// Prime state outside the mu — primeFromHistory takes its own
+	// locks on the per-kind state maps. Replay errors are non-fatal:
+	// the worst case is a few spurious alerts on first scan, which
+	// suppression then absorbs.
+	if p.replayDepth > 0 {
+		if err := p.primeFromHistory(ctx); err != nil {
+			p.logger.WarnContext(ctx, "observation pipeline state replay failed",
+				"error", err)
+		}
+	}
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.started {
@@ -140,8 +177,82 @@ func (p *ObservationPipeline) Start(ctx context.Context) error {
 	p.wg.Add(1)
 	go p.loop(loopCtx)
 	p.logger.InfoContext(ctx, "observation alert pipeline started",
-		"interval", p.interval)
+		"interval", p.interval, "replay_depth", p.replayDepth)
 	return nil
+}
+
+// primeFromHistory reads recent observations and walks them through
+// the same payload-decode logic the scan loop uses, but stops short
+// of firing alerts. The point is to populate ifaceState / bgpState /
+// storageState so the first real scan after restart compares against
+// real previous values instead of zero.
+func (p *ObservationPipeline) primeFromHistory(ctx context.Context) error {
+	for _, kind := range observationKinds() {
+		observations, err := p.obs.List(ctx, database.ListOptions{
+			Kind:  kind,
+			Limit: p.replayDepth,
+		})
+		if err != nil {
+			return fmt.Errorf("replay %s: %w", kind, err)
+		}
+		// Walk oldest-first so the most recent observation overwrites
+		// older state — matches what the scan loop would have done.
+		for _, obs := range slices.Backward(observations) {
+			p.primeOne(kind, obs)
+		}
+	}
+	return nil
+}
+
+// primeOne dispatches to the per-kind primer. Unknown kinds are
+// silently skipped — they were filtered out by observationKinds()
+// at the caller, but we double-check here for safety.
+func (p *ObservationPipeline) primeOne(kind string, obs *database.SNMPObservation) {
+	switch kind {
+	case "if_table":
+		p.primeIfTable(obs)
+	case "bgp4_mib":
+		p.primeBGP(obs)
+	case "host_resources":
+		p.primeHostResources(obs)
+	}
+}
+
+func (p *ObservationPipeline) primeIfTable(obs *database.SNMPObservation) {
+	var pay ifTableObsPayload
+	if err := json.Unmarshal([]byte(obs.PayloadJSON), &pay); err != nil {
+		return
+	}
+	for _, row := range pay.Rows {
+		key := fmt.Sprintf("if/%s/%d", obs.TargetID, row.IfIndex)
+		p.recordIface(key, row.IfOper)
+	}
+}
+
+func (p *ObservationPipeline) primeBGP(obs *database.SNMPObservation) {
+	var pay bgpObsPayload
+	if err := json.Unmarshal([]byte(obs.PayloadJSON), &pay); err != nil {
+		return
+	}
+	for _, peer := range pay.Peers {
+		key := fmt.Sprintf("bgp/%s/%s", obs.TargetID, peer.RemoteAddr)
+		p.recordBGP(key, peer.State)
+	}
+}
+
+func (p *ObservationPipeline) primeHostResources(obs *database.SNMPObservation) {
+	var pay hostResObsPayload
+	if err := json.Unmarshal([]byte(obs.PayloadJSON), &pay); err != nil {
+		return
+	}
+	for _, st := range pay.Storage {
+		if st.SizeBytes == 0 {
+			continue
+		}
+		pct := percentMultiplier * float64(st.UsedBytes) / float64(st.SizeBytes)
+		key := fmt.Sprintf("storage/%s/%d", obs.TargetID, st.Index)
+		p.recordStorage(key, pct)
+	}
 }
 
 // Stop terminates the scan loop. Honors ctx deadline.

--- a/internal/alerts/pipeline/suppression.go
+++ b/internal/alerts/pipeline/suppression.go
@@ -1,0 +1,89 @@
+package pipeline
+
+// suppression.go isolates the per-(rule, entity) "don't re-fire
+// inside this window" check both alert pipelines use. Operators
+// see one alert per rule+entity per suppression window rather than
+// a flood when the same condition persists across multiple scans.
+//
+// Two implementations:
+//
+//   - inMemorySuppressionStore — process-local map, lost on restart.
+//     Backward-compatible default for tests that don't wire a DB.
+//
+//   - DBSuppressionStore       — sqlite-backed, restart-safe (#1380).
+//     Production wiring; server.go passes db.AlertSuppressions() into
+//     each pipeline's config.
+//
+// Both implementations honor the same narrow contract so the
+// pipelines stay agnostic to where the marks live.
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// suppressionStore is the narrow surface alert pipelines need.
+// Both the in-memory and DB-backed implementations satisfy it.
+type suppressionStore interface {
+	// IsSuppressed reports whether fingerprint has a fire mark that
+	// has not yet expired.
+	IsSuppressed(ctx context.Context, fingerprint string, now time.Time) (bool, error)
+
+	// Mark records that fingerprint just fired and should be
+	// suppressed until "until".
+	Mark(ctx context.Context, fingerprint, ruleID, entityKey string, until time.Time) error
+}
+
+// inMemorySuppressionStore is the legacy backend — same behavior the
+// pipelines had before #1380, kept for tests that don't wire a DB.
+type inMemorySuppressionStore struct {
+	mu      sync.Mutex
+	emitted map[string]time.Time
+}
+
+func newInMemorySuppressionStore() *inMemorySuppressionStore {
+	return &inMemorySuppressionStore{emitted: make(map[string]time.Time)}
+}
+
+func (s *inMemorySuppressionStore) IsSuppressed(
+	_ context.Context, fingerprint string, now time.Time,
+) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	until, ok := s.emitted[fingerprint]
+	if !ok {
+		return false, nil
+	}
+	return now.Before(until), nil
+}
+
+func (s *inMemorySuppressionStore) Mark(
+	_ context.Context, fingerprint, _, _ string, until time.Time,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.emitted[fingerprint] = until
+	// Lazy eviction at the noticeable-size threshold mirrors the
+	// pre-#1380 behavior so the map stays bounded under sustained
+	// rule fire-rate.
+	const evictThreshold = 4096
+	if len(s.emitted) <= evictThreshold {
+		return nil
+	}
+	for k, v := range s.emitted {
+		if v.Before(until.Add(-time.Hour)) {
+			delete(s.emitted, k)
+		}
+	}
+	return nil
+}
+
+// NewDBSuppressionStore wires a database-backed suppression store
+// by returning the repo directly — *database.AlertSuppressionsRepository
+// already satisfies suppressionStore. Exported as a constructor so
+// server.go has a stable seam if we ever need to layer behavior
+// (metrics, retries) above the raw repo.
+func NewDBSuppressionStore(repo suppressionStore) suppressionStore {
+	return repo
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -463,13 +463,15 @@ func initAlertPipelines(services *ServiceContainer, db *database.DB) {
 	logger := logging.GetLogger()
 	settings := db.Settings()
 	alerts := db.Alerts()
+	suppressions := alertpipeline.NewDBSuppressionStore(db.AlertSuppressions())
 
 	if p, err := alertpipeline.NewListenerPipeline(alertpipeline.ListenerConfig{
-		Events:     db.ListenerEvents(),
-		Alerts:     alerts,
-		Settings:   settings,
-		Logger:     logger,
-		AlertRules: db.AlertRules(),
+		Events:       db.ListenerEvents(),
+		Alerts:       alerts,
+		Settings:     settings,
+		Logger:       logger,
+		AlertRules:   db.AlertRules(),
+		Suppressions: suppressions,
 	}); err != nil {
 		logger.Warn("listener alert pipeline init failed", "error", err)
 	} else if regErr := registerEngineIfLicensed(services, p); regErr != nil {
@@ -477,7 +479,11 @@ func initAlertPipelines(services *ServiceContainer, db *database.DB) {
 	}
 
 	if p, err := alertpipeline.NewObservationPipeline(alertpipeline.ObservationConfig{
-		Observations: db.SNMPObservations(), Alerts: alerts, Settings: settings, Logger: logger,
+		Observations: db.SNMPObservations(),
+		Alerts:       alerts,
+		Settings:     settings,
+		Logger:       logger,
+		Suppressions: suppressions,
 	}); err != nil {
 		logger.Warn("observation alert pipeline init failed", "error", err)
 	} else if regErr := registerEngineIfLicensed(services, p); regErr != nil {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -64,21 +64,22 @@ type DB struct {
 	closed bool
 
 	// Repositories - lazily initialized
-	profiles         *ProfileRepository
-	metrics          *MetricsRepository
-	devices          *DeviceRepository
-	alerts           *AlertRepository
-	settings         *SettingsRepository
-	logs             *LogRepository
-	healthChecks     *HealthCheckRepository
-	discovery        *DiscoveryRepository
-	clients          *ClientRepository
-	probes           *ProbeRepository
-	pollingTargets   *PollingTargetRepository
-	snmpObservations *SNMPObservationsRepository
-	listenerEvents   *ListenerEventsRepository
-	topology         *TopologyRepository
-	alertRules       *AlertRulesRepository
+	profiles          *ProfileRepository
+	metrics           *MetricsRepository
+	devices           *DeviceRepository
+	alerts            *AlertRepository
+	settings          *SettingsRepository
+	logs              *LogRepository
+	healthChecks      *HealthCheckRepository
+	discovery         *DiscoveryRepository
+	clients           *ClientRepository
+	probes            *ProbeRepository
+	pollingTargets    *PollingTargetRepository
+	snmpObservations  *SNMPObservationsRepository
+	listenerEvents    *ListenerEventsRepository
+	topology          *TopologyRepository
+	alertRules        *AlertRulesRepository
+	alertSuppressions *AlertSuppressionsRepository
 }
 
 // Config holds database configuration options.
@@ -544,6 +545,20 @@ func (db *DB) AlertRules() *AlertRulesRepository {
 		db.alertRules = &AlertRulesRepository{db: db}
 	}
 	return db.alertRules
+}
+
+// AlertSuppressions returns the repo for persisted suppression
+// markers used by the alert pipelines (#1380). Persisting means a
+// restart mid-incident doesn't re-fire alerts that were already
+// emitted.
+func (db *DB) AlertSuppressions() *AlertSuppressionsRepository {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.alertSuppressions == nil {
+		db.alertSuppressions = &AlertSuppressionsRepository{db: db}
+	}
+	return db.alertSuppressions
 }
 
 // Exec executes a query without returning any rows.

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1920,6 +1920,26 @@ func getMigrationDefs() []migrationDef {
 			CREATE INDEX IF NOT EXISTS idx_arp_bindings_last_seen ON topology_arp_bindings(last_seen);
 		`,
 		},
+		{
+			// Stage A5/#1380 — persistent alert suppression. Replaces
+			// the in-memory map both alert pipelines used to keep so
+			// a restart mid-incident doesn't re-fire alerts that were
+			// already emitted. fingerprint is the sha256 hash from
+			// the original suppression key (rule_id + source + kind).
+			Description: "Create alert_suppressions",
+			Up: `
+				CREATE TABLE IF NOT EXISTS alert_suppressions (
+					fingerprint TEXT PRIMARY KEY,
+					rule_id TEXT NOT NULL,
+					entity_key TEXT NOT NULL,
+					suppress_until TEXT NOT NULL,
+					created_at TEXT NOT NULL
+				);
+
+				CREATE INDEX IF NOT EXISTS idx_alert_suppressions_until
+				  ON alert_suppressions(suppress_until);
+			`,
+		},
 	}
 }
 

--- a/internal/database/repository_alert_suppressions.go
+++ b/internal/database/repository_alert_suppressions.go
@@ -1,0 +1,92 @@
+package database
+
+// repository_alert_suppressions persists the per-(rule, entity) "do
+// not re-fire until" marks the alert pipelines used to keep in
+// memory. Restart-safe so a Seed restart mid-incident doesn't
+// re-fire alerts that were already emitted (#1380).
+//
+// fingerprint is the same sha256-derived key the pipelines compute
+// when they decide whether to emit; passing it through unchanged
+// means existing in-memory call sites only need to swap the map
+// for this repo without recomputing.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// AlertSuppressionsRepository is the read/write surface for the
+// alert_suppressions table.
+type AlertSuppressionsRepository struct {
+	db *DB
+}
+
+// IsSuppressed returns true when fingerprint has a non-expired row.
+// Expired rows are treated as if absent and left for PurgeExpired
+// to clean up.
+func (r *AlertSuppressionsRepository) IsSuppressed(
+	ctx context.Context, fingerprint string, now time.Time,
+) (bool, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT suppress_until FROM alert_suppressions
+		WHERE fingerprint = ?
+	`, fingerprint)
+	var until string
+	if err := row.Scan(&until); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("alert_suppressions IsSuppressed: %w", err)
+	}
+	parsed, perr := time.Parse(time.RFC3339Nano, until)
+	if perr != nil {
+		return false, fmt.Errorf("alert_suppressions parse suppress_until %q: %w", until, perr)
+	}
+	return now.Before(parsed), nil
+}
+
+// Mark sets / extends a suppression. Repeating Mark on the same
+// fingerprint overwrites suppress_until — useful when the same
+// rule fires again before its prior window expires (extends the
+// window rather than stacking).
+func (r *AlertSuppressionsRepository) Mark(
+	ctx context.Context, fingerprint, ruleID, entityKey string,
+	suppressUntil time.Time,
+) error {
+	if fingerprint == "" {
+		return errors.New("alert_suppressions: fingerprint required")
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO alert_suppressions
+		  (fingerprint, rule_id, entity_key, suppress_until, created_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(fingerprint) DO UPDATE SET
+			suppress_until = excluded.suppress_until
+	`,
+		fingerprint, ruleID, entityKey,
+		suppressUntil.UTC().Format(time.RFC3339Nano), now,
+	)
+	if err != nil {
+		return fmt.Errorf("alert_suppressions Mark: %w", err)
+	}
+	return nil
+}
+
+// PurgeExpired deletes rows whose suppress_until is in the past.
+// Returns the number of rows removed.
+func (r *AlertSuppressionsRepository) PurgeExpired(
+	ctx context.Context, now time.Time,
+) (int64, error) {
+	res, err := r.db.Exec(ctx, `
+		DELETE FROM alert_suppressions WHERE suppress_until < ?
+	`, now.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return 0, fmt.Errorf("alert_suppressions PurgeExpired: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}

--- a/internal/database/repository_alert_suppressions_test.go
+++ b/internal/database/repository_alert_suppressions_test.go
@@ -1,0 +1,123 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+func newSuppressionDB(t *testing.T) *database.DB {
+	t.Helper()
+	db, err := database.Open(t.TempDir() + "/seed.db")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestAlertSuppressions_MarkAndIsSuppressedRoundtrip(t *testing.T) {
+	t.Parallel()
+	db := newSuppressionDB(t)
+	ctx := context.Background()
+	repo := db.AlertSuppressions()
+
+	now := time.Now().UTC()
+	until := now.Add(5 * time.Minute)
+	if err := repo.Mark(ctx, "fp-1", "rule-a", "10.0.0.1", until); err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+
+	suppressed, err := repo.IsSuppressed(ctx, "fp-1", now)
+	if err != nil {
+		t.Fatalf("IsSuppressed: %v", err)
+	}
+	if !suppressed {
+		t.Error("fingerprint should be suppressed within window")
+	}
+}
+
+func TestAlertSuppressions_IsSuppressedFalseWhenExpired(t *testing.T) {
+	t.Parallel()
+	db := newSuppressionDB(t)
+	ctx := context.Background()
+	repo := db.AlertSuppressions()
+
+	past := time.Now().UTC().Add(-time.Hour)
+	if err := repo.Mark(ctx, "fp-2", "rule-a", "x", past); err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+
+	suppressed, _ := repo.IsSuppressed(ctx, "fp-2", time.Now().UTC())
+	if suppressed {
+		t.Error("expired suppression should report not-suppressed")
+	}
+}
+
+func TestAlertSuppressions_IsSuppressedFalseWhenAbsent(t *testing.T) {
+	t.Parallel()
+	db := newSuppressionDB(t)
+	suppressed, err := db.AlertSuppressions().IsSuppressed(
+		context.Background(), "never-marked", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("IsSuppressed on absent row: %v", err)
+	}
+	if suppressed {
+		t.Error("absent fingerprint should not be suppressed")
+	}
+}
+
+func TestAlertSuppressions_MarkOverwrites(t *testing.T) {
+	t.Parallel()
+	db := newSuppressionDB(t)
+	ctx := context.Background()
+	repo := db.AlertSuppressions()
+	now := time.Now().UTC()
+
+	short := now.Add(time.Second)
+	long := now.Add(time.Hour)
+	if err := repo.Mark(ctx, "fp", "rule", "x", short); err != nil {
+		t.Fatalf("first Mark: %v", err)
+	}
+	if err := repo.Mark(ctx, "fp", "rule", "x", long); err != nil {
+		t.Fatalf("second Mark: %v", err)
+	}
+
+	// At a moment past the short deadline but before the long one,
+	// the overwriting Mark should still hold.
+	check := short.Add(time.Minute)
+	suppressed, _ := repo.IsSuppressed(ctx, "fp", check)
+	if !suppressed {
+		t.Error("second Mark should overwrite first; expected still-suppressed")
+	}
+}
+
+func TestAlertSuppressions_PurgeExpiredRemovesOnlyExpired(t *testing.T) {
+	t.Parallel()
+	db := newSuppressionDB(t)
+	ctx := context.Background()
+	repo := db.AlertSuppressions()
+	now := time.Now().UTC()
+
+	if err := repo.Mark(ctx, "expired", "r", "x", now.Add(-time.Hour)); err != nil {
+		t.Fatalf("Mark expired: %v", err)
+	}
+	if err := repo.Mark(ctx, "active", "r", "y", now.Add(time.Hour)); err != nil {
+		t.Fatalf("Mark active: %v", err)
+	}
+
+	removed, err := repo.PurgeExpired(ctx, now)
+	if err != nil {
+		t.Fatalf("PurgeExpired: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("removed = %d, want 1", removed)
+	}
+
+	stillActive, _ := repo.IsSuppressed(ctx, "active", now)
+	if !stillActive {
+		t.Error("active suppression should survive purge")
+	}
+}


### PR DESCRIPTION
Closes #1381 (Phase 4 / PR 12 of plan #1367). Stacked on #1386 → #1390 → #1393.

Adds `primeFromHistory` to the observation pipeline: at Start, walks recent observations per kind and populates the per-entity state caches BEFORE the scan loop emits alerts. Without this a restart re-fires every "interface down" alert on the first scan.

Replay depth bounded by `ObservationConfig.ReplayDepth` (default 2 = previous + current). Replay errors non-fatal: at worst a few spurious first-scan alerts which #1380's persistent suppression absorbs.

Plan rejected snapshot-per-transition in favor of replay because it derives state from the existing snmp_observations table — no new schema, no double-write amplification, naturally bounded by observation retention.

`make lint` clean; observation pipeline tests still pass via the legacy zero-depth path.