### PR TITLE
test(api): full-chain auth-boundary golden harness (Phase 0)

### DIFF
--- a/internal/api/golden_http_authchain_test.go
+++ b/internal/api/golden_http_authchain_test.go
@@ -1,0 +1,156 @@
+package api_test
+
+// golden_http_authchain_test.go extends the characterization harness to the
+// FULL middleware chain (server.Handler()), not just the bare mux. It boots a
+// DB-backed server and snapshots (status, stable security headers, normalized
+// body) for a representative slice of routes: public pass-through, protected
+// GET/POST (unauthenticated → the auth boundary), and a feature-gated route.
+//
+// These goldens pin the behavior the Phase-1 capability registry must preserve:
+// the auth/CSRF/security-header chain and the per-route gating outcomes.
+//
+// Regenerate:  UPDATE_GOLDEN=1 go test ./internal/api/ -run TestGoldenHTTPAuthChain
+// Verify:      go test ./internal/api/ -run TestGoldenHTTPAuthChain
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	api "github.com/krisarmstrong/seed/internal/api"
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/netif"
+	"github.com/krisarmstrong/seed/internal/testutil"
+)
+
+// stableSecurityHeaderNames is the deterministic subset of response headers worth
+// snapshotting: set globally by securityHeadersMiddleware on every response.
+// Volatile headers (Date, Content-Length, etc.) are intentionally excluded.
+func stableSecurityHeaderNames() []string {
+	return []string{
+		"Content-Security-Policy",
+		"Referrer-Policy",
+		"X-Content-Type-Options",
+		"X-Frame-Options",
+		"X-Xss-Protection",
+	}
+}
+
+// authChainRoutes is the representative slice through the full chain: public
+// pass-through (version, status), protected GET (settings, profiles), writeGated
+// mutating POST (settings/link, canopy/survey/create), and a feature-gated route
+// (roots/path). The harness records whatever the current behavior is
+// (characterization); it asserts nothing — a refactor that changes any outcome
+// produces a reviewable golden diff.
+func authChainRoutes() []goldenRoute {
+	return []goldenRoute{
+		{name: "version", method: http.MethodGet, path: "/__version"},
+		{name: "status", method: http.MethodGet, path: "/api/v1/status"},
+		{name: "settings-get", method: http.MethodGet, path: "/api/v1/settings"},
+		{name: "profiles-get", method: http.MethodGet, path: "/api/v1/profiles"},
+		{name: "settings-link-post", method: http.MethodPost, path: "/api/v1/settings/link"},
+		{name: "survey-create-post", method: http.MethodPost, path: "/api/v1/canopy/survey/create"},
+		{name: "roots-path-get", method: http.MethodGet, path: "/api/v1/roots/path"},
+	}
+}
+
+func TestGoldenHTTPAuthChain(t *testing.T) {
+	srv := newFullChainServer(t)
+	defer srv.close()
+
+	for _, rt := range authChainRoutes() {
+		t.Run(rt.name, func(t *testing.T) {
+			status, headers, body := doFullChainRequest(t, srv.ts.URL+rt.path, rt.method)
+			snapshot := formatChainSnapshot(status, headers, normalizeJSON(t, body))
+			goldenPath := filepath.Join("testdata", "golden", "authchain", rt.name+".txt")
+			compareGolden(t, goldenPath, snapshot)
+		})
+	}
+}
+
+// newFullChainServer boots a DB-backed server and serves the full Handler()
+// chain (recover → … → auth → CSRF → mux), unlike newTestEndpointServer which
+// serves the bare mux.
+func newFullChainServer(t *testing.T) *testEndpointServer {
+	t.Helper()
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test-config.yaml")
+
+	cfg := testutil.NewConfigBuilder().WithPort(8080).Build()
+	if err := cfg.Save(configPath); err != nil {
+		t.Fatalf("save test config: %v", err)
+	}
+
+	db, err := database.Open(filepath.Join(tmpDir, "seed.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	netMgr, err := netif.NewManager("")
+	if err != nil {
+		t.Logf("warning: network manager: %v", err)
+	}
+
+	server := api.NewServer(cfg, configPath, "", netMgr, false, nil, db, nil)
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ts := httptest.NewUnstartedServer(server.Handler())
+	ts.Listener = ln
+	ts.Start()
+	return &testEndpointServer{ts: ts, server: server}
+}
+
+// doFullChainRequest issues the request and returns status, headers, and body.
+func doFullChainRequest(t *testing.T, url, method string) (int, http.Header, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp.StatusCode, resp.Header, body
+}
+
+// formatChainSnapshot renders status + the stable security headers + body.
+func formatChainSnapshot(status int, headers http.Header, normalizedBody string) string {
+	var b strings.Builder
+	b.WriteString("status: ")
+	b.WriteString(strconv.Itoa(status))
+	b.WriteString("\nheaders:\n")
+	for _, name := range stableSecurityHeaderNames() {
+		val := headers.Get(name)
+		if val == "" {
+			val = "(absent)"
+		}
+		b.WriteString("  ")
+		b.WriteString(name)
+		b.WriteString(": ")
+		b.WriteString(val)
+		b.WriteString("\n")
+	}
+	if normalizedBody != "" {
+		b.WriteString("body:\n")
+		b.WriteString(normalizedBody)
+		if !strings.HasSuffix(normalizedBody, "\n") {
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}

--- a/internal/api/testdata/golden/authchain/profiles-get.txt
+++ b/internal/api/testdata/golden/authchain/profiles-get.txt
@@ -1,0 +1,12 @@
+status: 401
+headers:
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Xss-Protection: 1; mode=block
+body:
+{
+  "code": "UNAUTHORIZED",
+  "error": "Unauthorized"
+}

--- a/internal/api/testdata/golden/authchain/roots-path-get.txt
+++ b/internal/api/testdata/golden/authchain/roots-path-get.txt
@@ -1,0 +1,12 @@
+status: 401
+headers:
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Xss-Protection: 1; mode=block
+body:
+{
+  "code": "UNAUTHORIZED",
+  "error": "Unauthorized"
+}

--- a/internal/api/testdata/golden/authchain/settings-get.txt
+++ b/internal/api/testdata/golden/authchain/settings-get.txt
@@ -1,0 +1,12 @@
+status: 401
+headers:
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Xss-Protection: 1; mode=block
+body:
+{
+  "code": "UNAUTHORIZED",
+  "error": "Unauthorized"
+}

--- a/internal/api/testdata/golden/authchain/settings-link-post.txt
+++ b/internal/api/testdata/golden/authchain/settings-link-post.txt
@@ -1,0 +1,12 @@
+status: 401
+headers:
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Xss-Protection: 1; mode=block
+body:
+{
+  "code": "UNAUTHORIZED",
+  "error": "Unauthorized"
+}

--- a/internal/api/testdata/golden/authchain/status.txt
+++ b/internal/api/testdata/golden/authchain/status.txt
@@ -1,0 +1,12 @@
+status: 401
+headers:
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Xss-Protection: 1; mode=block
+body:
+{
+  "code": "UNAUTHORIZED",
+  "error": "Unauthorized"
+}

--- a/internal/api/testdata/golden/authchain/survey-create-post.txt
+++ b/internal/api/testdata/golden/authchain/survey-create-post.txt
@@ -1,0 +1,12 @@
+status: 401
+headers:
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Xss-Protection: 1; mode=block
+body:
+{
+  "code": "UNAUTHORIZED",
+  "error": "Unauthorized"
+}

--- a/internal/api/testdata/golden/authchain/version.txt
+++ b/internal/api/testdata/golden/authchain/version.txt
@@ -1,0 +1,15 @@
+status: 200
+headers:
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Xss-Protection: 1; mode=block
+body:
+{
+  "buildTime": "\u003cvolatile\u003e",
+  "commit": "\u003cvolatile\u003e",
+  "tlsFingerprint": "",
+  "uiBuildHash": "\u003cvolatile\u003e",
+  "version": "\u003cvolatile\u003e"
+}


### PR DESCRIPTION
Extends the golden harness to the **full middleware chain** (`server.Handler()`) on a DB-backed server. Snapshots status + stable security headers + normalized body for a representative slice: public 200, protected GET/POST → 401 UNAUTHORIZED, feature-gated route. Deterministic across replays; lint + full suite green.

Completes the Phase-0 safety net: these goldens pin the auth/security-header behavior the Phase-1 capability registry must preserve.