### PR TITLE
feat(contract): widen DTO coverage batch 2 (+7); flag nested-defs blocker

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -106,6 +106,47 @@ func schemaTargets() []schemaTarget {
 			filename: "license-status-response.schema.json",
 			title:    "LicenseStatusResponse",
 		},
+		// Batch 2: common error envelopes + recovery/config/roots DTOs.
+		{
+			value:    &api.ErrorResponse{},
+			filename: "error-response.schema.json",
+			title:    "ErrorResponse",
+		},
+		{
+			value:    &api.FeatureGateResponse{},
+			filename: "feature-gate-response.schema.json",
+			title:    "FeatureGateResponse",
+		},
+		{
+			value:    &api.RecoveryStatusResponse{},
+			filename: "recovery-status-response.schema.json",
+			title:    "RecoveryStatusResponse",
+		},
+		{
+			value:    &api.RecoveryInstructionsResponse{},
+			filename: "recovery-instructions-response.schema.json",
+			title:    "RecoveryInstructionsResponse",
+		},
+		{
+			value:    &api.RecoveryCompleteResponse{},
+			filename: "recovery-complete-response.schema.json",
+			title:    "RecoveryCompleteResponse",
+		},
+		{
+			value:    &api.ConfigVersionResponse{},
+			filename: "config-version-response.schema.json",
+			title:    "ConfigVersionResponse",
+		},
+		// NOTE: nested-type DTOs (e.g. BackupListResponse → BackupInfo) are
+		// deferred until gen-types.mjs bundles cross-$defs refs —
+		// json-schema-to-typescript v15 errors "Refs should have been resolved"
+		// on invopop's sibling-$def references. Tracked as the gating fix before
+		// the bulk DTO rollout (ADR-0003 / Phase 2).
+		{
+			value:    &api.TracerouteRequest{},
+			filename: "traceroute-request.schema.json",
+			title:    "TracerouteRequest",
+		},
 	}
 }
 

--- a/docs/schemas/api/config-version-response.schema.json
+++ b/docs/schemas/api/config-version-response.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/config-version-response.schema.json",
+  "$ref": "#/$defs/ConfigVersionResponse",
+  "$defs": {
+    "ConfigVersionResponse": {
+      "properties": {
+        "current": {
+          "type": "integer"
+        },
+        "latest": {
+          "type": "integer"
+        },
+        "needs_migration": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "current",
+        "latest",
+        "needs_migration"
+      ]
+    }
+  },
+  "title": "ConfigVersionResponse",
+  "description": "ConfigVersionResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/error-response.schema.json
+++ b/docs/schemas/api/error-response.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/error-response.schema.json",
+  "$ref": "#/$defs/ErrorResponse",
+  "$defs": {
+    "ErrorResponse": {
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        },
+        "details": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "error",
+        "code"
+      ]
+    }
+  },
+  "title": "ErrorResponse",
+  "description": "ErrorResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/feature-gate-response.schema.json
+++ b/docs/schemas/api/feature-gate-response.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/feature-gate-response.schema.json",
+  "$ref": "#/$defs/FeatureGateResponse",
+  "$defs": {
+    "FeatureGateResponse": {
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        },
+        "requiredFeature": {
+          "type": "string"
+        },
+        "currentTier": {
+          "type": "string"
+        },
+        "upgradeMessage": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "error",
+        "code",
+        "requiredFeature",
+        "currentTier",
+        "upgradeMessage"
+      ]
+    }
+  },
+  "title": "FeatureGateResponse",
+  "description": "FeatureGateResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/recovery-complete-response.schema.json
+++ b/docs/schemas/api/recovery-complete-response.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/recovery-complete-response.schema.json",
+  "$ref": "#/$defs/RecoveryCompleteResponse",
+  "$defs": {
+    "RecoveryCompleteResponse": {
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "success",
+        "message"
+      ]
+    }
+  },
+  "title": "RecoveryCompleteResponse",
+  "description": "RecoveryCompleteResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/recovery-instructions-response.schema.json
+++ b/docs/schemas/api/recovery-instructions-response.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/recovery-instructions-response.schema.json",
+  "$ref": "#/$defs/RecoveryInstructionsResponse",
+  "$defs": {
+    "RecoveryInstructionsResponse": {
+      "properties": {
+        "triggerFile": {
+          "type": "string"
+        },
+        "tokenFile": {
+          "type": "string"
+        },
+        "expiryTime": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "triggerFile",
+        "tokenFile",
+        "expiryTime",
+        "steps"
+      ]
+    }
+  },
+  "title": "RecoveryInstructionsResponse",
+  "description": "RecoveryInstructionsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/recovery-status-response.schema.json
+++ b/docs/schemas/api/recovery-status-response.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/recovery-status-response.schema.json",
+  "$ref": "#/$defs/RecoveryStatusResponse",
+  "$defs": {
+    "RecoveryStatusResponse": {
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "remainingTime": {
+          "type": "integer"
+        },
+        "instructions": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "active"
+      ]
+    }
+  },
+  "title": "RecoveryStatusResponse",
+  "description": "RecoveryStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/traceroute-request.schema.json
+++ b/docs/schemas/api/traceroute-request.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/traceroute-request.schema.json",
+  "$ref": "#/$defs/TracerouteRequest",
+  "$defs": {
+    "TracerouteRequest": {
+      "properties": {
+        "target": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "maxHops": {
+          "type": "integer"
+        },
+        "timeout": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "target",
+        "protocol",
+        "port",
+        "maxHops",
+        "timeout"
+      ]
+    }
+  },
+  "title": "TracerouteRequest",
+  "description": "TracerouteRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/src/types/generated/config-version-response.ts
+++ b/ui/src/types/generated/config-version-response.ts
@@ -1,0 +1,15 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * ConfigVersionResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface ConfigVersionResponse {
+  current: number;
+  latest: number;
+  needs_migration: boolean;
+}

--- a/ui/src/types/generated/error-response.ts
+++ b/ui/src/types/generated/error-response.ts
@@ -1,0 +1,15 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * ErrorResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface ErrorResponse {
+  error: string;
+  code: string;
+  details?: string;
+}

--- a/ui/src/types/generated/feature-gate-response.ts
+++ b/ui/src/types/generated/feature-gate-response.ts
@@ -1,0 +1,17 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * FeatureGateResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface FeatureGateResponse {
+  error: string;
+  code: string;
+  requiredFeature: string;
+  currentTier: string;
+  upgradeMessage: string;
+}

--- a/ui/src/types/generated/recovery-complete-response.ts
+++ b/ui/src/types/generated/recovery-complete-response.ts
@@ -1,0 +1,14 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * RecoveryCompleteResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface RecoveryCompleteResponse {
+  success: boolean;
+  message: string;
+}

--- a/ui/src/types/generated/recovery-instructions-response.ts
+++ b/ui/src/types/generated/recovery-instructions-response.ts
@@ -1,0 +1,16 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * RecoveryInstructionsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface RecoveryInstructionsResponse {
+  triggerFile: string;
+  tokenFile: string;
+  expiryTime: string;
+  steps: string[];
+}

--- a/ui/src/types/generated/recovery-status-response.ts
+++ b/ui/src/types/generated/recovery-status-response.ts
@@ -1,0 +1,15 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * RecoveryStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface RecoveryStatusResponse {
+  active: boolean;
+  remainingTime?: number;
+  instructions?: string;
+}

--- a/ui/src/types/generated/traceroute-request.ts
+++ b/ui/src/types/generated/traceroute-request.ts
@@ -1,0 +1,17 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+/**
+ * TracerouteRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
+ */
+export interface TracerouteRequest {
+  target: string;
+  protocol: string;
+  port: number;
+  maxHops: number;
+  timeout: number;
+}


### PR DESCRIPTION
Coverage 11 → 18 DTOs (error envelopes, recovery, config-version, traceroute). Both drift gates green.

**Known blocker recorded:** nested-type DTOs break json-schema-to-typescript ('Refs should have been resolved'). The gating fix before the bulk rollout is to bundle cross-$defs refs in gen-types.mjs. Deferred with a note in main.go.