### PR TITLE
feat(contract): widen DTO coverage batch 4 (+10 SAP/network settings)

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -50,6 +50,7 @@ func schemaTargets() []schemaTarget {
 	t := requestSchemaTargets()
 	t = append(t, coreResponseSchemaTargets()...)
 	t = append(t, networkResponseSchemaTargets()...)
+	t = append(t, networkSettingsSchemaTargets()...)
 	return t
 }
 
@@ -142,6 +143,53 @@ func networkResponseSchemaTargets() []schemaTarget {
 			filename: "problem-scan-response.schema.json",
 			title:    "ProblemScanResponse",
 		},
+	}
+}
+
+// networkSettingsSchemaTargets are flat / self-contained SAP + network
+// settings DTOs (Phase 2). Every entry is either flat or nests only local,
+// purpose-built transport sub-structs defined in internal/api (e.g.
+// VLANTrafficEntry, PoEInfo, SFPInfo, the already-covered SpeedtestResponse) —
+// no internal domain types cross the wire. DTOs that nest domain types
+// (PathResponse→discovery, RogueServersResponse→dhcp, DNSResponse) or compose
+// other top-level responses (OptionsResponse) are deferred to Phase 3, where
+// they get hand-designed flat transport DTOs.
+func networkSettingsSchemaTargets() []schemaTarget {
+	return []schemaTarget{
+		{value: &api.IPSettingsRequest{}, filename: "ip-settings-request.schema.json", title: "IPSettingsRequest"},
+		{
+			value:    &api.IPSettingsResponse{},
+			filename: "ip-settings-response.schema.json",
+			title:    "IPSettingsResponse",
+		},
+		{value: &api.SubnetRequest{}, filename: "subnet-request.schema.json", title: "SubnetRequest"},
+		{value: &api.SubnetResponse{}, filename: "subnet-response.schema.json", title: "SubnetResponse"},
+		{
+			value:    &api.VLANInterfaceRequest{},
+			filename: "vlan-interface-request.schema.json",
+			title:    "VLANInterfaceRequest",
+		},
+		{
+			value:    &api.VLANTrafficResponse{},
+			filename: "vlan-traffic-response.schema.json",
+			title:    "VLANTrafficResponse",
+		},
+		{
+			value:    &api.SpeedtestStatusResponse{},
+			filename: "speedtest-status-response.schema.json",
+			title:    "SpeedtestStatusResponse",
+		},
+		{
+			value:    &api.RogueDHCPConfigResponse{},
+			filename: "rogue-dhcp-config-response.schema.json",
+			title:    "RogueDHCPConfigResponse",
+		},
+		{
+			value:    &api.DNSServerResponse{},
+			filename: "dns-server-response.schema.json",
+			title:    "DNSServerResponse",
+		},
+		{value: &api.LinkResponse{}, filename: "link-response.schema.json", title: "LinkResponse"},
 	}
 }
 

--- a/docs/schemas/api/dns-server-response.schema.json
+++ b/docs/schemas/api/dns-server-response.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/dns-server-response.schema.json",
+  "$ref": "#/$defs/DNSServerResponse",
+  "$defs": {
+    "DNSServerResponse": {
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "address",
+        "enabled"
+      ]
+    }
+  },
+  "title": "DNSServerResponse",
+  "description": "DNSServerResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/ip-settings-request.schema.json
+++ b/docs/schemas/api/ip-settings-request.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/ip-settings-request.schema.json",
+  "$ref": "#/$defs/IPSettingsRequest",
+  "$defs": {
+    "IPSettingsRequest": {
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "netmask": {
+          "type": "string"
+        },
+        "gateway": {
+          "type": "string"
+        },
+        "dns": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mode",
+        "address",
+        "netmask",
+        "gateway",
+        "dns"
+      ]
+    }
+  },
+  "title": "IPSettingsRequest",
+  "description": "IPSettingsRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/ip-settings-response.schema.json
+++ b/docs/schemas/api/ip-settings-response.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/ip-settings-response.schema.json",
+  "$ref": "#/$defs/IPSettingsResponse",
+  "$defs": {
+    "IPSettingsResponse": {
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "netmask": {
+          "type": "string"
+        },
+        "gateway": {
+          "type": "string"
+        },
+        "dns": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mode"
+      ]
+    }
+  },
+  "title": "IPSettingsResponse",
+  "description": "IPSettingsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/link-response.schema.json
+++ b/docs/schemas/api/link-response.schema.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/link-response.schema.json",
+  "$ref": "#/$defs/LinkResponse",
+  "$defs": {
+    "LinkHistoryEvent": {
+      "properties": {
+        "state": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "state",
+        "timestamp"
+      ]
+    },
+    "LinkResponse": {
+      "properties": {
+        "interface": {
+          "type": "string"
+        },
+        "linkUp": {
+          "type": "boolean"
+        },
+        "carrier": {
+          "type": "boolean"
+        },
+        "hasIP": {
+          "type": "boolean"
+        },
+        "speed": {
+          "type": "string"
+        },
+        "duplex": {
+          "type": "string"
+        },
+        "advertisedSpeeds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mtu": {
+          "type": "integer"
+        },
+        "autoNeg": {
+          "type": "boolean"
+        },
+        "flapCount24h": {
+          "type": "integer"
+        },
+        "history": {
+          "items": {
+            "$ref": "#/$defs/LinkHistoryEvent"
+          },
+          "type": "array"
+        },
+        "uptimeMs": {
+          "type": "integer"
+        },
+        "poe": {
+          "$ref": "#/$defs/PoEInfo"
+        },
+        "sfp": {
+          "$ref": "#/$defs/SFPInfo"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "interface",
+        "linkUp",
+        "carrier",
+        "hasIP",
+        "speed",
+        "duplex",
+        "advertisedSpeeds",
+        "mtu",
+        "autoNeg",
+        "flapCount24h"
+      ]
+    },
+    "PoEInfo": {
+      "properties": {
+        "detected": {
+          "type": "boolean"
+        },
+        "standard": {
+          "type": "string"
+        },
+        "class": {
+          "type": "integer"
+        },
+        "powerMw": {
+          "type": "number"
+        },
+        "voltage": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "detected"
+      ]
+    },
+    "SFPDDMInfo": {
+      "properties": {
+        "temperature": {
+          "type": "number"
+        },
+        "voltage": {
+          "type": "number"
+        },
+        "txPowerDbm": {
+          "type": "number"
+        },
+        "txPowerMw": {
+          "type": "number"
+        },
+        "rxPowerDbm": {
+          "type": "number"
+        },
+        "rxPowerMw": {
+          "type": "number"
+        },
+        "laserBiasMa": {
+          "type": "number"
+        },
+        "alarms": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "temperature",
+        "voltage",
+        "txPowerDbm",
+        "txPowerMw",
+        "rxPowerDbm",
+        "rxPowerMw",
+        "laserBiasMa"
+      ]
+    },
+    "SFPInfo": {
+      "properties": {
+        "present": {
+          "type": "boolean"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "partNumber": {
+          "type": "string"
+        },
+        "serial": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "wavelength": {
+          "type": "integer"
+        },
+        "distance": {
+          "type": "integer"
+        },
+        "connector": {
+          "type": "string"
+        },
+        "ddmSupport": {
+          "type": "boolean"
+        },
+        "ddm": {
+          "$ref": "#/$defs/SFPDDMInfo"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "present",
+        "ddmSupport"
+      ]
+    }
+  },
+  "title": "LinkResponse",
+  "description": "LinkResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/rogue-dhcp-config-response.schema.json
+++ b/docs/schemas/api/rogue-dhcp-config-response.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/rogue-dhcp-config-response.schema.json",
+  "$ref": "#/$defs/RogueDHCPConfigResponse",
+  "$defs": {
+    "RogueDHCPConfigResponse": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "knownServers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "alertOnDetection": {
+          "type": "boolean"
+        },
+        "interface": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled",
+        "knownServers",
+        "alertOnDetection",
+        "interface"
+      ]
+    }
+  },
+  "title": "RogueDHCPConfigResponse",
+  "description": "RogueDHCPConfigResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/speedtest-status-response.schema.json
+++ b/docs/schemas/api/speedtest-status-response.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/speedtest-status-response.schema.json",
+  "$ref": "#/$defs/SpeedtestStatusResponse",
+  "$defs": {
+    "SpeedtestResponse": {
+      "properties": {
+        "download": {
+          "type": "number"
+        },
+        "upload": {
+          "type": "number"
+        },
+        "latency": {
+          "type": "number"
+        },
+        "server": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "distance": {
+          "type": "number"
+        },
+        "timestamp": {
+          "type": "string"
+        },
+        "testDuration": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "download",
+        "upload",
+        "latency",
+        "server",
+        "location",
+        "host",
+        "distance",
+        "timestamp",
+        "testDuration"
+      ]
+    },
+    "SpeedtestStatusResponse": {
+      "properties": {
+        "running": {
+          "type": "boolean"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "progress": {
+          "type": "number"
+        },
+        "last": {
+          "$ref": "#/$defs/SpeedtestResponse"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "running",
+        "phase",
+        "progress"
+      ]
+    }
+  },
+  "title": "SpeedtestStatusResponse",
+  "description": "SpeedtestStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/subnet-request.schema.json
+++ b/docs/schemas/api/subnet-request.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/subnet-request.schema.json",
+  "$ref": "#/$defs/SubnetRequest",
+  "$defs": {
+    "SubnetRequest": {
+      "properties": {
+        "cidr": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "cidr",
+        "name",
+        "enabled"
+      ]
+    }
+  },
+  "title": "SubnetRequest",
+  "description": "SubnetRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/subnet-response.schema.json
+++ b/docs/schemas/api/subnet-response.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/subnet-response.schema.json",
+  "$ref": "#/$defs/SubnetResponse",
+  "$defs": {
+    "SubnetResponse": {
+      "properties": {
+        "cidr": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "cidr",
+        "name",
+        "enabled"
+      ]
+    }
+  },
+  "title": "SubnetResponse",
+  "description": "SubnetResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/vlan-interface-request.schema.json
+++ b/docs/schemas/api/vlan-interface-request.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/vlan-interface-request.schema.json",
+  "$ref": "#/$defs/VLANInterfaceRequest",
+  "$defs": {
+    "VLANInterfaceRequest": {
+      "properties": {
+        "interface": {
+          "type": "string"
+        },
+        "vlanId": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "interface",
+        "vlanId"
+      ]
+    }
+  },
+  "title": "VLANInterfaceRequest",
+  "description": "VLANInterfaceRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/vlan-traffic-response.schema.json
+++ b/docs/schemas/api/vlan-traffic-response.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/vlan-traffic-response.schema.json",
+  "$ref": "#/$defs/VLANTrafficResponse",
+  "$defs": {
+    "VLANTrafficEntry": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "packets": {
+          "type": "integer"
+        },
+        "bytes": {
+          "type": "integer"
+        },
+        "lastSeen": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "packets",
+        "bytes",
+        "lastSeen"
+      ]
+    },
+    "VLANTrafficResponse": {
+      "properties": {
+        "vlans": {
+          "items": {
+            "$ref": "#/$defs/VLANTrafficEntry"
+          },
+          "type": "array"
+        },
+        "running": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "vlans",
+        "running"
+      ]
+    }
+  },
+  "title": "VLANTrafficResponse",
+  "description": "VLANTrafficResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/src/types/generated/dns-server-response.ts
+++ b/ui/src/types/generated/dns-server-response.ts
@@ -1,0 +1,11 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface DNSServerResponse {
+  address: string;
+  enabled: boolean;
+}

--- a/ui/src/types/generated/ip-settings-request.ts
+++ b/ui/src/types/generated/ip-settings-request.ts
@@ -1,0 +1,14 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface IPSettingsRequest {
+  mode: string;
+  address: string;
+  netmask: string;
+  gateway: string;
+  dns: string[];
+}

--- a/ui/src/types/generated/ip-settings-response.ts
+++ b/ui/src/types/generated/ip-settings-response.ts
@@ -1,0 +1,14 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface IPSettingsResponse {
+  mode: string;
+  address?: string;
+  netmask?: string;
+  gateway?: string;
+  dns?: string[];
+}

--- a/ui/src/types/generated/link-response.ts
+++ b/ui/src/types/generated/link-response.ts
@@ -1,0 +1,57 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface LinkResponse {
+  interface: string;
+  linkUp: boolean;
+  carrier: boolean;
+  hasIP: boolean;
+  speed: string;
+  duplex: string;
+  advertisedSpeeds: string[];
+  mtu: number;
+  autoNeg: boolean;
+  flapCount24h: number;
+  history?: LinkHistoryEvent[];
+  uptimeMs?: number;
+  poe?: PoEInfo;
+  sfp?: SFPInfo;
+}
+export interface LinkHistoryEvent {
+  state: string;
+  timestamp: string;
+}
+export interface PoEInfo {
+  detected: boolean;
+  standard?: string;
+  class?: number;
+  powerMw?: number;
+  voltage?: number;
+}
+export interface SFPInfo {
+  present: boolean;
+  vendor?: string;
+  partNumber?: string;
+  serial?: string;
+  type?: string;
+  wavelength?: number;
+  distance?: number;
+  connector?: string;
+  ddmSupport: boolean;
+  ddm?: SFPDDMInfo;
+}
+export interface SFPDDMInfo {
+  temperature: number;
+  voltage: number;
+  txPowerDbm: number;
+  txPowerMw: number;
+  rxPowerDbm: number;
+  rxPowerMw: number;
+  laserBiasMa: number;
+  alarms?: string[];
+  warnings?: string[];
+}

--- a/ui/src/types/generated/rogue-dhcp-config-response.ts
+++ b/ui/src/types/generated/rogue-dhcp-config-response.ts
@@ -1,0 +1,13 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface RogueDHCPConfigResponse {
+  enabled: boolean;
+  knownServers: string[];
+  alertOnDetection: boolean;
+  interface: string;
+}

--- a/ui/src/types/generated/speedtest-status-response.ts
+++ b/ui/src/types/generated/speedtest-status-response.ts
@@ -1,0 +1,24 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface SpeedtestStatusResponse {
+  running: boolean;
+  phase: string;
+  progress: number;
+  last?: SpeedtestResponse;
+}
+export interface SpeedtestResponse {
+  download: number;
+  upload: number;
+  latency: number;
+  server: string;
+  location: string;
+  host: string;
+  distance: number;
+  timestamp: string;
+  testDuration: number;
+}

--- a/ui/src/types/generated/subnet-request.ts
+++ b/ui/src/types/generated/subnet-request.ts
@@ -1,0 +1,12 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface SubnetRequest {
+  cidr: string;
+  name: string;
+  enabled: boolean;
+}

--- a/ui/src/types/generated/subnet-response.ts
+++ b/ui/src/types/generated/subnet-response.ts
@@ -1,0 +1,12 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface SubnetResponse {
+  cidr: string;
+  name: string;
+  enabled: boolean;
+}

--- a/ui/src/types/generated/vlan-interface-request.ts
+++ b/ui/src/types/generated/vlan-interface-request.ts
@@ -1,0 +1,11 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface VLANInterfaceRequest {
+  interface: string;
+  vlanId: number;
+}

--- a/ui/src/types/generated/vlan-traffic-response.ts
+++ b/ui/src/types/generated/vlan-traffic-response.ts
@@ -1,0 +1,17 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface VLANTrafficResponse {
+  vlans: VLANTrafficEntry[];
+  running: boolean;
+}
+export interface VLANTrafficEntry {
+  id: number;
+  packets: number;
+  bytes: number;
+  lastSeen: string;
+}


### PR DESCRIPTION
Adds flat / self-contained transport DTOs to the code-first schema pipeline
(ADR-0003): IP settings, subnet, VLAN interface + traffic, speedtest status,
rogue-DHCP config, DNS server, and link. Each is either flat or nests only
local purpose-built sub-structs in internal/api (VLANTrafficEntry, PoEInfo,
SFPInfo, SpeedtestResponse) — no internal domain shape crosses the wire.

Deferred to Phase 3 (need hand-designed flat transport DTOs, not generated
from internal domain types): PathResponse (discovery.*), RogueServersResponse
(dhcp.*), DNSResponse (deep result tree), OptionsResponse (composes other
responses), Profile*/*Settings.

Coverage 28 -> 38. Verified: no $ref cycles (non-recursive policy holds),
round-trip guardrail green, schema + types drift gates clean, lint 0 issues.
