### PR TITLE
fix(contract): gen-types handles nested-type DTOs (unblocks Phase 2 rollout)

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -137,11 +137,14 @@ func schemaTargets() []schemaTarget {
 			filename: "config-version-response.schema.json",
 			title:    "ConfigVersionResponse",
 		},
-		// NOTE: nested-type DTOs (e.g. BackupListResponse → BackupInfo) are
-		// deferred until gen-types.mjs bundles cross-$defs refs —
-		// json-schema-to-typescript v15 errors "Refs should have been resolved"
-		// on invopop's sibling-$def references. Tracked as the gating fix before
-		// the bulk DTO rollout (ADR-0003 / Phase 2).
+		// Nested-type DTO: BackupListResponse embeds []BackupInfo. Generates
+		// correctly now that gen-types.mjs strips the external $id so nested
+		// `#/$defs/...` refs resolve locally (the prior blocker).
+		{
+			value:    &api.BackupListResponse{},
+			filename: "backup-list-response.schema.json",
+			title:    "BackupListResponse",
+		},
 		{
 			value:    &api.TracerouteRequest{},
 			filename: "traceroute-request.schema.json",

--- a/docs/schemas/api/backup-list-response.schema.json
+++ b/docs/schemas/api/backup-list-response.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/backup-list-response.schema.json",
+  "$ref": "#/$defs/BackupListResponse",
+  "$defs": {
+    "BackupInfo": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "path",
+        "size",
+        "created_at",
+        "version"
+      ]
+    },
+    "BackupListResponse": {
+      "properties": {
+        "backups": {
+          "items": {
+            "$ref": "#/$defs/BackupInfo"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "backups"
+      ]
+    }
+  },
+  "title": "BackupListResponse",
+  "description": "BackupListResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/scripts/gen-types.mjs
+++ b/ui/scripts/gen-types.mjs
@@ -50,9 +50,34 @@ async function main() {
   for (const filename of schemas) {
     const schemaPath = resolve(SCHEMA_DIR, filename);
     const raw = await readFile(schemaPath, 'utf8');
-    const schema = JSON.parse(raw);
 
-    const ts = await compile(schema, schema.title || filename, {
+    // Normalize invopop's draft-2020 output for json-schema-to-typescript.
+    // invopop emits `{ $id, $ref: "#/$defs/Root", $defs: { Root, Nested, … } }`.
+    // j-s-to-ts mishandles that shape: dereferencing the ROOT $ref replaces the
+    // whole document with Root's body and discards `$defs`, so any nested ref
+    // (e.g. Root.items.$ref → Nested) then dangles and it throws "Refs should
+    // have been resolved...". Three in-memory fixes (committed schema files are
+    // unchanged, so schema-drift checks are unaffected):
+    //   1. `$defs` → `definitions` (the draft-07 key j-s-to-ts resolves best).
+    //   2. drop the external `$id` URL so internal refs resolve locally.
+    //   3. INLINE the root $ref to the top level while KEEPING `definitions`,
+    //      so nested refs still resolve.
+    const schema = JSON.parse(
+      raw.replaceAll('#/$defs/', '#/definitions/').replaceAll('"$defs"', '"definitions"'),
+    );
+    delete schema.$id;
+
+    let root = schema;
+    if (typeof schema.$ref === 'string' && schema.$ref.startsWith('#/definitions/')) {
+      const name = schema.$ref.slice('#/definitions/'.length);
+      const defs = { ...schema.definitions };
+      const inlined = defs[name];
+      delete defs[name]; // avoid a duplicate of the root type
+      root = { $schema: schema.$schema, ...inlined };
+      if (Object.keys(defs).length > 0) root.definitions = defs;
+    }
+
+    const ts = await compile(root, schema.title || filename, {
       bannerComment: '',
       style: { singleQuote: true, semi: true },
       additionalProperties: false,

--- a/ui/src/types/generated/backup-list-response.ts
+++ b/ui/src/types/generated/backup-list-response.ts
@@ -5,7 +5,13 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-export interface RecoveryCompleteResponse {
-  success: boolean;
-  message: string;
+export interface BackupListResponse {
+  backups: BackupInfo[];
+}
+export interface BackupInfo {
+  name: string;
+  path: string;
+  size: number;
+  created_at: string;
+  version: number;
 }

--- a/ui/src/types/generated/config-version-response.ts
+++ b/ui/src/types/generated/config-version-response.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * ConfigVersionResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface ConfigVersionResponse {
   current: number;
   latest: number;

--- a/ui/src/types/generated/csrf-token-response.ts
+++ b/ui/src/types/generated/csrf-token-response.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * CSRFTokenResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface CSRFTokenResponse {
   token: string;
 }

--- a/ui/src/types/generated/error-response.ts
+++ b/ui/src/types/generated/error-response.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * ErrorResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface ErrorResponse {
   error: string;
   code: string;

--- a/ui/src/types/generated/feature-gate-response.ts
+++ b/ui/src/types/generated/feature-gate-response.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * FeatureGateResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface FeatureGateResponse {
   error: string;
   code: string;

--- a/ui/src/types/generated/license-status-response.ts
+++ b/ui/src/types/generated/license-status-response.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * LicenseStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface LicenseStatusResponse {
   tier: string;
   tierValue: number;

--- a/ui/src/types/generated/login-response.ts
+++ b/ui/src/types/generated/login-response.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * LoginResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface LoginResponse {
   token?: string;
   expires?: number;

--- a/ui/src/types/generated/login.ts
+++ b/ui/src/types/generated/login.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * LoginRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface LoginRequest {
   username: string;
   password: string;

--- a/ui/src/types/generated/path.ts
+++ b/ui/src/types/generated/path.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * PathRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface PathRequest {
   source: string;
   destination: string;

--- a/ui/src/types/generated/recovery-complete.ts
+++ b/ui/src/types/generated/recovery-complete.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * RecoveryCompleteRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface RecoveryCompleteRequest {
   token: string;
   password: string;

--- a/ui/src/types/generated/recovery-instructions-response.ts
+++ b/ui/src/types/generated/recovery-instructions-response.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * RecoveryInstructionsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface RecoveryInstructionsResponse {
   triggerFile: string;
   tokenFile: string;

--- a/ui/src/types/generated/recovery-status-response.ts
+++ b/ui/src/types/generated/recovery-status-response.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * RecoveryStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface RecoveryStatusResponse {
   active: boolean;
   remainingTime?: number;

--- a/ui/src/types/generated/set-mtu.ts
+++ b/ui/src/types/generated/set-mtu.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * SetMTURequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface SetMTURequest {
   interface: string;
   mtu: number;

--- a/ui/src/types/generated/setup-complete.ts
+++ b/ui/src/types/generated/setup-complete.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * SetupCompleteRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface SetupCompleteRequest {
   password: string;
   setupToken: string;

--- a/ui/src/types/generated/setup-status-response.ts
+++ b/ui/src/types/generated/setup-status-response.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * SetupStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface SetupStatusResponse {
   needsSetup: boolean;
   suggestedPassword?: string;

--- a/ui/src/types/generated/status-response.ts
+++ b/ui/src/types/generated/status-response.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * StatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface StatusResponse {
   status: string;
   version: string;

--- a/ui/src/types/generated/traceroute-request.ts
+++ b/ui/src/types/generated/traceroute-request.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * TracerouteRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface TracerouteRequest {
   target: string;
   protocol: string;

--- a/ui/src/types/generated/wifi-connect.ts
+++ b/ui/src/types/generated/wifi-connect.ts
@@ -5,9 +5,6 @@
  * after Go DTO changes). The schema source of truth lives at
  * docs/schemas/api/; the Go DTO source lives at internal/api/.
  */
-/**
- * WiFiConnectRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes.
- */
 export interface WiFiConnectRequest {
   ssid: string;
   password?: string;


### PR DESCRIPTION
Fixes the Phase-2 blocker: json-schema-to-typescript discarded `$defs` when dereferencing invopop's root `$ref`, dangling nested refs. gen-types.mjs now inlines the root ref while keeping definitions (+ $defs→definitions, drop $id) — all in-memory, drift checks unaffected. Proven on BackupListResponse (nested). Flat DTOs unchanged, gates green. Most remaining DTOs are nested → now unblocked.