### PR TITLE
feat(contract): widen DTO coverage batch 7 (+16 users/tokens/update/sso/logs)

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -149,6 +149,24 @@ func schemaTargets() []schemaTarget {
 		{&api.EngineScanRequest{}, "engine-scan-request.schema.json"},
 		{&api.SetInterfaceRequest{}, "set-interface-request.schema.json"},
 		{&api.WiFiSettingsResponse{}, "wifi-settings-response.schema.json"},
+
+		// Users / API tokens / update / SSO / logs.
+		{&api.UserResponse{}, "user-response.schema.json"},
+		{&api.CreateUserRequest{}, "create-user-request.schema.json"},
+		{&api.UpdateUserRequest{}, "update-user-request.schema.json"},
+		{&api.MintTokenRequest{}, "mint-token-request.schema.json"},
+		{&api.MintTokenResponse{}, "mint-token-response.schema.json"},
+		{&api.UpdateCheckResponse{}, "update-check-response.schema.json"},
+		{&api.UpdateConfigRequest{}, "update-config-request.schema.json"},
+		{&api.UpdateConfigResponse{}, "update-config-response.schema.json"},
+		{&api.UpdateStatusResponse{}, "update-status-response.schema.json"},
+		{&api.SSOProvidersResponse{}, "sso-providers-response.schema.json"},
+		{&api.NVDAPIKeyValidateRequest{}, "nvd-api-key-validate-request.schema.json"},
+		{&api.NVDAPIKeyValidateResponse{}, "nvd-api-key-validate-response.schema.json"},
+		{&api.RestoreRequest{}, "restore-request.schema.json"},
+		{&api.ClientLogRequest{}, "client-log-request.schema.json"},
+		{&api.LogStatsResponse{}, "log-stats-response.schema.json"},
+		{&api.SNMPv3CredentialResponse{}, "snmpv3-credential-response.schema.json"},
 	}
 
 	targets := make([]schemaTarget, len(rows))

--- a/docs/schemas/api/client-log-request.schema.json
+++ b/docs/schemas/api/client-log-request.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/client-log-request.schema.json",
+  "$ref": "#/$defs/ClientLogRequest",
+  "$defs": {
+    "ClientLogEntry": {
+      "properties": {
+        "timestamp": {
+          "type": "string"
+        },
+        "level": {
+          "type": "string"
+        },
+        "component": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "session_id": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "stack": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "timestamp",
+        "level",
+        "component",
+        "message"
+      ]
+    },
+    "ClientLogRequest": {
+      "properties": {
+        "entries": {
+          "items": {
+            "$ref": "#/$defs/ClientLogEntry"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "entries"
+      ]
+    }
+  },
+  "title": "ClientLogRequest",
+  "description": "ClientLogRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/create-user-request.schema.json
+++ b/docs/schemas/api/create-user-request.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/create-user-request.schema.json",
+  "$ref": "#/$defs/CreateUserRequest",
+  "$defs": {
+    "CreateUserRequest": {
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "username",
+        "password",
+        "role"
+      ]
+    }
+  },
+  "title": "CreateUserRequest",
+  "description": "CreateUserRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/log-stats-response.schema.json
+++ b/docs/schemas/api/log-stats-response.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/log-stats-response.schema.json",
+  "$ref": "#/$defs/LogStatsResponse",
+  "$defs": {
+    "LogStatsResponse": {
+      "properties": {
+        "total_count": {
+          "type": "integer"
+        },
+        "by_level": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "by_layer": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "by_component": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "errors_last_hour": {
+          "type": "integer"
+        },
+        "warnings_last_hour": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "total_count",
+        "by_level",
+        "by_layer",
+        "by_component",
+        "errors_last_hour",
+        "warnings_last_hour"
+      ]
+    }
+  },
+  "title": "LogStatsResponse",
+  "description": "LogStatsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/mint-token-request.schema.json
+++ b/docs/schemas/api/mint-token-request.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/mint-token-request.schema.json",
+  "$ref": "#/$defs/MintTokenRequest",
+  "$defs": {
+    "MintTokenRequest": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    }
+  },
+  "title": "MintTokenRequest",
+  "description": "MintTokenRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/mint-token-response.schema.json
+++ b/docs/schemas/api/mint-token-response.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/mint-token-response.schema.json",
+  "$ref": "#/$defs/MintTokenResponse",
+  "$defs": {
+    "MintTokenResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "scope": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "token",
+        "prefix",
+        "createdAt"
+      ]
+    }
+  },
+  "title": "MintTokenResponse",
+  "description": "MintTokenResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/nvd-api-key-validate-request.schema.json
+++ b/docs/schemas/api/nvd-api-key-validate-request.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/nvd-api-key-validate-request.schema.json",
+  "$ref": "#/$defs/NVDAPIKeyValidateRequest",
+  "$defs": {
+    "NVDAPIKeyValidateRequest": {
+      "properties": {
+        "apiKey": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "apiKey"
+      ]
+    }
+  },
+  "title": "NVDAPIKeyValidateRequest",
+  "description": "NVDAPIKeyValidateRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/nvd-api-key-validate-response.schema.json
+++ b/docs/schemas/api/nvd-api-key-validate-response.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/nvd-api-key-validate-response.schema.json",
+  "$ref": "#/$defs/NVDAPIKeyValidateResponse",
+  "$defs": {
+    "NVDAPIKeyValidateResponse": {
+      "properties": {
+        "valid": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "rateLimit": {
+          "type": "integer"
+        },
+        "obtainUrl": {
+          "type": "string"
+        },
+        "helpMessage": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "valid",
+        "message",
+        "rateLimit",
+        "obtainUrl",
+        "helpMessage"
+      ]
+    }
+  },
+  "title": "NVDAPIKeyValidateResponse",
+  "description": "NVDAPIKeyValidateResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/restore-request.schema.json
+++ b/docs/schemas/api/restore-request.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/restore-request.schema.json",
+  "$ref": "#/$defs/RestoreRequest",
+  "$defs": {
+    "RestoreRequest": {
+      "properties": {
+        "backup_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "backup_name"
+      ]
+    }
+  },
+  "title": "RestoreRequest",
+  "description": "RestoreRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/snmpv3-credential-response.schema.json
+++ b/docs/schemas/api/snmpv3-credential-response.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/snmpv3-credential-response.schema.json",
+  "$ref": "#/$defs/SNMPv3CredentialResponse",
+  "$defs": {
+    "SNMPv3CredentialResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "authProtocol": {
+          "type": "string"
+        },
+        "authPassword": {
+          "type": "string"
+        },
+        "privProtocol": {
+          "type": "string"
+        },
+        "privPassword": {
+          "type": "string"
+        },
+        "contextName": {
+          "type": "string"
+        },
+        "securityLevel": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "username",
+        "authProtocol",
+        "authPassword",
+        "privProtocol",
+        "privPassword",
+        "contextName",
+        "securityLevel"
+      ]
+    }
+  },
+  "title": "SNMPv3CredentialResponse",
+  "description": "SNMPv3CredentialResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/sso-providers-response.schema.json
+++ b/docs/schemas/api/sso-providers-response.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/sso-providers-response.schema.json",
+  "$ref": "#/$defs/SSOProvidersResponse",
+  "$defs": {
+    "SSOProvidersResponse": {
+      "properties": {
+        "providers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "providers"
+      ]
+    }
+  },
+  "title": "SSOProvidersResponse",
+  "description": "SSOProvidersResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/update-check-response.schema.json
+++ b/docs/schemas/api/update-check-response.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/update-check-response.schema.json",
+  "$ref": "#/$defs/UpdateCheckResponse",
+  "$defs": {
+    "UpdateCheckResponse": {
+      "properties": {
+        "available": {
+          "type": "boolean"
+        },
+        "currentVersion": {
+          "type": "string"
+        },
+        "latestVersion": {
+          "type": "string"
+        },
+        "releaseNotes": {
+          "type": "string"
+        },
+        "releaseUrl": {
+          "type": "string"
+        },
+        "publishedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "downloadUrl": {
+          "type": "string"
+        },
+        "downloadSize": {
+          "type": "integer"
+        },
+        "checksumUrl": {
+          "type": "string"
+        },
+        "canAutoUpdate": {
+          "type": "boolean"
+        },
+        "requiresRestart": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "available",
+        "currentVersion",
+        "latestVersion",
+        "canAutoUpdate",
+        "requiresRestart"
+      ]
+    }
+  },
+  "title": "UpdateCheckResponse",
+  "description": "UpdateCheckResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/update-config-request.schema.json
+++ b/docs/schemas/api/update-config-request.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/update-config-request.schema.json",
+  "$ref": "#/$defs/UpdateConfigRequest",
+  "$defs": {
+    "UpdateConfigRequest": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "checkInterval": {
+          "type": "string"
+        },
+        "autoDownload": {
+          "type": "boolean"
+        },
+        "autoApply": {
+          "type": "boolean"
+        },
+        "includePrerelease": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "title": "UpdateConfigRequest",
+  "description": "UpdateConfigRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/update-config-response.schema.json
+++ b/docs/schemas/api/update-config-response.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/update-config-response.schema.json",
+  "$ref": "#/$defs/UpdateConfigResponse",
+  "$defs": {
+    "UpdateConfigResponse": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "checkInterval": {
+          "type": "string"
+        },
+        "autoDownload": {
+          "type": "boolean"
+        },
+        "autoApply": {
+          "type": "boolean"
+        },
+        "includePrerelease": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled",
+        "checkInterval",
+        "autoDownload",
+        "autoApply",
+        "includePrerelease"
+      ]
+    }
+  },
+  "title": "UpdateConfigResponse",
+  "description": "UpdateConfigResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/update-status-response.schema.json
+++ b/docs/schemas/api/update-status-response.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/update-status-response.schema.json",
+  "$ref": "#/$defs/UpdateStatusResponse",
+  "$defs": {
+    "UpdateStatusResponse": {
+      "properties": {
+        "state": {
+          "type": "string"
+        },
+        "progress": {
+          "type": "number"
+        },
+        "message": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        },
+        "downloadedBytes": {
+          "type": "integer"
+        },
+        "totalBytes": {
+          "type": "integer"
+        },
+        "startedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastCheck": {
+          "type": "string"
+        },
+        "updateReady": {
+          "type": "boolean"
+        },
+        "requiresAction": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "state",
+        "progress",
+        "updateReady",
+        "requiresAction"
+      ]
+    }
+  },
+  "title": "UpdateStatusResponse",
+  "description": "UpdateStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/update-user-request.schema.json
+++ b/docs/schemas/api/update-user-request.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/update-user-request.schema.json",
+  "$ref": "#/$defs/UpdateUserRequest",
+  "$defs": {
+    "UpdateUserRequest": {
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        },
+        "isActive": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "title": "UpdateUserRequest",
+  "description": "UpdateUserRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/user-response.schema.json
+++ b/docs/schemas/api/user-response.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/user-response.schema.json",
+  "$ref": "#/$defs/UserResponse",
+  "$defs": {
+    "UserResponse": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "username": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        },
+        "isActive": {
+          "type": "boolean"
+        },
+        "authProvider": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "lastLogin": {
+          "type": "string"
+        },
+        "lockedUntilFuture": {
+          "type": "boolean"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "username",
+        "role",
+        "isActive",
+        "authProvider",
+        "createdAt",
+        "updatedAt"
+      ]
+    }
+  },
+  "title": "UserResponse",
+  "description": "UserResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/src/types/generated/client-log-request.ts
+++ b/ui/src/types/generated/client-log-request.ts
@@ -1,0 +1,20 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface ClientLogRequest {
+  entries: ClientLogEntry[];
+}
+export interface ClientLogEntry {
+  timestamp: string;
+  level: string;
+  component: string;
+  message: string;
+  request_id?: string;
+  session_id?: string;
+  metadata?: {};
+  stack?: string;
+}

--- a/ui/src/types/generated/create-user-request.ts
+++ b/ui/src/types/generated/create-user-request.ts
@@ -1,0 +1,12 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface CreateUserRequest {
+  username: string;
+  password: string;
+  role: string;
+}

--- a/ui/src/types/generated/log-stats-response.ts
+++ b/ui/src/types/generated/log-stats-response.ts
@@ -1,0 +1,21 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface LogStatsResponse {
+  total_count: number;
+  by_level: {
+    [k: string]: number;
+  };
+  by_layer: {
+    [k: string]: number;
+  };
+  by_component: {
+    [k: string]: number;
+  };
+  errors_last_hour: number;
+  warnings_last_hour: number;
+}

--- a/ui/src/types/generated/mint-token-request.ts
+++ b/ui/src/types/generated/mint-token-request.ts
@@ -1,0 +1,11 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface MintTokenRequest {
+  name: string;
+  scope?: string;
+}

--- a/ui/src/types/generated/mint-token-response.ts
+++ b/ui/src/types/generated/mint-token-response.ts
@@ -1,0 +1,15 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface MintTokenResponse {
+  id: string;
+  name: string;
+  token: string;
+  prefix: string;
+  createdAt: string;
+  scope?: string;
+}

--- a/ui/src/types/generated/nvd-api-key-validate-request.ts
+++ b/ui/src/types/generated/nvd-api-key-validate-request.ts
@@ -1,0 +1,10 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface NVDAPIKeyValidateRequest {
+  apiKey: string;
+}

--- a/ui/src/types/generated/nvd-api-key-validate-response.ts
+++ b/ui/src/types/generated/nvd-api-key-validate-response.ts
@@ -1,0 +1,14 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface NVDAPIKeyValidateResponse {
+  valid: boolean;
+  message: string;
+  rateLimit: number;
+  obtainUrl: string;
+  helpMessage: string;
+}

--- a/ui/src/types/generated/restore-request.ts
+++ b/ui/src/types/generated/restore-request.ts
@@ -1,0 +1,10 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface RestoreRequest {
+  backup_name: string;
+}

--- a/ui/src/types/generated/snmpv3-credential-response.ts
+++ b/ui/src/types/generated/snmpv3-credential-response.ts
@@ -1,0 +1,17 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface SNMPv3CredentialResponse {
+  name: string;
+  username: string;
+  authProtocol: string;
+  authPassword: string;
+  privProtocol: string;
+  privPassword: string;
+  contextName: string;
+  securityLevel: string;
+}

--- a/ui/src/types/generated/sso-providers-response.ts
+++ b/ui/src/types/generated/sso-providers-response.ts
@@ -1,0 +1,10 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface SSOProvidersResponse {
+  providers: string[];
+}

--- a/ui/src/types/generated/update-check-response.ts
+++ b/ui/src/types/generated/update-check-response.ts
@@ -1,0 +1,20 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface UpdateCheckResponse {
+  available: boolean;
+  currentVersion: string;
+  latestVersion: string;
+  releaseNotes?: string;
+  releaseUrl?: string;
+  publishedAt?: string;
+  downloadUrl?: string;
+  downloadSize?: number;
+  checksumUrl?: string;
+  canAutoUpdate: boolean;
+  requiresRestart: boolean;
+}

--- a/ui/src/types/generated/update-config-request.ts
+++ b/ui/src/types/generated/update-config-request.ts
@@ -1,0 +1,14 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface UpdateConfigRequest {
+  enabled?: boolean;
+  checkInterval?: string;
+  autoDownload?: boolean;
+  autoApply?: boolean;
+  includePrerelease?: boolean;
+}

--- a/ui/src/types/generated/update-config-response.ts
+++ b/ui/src/types/generated/update-config-response.ts
@@ -1,0 +1,14 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface UpdateConfigResponse {
+  enabled: boolean;
+  checkInterval: string;
+  autoDownload: boolean;
+  autoApply: boolean;
+  includePrerelease: boolean;
+}

--- a/ui/src/types/generated/update-status-response.ts
+++ b/ui/src/types/generated/update-status-response.ts
@@ -1,0 +1,19 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface UpdateStatusResponse {
+  state: string;
+  progress: number;
+  message?: string;
+  error?: string;
+  downloadedBytes?: number;
+  totalBytes?: number;
+  startedAt?: string;
+  lastCheck?: string;
+  updateReady: boolean;
+  requiresAction: boolean;
+}

--- a/ui/src/types/generated/update-user-request.ts
+++ b/ui/src/types/generated/update-user-request.ts
@@ -1,0 +1,12 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface UpdateUserRequest {
+  password?: string;
+  role?: string;
+  isActive?: boolean;
+}

--- a/ui/src/types/generated/user-response.ts
+++ b/ui/src/types/generated/user-response.ts
@@ -1,0 +1,20 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface UserResponse {
+  id: number;
+  username: string;
+  role: string;
+  isActive: boolean;
+  authProvider: string;
+  email?: string;
+  displayName?: string;
+  lastLogin?: string;
+  lockedUntilFuture?: boolean;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
Adds flat / self-contained admin-surface DTOs to the code-first registry:
user CRUD (UserResponse, CreateUserRequest, UpdateUserRequest), API-token
mint request/response, software-update check/config/status DTOs, SSO providers
response, NVD API-key validate request/response, config restore request,
client-log request, log-stats response, and SNMPv3 credential response.

Coverage 71 -> 87. Verified: no $ref cycles, round-trip guardrail green,
schema + types drift gates clean, lint 0 issues.
