### PR TITLE
feat(alerts): time-windowed rule thresholds

### DIFF
--- a/internal/alerts/pipeline/listener_pipeline.go
+++ b/internal/alerts/pipeline/listener_pipeline.go
@@ -78,6 +78,19 @@ type Rule struct {
 	// Build returns the alert to write. The returned Source is used
 	// in the suppression fingerprint alongside the rule ID.
 	Build func(evt *database.ListenerEvent) *database.Alert
+
+	// Threshold is how many matching events must accrue inside
+	// Window before this rule fires. Threshold=1 / Window=0 is the
+	// pre-#1379 fire-on-first-match path.
+	Threshold int
+
+	// Window is the time window over which Threshold accrues.
+	// Window=0 means "no window" (fire on first match).
+	Window time.Duration
+
+	// counter is the optional per-(rule, entity) rolling counter.
+	// nil when Threshold <= 1.
+	counter *windowCounter
 }
 
 // ListenerPipeline scans listener_events on a tick and writes alerts
@@ -412,6 +425,14 @@ func (p *ListenerPipeline) evaluate(ctx context.Context, evt *database.ListenerE
 		}
 		if suppressed {
 			continue
+		}
+		// Time-windowed threshold (#1379): only fire when the rule's
+		// counter crosses Threshold inside Window. Counter==nil means
+		// fire on first match (legacy path).
+		if rule.counter != nil {
+			if !rule.counter.Hit(evt.SourceAddr, now) {
+				continue
+			}
 		}
 		alert := rule.Build(evt)
 		if alert == nil {

--- a/internal/alerts/pipeline/listener_rules_loader.go
+++ b/internal/alerts/pipeline/listener_rules_loader.go
@@ -83,8 +83,18 @@ func compileOne(row *database.AlertRule) Rule {
 	titleRenderer := compileTemplate(row.AlertTitle)
 	messageRenderer := compileTemplate(row.AlertMessage)
 
+	threshold := max(row.ThresholdCount, 1)
+	window := time.Duration(row.WindowSeconds) * time.Second
+	var counter *windowCounter
+	if threshold > 1 && window > 0 {
+		counter = newWindowCounter(window, threshold)
+	}
+
 	return Rule{
-		ID: "db." + strconv.FormatInt(row.ID, 10),
+		ID:        "db." + strconv.FormatInt(row.ID, 10),
+		Threshold: threshold,
+		Window:    window,
+		counter:   counter,
 		Match: func(evt *database.ListenerEvent) bool {
 			if matchKind != "" && evt.Kind != matchKind {
 				return false

--- a/internal/alerts/pipeline/window_counter.go
+++ b/internal/alerts/pipeline/window_counter.go
@@ -1,0 +1,66 @@
+package pipeline
+
+// window_counter implements the time-windowed alert-rule threshold
+// described in #1379. Each (rule, entity) pair gets a rolling counter
+// that increments per match. When the counter reaches threshold
+// inside window_seconds, the rule fires once and the counter resets.
+// Old hits outside the window are pruned lazily on each Hit call.
+//
+// V1.0 keeps the counter in-memory. A restart clears all counters,
+// which means a rule mid-accrual ("2 of 3") loses its progress.
+// That's the same restart-safety tradeoff every in-memory subsystem
+// has and is acceptable for V1.0; persistent counters land in a
+// follow-up if customer demand surfaces.
+
+import (
+	"sync"
+	"time"
+)
+
+// windowCounter is the per-rule state holder. One counter per Rule;
+// the rule's Match closure decides whether to call Hit. windowCounter
+// is safe for concurrent use.
+type windowCounter struct {
+	window    time.Duration
+	threshold int
+
+	mu     sync.Mutex
+	events map[string][]time.Time
+}
+
+// newWindowCounter constructs a counter with the given window +
+// threshold. Both must be positive (validated by the caller).
+func newWindowCounter(window time.Duration, threshold int) *windowCounter {
+	return &windowCounter{
+		window:    window,
+		threshold: threshold,
+		events:    make(map[string][]time.Time),
+	}
+}
+
+// Hit records one matching event for entityKey at now. Returns true
+// when this hit caused the counter to cross the threshold; the
+// counter then resets so a subsequent steady stream doesn't keep
+// firing on every hit past N.
+func (c *windowCounter) Hit(entityKey string, now time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cutoff := now.Add(-c.window)
+	existing := c.events[entityKey]
+	hits := make([]time.Time, 0, len(existing)+1)
+	for _, t := range existing {
+		if t.After(cutoff) {
+			hits = append(hits, t)
+		}
+	}
+	hits = append(hits, now)
+	fresh := hits
+	if len(fresh) >= c.threshold {
+		// Threshold met — reset so the next stream of hits starts
+		// fresh rather than rapid-firing.
+		delete(c.events, entityKey)
+		return true
+	}
+	c.events[entityKey] = fresh
+	return false
+}

--- a/internal/alerts/pipeline/window_counter_test.go
+++ b/internal/alerts/pipeline/window_counter_test.go
@@ -1,0 +1,133 @@
+package pipeline_test
+
+// Behavioral tests for the time-windowed counter exercise the
+// counter via the Rule struct (the only public seam). A rule with
+// Threshold=N and Window=W needs N matching events inside W to
+// fire; old hits outside the window get pruned.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/alerts/pipeline"
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+func windowedRule(window time.Duration, threshold int) *database.AlertRule {
+	return &database.AlertRule{
+		ID: 1, Name: "win", Enabled: true,
+		MatchKind:      "syslog-udp",
+		MatchSeverity:  "error",
+		AlertType:      database.AlertTypeSystem,
+		AlertSeverity:  database.AlertSeverityError,
+		AlertTitle:     "Windowed fire",
+		WindowSeconds:  int(window.Seconds()),
+		ThresholdCount: threshold,
+	}
+}
+
+func runScanWithEvents(
+	t *testing.T, rule *database.AlertRule, events []*database.ListenerEvent,
+) []*database.Alert {
+	t.Helper()
+	// Each event triggers one scan with a fresh fakeEvents slice so
+	// we control timing via the event's ObservedAt + the pipeline's
+	// Now func.
+	fakeEv := &fakeEvents{}
+	alerts := &fakeAlerts{}
+	rules := pipeline.CompileRulesFromDB([]*database.AlertRule{rule})
+	currentNow := events[0].ObservedAt
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events:   fakeEv,
+		Alerts:   alerts,
+		Settings: newFakeSettings(),
+		Logger:   silentLogger(),
+		Now:      func() time.Time { return currentNow },
+		Rules:    rules,
+	})
+	for _, evt := range events {
+		currentNow = evt.ObservedAt
+		fakeEv.rows = []*database.ListenerEvent{evt}
+		_ = p.ScanOnce(context.Background())
+	}
+	return alerts.created
+}
+
+func TestWindowedRule_BelowThresholdDoesNotFire(t *testing.T) {
+	t.Parallel()
+	rule := windowedRule(time.Minute, 3)
+	t0 := at()
+	events := []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", t0, "a"),
+		syslogEvent("error", "10.0.0.1:514", t0.Add(time.Second), "b"),
+	}
+	got := runScanWithEvents(t, rule, events)
+	if len(got) != 0 {
+		t.Errorf("two hits with threshold=3 should not fire; got %d alerts", len(got))
+	}
+}
+
+func TestWindowedRule_ThirdHitFires(t *testing.T) {
+	t.Parallel()
+	rule := windowedRule(time.Minute, 3)
+	t0 := at()
+	events := []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", t0, "a"),
+		syslogEvent("error", "10.0.0.1:514", t0.Add(time.Second), "b"),
+		syslogEvent("error", "10.0.0.1:514", t0.Add(2*time.Second), "c"),
+	}
+	got := runScanWithEvents(t, rule, events)
+	if len(got) != 1 {
+		t.Errorf("third hit inside window should fire once; got %d alerts", len(got))
+	}
+}
+
+func TestWindowedRule_StaleHitsDoNotAccumulate(t *testing.T) {
+	t.Parallel()
+	rule := windowedRule(time.Minute, 3)
+	t0 := at()
+	events := []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", t0, "a"),
+		syslogEvent("error", "10.0.0.1:514", t0.Add(time.Second), "b"),
+		// Two minutes later — first two are past the window.
+		syslogEvent("error", "10.0.0.1:514", t0.Add(2*time.Minute), "c"),
+	}
+	got := runScanWithEvents(t, rule, events)
+	if len(got) != 0 {
+		t.Errorf("expired predecessors should not count toward threshold; got %d alerts", len(got))
+	}
+}
+
+func TestWindowedRule_DifferentEntitiesIndependent(t *testing.T) {
+	t.Parallel()
+	rule := windowedRule(time.Minute, 2)
+	t0 := at()
+	events := []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", t0, "a-1"),
+		syslogEvent("error", "10.0.0.2:514", t0.Add(time.Second), "b-1"),
+	}
+	got := runScanWithEvents(t, rule, events)
+	if len(got) != 0 {
+		t.Errorf("first hit per entity should not fire (threshold=2); got %d", len(got))
+	}
+}
+
+func TestWindowedRule_DefaultPreservesLegacyBehavior(t *testing.T) {
+	t.Parallel()
+	// Window=0, Threshold=1 (defaults): fire on first match.
+	rule := &database.AlertRule{
+		ID: 1, Name: "legacy", Enabled: true,
+		MatchKind:     "syslog-udp",
+		MatchSeverity: "error",
+		AlertType:     database.AlertTypeSystem,
+		AlertSeverity: database.AlertSeverityError,
+		AlertTitle:    "Legacy",
+	}
+	t0 := at()
+	got := runScanWithEvents(t, rule,
+		[]*database.ListenerEvent{syslogEvent("error", "10.0.0.1:514", t0, "x")})
+	if len(got) != 1 {
+		t.Errorf("legacy threshold=1 should fire on first match; got %d", len(got))
+	}
+}

--- a/internal/api/handlers_alert_rules.go
+++ b/internal/api/handlers_alert_rules.go
@@ -38,6 +38,8 @@ type alertRuleInput struct {
 	AlertSeverity        string `json:"alertSeverity"`
 	AlertTitle           string `json:"alertTitle"`
 	AlertMessage         string `json:"alertMessage"`
+	WindowSeconds        int    `json:"windowSeconds,omitempty"`
+	ThresholdCount       int    `json:"thresholdCount,omitempty"`
 }
 
 func (s *Server) handleAlertRules(w http.ResponseWriter, r *http.Request) {
@@ -235,6 +237,7 @@ func decodeAlertRuleInput(r *http.Request) (*alertRuleInput, error) {
 }
 
 func inputToRule(in *alertRuleInput, id int64) *database.AlertRule {
+	threshold := max(in.ThresholdCount, 1)
 	return &database.AlertRule{
 		ID:                   id,
 		Name:                 in.Name,
@@ -246,6 +249,8 @@ func inputToRule(in *alertRuleInput, id int64) *database.AlertRule {
 		AlertSeverity:        in.AlertSeverity,
 		AlertTitle:           in.AlertTitle,
 		AlertMessage:         in.AlertMessage,
+		WindowSeconds:        in.WindowSeconds,
+		ThresholdCount:       threshold,
 	}
 }
 
@@ -261,6 +266,8 @@ func encodeAlertRule(rule *database.AlertRule) map[string]any {
 		"alertSeverity":        rule.AlertSeverity,
 		"alertTitle":           rule.AlertTitle,
 		"alertMessage":         rule.AlertMessage,
+		"windowSeconds":        rule.WindowSeconds,
+		"thresholdCount":       rule.ThresholdCount,
 		"createdAt":            formatTime(rule.CreatedAt),
 		"updatedAt":            formatTime(rule.UpdatedAt),
 	}

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1940,6 +1940,19 @@ func getMigrationDefs() []migrationDef {
 				  ON alert_suppressions(suppress_until);
 			`,
 		},
+		{
+			// #1379 — time-windowed alert rules. window_seconds=0
+			// preserves fire-on-first-match (legacy default).
+			// threshold_count is the count of matching events that
+			// must accrue inside window_seconds before the rule fires.
+			Description: "Add window_seconds + threshold_count to alert_rules",
+			Up: `
+				ALTER TABLE alert_rules
+				  ADD COLUMN window_seconds INTEGER NOT NULL DEFAULT 0;
+				ALTER TABLE alert_rules
+				  ADD COLUMN threshold_count INTEGER NOT NULL DEFAULT 1;
+			`,
+		},
 	}
 }
 

--- a/internal/database/repository_alert_rules.go
+++ b/internal/database/repository_alert_rules.go
@@ -10,6 +10,13 @@ import (
 
 // AlertRule is one row of alert_rules. Match fields default to ""
 // which the listener pipeline treats as "any value matches".
+//
+// Time-windowed rules (#1379): WindowSeconds > 0 + ThresholdCount > 1
+// means "fire only after N matching events within W seconds." The
+// default (0/1) preserves the pre-#1379 fire-on-first-match
+// behavior. Validation rejects ThresholdCount > 1 with WindowSeconds
+// = 0 because a threshold without a window has no time bound and
+// would silently never reset.
 type AlertRule struct {
 	ID                   int64
 	Name                 string
@@ -21,6 +28,8 @@ type AlertRule struct {
 	AlertSeverity        string
 	AlertTitle           string
 	AlertMessage         string
+	WindowSeconds        int
+	ThresholdCount       int
 	CreatedAt            time.Time
 	UpdatedAt            time.Time
 }
@@ -33,8 +42,12 @@ type AlertRulesRepository struct {
 // ErrAlertRuleNotFound is returned when a rule lookup misses.
 var ErrAlertRuleNotFound = errors.New("alert rule not found")
 
-// Create inserts a new rule.
-func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) error {
+// validateRule enforces invariants both Create and Update need.
+// Time-window validation (#1379): threshold > 1 requires a window;
+// negative values are nonsense for either field. ThresholdCount == 0
+// is normalized to 1 in-place so callers (handlers, tests) that
+// don't think about windowing don't need to set the field.
+func validateRule(rule *AlertRule) error {
 	if rule.Name == "" {
 		return errors.New("alert_rules: Name required")
 	}
@@ -43,6 +56,26 @@ func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) erro
 	}
 	if rule.AlertTitle == "" {
 		return errors.New("alert_rules: AlertTitle required")
+	}
+	if rule.WindowSeconds < 0 {
+		return errors.New("alert_rules: WindowSeconds must be >= 0")
+	}
+	if rule.ThresholdCount == 0 {
+		rule.ThresholdCount = 1
+	}
+	if rule.ThresholdCount < 1 {
+		return errors.New("alert_rules: ThresholdCount must be >= 1")
+	}
+	if rule.ThresholdCount > 1 && rule.WindowSeconds <= 0 {
+		return errors.New("alert_rules: ThresholdCount > 1 requires WindowSeconds > 0")
+	}
+	return nil
+}
+
+// Create inserts a new rule.
+func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) error {
+	if err := validateRule(rule); err != nil {
+		return err
 	}
 	now := time.Now().UTC()
 	rule.CreatedAt = now
@@ -55,8 +88,9 @@ func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) erro
 		INSERT INTO alert_rules
 		  (name, enabled, match_kind, match_severity, match_payload_contains,
 		   alert_type, alert_severity, alert_title, alert_message,
+		   window_seconds, threshold_count,
 		   created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		rule.Name, enabled,
 		toNullString(rule.MatchKind),
@@ -64,6 +98,7 @@ func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) erro
 		toNullString(rule.MatchPayloadContains),
 		rule.AlertType, rule.AlertSeverity,
 		rule.AlertTitle, rule.AlertMessage,
+		rule.WindowSeconds, rule.ThresholdCount,
 		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano),
 	)
 	if err != nil {
@@ -80,6 +115,7 @@ func (r *AlertRulesRepository) Get(ctx context.Context, id int64) (*AlertRule, e
 	row := r.db.QueryRow(ctx, `
 		SELECT id, name, enabled, match_kind, match_severity, match_payload_contains,
 		       alert_type, alert_severity, alert_title, alert_message,
+		       window_seconds, threshold_count,
 		       created_at, updated_at
 		FROM alert_rules WHERE id = ?
 	`, id)
@@ -93,6 +129,7 @@ func (r *AlertRulesRepository) List(ctx context.Context, enabledOnly bool) ([]*A
 	query := `
 		SELECT id, name, enabled, match_kind, match_severity, match_payload_contains,
 		       alert_type, alert_severity, alert_title, alert_message,
+		       window_seconds, threshold_count,
 		       created_at, updated_at
 		FROM alert_rules
 	`
@@ -110,8 +147,8 @@ func (r *AlertRulesRepository) Update(ctx context.Context, rule *AlertRule) erro
 	if rule.ID == 0 {
 		return errors.New("alert_rules: ID required for Update")
 	}
-	if rule.Name == "" || rule.AlertType == "" || rule.AlertSeverity == "" || rule.AlertTitle == "" {
-		return errors.New("alert_rules: Name + AlertType + AlertSeverity + AlertTitle required")
+	if err := validateRule(rule); err != nil {
+		return err
 	}
 	enabled := 0
 	if rule.Enabled {
@@ -122,6 +159,7 @@ func (r *AlertRulesRepository) Update(ctx context.Context, rule *AlertRule) erro
 			name = ?, enabled = ?,
 			match_kind = ?, match_severity = ?, match_payload_contains = ?,
 			alert_type = ?, alert_severity = ?, alert_title = ?, alert_message = ?,
+			window_seconds = ?, threshold_count = ?,
 			updated_at = ?
 		WHERE id = ?
 	`,
@@ -131,6 +169,7 @@ func (r *AlertRulesRepository) Update(ctx context.Context, rule *AlertRule) erro
 		toNullString(rule.MatchPayloadContains),
 		rule.AlertType, rule.AlertSeverity,
 		rule.AlertTitle, rule.AlertMessage,
+		rule.WindowSeconds, rule.ThresholdCount,
 		time.Now().UTC().Format(time.RFC3339Nano),
 		rule.ID,
 	)
@@ -172,6 +211,7 @@ func scanAlertRule(scan func(...any) error) (*AlertRule, error) {
 		&matchKind, &matchSev, &matchPayload,
 		&rule.AlertType, &rule.AlertSeverity,
 		&rule.AlertTitle, &rule.AlertMessage,
+		&rule.WindowSeconds, &rule.ThresholdCount,
 		&createdStr, &updatedStr,
 	)
 	if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
Closes #1379 (Phase 4 / PR 11 of plan #1367). Stacked on #1386 → #1390 → #1393.

Operators can now define rules like "alert when X for > N samples in W seconds" via `window_seconds` + `threshold_count` columns. Defaults (window=0, threshold=1) preserve the pre-#1379 fire-on-first-match behavior bit-for-bit.

## Schema (additive)

```sql
ALTER TABLE alert_rules ADD COLUMN window_seconds INTEGER NOT NULL DEFAULT 0;
ALTER TABLE alert_rules ADD COLUMN threshold_count INTEGER NOT NULL DEFAULT 1;
```

## Validation

- `threshold > 1` with `window = 0` rejected: a threshold without a window has no time bound and would silently never reset.
- `threshold == 0` normalized to 1 in-place so callers that don't think about windowing don't need to set it.
- `window < 0` rejected as nonsense.

## Pipeline

New `windowCounter` in `internal/alerts/pipeline/window_counter.go` maintains per-(rule, entity) rolling hit lists. On `Hit` it prunes expired timestamps + checks against threshold; firing resets the counter so a steady stream doesn't rapid-fire past N. The counter is attached to the compiled Rule by the loader when threshold > 1.

## V1.0 trade-off

In-memory only — a restart clears mid-accrual counters (same trade-off the suppression store had pre-#1380). Persistent counters can land in a follow-up if customer demand surfaces.

## Tests

`internal/alerts/pipeline/window_counter_test.go` — 5 behavioral cases via the public Rule seam: below-threshold no-fire, threshold reached fires, stale hits don't accumulate, per-entity independence, default (threshold=1) preserves legacy.

`make lint` 0 issues, `go test ./...` clean.