### PR TITLE
feat(api): capability manifest + /__capabilities + route-policy CI gate (Phase 1 complete)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
       - name: Output-escaping / XSS gate (#1225)
         run: ./scripts/check-output-escaping.sh
 
+      - name: Route-policy gate — capability registry (ADR-0002)
+        run: ./scripts/check-route-policy.sh
+
       - name: Run staticcheck
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/internal/api/golden_http_test.go
+++ b/internal/api/golden_http_test.go
@@ -50,6 +50,9 @@ type goldenRoute struct {
 func goldenRoutes() []goldenRoute {
 	return []goldenRoute{
 		{name: "version", method: http.MethodGet, path: "/__version", body: bodyGolden},
+		// The capability manifest pins every route's policy (role/feature/rate) in
+		// one snapshot — the strongest regression detector for the registry.
+		{name: "capabilities", method: http.MethodGet, path: "/__capabilities", body: bodyGolden},
 		{name: "status", method: http.MethodGet, path: "/api/v1/status", body: bodyGolden},
 		{name: "settings", method: http.MethodGet, path: "/api/v1/settings", body: bodyGolden},
 		{name: "interfaces", method: http.MethodGet, path: "/api/v1/interfaces", body: bodyStatusOnly},

--- a/internal/api/route.go
+++ b/internal/api/route.go
@@ -7,9 +7,11 @@ package api
 // class). See docs/architecture/decisions/0002-capability-registry.md.
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/logging"
 )
 
 // route declares an HTTP route and its per-route policy. Authentication and CSRF
@@ -37,6 +39,9 @@ type route struct {
 // than at each call site — makes the policy declarative and the ordering
 // uniform, and is the single choke point a future audit/CI gate can enforce.
 func (s *Server) register(rt route) {
+	// Record the route for the /__capabilities manifest before composing.
+	s.manifest = append(s.manifest, rt)
+
 	h := rt.handler
 
 	// requireRole closest to the handler.
@@ -60,5 +65,35 @@ func (s *Server) register(rt route) {
 func (s *Server) registerAll(routes []route) {
 	for _, rt := range routes {
 		s.register(rt)
+	}
+}
+
+// capabilityView is the JSON-serializable projection of a route's policy for
+// the /__capabilities manifest (the handler func itself is not exposed).
+type capabilityView struct {
+	Path        string `json:"path"`
+	MinRole     string `json:"minRole,omitempty"`
+	Feature     string `json:"feature,omitempty"`
+	RateLimited bool   `json:"rateLimited,omitempty"`
+}
+
+// handleCapabilities serves the route-policy manifest: every route registered
+// through register() with its per-route policy (role / feature / rate-limit).
+// No auth — like /__version, it is a deployment/audit introspection surface.
+// Auth and CSRF are global and intentionally not represented here.
+func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
+	views := make([]capabilityView, 0, len(s.manifest))
+	for _, rt := range s.manifest {
+		views = append(views, capabilityView{
+			Path:        rt.path,
+			MinRole:     rt.minRole,
+			Feature:     rt.feature,
+			RateLimited: rt.rateLimited,
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(views); err != nil {
+		logging.FromContext(r.Context()).ErrorContext(r.Context(),
+			"failed to encode capabilities manifest", "error", err)
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -110,6 +110,11 @@ type Server struct {
 	mux                 *http.ServeMux
 	acmeChallengeServer *http.Server // HTTP-01 challenge server for ACME (fixes #837)
 
+	// manifest records every route registered through register() (the
+	// capability registry, ADR-0002). Exposed read-only via /__capabilities
+	// for fleet policy audits.
+	manifest []route
+
 	// Service container - holds all domain services (#888)
 	services *ServiceContainer
 

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -14,6 +14,11 @@ import (
 // setupRoutes configures all HTTP routes.
 func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("/__version", s.handleBuildVersion)
+	// /__capabilities exposes the route-policy manifest (ADR-0002). Registered
+	// directly (not via register()) because it is infra introspection, not an
+	// API surface — same as /__version. Reads s.manifest at request time, after
+	// the module setups below have populated it.
+	s.mux.HandleFunc("/__capabilities", s.handleCapabilities)
 	s.setupCoreRoutes()
 	s.setupAPITokenRoutes()
 	s.registerUpdateRoutes()
@@ -334,7 +339,7 @@ func (s *Server) setupSSEAndStatic() {
 	// per-endpoint REST handlers without the WebSocket-like stream.
 	// `/discovery/engine/events` (the discovery-lifecycle SSE) is
 	// intentionally NOT gated here — discovery is a Free-tier surface.
-	s.mux.HandleFunc(APIVersionPrefix+"/events", s.requireFeature("live_telemetry", s.handleSSE))
+	s.register(route{path: APIVersionPrefix + "/events", handler: s.handleSSE, feature: "live_telemetry"})
 	frontendFS, err := getUIFS()
 	if err != nil {
 		logging.GetLogger().

--- a/internal/api/testdata/golden/capabilities.txt
+++ b/internal/api/testdata/golden/capabilities.txt
@@ -1,0 +1,626 @@
+status: 200
+body:
+[
+  {
+    "path": "/api/v1/auth/login"
+  },
+  {
+    "path": "/api/v1/auth/logout"
+  },
+  {
+    "path": "/api/v1/auth/refresh"
+  },
+  {
+    "path": "/api/v1/auth/csrf"
+  },
+  {
+    "path": "/api/v1/auth/login/totp"
+  },
+  {
+    "path": "/api/v1/auth/totp/setup"
+  },
+  {
+    "path": "/api/v1/auth/totp/verify"
+  },
+  {
+    "path": "/api/v1/auth/totp/disable"
+  },
+  {
+    "path": "/api/v1/auth/mfa/status"
+  },
+  {
+    "path": "/api/v1/auth/webauthn/register/begin"
+  },
+  {
+    "path": "/api/v1/auth/webauthn/register/finish"
+  },
+  {
+    "path": "/api/v1/auth/webauthn/login/begin"
+  },
+  {
+    "path": "/api/v1/auth/webauthn/login/finish"
+  },
+  {
+    "path": "/api/v1/status"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/settings"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/settings/defaults"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/settings/link"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/settings/cable"
+  },
+  {
+    "path": "/api/v1/interfaces"
+  },
+  {
+    "path": "/api/v1/interface"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/network/mtu"
+  },
+  {
+    "path": "/api/v1/config/backups"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/config/backup"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/config/backup/delete"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/config/restore"
+  },
+  {
+    "path": "/api/v1/config/version"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/profiles"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/profiles/active"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/profiles/import"
+  },
+  {
+    "path": "/api/v1/profiles/export"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/profiles/"
+  },
+  {
+    "path": "/api/v1/setup/status"
+  },
+  {
+    "path": "/api/v1/setup/complete"
+  },
+  {
+    "path": "/api/v1/recovery/status"
+  },
+  {
+    "path": "/api/v1/recovery/complete"
+  },
+  {
+    "path": "/api/v1/recovery/instructions"
+  },
+  {
+    "path": "/api/v1/sso/providers"
+  },
+  {
+    "path": "/api/v1/sso/login"
+  },
+  {
+    "path": "/api/v1/sso/callback"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/sso/settings"
+  },
+  {
+    "feature": "sso",
+    "minRole": "operator",
+    "path": "/api/v1/sso/update"
+  },
+  {
+    "path": "/api/v1/health"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/tokens"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/tokens/"
+  },
+  {
+    "path": "/api/v1/license"
+  },
+  {
+    "path": "/api/v1/users/me"
+  },
+  {
+    "path": "/api/v1/users"
+  },
+  {
+    "path": "/api/v1/users/"
+  },
+  {
+    "path": "GET /api/v1/updates/check"
+  },
+  {
+    "path": "GET /api/v1/updates/status"
+  },
+  {
+    "path": "GET /api/v1/updates/info"
+  },
+  {
+    "minRole": "operator",
+    "path": "POST /api/v1/updates/download"
+  },
+  {
+    "minRole": "operator",
+    "path": "POST /api/v1/updates/apply"
+  },
+  {
+    "minRole": "operator",
+    "path": "POST /api/v1/updates/rollback"
+  },
+  {
+    "path": "GET /api/v1/updates/config"
+  },
+  {
+    "minRole": "operator",
+    "path": "PATCH /api/v1/updates/config"
+  },
+  {
+    "path": "/api/v1/sap/link"
+  },
+  {
+    "path": "/api/v1/sap/cable"
+  },
+  {
+    "path": "/api/v1/sap/dns"
+  },
+  {
+    "path": "/api/v1/sap/dns/security"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/sap/dns/security/settings"
+  },
+  {
+    "path": "/api/v1/sap/gateway"
+  },
+  {
+    "path": "/api/v1/sap/dhcp/rogue"
+  },
+  {
+    "path": "/api/v1/sap/dhcp/rogue/servers"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/sap/dhcp/rogue/config"
+  },
+  {
+    "path": "/api/v1/sap/vlan"
+  },
+  {
+    "path": "/api/v1/sap/vlan/traffic"
+  },
+  {
+    "path": "/api/v1/sap/vlan/interface"
+  },
+  {
+    "path": "/api/v1/sap/speedtest",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/sap/speedtest/status"
+  },
+  {
+    "path": "/api/v1/sap/iperf/info"
+  },
+  {
+    "path": "/api/v1/sap/iperf/client",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/sap/iperf/client/status"
+  },
+  {
+    "path": "/api/v1/sap/iperf/server"
+  },
+  {
+    "path": "/api/v1/sap/iperf/server/status"
+  },
+  {
+    "path": "/api/v1/sap/iperf/suggestions"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/sap/health-checks/settings"
+  },
+  {
+    "path": "/api/v1/sap/health-checks/run",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/sap/health-checks/results"
+  },
+  {
+    "path": "/api/v1/sap/health-checks/history"
+  },
+  {
+    "path": "/api/v1/sap/health-checks/scores"
+  },
+  {
+    "path": "/api/v1/sap/health-checks/sla"
+  },
+  {
+    "path": "/api/v1/sap/health-checks/alerts"
+  },
+  {
+    "feature": "anomaly_detection",
+    "path": "/api/v1/sap/health-checks/anomalies"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/sap/snmp/settings"
+  },
+  {
+    "path": "/api/v1/sap/system/health"
+  },
+  {
+    "path": "/api/v1/sap/ipconfig"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/sap/ipconfig/settings"
+  },
+  {
+    "path": "/api/v1/sap/publicip"
+  },
+  {
+    "path": "/api/v1/shell/discovery"
+  },
+  {
+    "path": "/api/v1/shell/discovery/probe"
+  },
+  {
+    "path": "/api/v1/shell/discovery/portscan"
+  },
+  {
+    "path": "/api/v1/shell/discovery/options"
+  },
+  {
+    "path": "/api/v1/shell/discovery/service/status"
+  },
+  {
+    "path": "/api/v1/shell/discovery/fingerprint"
+  },
+  {
+    "path": "/api/v1/shell/devices"
+  },
+  {
+    "path": "/api/v1/shell/devices/scan",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/shell/devices/status"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/shell/devices/settings"
+  },
+  {
+    "path": "/api/v1/shell/devices/subnets"
+  },
+  {
+    "feature": "compliance_advanced",
+    "path": "/api/v1/shell/vulnerabilities/scan",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/shell/vulnerabilities/status"
+  },
+  {
+    "path": "/api/v1/shell/vulnerabilities/results"
+  },
+  {
+    "path": "/api/v1/shell/vulnerabilities/device"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/shell/vulnerabilities/settings"
+  },
+  {
+    "path": "/api/v1/shell/vulnerabilities/validate-api-key"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/shell/guest-audit/settings"
+  },
+  {
+    "feature": "compliance_advanced",
+    "path": "/api/v1/shell/guest-audit/run",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/shell/pipeline/status"
+  },
+  {
+    "path": "/api/v1/shell/pipeline/start"
+  },
+  {
+    "path": "/api/v1/shell/pipeline/cancel"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/shell/pipeline/config"
+  },
+  {
+    "path": "/api/v1/shell/pipeline/port-intensity"
+  },
+  {
+    "path": "/api/v1/shell/pipeline/timing-profiles"
+  },
+  {
+    "path": "/api/v1/shell/problems"
+  },
+  {
+    "path": "/api/v1/shell/problems/scan"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/shell/problems/thresholds"
+  },
+  {
+    "path": "/api/v1/shell/bluetooth/scan"
+  },
+  {
+    "path": "/api/v1/shell/bluetooth/devices"
+  },
+  {
+    "path": "/api/v1/shell/bluetooth/stats"
+  },
+  {
+    "path": "/api/v1/shell/bluetooth/status"
+  },
+  {
+    "path": "/api/v1/shell/wifi/discovery/scan"
+  },
+  {
+    "path": "/api/v1/shell/wifi/discovery/networks"
+  },
+  {
+    "path": "/api/v1/shell/wifi/discovery/aps"
+  },
+  {
+    "path": "/api/v1/shell/wifi/discovery/stats"
+  },
+  {
+    "path": "/api/v1/discovery/engine"
+  },
+  {
+    "path": "/api/v1/discovery/engine/scan",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/discovery/engine/quick",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/discovery/engine/full",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/discovery/engine/stats"
+  },
+  {
+    "path": "/api/v1/discovery/engine/capabilities"
+  },
+  {
+    "path": "/api/v1/discovery/engine/device/"
+  },
+  {
+    "path": "/api/v1/discovery/engine/events"
+  },
+  {
+    "feature": "path_analysis",
+    "path": "/api/v1/roots/traceroute",
+    "rateLimited": true
+  },
+  {
+    "feature": "path_analysis",
+    "path": "/api/v1/roots/path"
+  },
+  {
+    "path": "/api/v1/canopy/wifi"
+  },
+  {
+    "path": "/api/v1/canopy/wifi/scan"
+  },
+  {
+    "path": "/api/v1/canopy/wifi/status"
+  },
+  {
+    "path": "/api/v1/canopy/wifi/channel-graph"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/wifi/settings"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/wifi/connect"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/wifi/disconnect"
+  },
+  {
+    "path": "/api/v1/canopy/wifi/saved"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/wifi/forget"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/create"
+  },
+  {
+    "path": "/api/v1/canopy/survey/list"
+  },
+  {
+    "path": "/api/v1/canopy/survey"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/delete"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/start"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/pause"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/complete"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/sample"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/floorplan"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/settings"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/imported-data"
+  },
+  {
+    "feature": "airmapper_baseline_diff",
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/import/airmapper",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/canopy/survey/heatmap",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/canopy/survey/dead-zones"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/floors"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/floor"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/floor/floorplan"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/floor/sample"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/canopy/survey/active-floor"
+  },
+  {
+    "path": "/api/v1/canopy/survey/report",
+    "rateLimited": true
+  },
+  {
+    "feature": "export_csv_json",
+    "path": "/api/v1/harvest/export"
+  },
+  {
+    "path": "/api/v1/harvest/logs"
+  },
+  {
+    "path": "/api/v1/harvest/logs/client"
+  },
+  {
+    "path": "/api/v1/harvest/logs/query"
+  },
+  {
+    "path": "/api/v1/harvest/logs/stats"
+  },
+  {
+    "path": "/api/v1/harvest/logs/recent"
+  },
+  {
+    "path": "/api/v1/topology/nodes"
+  },
+  {
+    "path": "/api/v1/topology/nodes/"
+  },
+  {
+    "path": "/api/v1/topology/links"
+  },
+  {
+    "path": "/api/v1/topology/arp"
+  },
+  {
+    "path": "/api/v1/alerts"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/alerts/"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/polling-targets"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/polling-targets/"
+  },
+  {
+    "path": "/api/v1/engines"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/alert-rules"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/alert-rules/"
+  },
+  {
+    "feature": "live_telemetry",
+    "path": "/api/v1/events"
+  }
+]

--- a/scripts/check-route-policy.sh
+++ b/scripts/check-route-policy.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# check-route-policy.sh — capability-registry enforcement gate (ADR-0002).
+#
+# Every API route MUST be registered through the capability registry
+# (register / registerAll in internal/api/route.go), which composes its
+# per-route policy — role gate, license-feature gate, rate limiting — in one
+# canonical order. Hand-wrapping a route directly on the mux bypasses that
+# composition and is how a mutating route silently ships without a role/feature
+# gate ("forgot the wrapper", a documented regression class).
+#
+# This gate fails if any API route (an APIVersionPrefix path) is registered
+# directly via s.mux.Handle/HandleFunc instead of through register(). The only
+# permitted direct mux registrations are infra introspection / static serving
+# (/__version, /__capabilities, "/" SPA fallback) and register()'s own
+# implementation — none of which reference APIVersionPrefix.
+#
+# Run locally: scripts/check-route-policy.sh
+set -euo pipefail
+
+API_DIR="internal/api"
+
+violations=$(grep -rnE 's\.mux\.Handle(Func)?\(APIVersionPrefix' "$API_DIR"/*.go \
+	| grep -v '_test.go' || true)
+
+if [[ -n "$violations" ]]; then
+	echo "❌ Route-policy gate (ADR-0002): API routes must be registered via"
+	echo "   register()/registerAll(), not s.mux.Handle*() directly."
+	echo "   Replace the direct registration with a route{} entry"
+	echo "   (path/handler/minRole/feature/rateLimited)."
+	echo ""
+	echo "$violations"
+	exit 1
+fi
+
+echo "✓ Route-policy gate: all API routes go through the capability registry."


### PR DESCRIPTION
Completes Phase 1 (ADR-0002).

- **Manifest**: register() records every route; `GET /__capabilities` exposes it as JSON (path/role/feature/rate-limit) — the machine-readable fleet-audit surface. Last direct API registration (/events) converted to register().
- **CI gate**: `scripts/check-route-policy.sh` fails if any API route is registered directly on the mux instead of through register() — 'forgot the wrapper' becomes structurally impossible. Wired into ci.yml; verified it catches a planted violation.
- **Capabilities golden**: pins all 182 registered routes' policies in one snapshot — the strongest route-surface regression detector.

Full suite green, 0 lint, gate passes.