### PR TITLE
feat(contract): code-first decision (ADR-0003 amended) + widen DTO coverage

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -78,6 +78,34 @@ func schemaTargets() []schemaTarget {
 			filename: "wifi-connect.schema.json",
 			title:    "WiFiConnectRequest",
 		},
+		// Phase 2 (ADR-0003, code-first): widening coverage to response DTOs,
+		// starting with the core auth/status responses that pair with the
+		// request DTOs above.
+		{
+			value:    &api.StatusResponse{},
+			filename: "status-response.schema.json",
+			title:    "StatusResponse",
+		},
+		{
+			value:    &api.LoginResponse{},
+			filename: "login-response.schema.json",
+			title:    "LoginResponse",
+		},
+		{
+			value:    &api.CSRFTokenResponse{},
+			filename: "csrf-token-response.schema.json",
+			title:    "CSRFTokenResponse",
+		},
+		{
+			value:    &api.SetupStatusResponse{},
+			filename: "setup-status-response.schema.json",
+			title:    "SetupStatusResponse",
+		},
+		{
+			value:    &api.LicenseStatusResponse{},
+			filename: "license-status-response.schema.json",
+			title:    "LicenseStatusResponse",
+		},
 	}
 }
 

--- a/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
+++ b/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
@@ -304,21 +304,30 @@ func (s *Server) register(rt Route) { /* … */ s.manifest = append(s.manifest, 
 
 Greenfield bonus: normalize the gating-order divergences directly — no preserve-and-flag ceremony.
 
-### 5.2 Contract-first boundary
+### 5.2 Contract boundary — code-first (ADR-0003, amended)
 
-**Problem killed:** ~5% of routes are schema-generated; the rest (and the
-~1,300 LOC Profile/Settings types) are hand-typed twice → silent drift.
+**Problem killed:** most request/response types are hand-typed *twice* (the
+~1,300 LOC Profile/Settings types worst of all) with no enforced link → silent drift.
 
-**Change:** OpenAPI 3.1 in `contract/` is the source of truth. Generate Go
-transport DTOs (`oapi-codegen`, types mode) and the TS client (`openapi-typescript`).
-Greenfield → **author the API we want**; reverse-gen only as a starting draft, then
-refine without fear of breaking consumers.
+**Change (corrected from the original OpenAPI-first plan — see ADR-0003):** there is
+already a working, CI-gated **code-first** pipeline; the fix is *coverage*, not new
+tooling.
 
-- Transport DTOs live in `adapters/http`; handlers map DTO↔domain → modules never import contract types (purity preserved).
-- **Lint the spec with Spectral** in CI (consistent envelopes, RFC3339, pagination, error shape).
-- Extend the drift-gate pattern: `check-contract-drift.sh` regenerates and fails on diff.
-- Roll module-by-module (start with Sap — smallest, read-heavy). End state: delete hand-written `client.ts` and hand-maintained `profile.ts`/`settings.ts`.
-- Auto-publish a Redoc reference (gated) from the spec.
+```
+Go DTO ──seed-schema──► docs/schemas/api/*.schema.json ──gen-types──► ui generated TS
+   gated by check-schema-drift.sh + check-types-drift.sh
+```
+
+- **Go DTOs stay the single source of truth.** Widen `seed-schema`'s target list from
+  6 → all request/response DTOs; TS regenerates; drift fails CI.
+- **Delete hand-maintained TS twins** (`profile.ts`, `settings.ts`, hand-written
+  `client.ts` call sites) as each DTO is generated.
+- **OpenAPI is a deferred additive output**, not a rewrite: emit OpenAPI 3.1 from the
+  capability manifest (§5.1) + the schemas only when there's a reader (Redoc docs or a
+  third-party consumer). Non-breaking bolt-on, no rework. Mirrors the org's "API
+  versioning deferred until 3rd-party needs arise."
+- Rejected: hand-authored OpenAPI-first — discards working infra, adds a permanent
+  spec-vs-code sync burden for an API that currently serves only our own frontend.
 
 ### 5.3 Component lifecycle (`platform/lifecycle`)
 
@@ -708,7 +717,7 @@ allow-lists, the exact event catalog entries. Each is decided in its phase.
 |---|---|
 | [0001](decisions/0001-modulith-hexagon.md) | Modulith hexagon (modules / platform / adapters), not microservices, not layer-first |
 | [0002](decisions/0002-capability-registry.md) | Capability registry — authz/feature/rate-limit by construction |
-| [0003](decisions/0003-contract-first-boundary.md) | Contract-first OpenAPI boundary, generated both sides |
+| [0003](decisions/0003-contract-first-boundary.md) | Contract boundary — code-first (Go DTOs → schema → TS); OpenAPI deferred (amended) |
 | [0004](decisions/0004-event-bus.md) | In-process domain event bus for cross-module comms |
 | [0005](decisions/0005-unified-jobs.md) | Unified async job runner replacing per-feature run/status/cancel |
 | [0006](decisions/0006-migrations-sql-goose-strict.md) | Schema as embedded `.sql` files, run by goose, STRICT tables, single baseline |

--- a/docs/architecture/decisions/0003-contract-first-boundary.md
+++ b/docs/architecture/decisions/0003-contract-first-boundary.md
@@ -1,34 +1,59 @@
-# ADR-0003: Contract-first OpenAPI boundary
+# ADR-0003: Contract boundary (code-first, OpenAPI deferred)
 
-**Status:** Accepted — 2026-05-31
+**Status:** Amended — 2026-05-31 (supersedes the original OpenAPI-first decision below)
 
 ## Context
 
-Only ~6 of ~120 routes flow through the JSON-Schema→TS generation pipeline. The rest
-are hand-typed on both the Go and TS sides, and the two largest type files
-(`profile.ts` ~601 LOC, `settings.ts` ~757 LOC) are hand-maintained in TS with no
-enforced link to their Go counterparts. This is the single largest latent-bug surface:
-the frontend/backend contract drifts silently.
+The frontend/backend contract is the single largest latent-bug surface: most
+request/response types are hand-typed on *both* the Go and TS sides — the two
+largest, `profile.ts` (~601 LOC) and `settings.ts` (~757 LOC), are hand-maintained
+in TS with no enforced link to their Go counterparts, so the contract drifts silently.
+
+**Correction (recorded deliberately).** This ADR originally recommended a
+hand-authored **OpenAPI-first** boundary (author specs in `contract/`, add
+`oapi-codegen`, replace the existing generator). That recommendation was made on an
+**incompletely-verified view of the codebase** — it reached for the standard
+"contract-first OpenAPI" best-practice label instead of reckoning with what already
+exists. On actually reading `cmd/seed-schema`, there is already a working, CI-gated
+**code-first** pipeline:
+
+```
+Go DTO ──seed-schema (invopop/jsonschema)──► docs/schemas/api/*.schema.json
+                                                   │ json-schema-to-typescript (ui/scripts/gen-types.mjs)
+                                                   ▼
+                                            ui generated TS types
+   gated by check-schema-drift.sh + check-types-drift.sh
+```
+
+The Go struct is the single source of truth; TS is generated; drift fails CI. The real
+problem is **coverage** (6 of ~180 routes), not the absence of machinery.
 
 ## Decision
 
-An **OpenAPI 3.1 spec in `contract/` is the source of truth.** Generate Go transport
-DTOs (`oapi-codegen`, types mode) into `adapters/http`, and the TS client
-(`openapi-typescript`). Greenfield (no consumers) → design the API we want;
-reverse-generate only as a starting draft, then refine.
+**Code-first. Extend the existing Go-first pipeline; do not hand-author specs.**
 
-- Transport DTOs live in `adapters/http`; handlers map DTO↔domain so `modules/` never
-  import contract types (purity preserved).
-- Spectral lints the spec in CI (consistent error envelope, RFC3339, pagination).
-- `check-contract-drift.sh` regenerates and fails on diff (extends the existing
-  schema-drift gate to the whole boundary).
-- A gated Redoc reference is auto-published from the spec.
-- Roll module-by-module (Sap first). End state: delete hand-written `client.ts` and
-  hand-maintained domain types.
+- **Go DTOs remain the single source of truth.** Widen `seed-schema`'s target list from
+  6 DTOs to all request/response types, generating TS via the existing `gen-types`
+  step, gated by `check-schema-drift.sh` + `check-types-drift.sh`.
+- **Replace hand-maintained dual types** — once a DTO is generated, delete its
+  hand-written TS twin (`profile.ts`, `settings.ts`, etc.) in favour of the generated
+  type.
+- **OpenAPI is a deferred, additive output, not a rewrite.** When there is a reader for
+  it — published API docs (Redoc) or a third-party consumer — emit an OpenAPI 3.1
+  document from the route registry manifest (`/__capabilities`, ADR-0002) + the
+  seed-schema DTOs. This is a non-breaking bolt-on: the Go DTOs, schemas, registry and
+  TS pipeline are unchanged; an emitter is added on top. This mirrors the existing
+  org decision that API versioning is "deferred until 3rd-party needs arise."
+
+Rejected: hand-authored OpenAPI-first (the original recommendation) — it discards a
+working, CI-gated pipeline and adds a permanent spec-vs-implementation sync burden for
+an API that currently serves only our own frontend with no external consumers.
 
 ## Consequences
 
-- The FE/BE contract cannot drift — generation + drift gate enforce it.
-- Clean API taxonomy, not inherited wartiness (greenfield).
-- Adds a codegen step to the build; CI must run it and gate on drift.
-- New endpoints must start from the spec, not the handler.
+- The FE/BE contract cannot drift for any covered DTO — generation + drift gate enforce it.
+- Far less disruption than OpenAPI-first: extend coverage rather than replace tooling.
+- The OpenAPI/Redoc capability is preserved as a future additive step, reusing the
+  Phase-1 capability manifest — no rework, no lock-out.
+- New endpoints add their DTO to the `seed-schema` target list; the schema + TS type
+  generate from the Go struct.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -10,7 +10,7 @@ See the [Re-Architecture Blueprint](../RE_ARCHITECTURE_BLUEPRINT.md) for the ful
 |---|---|---|
 | [0001](0001-modulith-hexagon.md) | Modulith hexagon structure | Accepted |
 | [0002](0002-capability-registry.md) | Capability registry for route policy | Accepted |
-| [0003](0003-contract-first-boundary.md) | Contract-first OpenAPI boundary | Accepted |
+| [0003](0003-contract-first-boundary.md) | Contract boundary — code-first; OpenAPI deferred | Amended |
 | [0004](0004-event-bus.md) | In-process domain event bus | Accepted |
 | [0005](0005-unified-jobs.md) | Unified async job runner | Accepted |
 | [0006](0006-migrations-sql-goose-strict.md) | Schema as embedded `.sql` files, goose, STRICT tables | Accepted |

--- a/docs/schemas/api/csrf-token-response.schema.json
+++ b/docs/schemas/api/csrf-token-response.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/csrf-token-response.schema.json",
+  "$ref": "#/$defs/CSRFTokenResponse",
+  "$defs": {
+    "CSRFTokenResponse": {
+      "properties": {
+        "token": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "token"
+      ]
+    }
+  },
+  "title": "CSRFTokenResponse",
+  "description": "CSRFTokenResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/license-status-response.schema.json
+++ b/docs/schemas/api/license-status-response.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/license-status-response.schema.json",
+  "$ref": "#/$defs/LicenseStatusResponse",
+  "$defs": {
+    "LicenseStatusResponse": {
+      "properties": {
+        "tier": {
+          "type": "string"
+        },
+        "tierValue": {
+          "type": "integer"
+        },
+        "isTrialMode": {
+          "type": "boolean"
+        },
+        "trialDaysLeft": {
+          "type": "integer"
+        },
+        "canMintTokens": {
+          "type": "boolean"
+        },
+        "activated": {
+          "type": "boolean"
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "tier",
+        "tierValue",
+        "isTrialMode",
+        "canMintTokens",
+        "activated"
+      ]
+    }
+  },
+  "title": "LicenseStatusResponse",
+  "description": "LicenseStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/login-response.schema.json
+++ b/docs/schemas/api/login-response.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/login-response.schema.json",
+  "$ref": "#/$defs/LoginResponse",
+  "$defs": {
+    "LoginResponse": {
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "expires": {
+          "type": "integer"
+        },
+        "mfa_required": {
+          "type": "boolean"
+        },
+        "mfa_token": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "title": "LoginResponse",
+  "description": "LoginResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/setup-status-response.schema.json
+++ b/docs/schemas/api/setup-status-response.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/setup-status-response.schema.json",
+  "$ref": "#/$defs/SetupStatusResponse",
+  "$defs": {
+    "SetupStatusResponse": {
+      "properties": {
+        "needsSetup": {
+          "type": "boolean"
+        },
+        "suggestedPassword": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "setupToken": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "needsSetup",
+        "username"
+      ]
+    }
+  },
+  "title": "SetupStatusResponse",
+  "description": "SetupStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/status-response.schema.json
+++ b/docs/schemas/api/status-response.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/status-response.schema.json",
+  "$ref": "#/$defs/StatusResponse",
+  "$defs": {
+    "StatusResponse": {
+      "properties": {
+        "status": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "uptime": {
+          "type": "integer"
+        },
+        "interface": {
+          "type": "string"
+        },
+        "isWireless": {
+          "type": "boolean"
+        },
+        "icmpAvailable": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "status",
+        "version",
+        "uptime",
+        "interface",
+        "isWireless",
+        "icmpAvailable"
+      ]
+    }
+  },
+  "title": "StatusResponse",
+  "description": "StatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/src/types/generated/csrf-token-response.ts
+++ b/ui/src/types/generated/csrf-token-response.ts
@@ -1,0 +1,13 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * CSRFTokenResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface CSRFTokenResponse {
+  token: string;
+}

--- a/ui/src/types/generated/license-status-response.ts
+++ b/ui/src/types/generated/license-status-response.ts
@@ -1,0 +1,19 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * LicenseStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface LicenseStatusResponse {
+  tier: string;
+  tierValue: number;
+  isTrialMode: boolean;
+  trialDaysLeft?: number;
+  canMintTokens: boolean;
+  activated: boolean;
+  expiresAt?: string;
+}

--- a/ui/src/types/generated/login-response.ts
+++ b/ui/src/types/generated/login-response.ts
@@ -1,0 +1,16 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * LoginResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface LoginResponse {
+  token?: string;
+  expires?: number;
+  mfa_required?: boolean;
+  mfa_token?: string;
+}

--- a/ui/src/types/generated/setup-status-response.ts
+++ b/ui/src/types/generated/setup-status-response.ts
@@ -1,0 +1,16 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * SetupStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface SetupStatusResponse {
+  needsSetup: boolean;
+  suggestedPassword?: string;
+  username: string;
+  setupToken?: string;
+}

--- a/ui/src/types/generated/status-response.ts
+++ b/ui/src/types/generated/status-response.ts
@@ -1,0 +1,18 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * StatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface StatusResponse {
+  status: string;
+  version: string;
+  uptime: number;
+  interface: string;
+  isWireless: boolean;
+  icmpAvailable: boolean;
+}


### PR DESCRIPTION
Phase 2 kickoff.

**Decision corrected (ADR-0003 amended):** original recommendation was hand-authored OpenAPI-first, made on an incompletely-verified view (reached for the best-practice label over reading `cmd/seed-schema`, a working CI-gated Go-first pipeline). Corrected to **code-first** — Go DTOs stay source of truth, widen coverage, generate TS, drift-gate; OpenAPI deferred as an additive output. Trail recorded in the ADR.

**First widening batch:** core auth/status response DTOs added to seed-schema, completing request/response pairs. Schemas + generated TS regenerated; both drift gates green. Coverage 6 → 11 DTOs.