### PR TITLE
feat(ui): alert-rules editor page

### DIFF
--- a/internal/alerts/pipeline/listener_pipeline.go
+++ b/internal/alerts/pipeline/listener_pipeline.go
@@ -78,6 +78,19 @@ type Rule struct {
 	// Build returns the alert to write. The returned Source is used
 	// in the suppression fingerprint alongside the rule ID.
 	Build func(evt *database.ListenerEvent) *database.Alert
+
+	// Threshold is how many matching events must accrue inside
+	// Window before this rule fires. Threshold=1 / Window=0 is the
+	// pre-#1379 fire-on-first-match path.
+	Threshold int
+
+	// Window is the time window over which Threshold accrues.
+	// Window=0 means "no window" (fire on first match).
+	Window time.Duration
+
+	// counter is the optional per-(rule, entity) rolling counter.
+	// nil when Threshold <= 1.
+	counter *windowCounter
 }
 
 // ListenerPipeline scans listener_events on a tick and writes alerts
@@ -412,6 +425,14 @@ func (p *ListenerPipeline) evaluate(ctx context.Context, evt *database.ListenerE
 		}
 		if suppressed {
 			continue
+		}
+		// Time-windowed threshold (#1379): only fire when the rule's
+		// counter crosses Threshold inside Window. Counter==nil means
+		// fire on first match (legacy path).
+		if rule.counter != nil {
+			if !rule.counter.Hit(evt.SourceAddr, now) {
+				continue
+			}
 		}
 		alert := rule.Build(evt)
 		if alert == nil {

--- a/internal/alerts/pipeline/listener_rules_loader.go
+++ b/internal/alerts/pipeline/listener_rules_loader.go
@@ -83,8 +83,18 @@ func compileOne(row *database.AlertRule) Rule {
 	titleRenderer := compileTemplate(row.AlertTitle)
 	messageRenderer := compileTemplate(row.AlertMessage)
 
+	threshold := max(row.ThresholdCount, 1)
+	window := time.Duration(row.WindowSeconds) * time.Second
+	var counter *windowCounter
+	if threshold > 1 && window > 0 {
+		counter = newWindowCounter(window, threshold)
+	}
+
 	return Rule{
-		ID: "db." + strconv.FormatInt(row.ID, 10),
+		ID:        "db." + strconv.FormatInt(row.ID, 10),
+		Threshold: threshold,
+		Window:    window,
+		counter:   counter,
 		Match: func(evt *database.ListenerEvent) bool {
 			if matchKind != "" && evt.Kind != matchKind {
 				return false

--- a/internal/alerts/pipeline/window_counter.go
+++ b/internal/alerts/pipeline/window_counter.go
@@ -1,0 +1,66 @@
+package pipeline
+
+// window_counter implements the time-windowed alert-rule threshold
+// described in #1379. Each (rule, entity) pair gets a rolling counter
+// that increments per match. When the counter reaches threshold
+// inside window_seconds, the rule fires once and the counter resets.
+// Old hits outside the window are pruned lazily on each Hit call.
+//
+// V1.0 keeps the counter in-memory. A restart clears all counters,
+// which means a rule mid-accrual ("2 of 3") loses its progress.
+// That's the same restart-safety tradeoff every in-memory subsystem
+// has and is acceptable for V1.0; persistent counters land in a
+// follow-up if customer demand surfaces.
+
+import (
+	"sync"
+	"time"
+)
+
+// windowCounter is the per-rule state holder. One counter per Rule;
+// the rule's Match closure decides whether to call Hit. windowCounter
+// is safe for concurrent use.
+type windowCounter struct {
+	window    time.Duration
+	threshold int
+
+	mu     sync.Mutex
+	events map[string][]time.Time
+}
+
+// newWindowCounter constructs a counter with the given window +
+// threshold. Both must be positive (validated by the caller).
+func newWindowCounter(window time.Duration, threshold int) *windowCounter {
+	return &windowCounter{
+		window:    window,
+		threshold: threshold,
+		events:    make(map[string][]time.Time),
+	}
+}
+
+// Hit records one matching event for entityKey at now. Returns true
+// when this hit caused the counter to cross the threshold; the
+// counter then resets so a subsequent steady stream doesn't keep
+// firing on every hit past N.
+func (c *windowCounter) Hit(entityKey string, now time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cutoff := now.Add(-c.window)
+	existing := c.events[entityKey]
+	hits := make([]time.Time, 0, len(existing)+1)
+	for _, t := range existing {
+		if t.After(cutoff) {
+			hits = append(hits, t)
+		}
+	}
+	hits = append(hits, now)
+	fresh := hits
+	if len(fresh) >= c.threshold {
+		// Threshold met — reset so the next stream of hits starts
+		// fresh rather than rapid-firing.
+		delete(c.events, entityKey)
+		return true
+	}
+	c.events[entityKey] = fresh
+	return false
+}

--- a/internal/alerts/pipeline/window_counter_test.go
+++ b/internal/alerts/pipeline/window_counter_test.go
@@ -1,0 +1,133 @@
+package pipeline_test
+
+// Behavioral tests for the time-windowed counter exercise the
+// counter via the Rule struct (the only public seam). A rule with
+// Threshold=N and Window=W needs N matching events inside W to
+// fire; old hits outside the window get pruned.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/alerts/pipeline"
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+func windowedRule(window time.Duration, threshold int) *database.AlertRule {
+	return &database.AlertRule{
+		ID: 1, Name: "win", Enabled: true,
+		MatchKind:      "syslog-udp",
+		MatchSeverity:  "error",
+		AlertType:      database.AlertTypeSystem,
+		AlertSeverity:  database.AlertSeverityError,
+		AlertTitle:     "Windowed fire",
+		WindowSeconds:  int(window.Seconds()),
+		ThresholdCount: threshold,
+	}
+}
+
+func runScanWithEvents(
+	t *testing.T, rule *database.AlertRule, events []*database.ListenerEvent,
+) []*database.Alert {
+	t.Helper()
+	// Each event triggers one scan with a fresh fakeEvents slice so
+	// we control timing via the event's ObservedAt + the pipeline's
+	// Now func.
+	fakeEv := &fakeEvents{}
+	alerts := &fakeAlerts{}
+	rules := pipeline.CompileRulesFromDB([]*database.AlertRule{rule})
+	currentNow := events[0].ObservedAt
+	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
+		Events:   fakeEv,
+		Alerts:   alerts,
+		Settings: newFakeSettings(),
+		Logger:   silentLogger(),
+		Now:      func() time.Time { return currentNow },
+		Rules:    rules,
+	})
+	for _, evt := range events {
+		currentNow = evt.ObservedAt
+		fakeEv.rows = []*database.ListenerEvent{evt}
+		_ = p.ScanOnce(context.Background())
+	}
+	return alerts.created
+}
+
+func TestWindowedRule_BelowThresholdDoesNotFire(t *testing.T) {
+	t.Parallel()
+	rule := windowedRule(time.Minute, 3)
+	t0 := at()
+	events := []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", t0, "a"),
+		syslogEvent("error", "10.0.0.1:514", t0.Add(time.Second), "b"),
+	}
+	got := runScanWithEvents(t, rule, events)
+	if len(got) != 0 {
+		t.Errorf("two hits with threshold=3 should not fire; got %d alerts", len(got))
+	}
+}
+
+func TestWindowedRule_ThirdHitFires(t *testing.T) {
+	t.Parallel()
+	rule := windowedRule(time.Minute, 3)
+	t0 := at()
+	events := []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", t0, "a"),
+		syslogEvent("error", "10.0.0.1:514", t0.Add(time.Second), "b"),
+		syslogEvent("error", "10.0.0.1:514", t0.Add(2*time.Second), "c"),
+	}
+	got := runScanWithEvents(t, rule, events)
+	if len(got) != 1 {
+		t.Errorf("third hit inside window should fire once; got %d alerts", len(got))
+	}
+}
+
+func TestWindowedRule_StaleHitsDoNotAccumulate(t *testing.T) {
+	t.Parallel()
+	rule := windowedRule(time.Minute, 3)
+	t0 := at()
+	events := []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", t0, "a"),
+		syslogEvent("error", "10.0.0.1:514", t0.Add(time.Second), "b"),
+		// Two minutes later — first two are past the window.
+		syslogEvent("error", "10.0.0.1:514", t0.Add(2*time.Minute), "c"),
+	}
+	got := runScanWithEvents(t, rule, events)
+	if len(got) != 0 {
+		t.Errorf("expired predecessors should not count toward threshold; got %d alerts", len(got))
+	}
+}
+
+func TestWindowedRule_DifferentEntitiesIndependent(t *testing.T) {
+	t.Parallel()
+	rule := windowedRule(time.Minute, 2)
+	t0 := at()
+	events := []*database.ListenerEvent{
+		syslogEvent("error", "10.0.0.1:514", t0, "a-1"),
+		syslogEvent("error", "10.0.0.2:514", t0.Add(time.Second), "b-1"),
+	}
+	got := runScanWithEvents(t, rule, events)
+	if len(got) != 0 {
+		t.Errorf("first hit per entity should not fire (threshold=2); got %d", len(got))
+	}
+}
+
+func TestWindowedRule_DefaultPreservesLegacyBehavior(t *testing.T) {
+	t.Parallel()
+	// Window=0, Threshold=1 (defaults): fire on first match.
+	rule := &database.AlertRule{
+		ID: 1, Name: "legacy", Enabled: true,
+		MatchKind:     "syslog-udp",
+		MatchSeverity: "error",
+		AlertType:     database.AlertTypeSystem,
+		AlertSeverity: database.AlertSeverityError,
+		AlertTitle:    "Legacy",
+	}
+	t0 := at()
+	got := runScanWithEvents(t, rule,
+		[]*database.ListenerEvent{syslogEvent("error", "10.0.0.1:514", t0, "x")})
+	if len(got) != 1 {
+		t.Errorf("legacy threshold=1 should fire on first match; got %d", len(got))
+	}
+}

--- a/internal/api/handlers_alert_rules.go
+++ b/internal/api/handlers_alert_rules.go
@@ -38,6 +38,8 @@ type alertRuleInput struct {
 	AlertSeverity        string `json:"alertSeverity"`
 	AlertTitle           string `json:"alertTitle"`
 	AlertMessage         string `json:"alertMessage"`
+	WindowSeconds        int    `json:"windowSeconds,omitempty"`
+	ThresholdCount       int    `json:"thresholdCount,omitempty"`
 }
 
 func (s *Server) handleAlertRules(w http.ResponseWriter, r *http.Request) {
@@ -235,6 +237,7 @@ func decodeAlertRuleInput(r *http.Request) (*alertRuleInput, error) {
 }
 
 func inputToRule(in *alertRuleInput, id int64) *database.AlertRule {
+	threshold := max(in.ThresholdCount, 1)
 	return &database.AlertRule{
 		ID:                   id,
 		Name:                 in.Name,
@@ -246,6 +249,8 @@ func inputToRule(in *alertRuleInput, id int64) *database.AlertRule {
 		AlertSeverity:        in.AlertSeverity,
 		AlertTitle:           in.AlertTitle,
 		AlertMessage:         in.AlertMessage,
+		WindowSeconds:        in.WindowSeconds,
+		ThresholdCount:       threshold,
 	}
 }
 
@@ -261,6 +266,8 @@ func encodeAlertRule(rule *database.AlertRule) map[string]any {
 		"alertSeverity":        rule.AlertSeverity,
 		"alertTitle":           rule.AlertTitle,
 		"alertMessage":         rule.AlertMessage,
+		"windowSeconds":        rule.WindowSeconds,
+		"thresholdCount":       rule.ThresholdCount,
 		"createdAt":            formatTime(rule.CreatedAt),
 		"updatedAt":            formatTime(rule.UpdatedAt),
 	}

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1940,6 +1940,19 @@ func getMigrationDefs() []migrationDef {
 				  ON alert_suppressions(suppress_until);
 			`,
 		},
+		{
+			// #1379 — time-windowed alert rules. window_seconds=0
+			// preserves fire-on-first-match (legacy default).
+			// threshold_count is the count of matching events that
+			// must accrue inside window_seconds before the rule fires.
+			Description: "Add window_seconds + threshold_count to alert_rules",
+			Up: `
+				ALTER TABLE alert_rules
+				  ADD COLUMN window_seconds INTEGER NOT NULL DEFAULT 0;
+				ALTER TABLE alert_rules
+				  ADD COLUMN threshold_count INTEGER NOT NULL DEFAULT 1;
+			`,
+		},
 	}
 }
 

--- a/internal/database/repository_alert_rules.go
+++ b/internal/database/repository_alert_rules.go
@@ -10,6 +10,13 @@ import (
 
 // AlertRule is one row of alert_rules. Match fields default to ""
 // which the listener pipeline treats as "any value matches".
+//
+// Time-windowed rules (#1379): WindowSeconds > 0 + ThresholdCount > 1
+// means "fire only after N matching events within W seconds." The
+// default (0/1) preserves the pre-#1379 fire-on-first-match
+// behavior. Validation rejects ThresholdCount > 1 with WindowSeconds
+// = 0 because a threshold without a window has no time bound and
+// would silently never reset.
 type AlertRule struct {
 	ID                   int64
 	Name                 string
@@ -21,6 +28,8 @@ type AlertRule struct {
 	AlertSeverity        string
 	AlertTitle           string
 	AlertMessage         string
+	WindowSeconds        int
+	ThresholdCount       int
 	CreatedAt            time.Time
 	UpdatedAt            time.Time
 }
@@ -33,8 +42,12 @@ type AlertRulesRepository struct {
 // ErrAlertRuleNotFound is returned when a rule lookup misses.
 var ErrAlertRuleNotFound = errors.New("alert rule not found")
 
-// Create inserts a new rule.
-func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) error {
+// validateRule enforces invariants both Create and Update need.
+// Time-window validation (#1379): threshold > 1 requires a window;
+// negative values are nonsense for either field. ThresholdCount == 0
+// is normalized to 1 in-place so callers (handlers, tests) that
+// don't think about windowing don't need to set the field.
+func validateRule(rule *AlertRule) error {
 	if rule.Name == "" {
 		return errors.New("alert_rules: Name required")
 	}
@@ -43,6 +56,26 @@ func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) erro
 	}
 	if rule.AlertTitle == "" {
 		return errors.New("alert_rules: AlertTitle required")
+	}
+	if rule.WindowSeconds < 0 {
+		return errors.New("alert_rules: WindowSeconds must be >= 0")
+	}
+	if rule.ThresholdCount == 0 {
+		rule.ThresholdCount = 1
+	}
+	if rule.ThresholdCount < 1 {
+		return errors.New("alert_rules: ThresholdCount must be >= 1")
+	}
+	if rule.ThresholdCount > 1 && rule.WindowSeconds <= 0 {
+		return errors.New("alert_rules: ThresholdCount > 1 requires WindowSeconds > 0")
+	}
+	return nil
+}
+
+// Create inserts a new rule.
+func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) error {
+	if err := validateRule(rule); err != nil {
+		return err
 	}
 	now := time.Now().UTC()
 	rule.CreatedAt = now
@@ -55,8 +88,9 @@ func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) erro
 		INSERT INTO alert_rules
 		  (name, enabled, match_kind, match_severity, match_payload_contains,
 		   alert_type, alert_severity, alert_title, alert_message,
+		   window_seconds, threshold_count,
 		   created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		rule.Name, enabled,
 		toNullString(rule.MatchKind),
@@ -64,6 +98,7 @@ func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) erro
 		toNullString(rule.MatchPayloadContains),
 		rule.AlertType, rule.AlertSeverity,
 		rule.AlertTitle, rule.AlertMessage,
+		rule.WindowSeconds, rule.ThresholdCount,
 		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano),
 	)
 	if err != nil {
@@ -80,6 +115,7 @@ func (r *AlertRulesRepository) Get(ctx context.Context, id int64) (*AlertRule, e
 	row := r.db.QueryRow(ctx, `
 		SELECT id, name, enabled, match_kind, match_severity, match_payload_contains,
 		       alert_type, alert_severity, alert_title, alert_message,
+		       window_seconds, threshold_count,
 		       created_at, updated_at
 		FROM alert_rules WHERE id = ?
 	`, id)
@@ -93,6 +129,7 @@ func (r *AlertRulesRepository) List(ctx context.Context, enabledOnly bool) ([]*A
 	query := `
 		SELECT id, name, enabled, match_kind, match_severity, match_payload_contains,
 		       alert_type, alert_severity, alert_title, alert_message,
+		       window_seconds, threshold_count,
 		       created_at, updated_at
 		FROM alert_rules
 	`
@@ -110,8 +147,8 @@ func (r *AlertRulesRepository) Update(ctx context.Context, rule *AlertRule) erro
 	if rule.ID == 0 {
 		return errors.New("alert_rules: ID required for Update")
 	}
-	if rule.Name == "" || rule.AlertType == "" || rule.AlertSeverity == "" || rule.AlertTitle == "" {
-		return errors.New("alert_rules: Name + AlertType + AlertSeverity + AlertTitle required")
+	if err := validateRule(rule); err != nil {
+		return err
 	}
 	enabled := 0
 	if rule.Enabled {
@@ -122,6 +159,7 @@ func (r *AlertRulesRepository) Update(ctx context.Context, rule *AlertRule) erro
 			name = ?, enabled = ?,
 			match_kind = ?, match_severity = ?, match_payload_contains = ?,
 			alert_type = ?, alert_severity = ?, alert_title = ?, alert_message = ?,
+			window_seconds = ?, threshold_count = ?,
 			updated_at = ?
 		WHERE id = ?
 	`,
@@ -131,6 +169,7 @@ func (r *AlertRulesRepository) Update(ctx context.Context, rule *AlertRule) erro
 		toNullString(rule.MatchPayloadContains),
 		rule.AlertType, rule.AlertSeverity,
 		rule.AlertTitle, rule.AlertMessage,
+		rule.WindowSeconds, rule.ThresholdCount,
 		time.Now().UTC().Format(time.RFC3339Nano),
 		rule.ID,
 	)
@@ -172,6 +211,7 @@ func scanAlertRule(scan func(...any) error) (*AlertRule, error) {
 		&matchKind, &matchSev, &matchPayload,
 		&rule.AlertType, &rule.AlertSeverity,
 		&rule.AlertTitle, &rule.AlertMessage,
+		&rule.WindowSeconds, &rule.ThresholdCount,
 		&createdStr, &updatedStr,
 	)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/ui/src/hooks/useAlertRules.ts
+++ b/ui/src/hooks/useAlertRules.ts
@@ -1,0 +1,74 @@
+/**
+ * Data hook for the /api/v1/alert-rules surface (#1384).
+ *
+ * Same framework-light pattern as usePollingTargets — fetch on
+ * mount, expose CRUD mutations that re-fetch after writing so the
+ * UI shows server-canonical state.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '../api/client';
+import type { AlertRule, AlertRuleInput, AlertRulesListResponse } from '../types/alertRules';
+
+const ENDPOINT = '/api/v1/alert-rules';
+
+export interface UseAlertRulesResult {
+  rules: AlertRule[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  create: (input: AlertRuleInput) => Promise<AlertRule>;
+  update: (id: number, input: AlertRuleInput) => Promise<AlertRule>;
+  remove: (id: number) => Promise<void>;
+}
+
+export function useAlertRules(): UseAlertRulesResult {
+  const [rules, setRules] = useState<AlertRule[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await api.get<AlertRulesListResponse>(ENDPOINT);
+      setRules(resp.rules ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load alert rules');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const create = useCallback(
+    async (input: AlertRuleInput): Promise<AlertRule> => {
+      const created = await api.post<AlertRule>(ENDPOINT, input);
+      await refresh();
+      return created;
+    },
+    [refresh],
+  );
+
+  const update = useCallback(
+    async (id: number, input: AlertRuleInput): Promise<AlertRule> => {
+      const updated = await api.put<AlertRule>(`${ENDPOINT}/${id}`, input);
+      await refresh();
+      return updated;
+    },
+    [refresh],
+  );
+
+  const remove = useCallback(
+    async (id: number): Promise<void> => {
+      await api.delete(`${ENDPOINT}/${id}`);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  return { rules, loading, error, refresh, create, update, remove };
+}

--- a/ui/src/pageRegistry.tsx
+++ b/ui/src/pageRegistry.tsx
@@ -8,6 +8,7 @@
 import type { LucideIcon } from 'lucide-react';
 import {
   Activity,
+  AlertTriangle,
   BarChart3,
   Bell,
   Network,
@@ -46,6 +47,9 @@ const TopologyPage = lazy(() =>
 );
 const AlertsPage = lazy(() =>
   import('./pages/AlertsPage').then((m) => ({ default: m.AlertsPage })),
+);
+const AlertRulesPage = lazy(() =>
+  import('./pages/AlertRulesPage').then((m) => ({ default: m.AlertRulesPage })),
 );
 
 export interface PageConfig {
@@ -145,5 +149,13 @@ export const pages: PageConfig[] = [
     description: 'Events emitted by the listener + observation pipelines.',
     icon: Bell,
     component: AlertsPage,
+  },
+  {
+    path: '/alert-rules',
+    label: 'Alert rules',
+    title: 'Alert rules',
+    description: 'Operator-defined rules feeding the listener pipeline.',
+    icon: AlertTriangle,
+    component: AlertRulesPage,
   },
 ];

--- a/ui/src/pages/AlertRulesPage.tsx
+++ b/ui/src/pages/AlertRulesPage.tsx
@@ -1,0 +1,393 @@
+/**
+ * AlertRulesPage
+ *
+ * Operator-facing CRUD over /api/v1/alert-rules (#1384). Rules
+ * defined here drive the listener alert pipeline at runtime — see
+ * internal/alerts/pipeline/listener_rules_loader.go for the
+ * DB-only-when-non-empty semantics.
+ *
+ * Template syntax in AlertTitle / AlertMessage is documented inline:
+ *   {{.SourceAddr}} {{.Severity}} {{.Kind}} {{.MatchedRuleName}}
+ *   {{.Payload.<field>}} from the event's JSON payload
+ */
+
+import { AlertTriangle, Plus, X } from 'lucide-react';
+import { type FormEvent, type JSX, useState } from 'react';
+import { useAlertRules } from '../hooks/useAlertRules';
+import type { AlertRule, AlertRuleInput } from '../types/alertRules';
+import { Breadcrumbs } from '../ui/Breadcrumbs';
+import { PageHeader } from '../ui/PageHeader';
+
+const MATCH_KINDS = ['', 'syslog-udp', 'snmp-trap-v2c'] as const;
+const ALERT_TYPES = ['system', 'connectivity', 'security', 'performance'] as const;
+const SEVERITIES = ['info', 'warning', 'error', 'critical'] as const;
+
+export function AlertRulesPage(): JSX.Element {
+  const { rules, loading, error, create, update, remove } = useAlertRules();
+  const [editing, setEditing] = useState<AlertRule | null>(null);
+  const [showCreate, setShowCreate] = useState<boolean>(false);
+
+  return (
+    <section className="stack-xl">
+      <Breadcrumbs />
+      <PageHeader
+        icon={AlertTriangle}
+        title="Alert rules"
+        description="Operator-defined rules drive the listener alert pipeline. When this list is empty the pipeline falls back to built-in defaults."
+        iconColorClass="text-amber-400"
+      />
+
+      {error ? (
+        <div className="rounded-md border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-200">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-zinc-400">
+          {loading ? 'Loading…' : `${rules.length} rule${rules.length === 1 ? '' : 's'}`}
+        </p>
+        <button
+          type="button"
+          onClick={(): void => setShowCreate(true)}
+          data-testid="alert-rules-add"
+          className="inline-flex items-center gap-2 rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+        >
+          <Plus className="h-4 w-4" />
+          Add rule
+        </button>
+      </div>
+
+      {!loading && rules.length === 0 ? (
+        <p className="rounded-md border border-zinc-700 bg-zinc-900 p-4 text-sm text-zinc-400">
+          No operator-defined rules yet. The listener pipeline is using the built-in default ruleset
+          (severe syslog, linkDown traps, authentication failures). Adding any enabled rule below
+          replaces the defaults entirely.
+        </p>
+      ) : null}
+
+      <ul className="stack-sm" data-testid="alert-rules-list">
+        {rules.map((rule) => (
+          <li
+            key={rule.id}
+            data-testid={`alert-rule-row-${rule.id}`}
+            className="rounded-md border border-zinc-700 bg-zinc-900 p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="stack-xs">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-zinc-100">{rule.name}</span>
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-xs ${
+                      rule.enabled
+                        ? 'bg-emerald-500/20 text-emerald-300'
+                        : 'bg-zinc-700 text-zinc-400'
+                    }`}
+                  >
+                    {rule.enabled ? 'enabled' : 'disabled'}
+                  </span>
+                  <span className="text-xs text-zinc-500">
+                    {rule.alertType} / {rule.alertSeverity}
+                  </span>
+                </div>
+                <span className="text-xs text-zinc-400">{rule.alertTitle}</span>
+                {rule.windowSeconds > 0 ? (
+                  <span className="text-xs text-zinc-500">
+                    Fires after {rule.thresholdCount} matches in {rule.windowSeconds}s
+                  </span>
+                ) : null}
+              </div>
+              <div className="flex shrink-0 gap-2">
+                <button
+                  type="button"
+                  onClick={(): void => setEditing(rule)}
+                  className="rounded-md border border-zinc-600 px-2 py-1 text-xs text-zinc-200 hover:border-zinc-500"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={(): void => {
+                    if (window.confirm(`Delete rule "${rule.name}"?`)) {
+                      void remove(rule.id);
+                    }
+                  }}
+                  className="rounded-md border border-rose-500/50 px-2 py-1 text-xs text-rose-300 hover:border-rose-500"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {showCreate ? (
+        <RuleForm
+          mode="create"
+          onClose={(): void => setShowCreate(false)}
+          onSubmit={async (input): Promise<void> => {
+            await create(input);
+            setShowCreate(false);
+          }}
+        />
+      ) : null}
+
+      {editing ? (
+        <RuleForm
+          mode="edit"
+          initial={editing}
+          onClose={(): void => setEditing(null)}
+          onSubmit={async (input): Promise<void> => {
+            await update(editing.id, input);
+            setEditing(null);
+          }}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+interface RuleFormProps {
+  mode: 'create' | 'edit';
+  initial?: AlertRule;
+  onClose: () => void;
+  onSubmit: (input: AlertRuleInput) => Promise<void>;
+}
+
+function RuleForm({ mode, initial, onClose, onSubmit }: RuleFormProps): JSX.Element {
+  const [name, setName] = useState<string>(initial?.name ?? '');
+  const [enabled, setEnabled] = useState<boolean>(initial?.enabled ?? true);
+  const [matchKind, setMatchKind] = useState<string>(initial?.matchKind ?? '');
+  const [matchSeverity, setMatchSeverity] = useState<string>(initial?.matchSeverity ?? '');
+  const [matchPayloadContains, setMatchPayloadContains] = useState<string>(
+    initial?.matchPayloadContains ?? '',
+  );
+  const [alertType, setAlertType] = useState<string>(initial?.alertType ?? 'system');
+  const [alertSeverity, setAlertSeverity] = useState<string>(initial?.alertSeverity ?? 'error');
+  const [alertTitle, setAlertTitle] = useState<string>(initial?.alertTitle ?? '');
+  const [alertMessage, setAlertMessage] = useState<string>(initial?.alertMessage ?? '');
+  const [windowSeconds, setWindowSeconds] = useState<number>(initial?.windowSeconds ?? 0);
+  const [thresholdCount, setThresholdCount] = useState<number>(initial?.thresholdCount ?? 1);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault();
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      await onSubmit({
+        name,
+        enabled,
+        matchKind,
+        matchSeverity,
+        matchPayloadContains,
+        alertType,
+        alertSeverity,
+        alertTitle,
+        alertMessage,
+        windowSeconds,
+        thresholdCount,
+      });
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to save rule');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-zinc-950/70 p-4">
+      <form
+        onSubmit={handleSubmit}
+        data-testid="alert-rule-form"
+        className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-900 p-6 stack-md"
+      >
+        <div className="flex items-start justify-between">
+          <h2 className="text-lg font-semibold text-zinc-100">
+            {mode === 'create' ? 'Add alert rule' : `Edit rule: ${initial?.name ?? ''}`}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-zinc-400 hover:text-zinc-200"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {formError ? (
+          <div className="rounded-md border border-rose-500/40 bg-rose-500/10 p-2 text-sm text-rose-200">
+            {formError}
+          </div>
+        ) : null}
+
+        <Field label="Name" required>
+          <input
+            type="text"
+            required
+            value={name}
+            onChange={(e): void => setName(e.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <label className="flex items-center gap-2 text-sm text-zinc-200">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e): void => setEnabled(e.target.checked)}
+          />
+          Enabled
+        </label>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Match kind">
+            <select
+              value={matchKind}
+              onChange={(e): void => setMatchKind(e.target.value)}
+              className={inputClass}
+            >
+              {MATCH_KINDS.map((k) => (
+                <option key={k} value={k}>
+                  {k === '' ? '(any)' : k}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Match severity">
+            <input
+              type="text"
+              placeholder="(any)"
+              value={matchSeverity}
+              onChange={(e): void => setMatchSeverity(e.target.value)}
+              className={inputClass}
+            />
+          </Field>
+        </div>
+
+        <Field label="Match payload contains (substring)">
+          <input
+            type="text"
+            placeholder="(any)"
+            value={matchPayloadContains}
+            onChange={(e): void => setMatchPayloadContains(e.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Alert type" required>
+            <select
+              value={alertType}
+              onChange={(e): void => setAlertType(e.target.value)}
+              className={inputClass}
+            >
+              {ALERT_TYPES.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Alert severity" required>
+            <select
+              value={alertSeverity}
+              onChange={(e): void => setAlertSeverity(e.target.value)}
+              className={inputClass}
+            >
+              {SEVERITIES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+
+        <Field
+          label="Alert title (supports {{.SourceAddr}}, {{.Severity}}, {{.Payload.<field>}})"
+          required
+        >
+          <input
+            type="text"
+            required
+            value={alertTitle}
+            onChange={(e): void => setAlertTitle(e.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <Field label="Alert message (template syntax also supported)">
+          <textarea
+            rows={2}
+            value={alertMessage}
+            onChange={(e): void => setAlertMessage(e.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Window seconds (0 = fire on first match)">
+            <input
+              type="number"
+              min={0}
+              value={windowSeconds}
+              onChange={(e): void => setWindowSeconds(Number(e.target.value))}
+              className={inputClass}
+            />
+          </Field>
+          <Field label="Threshold count (1 = single match)">
+            <input
+              type="number"
+              min={1}
+              value={thresholdCount}
+              onChange={(e): void => setThresholdCount(Number(e.target.value))}
+              className={inputClass}
+            />
+          </Field>
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-zinc-600 px-3 py-2 text-sm text-zinc-200"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:opacity-50"
+          >
+            {submitting ? 'Saving…' : mode === 'create' ? 'Create' : 'Save'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+const inputClass =
+  'w-full rounded-md border border-zinc-600 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500';
+
+interface FieldProps {
+  label: string;
+  required?: boolean;
+  children: JSX.Element;
+}
+
+function Field({ label, required, children }: FieldProps): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1 text-sm text-zinc-300">
+      <span>
+        {label}
+        {required ? <span className="ml-1 text-rose-400">*</span> : null}
+      </span>
+      {children}
+    </div>
+  );
+}

--- a/ui/src/types/alertRules.ts
+++ b/ui/src/types/alertRules.ts
@@ -1,0 +1,47 @@
+/**
+ * Alert rules — wire-shape mirror of /api/v1/alert-rules.
+ * Keep field names aligned with internal/api/handlers_alert_rules.go
+ * encodeAlertRule output so the JSON parses cleanly.
+ *
+ * Operators CRUD rules here; the listener pipeline reloads them on
+ * each scan and falls back to the hardcoded DefaultListenerRules
+ * when the table is empty (semantics decision in PR #1377).
+ */
+
+export interface AlertRule {
+  id: number;
+  name: string;
+  enabled: boolean;
+  matchKind: string;
+  matchSeverity: string;
+  matchPayloadContains: string;
+  alertType: string;
+  alertSeverity: string;
+  alertTitle: string;
+  alertMessage: string;
+  windowSeconds: number;
+  thresholdCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Wire shape for POST/PUT — omits server-managed audit columns. */
+export interface AlertRuleInput {
+  name: string;
+  enabled: boolean;
+  matchKind?: string;
+  matchSeverity?: string;
+  matchPayloadContains?: string;
+  alertType: string;
+  alertSeverity: string;
+  alertTitle: string;
+  alertMessage?: string;
+  windowSeconds?: number;
+  thresholdCount?: number;
+}
+
+/** GET /api/v1/alert-rules list envelope. */
+export interface AlertRulesListResponse {
+  count: number;
+  rules: AlertRule[];
+}


### PR DESCRIPTION
Closes #1384 (Phase 1 / PR 3 of plan #1367). Stacked on #1386 (and indirectly on #1390 / #1395 for full template + windowed-rule surface).

Operator-facing CRUD page over `/api/v1/alert-rules`. Rules defined here drive the listener alert pipeline at runtime per the DB-only-when-non-empty semantics from #1377.

## Files

```
ui/src/types/alertRules.ts          AlertRule + AlertRuleInput wire shapes
ui/src/hooks/useAlertRules.ts       fetch + CRUD hook, framework-light
ui/src/pages/AlertRulesPage.tsx     list + create/edit modal + delete
ui/src/pageRegistry.tsx             route + nav entry (AlertTriangle icon)
```

## UX notes

- Form documents the template syntax in-line (`{{.SourceAddr}}`, `{{.Payload.<field>}}`, etc.) so operators self-serve title/message interpolation (#1378).
- Time-windowed rule fields (`window_seconds` + `threshold_count`) surface as separate inputs; the legacy default (0/1) preserves fire-on-first-match.
- An empty rule table shows a banner explaining that the pipeline is running the built-in defaults — operators know what they're overriding when they add their first rule.
- `data-testid` selectors throughout for Playwright follow-up.

## Trade-off

A Playwright e2e spec is intentionally deferred to a follow-up. This PR ships the operator-usable surface; e2e coverage lands after the parent #1386 merges so the test fixtures can target real wire format from main.

## Verification

- `make lint` 0 issues (Go + Biome).
- `npx tsc --noEmit` clean.
- Page renders + form roundtrips against the existing handler (manual local smoke).