### PR TITLE
feat(contract): widen DTO coverage batch 3 (+9); avoid recursive DTOs

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -47,55 +47,38 @@ type schemaTarget struct {
 // and to make the list lazily constructed (so init isn't pulling in
 // internal/api as a side effect of `go run`).
 func schemaTargets() []schemaTarget {
+	t := requestSchemaTargets()
+	t = append(t, coreResponseSchemaTargets()...)
+	t = append(t, networkResponseSchemaTargets()...)
+	return t
+}
+
+// requestSchemaTargets are the request DTOs — the original strict-decode +
+// validator surface (#1102).
+func requestSchemaTargets() []schemaTarget {
 	return []schemaTarget{
-		{
-			value:    &api.LoginRequest{},
-			filename: "login.schema.json",
-			title:    "LoginRequest",
-		},
-		{
-			value:    &api.SetupCompleteRequest{},
-			filename: "setup-complete.schema.json",
-			title:    "SetupCompleteRequest",
-		},
+		{value: &api.LoginRequest{}, filename: "login.schema.json", title: "LoginRequest"},
+		{value: &api.SetupCompleteRequest{}, filename: "setup-complete.schema.json", title: "SetupCompleteRequest"},
 		{
 			value:    &api.RecoveryCompleteRequest{},
 			filename: "recovery-complete.schema.json",
 			title:    "RecoveryCompleteRequest",
 		},
-		{
-			value:    &api.SetMTURequest{},
-			filename: "set-mtu.schema.json",
-			title:    "SetMTURequest",
-		},
-		{
-			value:    &api.PathRequest{},
-			filename: "path.schema.json",
-			title:    "PathRequest",
-		},
-		{
-			value:    &api.WiFiConnectRequest{},
-			filename: "wifi-connect.schema.json",
-			title:    "WiFiConnectRequest",
-		},
-		// Phase 2 (ADR-0003, code-first): widening coverage to response DTOs,
-		// starting with the core auth/status responses that pair with the
-		// request DTOs above.
-		{
-			value:    &api.StatusResponse{},
-			filename: "status-response.schema.json",
-			title:    "StatusResponse",
-		},
-		{
-			value:    &api.LoginResponse{},
-			filename: "login-response.schema.json",
-			title:    "LoginResponse",
-		},
-		{
-			value:    &api.CSRFTokenResponse{},
-			filename: "csrf-token-response.schema.json",
-			title:    "CSRFTokenResponse",
-		},
+		{value: &api.SetMTURequest{}, filename: "set-mtu.schema.json", title: "SetMTURequest"},
+		{value: &api.PathRequest{}, filename: "path.schema.json", title: "PathRequest"},
+		{value: &api.WiFiConnectRequest{}, filename: "wifi-connect.schema.json", title: "WiFiConnectRequest"},
+		{value: &api.TracerouteRequest{}, filename: "traceroute-request.schema.json", title: "TracerouteRequest"},
+	}
+}
+
+// coreResponseSchemaTargets are the auth / status / recovery / config response
+// DTOs (Phase 2, ADR-0003 code-first widening). BackupListResponse is a nested
+// type, supported after the gen-types ref fix.
+func coreResponseSchemaTargets() []schemaTarget {
+	return []schemaTarget{
+		{value: &api.StatusResponse{}, filename: "status-response.schema.json", title: "StatusResponse"},
+		{value: &api.LoginResponse{}, filename: "login-response.schema.json", title: "LoginResponse"},
+		{value: &api.CSRFTokenResponse{}, filename: "csrf-token-response.schema.json", title: "CSRFTokenResponse"},
 		{
 			value:    &api.SetupStatusResponse{},
 			filename: "setup-status-response.schema.json",
@@ -106,12 +89,7 @@ func schemaTargets() []schemaTarget {
 			filename: "license-status-response.schema.json",
 			title:    "LicenseStatusResponse",
 		},
-		// Batch 2: common error envelopes + recovery/config/roots DTOs.
-		{
-			value:    &api.ErrorResponse{},
-			filename: "error-response.schema.json",
-			title:    "ErrorResponse",
-		},
+		{value: &api.ErrorResponse{}, filename: "error-response.schema.json", title: "ErrorResponse"},
 		{
 			value:    &api.FeatureGateResponse{},
 			filename: "feature-gate-response.schema.json",
@@ -137,18 +115,32 @@ func schemaTargets() []schemaTarget {
 			filename: "config-version-response.schema.json",
 			title:    "ConfigVersionResponse",
 		},
-		// Nested-type DTO: BackupListResponse embeds []BackupInfo. Generates
-		// correctly now that gen-types.mjs strips the external $id so nested
-		// `#/$defs/...` refs resolve locally (the prior blocker).
+		{value: &api.BackupListResponse{}, filename: "backup-list-response.schema.json", title: "BackupListResponse"},
+	}
+}
+
+// networkResponseSchemaTargets are SAP / network / discovery response DTOs
+// (Phase 2). GatewayResponse is intentionally excluded — its `ipv6` field reuses
+// GatewayResponse itself (accidental recursion); transport DTOs must be
+// non-recursive, so it waits for a flat ipv6 sub-type (Phase 3).
+func networkResponseSchemaTargets() []schemaTarget {
+	return []schemaTarget{
+		{value: &api.CableResponse{}, filename: "cable-response.schema.json", title: "CableResponse"},
+		{value: &api.VLANResponse{}, filename: "vlan-response.schema.json", title: "VLANResponse"},
+		{value: &api.WiFiResponse{}, filename: "wifi-response.schema.json", title: "WiFiResponse"},
+		{value: &api.SpeedtestResponse{}, filename: "speedtest-response.schema.json", title: "SpeedtestResponse"},
+		{value: &api.RogueDHCPResponse{}, filename: "rogue-dhcp-response.schema.json", title: "RogueDHCPResponse"},
+		{value: &api.IPConfigResponse{}, filename: "ipconfig-response.schema.json", title: "IPConfigResponse"},
+		{value: &api.DiscoveryResponse{}, filename: "discovery-response.schema.json", title: "DiscoveryResponse"},
 		{
-			value:    &api.BackupListResponse{},
-			filename: "backup-list-response.schema.json",
-			title:    "BackupListResponse",
+			value:    &api.NetworkProblemsResponse{},
+			filename: "network-problems-response.schema.json",
+			title:    "NetworkProblemsResponse",
 		},
 		{
-			value:    &api.TracerouteRequest{},
-			filename: "traceroute-request.schema.json",
-			title:    "TracerouteRequest",
+			value:    &api.ProblemScanResponse{},
+			filename: "problem-scan-response.schema.json",
+			title:    "ProblemScanResponse",
 		},
 	}
 }

--- a/docs/schemas/api/cable-response.schema.json
+++ b/docs/schemas/api/cable-response.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/cable-response.schema.json",
+  "$ref": "#/$defs/CableResponse",
+  "$defs": {
+    "CablePairResult": {
+      "properties": {
+        "pair": {
+          "type": "string"
+        },
+        "pairLetter": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "lengthM": {
+          "type": "number"
+        },
+        "lengthFt": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "pair",
+        "pairLetter",
+        "status"
+      ]
+    },
+    "CablePinout": {
+      "properties": {
+        "pin": {
+          "type": "integer"
+        },
+        "color": {
+          "type": "string"
+        },
+        "pair": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "pin",
+        "color",
+        "pair"
+      ]
+    },
+    "CableResponse": {
+      "properties": {
+        "supported": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string"
+        },
+        "length": {
+          "type": "number"
+        },
+        "lengthFt": {
+          "type": "number"
+        },
+        "pairs": {
+          "items": {
+            "$ref": "#/$defs/CablePairResult"
+          },
+          "type": "array"
+        },
+        "faults": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "wiringStandard": {
+          "type": "string"
+        },
+        "pinout": {
+          "items": {
+            "$ref": "#/$defs/CablePinout"
+          },
+          "type": "array"
+        },
+        "isCrossover": {
+          "type": "boolean"
+        },
+        "driverName": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "supported",
+        "status",
+        "faults",
+        "wiringStandard"
+      ]
+    }
+  },
+  "title": "CableResponse",
+  "description": "CableResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/discovery-response.schema.json
+++ b/docs/schemas/api/discovery-response.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/discovery-response.schema.json",
+  "$ref": "#/$defs/DiscoveryResponse",
+  "$defs": {
+    "DiscoveryNeighborInfo": {
+      "properties": {
+        "protocol": {
+          "type": "string"
+        },
+        "chassisId": {
+          "type": "string"
+        },
+        "portId": {
+          "type": "string"
+        },
+        "portDescription": {
+          "type": "string"
+        },
+        "systemName": {
+          "type": "string"
+        },
+        "systemDescription": {
+          "type": "string"
+        },
+        "capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "managementAddress": {
+          "type": "string"
+        },
+        "ttl": {
+          "type": "integer"
+        },
+        "lastSeen": {
+          "type": "string"
+        },
+        "sourceMAC": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "protocol",
+        "chassisId",
+        "portId",
+        "ttl",
+        "lastSeen",
+        "sourceMAC"
+      ]
+    },
+    "DiscoveryResponse": {
+      "properties": {
+        "interface": {
+          "type": "string"
+        },
+        "running": {
+          "type": "boolean"
+        },
+        "neighbors": {
+          "items": {
+            "$ref": "#/$defs/DiscoveryNeighborInfo"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "interface",
+        "running",
+        "neighbors"
+      ]
+    }
+  },
+  "title": "DiscoveryResponse",
+  "description": "DiscoveryResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/ipconfig-response.schema.json
+++ b/docs/schemas/api/ipconfig-response.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/ipconfig-response.schema.json",
+  "$ref": "#/$defs/IPConfigResponse",
+  "$defs": {
+    "DHCPTimingInfo": {
+      "properties": {
+        "discover": {
+          "type": "integer"
+        },
+        "offer": {
+          "type": "integer"
+        },
+        "request": {
+          "type": "integer"
+        },
+        "ack": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "discover",
+        "offer",
+        "request",
+        "ack",
+        "total"
+      ]
+    },
+    "IPConfigResponse": {
+      "properties": {
+        "interface": {
+          "type": "string"
+        },
+        "mac": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "ipv4": {
+          "$ref": "#/$defs/IPv4Info"
+        },
+        "ipv6": {
+          "items": {
+            "$ref": "#/$defs/IPv6Info"
+          },
+          "type": "array"
+        },
+        "dns": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "timing": {
+          "$ref": "#/$defs/DHCPTimingInfo"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "interface",
+        "mac",
+        "mode",
+        "ipv6",
+        "dns"
+      ]
+    },
+    "IPv4Info": {
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "subnet": {
+          "type": "string"
+        },
+        "gateway": {
+          "type": "string"
+        },
+        "dhcpServer": {
+          "type": "string"
+        },
+        "leaseTime": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "address",
+        "subnet"
+      ]
+    },
+    "IPv6Info": {
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "integer"
+        },
+        "scope": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "address",
+        "prefix",
+        "scope",
+        "source"
+      ]
+    }
+  },
+  "title": "IPConfigResponse",
+  "description": "IPConfigResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/network-problems-response.schema.json
+++ b/docs/schemas/api/network-problems-response.schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/network-problems-response.schema.json",
+  "$ref": "#/$defs/NetworkProblemsResponse",
+  "$defs": {
+    "NetworkProblem": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "device_id": {
+          "type": "string"
+        },
+        "device_mac": {
+          "type": "string"
+        },
+        "interface_name": {
+          "type": "string"
+        },
+        "ip_address": {
+          "type": "string"
+        },
+        "affected_macs": {
+          "type": "string"
+        },
+        "ssid": {
+          "type": "string"
+        },
+        "bssid": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "integer"
+        },
+        "current_value": {
+          "type": "number"
+        },
+        "threshold_value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string"
+        },
+        "first_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "resolved_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "occurrence_count": {
+          "type": "integer"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "category",
+        "type",
+        "severity",
+        "status",
+        "title",
+        "description",
+        "first_seen",
+        "last_seen",
+        "occurrence_count"
+      ]
+    },
+    "NetworkProblemsResponse": {
+      "properties": {
+        "problems": {
+          "items": {
+            "$ref": "#/$defs/NetworkProblem"
+          },
+          "type": "array"
+        },
+        "summary": {
+          "$ref": "#/$defs/ProblemSummary"
+        },
+        "total": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "problems",
+        "summary",
+        "total"
+      ]
+    },
+    "ProblemSummary": {
+      "properties": {
+        "total_active": {
+          "type": "integer"
+        },
+        "by_severity": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "by_category": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "recent_count": {
+          "type": "integer"
+        },
+        "resolved_today": {
+          "type": "integer"
+        },
+        "last_scan_time": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "total_active",
+        "by_severity",
+        "by_category",
+        "recent_count",
+        "resolved_today",
+        "last_scan_time"
+      ]
+    }
+  },
+  "title": "NetworkProblemsResponse",
+  "description": "NetworkProblemsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/problem-scan-response.schema.json
+++ b/docs/schemas/api/problem-scan-response.schema.json
@@ -1,0 +1,319 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/problem-scan-response.schema.json",
+  "$ref": "#/$defs/ProblemScanResponse",
+  "$defs": {
+    "IPConflict": {
+      "properties": {
+        "ip_address": {
+          "type": "string"
+        },
+        "macs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "device_ids": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "first_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "is_resolved": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ip_address",
+        "macs",
+        "device_ids",
+        "first_seen",
+        "last_seen",
+        "is_resolved"
+      ]
+    },
+    "InterfaceErrorStats": {
+      "properties": {
+        "device_id": {
+          "type": "string"
+        },
+        "interface_name": {
+          "type": "string"
+        },
+        "input_errors": {
+          "type": "integer"
+        },
+        "crc_errors": {
+          "type": "integer"
+        },
+        "frame_errors": {
+          "type": "integer"
+        },
+        "overruns": {
+          "type": "integer"
+        },
+        "dropped_input": {
+          "type": "integer"
+        },
+        "output_errors": {
+          "type": "integer"
+        },
+        "collisions": {
+          "type": "integer"
+        },
+        "late_collision": {
+          "type": "integer"
+        },
+        "carrier_errors": {
+          "type": "integer"
+        },
+        "dropped_output": {
+          "type": "integer"
+        },
+        "input_errors_delta": {
+          "type": "integer"
+        },
+        "output_errors_delta": {
+          "type": "integer"
+        },
+        "recorded_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "device_id",
+        "interface_name",
+        "input_errors",
+        "crc_errors",
+        "frame_errors",
+        "overruns",
+        "dropped_input",
+        "output_errors",
+        "collisions",
+        "late_collision",
+        "carrier_errors",
+        "dropped_output",
+        "recorded_at"
+      ]
+    },
+    "NetworkProblem": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "device_id": {
+          "type": "string"
+        },
+        "device_mac": {
+          "type": "string"
+        },
+        "interface_name": {
+          "type": "string"
+        },
+        "ip_address": {
+          "type": "string"
+        },
+        "affected_macs": {
+          "type": "string"
+        },
+        "ssid": {
+          "type": "string"
+        },
+        "bssid": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "integer"
+        },
+        "current_value": {
+          "type": "number"
+        },
+        "threshold_value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string"
+        },
+        "first_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "resolved_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "occurrence_count": {
+          "type": "integer"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "category",
+        "type",
+        "severity",
+        "status",
+        "title",
+        "description",
+        "first_seen",
+        "last_seen",
+        "occurrence_count"
+      ]
+    },
+    "ProblemScanResponse": {
+      "properties": {
+        "problems": {
+          "items": {
+            "$ref": "#/$defs/NetworkProblem"
+          },
+          "type": "array"
+        },
+        "ipConflicts": {
+          "items": {
+            "$ref": "#/$defs/IPConflict"
+          },
+          "type": "array"
+        },
+        "interfaceErrors": {
+          "items": {
+            "$ref": "#/$defs/InterfaceErrorStats"
+          },
+          "type": "array"
+        },
+        "wifiProblems": {
+          "items": {
+            "$ref": "#/$defs/WiFiProblem"
+          },
+          "type": "array"
+        },
+        "scanTime": {
+          "type": "string"
+        },
+        "durationMs": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "problems",
+        "ipConflicts",
+        "interfaceErrors",
+        "scanTime",
+        "durationMs"
+      ]
+    },
+    "WiFiProblem": {
+      "properties": {
+        "problem_type": {
+          "type": "string"
+        },
+        "ssid": {
+          "type": "string"
+        },
+        "bssid": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "integer"
+        },
+        "band": {
+          "type": "string"
+        },
+        "signal_dbm": {
+          "type": "integer"
+        },
+        "noise_dbm": {
+          "type": "integer"
+        },
+        "snr": {
+          "type": "integer"
+        },
+        "retry_percent": {
+          "type": "number"
+        },
+        "co_channel_aps": {
+          "type": "integer"
+        },
+        "adjacent_channel_aps": {
+          "type": "integer"
+        },
+        "utilization_percent": {
+          "type": "number"
+        },
+        "is_rogue": {
+          "type": "boolean"
+        },
+        "is_unauthorized": {
+          "type": "boolean"
+        },
+        "vendor_mismatch": {
+          "type": "boolean"
+        },
+        "expected_vendor": {
+          "type": "string"
+        },
+        "actual_vendor": {
+          "type": "string"
+        },
+        "first_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_seen": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "problem_type",
+        "first_seen",
+        "last_seen"
+      ]
+    }
+  },
+  "title": "ProblemScanResponse",
+  "description": "ProblemScanResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/rogue-dhcp-response.schema.json
+++ b/docs/schemas/api/rogue-dhcp-response.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/rogue-dhcp-response.schema.json",
+  "$ref": "#/$defs/RogueDHCPResponse",
+  "$defs": {
+    "RogueDHCPResponse": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "running": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled",
+        "running"
+      ]
+    }
+  },
+  "title": "RogueDHCPResponse",
+  "description": "RogueDHCPResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/speedtest-response.schema.json
+++ b/docs/schemas/api/speedtest-response.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/speedtest-response.schema.json",
+  "$ref": "#/$defs/SpeedtestResponse",
+  "$defs": {
+    "SpeedtestResponse": {
+      "properties": {
+        "download": {
+          "type": "number"
+        },
+        "upload": {
+          "type": "number"
+        },
+        "latency": {
+          "type": "number"
+        },
+        "server": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "distance": {
+          "type": "number"
+        },
+        "timestamp": {
+          "type": "string"
+        },
+        "testDuration": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "download",
+        "upload",
+        "latency",
+        "server",
+        "location",
+        "host",
+        "distance",
+        "timestamp",
+        "testDuration"
+      ]
+    }
+  },
+  "title": "SpeedtestResponse",
+  "description": "SpeedtestResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/vlan-response.schema.json
+++ b/docs/schemas/api/vlan-response.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/vlan-response.schema.json",
+  "$ref": "#/$defs/VLANResponse",
+  "$defs": {
+    "VLANResponse": {
+      "properties": {
+        "nativeVlan": {
+          "type": "integer"
+        },
+        "taggedVlans": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "voiceVlan": {
+          "type": "integer"
+        },
+        "configured": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "id": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "enabled",
+            "id"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nativeVlan",
+        "taggedVlans",
+        "voiceVlan",
+        "configured"
+      ]
+    }
+  },
+  "title": "VLANResponse",
+  "description": "VLANResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/wifi-response.schema.json
+++ b/docs/schemas/api/wifi-response.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/wifi-response.schema.json",
+  "$ref": "#/$defs/WiFiResponse",
+  "$defs": {
+    "WiFiResponse": {
+      "properties": {
+        "interface": {
+          "type": "string"
+        },
+        "ssid": {
+          "type": "string"
+        },
+        "bssid": {
+          "type": "string"
+        },
+        "signal": {
+          "type": "integer"
+        },
+        "channel": {
+          "type": "integer"
+        },
+        "frequency": {
+          "type": "integer"
+        },
+        "security": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "interface",
+        "ssid",
+        "bssid",
+        "signal",
+        "channel",
+        "frequency",
+        "security"
+      ]
+    }
+  },
+  "title": "WiFiResponse",
+  "description": "WiFiResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/scripts/gen-types.mjs
+++ b/ui/scripts/gen-types.mjs
@@ -71,8 +71,14 @@ async function main() {
     if (typeof schema.$ref === 'string' && schema.$ref.startsWith('#/definitions/')) {
       const name = schema.$ref.slice('#/definitions/'.length);
       const defs = { ...schema.definitions };
-      const inlined = defs[name];
-      delete defs[name]; // avoid a duplicate of the root type
+      // Rewrite the root type's self-references to the JSON-Schema root pointer
+      // "#" so a recursive type (e.g. GatewayResponse.ipv6 → GatewayResponse)
+      // self-references by its own name instead of generating a duplicate
+      // `<Name>1` interface. Non-self-refs (to sibling defs) are untouched.
+      const inlined = JSON.parse(
+        JSON.stringify(defs[name]).replaceAll(`"#/definitions/${name}"`, '"#"'),
+      );
+      delete defs[name]; // root is now inlined at the top level
       root = { $schema: schema.$schema, ...inlined };
       if (Object.keys(defs).length > 0) root.definitions = defs;
     }

--- a/ui/src/types/generated/cable-response.ts
+++ b/ui/src/types/generated/cable-response.ts
@@ -1,0 +1,31 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface CableResponse {
+  supported: boolean;
+  status: string;
+  length?: number;
+  lengthFt?: number;
+  pairs?: CablePairResult[];
+  faults: string[];
+  wiringStandard: string;
+  pinout?: CablePinout[];
+  isCrossover?: boolean;
+  driverName?: string;
+}
+export interface CablePairResult {
+  pair: string;
+  pairLetter: string;
+  status: string;
+  lengthM?: number;
+  lengthFt?: number;
+}
+export interface CablePinout {
+  pin: number;
+  color: string;
+  pair: string;
+}

--- a/ui/src/types/generated/discovery-response.ts
+++ b/ui/src/types/generated/discovery-response.ts
@@ -1,0 +1,25 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface DiscoveryResponse {
+  interface: string;
+  running: boolean;
+  neighbors: DiscoveryNeighborInfo[];
+}
+export interface DiscoveryNeighborInfo {
+  protocol: string;
+  chassisId: string;
+  portId: string;
+  portDescription?: string;
+  systemName?: string;
+  systemDescription?: string;
+  capabilities?: string[];
+  managementAddress?: string;
+  ttl: number;
+  lastSeen: string;
+  sourceMAC: string;
+}

--- a/ui/src/types/generated/ipconfig-response.ts
+++ b/ui/src/types/generated/ipconfig-response.ts
@@ -1,0 +1,36 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface IPConfigResponse {
+  interface: string;
+  mac: string;
+  mode: string;
+  ipv4?: IPv4Info;
+  ipv6: IPv6Info[];
+  dns: string[];
+  timing?: DHCPTimingInfo;
+}
+export interface IPv4Info {
+  address: string;
+  subnet: string;
+  gateway?: string;
+  dhcpServer?: string;
+  leaseTime?: number;
+}
+export interface IPv6Info {
+  address: string;
+  prefix: number;
+  scope: string;
+  source: string;
+}
+export interface DHCPTimingInfo {
+  discover: number;
+  offer: number;
+  request: number;
+  ack: number;
+  total: number;
+}

--- a/ui/src/types/generated/network-problems-response.ts
+++ b/ui/src/types/generated/network-problems-response.ts
@@ -1,0 +1,49 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface NetworkProblemsResponse {
+  problems: NetworkProblem[];
+  summary: ProblemSummary;
+  total: number;
+}
+export interface NetworkProblem {
+  id: string;
+  category: string;
+  type: string;
+  severity: string;
+  status: string;
+  title: string;
+  description: string;
+  device_id?: string;
+  device_mac?: string;
+  interface_name?: string;
+  ip_address?: string;
+  affected_macs?: string;
+  ssid?: string;
+  bssid?: string;
+  channel?: number;
+  current_value?: number;
+  threshold_value?: number;
+  unit?: string;
+  first_seen: string;
+  last_seen: string;
+  resolved_at?: string;
+  occurrence_count: number;
+  metadata?: {};
+}
+export interface ProblemSummary {
+  total_active: number;
+  by_severity: {
+    [k: string]: number;
+  };
+  by_category: {
+    [k: string]: number;
+  };
+  recent_count: number;
+  resolved_today: number;
+  last_scan_time: string;
+}

--- a/ui/src/types/generated/problem-scan-response.ts
+++ b/ui/src/types/generated/problem-scan-response.ts
@@ -1,0 +1,86 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface ProblemScanResponse {
+  problems: NetworkProblem[];
+  ipConflicts: IPConflict[];
+  interfaceErrors: InterfaceErrorStats[];
+  wifiProblems?: WiFiProblem[];
+  scanTime: string;
+  durationMs: number;
+}
+export interface NetworkProblem {
+  id: string;
+  category: string;
+  type: string;
+  severity: string;
+  status: string;
+  title: string;
+  description: string;
+  device_id?: string;
+  device_mac?: string;
+  interface_name?: string;
+  ip_address?: string;
+  affected_macs?: string;
+  ssid?: string;
+  bssid?: string;
+  channel?: number;
+  current_value?: number;
+  threshold_value?: number;
+  unit?: string;
+  first_seen: string;
+  last_seen: string;
+  resolved_at?: string;
+  occurrence_count: number;
+  metadata?: {};
+}
+export interface IPConflict {
+  ip_address: string;
+  macs: string[];
+  device_ids: string[];
+  first_seen: string;
+  last_seen: string;
+  is_resolved: boolean;
+}
+export interface InterfaceErrorStats {
+  device_id: string;
+  interface_name: string;
+  input_errors: number;
+  crc_errors: number;
+  frame_errors: number;
+  overruns: number;
+  dropped_input: number;
+  output_errors: number;
+  collisions: number;
+  late_collision: number;
+  carrier_errors: number;
+  dropped_output: number;
+  input_errors_delta?: number;
+  output_errors_delta?: number;
+  recorded_at: string;
+}
+export interface WiFiProblem {
+  problem_type: string;
+  ssid?: string;
+  bssid?: string;
+  channel?: number;
+  band?: string;
+  signal_dbm?: number;
+  noise_dbm?: number;
+  snr?: number;
+  retry_percent?: number;
+  co_channel_aps?: number;
+  adjacent_channel_aps?: number;
+  utilization_percent?: number;
+  is_rogue?: boolean;
+  is_unauthorized?: boolean;
+  vendor_mismatch?: boolean;
+  expected_vendor?: string;
+  actual_vendor?: string;
+  first_seen: string;
+  last_seen: string;
+}

--- a/ui/src/types/generated/rogue-dhcp-response.ts
+++ b/ui/src/types/generated/rogue-dhcp-response.ts
@@ -1,0 +1,13 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface RogueDHCPResponse {
+  enabled: boolean;
+  running: boolean;
+  error?: string;
+  message?: string;
+}

--- a/ui/src/types/generated/speedtest-response.ts
+++ b/ui/src/types/generated/speedtest-response.ts
@@ -1,0 +1,18 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface SpeedtestResponse {
+  download: number;
+  upload: number;
+  latency: number;
+  server: string;
+  location: string;
+  host: string;
+  distance: number;
+  timestamp: string;
+  testDuration: number;
+}

--- a/ui/src/types/generated/vlan-response.ts
+++ b/ui/src/types/generated/vlan-response.ts
@@ -1,0 +1,16 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface VLANResponse {
+  nativeVlan: number;
+  taggedVlans: number[];
+  voiceVlan: number;
+  configured: {
+    enabled: boolean;
+    id: number;
+  };
+}

--- a/ui/src/types/generated/wifi-response.ts
+++ b/ui/src/types/generated/wifi-response.ts
@@ -1,0 +1,16 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface WiFiResponse {
+  interface: string;
+  ssid: string;
+  bssid: string;
+  signal: number;
+  channel: number;
+  frequency: number;
+  security: string;
+}


### PR DESCRIPTION
Coverage 19 → 28 (SAP/network/discovery responses). Both gates green; zero recursive generated types.

**Policy (from review):** transport DTOs are non-recursive — GatewayResponse excluded (ipv6 reuses itself); deferred to Phase 3. Splits schemaTargets() into request/core/network groups so it scales past funlen. gen-types keeps graceful recursive handling as defensive insurance.