### PR TITLE
feat(contract): widen DTO coverage batch 6 (+11 iperf/tools/dns/engine)

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -136,6 +136,19 @@ func schemaTargets() []schemaTarget {
 		{&api.ProfilerResponse{}, "profiler-response.schema.json"},
 		{&api.TimingResponse{}, "timing-response.schema.json"},
 		{&api.FingerprintingResponse{}, "fingerprinting-response.schema.json"},
+
+		// iperf / tools / DNS / engine request + result DTOs.
+		{&api.IperfClientRequest{}, "iperf-client-request.schema.json"},
+		{&api.IperfServerRequest{}, "iperf-server-request.schema.json"},
+		{&api.IperfInfoResponse{}, "iperf-info-response.schema.json"},
+		{&api.IperfResultResponse{}, "iperf-result-response.schema.json"},
+		{&api.PortScanRequest{}, "port-scan-request.schema.json"},
+		{&api.TCPProbeRequest{}, "tcp-probe-request.schema.json"},
+		{&api.DNSResponse{}, "dns-response.schema.json"},
+		{&api.DNSSecurityScanRequest{}, "dns-security-scan-request.schema.json"},
+		{&api.EngineScanRequest{}, "engine-scan-request.schema.json"},
+		{&api.SetInterfaceRequest{}, "set-interface-request.schema.json"},
+		{&api.WiFiSettingsResponse{}, "wifi-settings-response.schema.json"},
 	}
 
 	targets := make([]schemaTarget, len(rows))

--- a/docs/schemas/api/dns-response.schema.json
+++ b/docs/schemas/api/dns-response.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/dns-response.schema.json",
+  "$ref": "#/$defs/DNSResponse",
+  "$defs": {
+    "DNSLookupResult": {
+      "properties": {
+        "result": {
+          "type": "string"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "timeMs": {
+          "type": "integer"
+        },
+        "status": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        },
+        "resolved": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "result",
+        "time",
+        "timeMs",
+        "status"
+      ]
+    },
+    "DNSResponse": {
+      "properties": {
+        "interface": {
+          "type": "string"
+        },
+        "server": {
+          "type": "string"
+        },
+        "servers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "testHostname": {
+          "type": "string"
+        },
+        "forward": {
+          "$ref": "#/$defs/DNSLookupResult"
+        },
+        "forwardIpv6": {
+          "$ref": "#/$defs/DNSLookupResult"
+        },
+        "reverse": {
+          "$ref": "#/$defs/DNSLookupResult"
+        },
+        "reverseIpv6": {
+          "$ref": "#/$defs/DNSLookupResult"
+        },
+        "perServerResults": {
+          "items": {
+            "$ref": "#/$defs/DNSServerTestResult"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "interface",
+        "server",
+        "servers",
+        "testHostname"
+      ]
+    },
+    "DNSServerTestResult": {
+      "properties": {
+        "server": {
+          "type": "string"
+        },
+        "forward": {
+          "$ref": "#/$defs/DNSLookupResult"
+        },
+        "forwardIpv6": {
+          "$ref": "#/$defs/DNSLookupResult"
+        },
+        "status": {
+          "type": "string"
+        },
+        "avgTimeMs": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "server",
+        "status",
+        "avgTimeMs"
+      ]
+    }
+  },
+  "title": "DNSResponse",
+  "description": "DNSResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/dns-security-scan-request.schema.json
+++ b/docs/schemas/api/dns-security-scan-request.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/dns-security-scan-request.schema.json",
+  "$ref": "#/$defs/DNSSecurityScanRequest",
+  "$defs": {
+    "DNSSecurityScanRequest": {
+      "properties": {
+        "servers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "servers"
+      ]
+    }
+  },
+  "title": "DNSSecurityScanRequest",
+  "description": "DNSSecurityScanRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/engine-scan-request.schema.json
+++ b/docs/schemas/api/engine-scan-request.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/engine-scan-request.schema.json",
+  "$ref": "#/$defs/EngineScanRequest",
+  "$defs": {
+    "EngineScanRequest": {
+      "properties": {
+        "scanType": {
+          "type": "string"
+        },
+        "includeWired": {
+          "type": "boolean"
+        },
+        "includeWifi": {
+          "type": "boolean"
+        },
+        "includeBluetooth": {
+          "type": "boolean"
+        },
+        "includeSnmp": {
+          "type": "boolean"
+        },
+        "includePortScan": {
+          "type": "boolean"
+        },
+        "includeVulnScan": {
+          "type": "boolean"
+        },
+        "freshWiredScan": {
+          "type": "boolean"
+        },
+        "freshWifiScan": {
+          "type": "boolean"
+        },
+        "freshBluetoothScan": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "scanType",
+        "includeWired",
+        "includeWifi",
+        "includeBluetooth",
+        "includeSnmp",
+        "includePortScan",
+        "includeVulnScan",
+        "freshWiredScan",
+        "freshWifiScan",
+        "freshBluetoothScan"
+      ]
+    }
+  },
+  "title": "EngineScanRequest",
+  "description": "EngineScanRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/iperf-client-request.schema.json
+++ b/docs/schemas/api/iperf-client-request.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/iperf-client-request.schema.json",
+  "$ref": "#/$defs/IperfClientRequest",
+  "$defs": {
+    "IperfClientRequest": {
+      "properties": {
+        "server": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "reverse": {
+          "type": "boolean"
+        },
+        "direction": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "integer"
+        },
+        "parallel": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "server",
+        "port",
+        "protocol",
+        "reverse",
+        "direction",
+        "duration",
+        "parallel"
+      ]
+    }
+  },
+  "title": "IperfClientRequest",
+  "description": "IperfClientRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/iperf-info-response.schema.json
+++ b/docs/schemas/api/iperf-info-response.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/iperf-info-response.schema.json",
+  "$ref": "#/$defs/IperfInfoResponse",
+  "$defs": {
+    "IperfInfoResponse": {
+      "properties": {
+        "installed": {
+          "type": "boolean"
+        },
+        "version": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "installed"
+      ]
+    }
+  },
+  "title": "IperfInfoResponse",
+  "description": "IperfInfoResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/iperf-result-response.schema.json
+++ b/docs/schemas/api/iperf-result-response.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/iperf-result-response.schema.json",
+  "$ref": "#/$defs/IperfResultResponse",
+  "$defs": {
+    "IperfResultResponse": {
+      "properties": {
+        "bandwidth": {
+          "type": "number"
+        },
+        "transfer": {
+          "type": "number"
+        },
+        "retransmits": {
+          "type": "integer"
+        },
+        "jitter": {
+          "type": "number"
+        },
+        "lostPackets": {
+          "type": "integer"
+        },
+        "lostPercent": {
+          "type": "number"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "direction": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "number"
+        },
+        "server": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "timestamp": {
+          "type": "string"
+        },
+        "downloadBandwidth": {
+          "type": "number"
+        },
+        "uploadBandwidth": {
+          "type": "number"
+        },
+        "downloadTransfer": {
+          "type": "number"
+        },
+        "uploadTransfer": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "bandwidth",
+        "transfer",
+        "retransmits",
+        "jitter",
+        "lostPackets",
+        "lostPercent",
+        "protocol",
+        "direction",
+        "duration",
+        "server",
+        "port",
+        "timestamp"
+      ]
+    }
+  },
+  "title": "IperfResultResponse",
+  "description": "IperfResultResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/iperf-server-request.schema.json
+++ b/docs/schemas/api/iperf-server-request.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/iperf-server-request.schema.json",
+  "$ref": "#/$defs/IperfServerRequest",
+  "$defs": {
+    "IperfServerRequest": {
+      "properties": {
+        "action": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "action",
+        "port"
+      ]
+    }
+  },
+  "title": "IperfServerRequest",
+  "description": "IperfServerRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/port-scan-request.schema.json
+++ b/docs/schemas/api/port-scan-request.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/port-scan-request.schema.json",
+  "$ref": "#/$defs/PortScanRequest",
+  "$defs": {
+    "PortScanRequest": {
+      "properties": {
+        "target": {
+          "type": "string"
+        },
+        "ports": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "profile": {
+          "type": "string"
+        },
+        "workers": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "target"
+      ]
+    }
+  },
+  "title": "PortScanRequest",
+  "description": "PortScanRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/set-interface-request.schema.json
+++ b/docs/schemas/api/set-interface-request.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/set-interface-request.schema.json",
+  "$ref": "#/$defs/SetInterfaceRequest",
+  "$defs": {
+    "SetInterfaceRequest": {
+      "properties": {
+        "interface": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "interface"
+      ]
+    }
+  },
+  "title": "SetInterfaceRequest",
+  "description": "SetInterfaceRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/tcp-probe-request.schema.json
+++ b/docs/schemas/api/tcp-probe-request.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/tcp-probe-request.schema.json",
+  "$ref": "#/$defs/TCPProbeRequest",
+  "$defs": {
+    "TCPProbeRequest": {
+      "properties": {
+        "target": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "ports": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "timeout": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "target",
+        "port",
+        "ports",
+        "timeout"
+      ]
+    }
+  },
+  "title": "TCPProbeRequest",
+  "description": "TCPProbeRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/wifi-settings-response.schema.json
+++ b/docs/schemas/api/wifi-settings-response.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/wifi-settings-response.schema.json",
+  "$ref": "#/$defs/WiFiSettingsResponse",
+  "$defs": {
+    "WiFiSettingsResponse": {
+      "properties": {
+        "interface": {
+          "type": "string"
+        },
+        "availableWifi": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "isWireless": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "interface",
+        "availableWifi",
+        "isWireless"
+      ]
+    }
+  },
+  "title": "WiFiSettingsResponse",
+  "description": "WiFiSettingsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/src/types/generated/dns-response.ts
+++ b/ui/src/types/generated/dns-response.ts
@@ -1,0 +1,33 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface DNSResponse {
+  interface: string;
+  server: string;
+  servers: string[];
+  testHostname: string;
+  forward?: DNSLookupResult;
+  forwardIpv6?: DNSLookupResult;
+  reverse?: DNSLookupResult;
+  reverseIpv6?: DNSLookupResult;
+  perServerResults?: DNSServerTestResult[];
+}
+export interface DNSLookupResult {
+  result: string;
+  time: number;
+  timeMs: number;
+  status: string;
+  error?: string;
+  resolved?: string[];
+}
+export interface DNSServerTestResult {
+  server: string;
+  forward?: DNSLookupResult;
+  forwardIpv6?: DNSLookupResult;
+  status: string;
+  avgTimeMs: number;
+}

--- a/ui/src/types/generated/dns-security-scan-request.ts
+++ b/ui/src/types/generated/dns-security-scan-request.ts
@@ -1,0 +1,10 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface DNSSecurityScanRequest {
+  servers: string[];
+}

--- a/ui/src/types/generated/engine-scan-request.ts
+++ b/ui/src/types/generated/engine-scan-request.ts
@@ -1,0 +1,19 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface EngineScanRequest {
+  scanType: string;
+  includeWired: boolean;
+  includeWifi: boolean;
+  includeBluetooth: boolean;
+  includeSnmp: boolean;
+  includePortScan: boolean;
+  includeVulnScan: boolean;
+  freshWiredScan: boolean;
+  freshWifiScan: boolean;
+  freshBluetoothScan: boolean;
+}

--- a/ui/src/types/generated/iperf-client-request.ts
+++ b/ui/src/types/generated/iperf-client-request.ts
@@ -1,0 +1,16 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface IperfClientRequest {
+  server: string;
+  port: number;
+  protocol: string;
+  reverse: boolean;
+  direction: string;
+  duration: number;
+  parallel: number;
+}

--- a/ui/src/types/generated/iperf-info-response.ts
+++ b/ui/src/types/generated/iperf-info-response.ts
@@ -1,0 +1,12 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface IperfInfoResponse {
+  installed: boolean;
+  version?: string;
+  error?: string;
+}

--- a/ui/src/types/generated/iperf-result-response.ts
+++ b/ui/src/types/generated/iperf-result-response.ts
@@ -1,0 +1,25 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface IperfResultResponse {
+  bandwidth: number;
+  transfer: number;
+  retransmits: number;
+  jitter: number;
+  lostPackets: number;
+  lostPercent: number;
+  protocol: string;
+  direction: string;
+  duration: number;
+  server: string;
+  port: number;
+  timestamp: string;
+  downloadBandwidth?: number;
+  uploadBandwidth?: number;
+  downloadTransfer?: number;
+  uploadTransfer?: number;
+}

--- a/ui/src/types/generated/iperf-server-request.ts
+++ b/ui/src/types/generated/iperf-server-request.ts
@@ -1,0 +1,11 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface IperfServerRequest {
+  action: string;
+  port: number;
+}

--- a/ui/src/types/generated/port-scan-request.ts
+++ b/ui/src/types/generated/port-scan-request.ts
@@ -1,0 +1,13 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface PortScanRequest {
+  target: string;
+  ports?: number[];
+  profile?: string;
+  workers?: number;
+}

--- a/ui/src/types/generated/set-interface-request.ts
+++ b/ui/src/types/generated/set-interface-request.ts
@@ -1,0 +1,10 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface SetInterfaceRequest {
+  interface: string;
+}

--- a/ui/src/types/generated/tcp-probe-request.ts
+++ b/ui/src/types/generated/tcp-probe-request.ts
@@ -1,0 +1,13 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface TCPProbeRequest {
+  target: string;
+  port: number;
+  ports: number[];
+  timeout: number;
+}

--- a/ui/src/types/generated/wifi-settings-response.ts
+++ b/ui/src/types/generated/wifi-settings-response.ts
@@ -1,0 +1,12 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface WiFiSettingsResponse {
+  interface: string;
+  availableWifi: string[];
+  isWireless: boolean;
+}


### PR DESCRIPTION
Adds flat / self-contained request + result DTOs to the code-first registry:
iperf client/server requests and info/result responses, port-scan and
tcp-probe requests, DNS response (its DNSLookupResult/DNSServerTestResult
sub-types are local flat API types, not domain mirrors — self-contained on
transitive analysis), DNS security-scan request, engine-scan request,
set-interface request, and WiFi settings response.

Coverage 60 -> 71. Verified: no $ref cycles, round-trip guardrail green,
schema + types drift gates clean, lint 0 issues.
