### PR TITLE
feat(contract): widen DTO coverage batch 8 (+10 survey) — self-contained set complete

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -167,6 +167,18 @@ func schemaTargets() []schemaTarget {
 		{&api.ClientLogRequest{}, "client-log-request.schema.json"},
 		{&api.LogStatsResponse{}, "log-stats-response.schema.json"},
 		{&api.SNMPv3CredentialResponse{}, "snmpv3-credential-response.schema.json"},
+
+		// Survey (Canopy) request DTOs + profile-import response.
+		{&api.CreateSurveyRequest{}, "create-survey-request.schema.json"},
+		{&api.AddFloorRequest{}, "add-floor-request.schema.json"},
+		{&api.UpdateFloorRequest{}, "update-floor-request.schema.json"},
+		{&api.UpdateFloorPlanRequest{}, "update-floor-plan-request.schema.json"},
+		{&api.SetActiveFloorRequest{}, "set-active-floor-request.schema.json"},
+		{&api.AddFloorSampleRequest{}, "add-floor-sample-request.schema.json"},
+		{&api.AddSampleRequest{}, "add-sample-request.schema.json"},
+		{&api.UpdateSurveySettingsRequest{}, "update-survey-settings-request.schema.json"},
+		{&api.GenerateReportRequest{}, "generate-report-request.schema.json"},
+		{&api.ProfileImportResponse{}, "profile-import-response.schema.json"},
 	}
 
 	targets := make([]schemaTarget, len(rows))

--- a/docs/schemas/api/add-floor-request.schema.json
+++ b/docs/schemas/api/add-floor-request.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/add-floor-request.schema.json",
+  "$ref": "#/$defs/AddFloorRequest",
+  "$defs": {
+    "AddFloorRequest": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "level": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "level"
+      ]
+    }
+  },
+  "title": "AddFloorRequest",
+  "description": "AddFloorRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/add-floor-sample-request.schema.json
+++ b/docs/schemas/api/add-floor-sample-request.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/add-floor-sample-request.schema.json",
+  "$ref": "#/$defs/AddFloorSampleRequest",
+  "$defs": {
+    "AddFloorSampleRequest": {
+      "properties": {
+        "x": {
+          "type": "integer"
+        },
+        "y": {
+          "type": "integer"
+        },
+        "sampleData": true
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "x",
+        "y",
+        "sampleData"
+      ]
+    }
+  },
+  "title": "AddFloorSampleRequest",
+  "description": "AddFloorSampleRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/add-sample-request.schema.json
+++ b/docs/schemas/api/add-sample-request.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/add-sample-request.schema.json",
+  "$ref": "#/$defs/AddSampleRequest",
+  "$defs": {
+    "AddSampleRequest": {
+      "properties": {
+        "x": {
+          "type": "integer"
+        },
+        "y": {
+          "type": "integer"
+        },
+        "sampleData": true
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "x",
+        "y",
+        "sampleData"
+      ]
+    }
+  },
+  "title": "AddSampleRequest",
+  "description": "AddSampleRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/create-survey-request.schema.json
+++ b/docs/schemas/api/create-survey-request.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/create-survey-request.schema.json",
+  "$ref": "#/$defs/CreateSurveyRequest",
+  "$defs": {
+    "CreateSurveyRequest": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "surveyType": {
+          "type": "string"
+        },
+        "interface": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "surveyType",
+        "interface"
+      ]
+    }
+  },
+  "title": "CreateSurveyRequest",
+  "description": "CreateSurveyRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/generate-report-request.schema.json
+++ b/docs/schemas/api/generate-report-request.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/generate-report-request.schema.json",
+  "$ref": "#/$defs/GenerateReportRequest",
+  "$defs": {
+    "GenerateReportRequest": {
+      "properties": {
+        "includeHeatmaps": {
+          "type": "boolean"
+        },
+        "includeRawData": {
+          "type": "boolean"
+        },
+        "includeRecommendations": {
+          "type": "boolean"
+        },
+        "includeExecutiveSummary": {
+          "type": "boolean"
+        },
+        "companyName": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "includeHeatmaps",
+        "includeRawData",
+        "includeRecommendations",
+        "includeExecutiveSummary"
+      ]
+    }
+  },
+  "title": "GenerateReportRequest",
+  "description": "GenerateReportRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/profile-import-response.schema.json
+++ b/docs/schemas/api/profile-import-response.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/profile-import-response.schema.json",
+  "$ref": "#/$defs/ProfileImportResponse",
+  "$defs": {
+    "ProfileImportResponse": {
+      "properties": {
+        "created": {
+          "type": "integer"
+        },
+        "updated": {
+          "type": "integer"
+        },
+        "skipped": {
+          "type": "integer"
+        },
+        "errors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "created",
+        "updated",
+        "skipped"
+      ]
+    }
+  },
+  "title": "ProfileImportResponse",
+  "description": "ProfileImportResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/set-active-floor-request.schema.json
+++ b/docs/schemas/api/set-active-floor-request.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/set-active-floor-request.schema.json",
+  "$ref": "#/$defs/SetActiveFloorRequest",
+  "$defs": {
+    "SetActiveFloorRequest": {
+      "properties": {
+        "floorId": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "floorId"
+      ]
+    }
+  },
+  "title": "SetActiveFloorRequest",
+  "description": "SetActiveFloorRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/update-floor-plan-request.schema.json
+++ b/docs/schemas/api/update-floor-plan-request.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/update-floor-plan-request.schema.json",
+  "$ref": "#/$defs/UpdateFloorPlanRequest",
+  "$defs": {
+    "UpdateFloorPlanRequest": {
+      "properties": {
+        "imageData": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "scaleM": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "imageData",
+        "width",
+        "height",
+        "scaleM"
+      ]
+    }
+  },
+  "title": "UpdateFloorPlanRequest",
+  "description": "UpdateFloorPlanRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/update-floor-request.schema.json
+++ b/docs/schemas/api/update-floor-request.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/update-floor-request.schema.json",
+  "$ref": "#/$defs/UpdateFloorRequest",
+  "$defs": {
+    "UpdateFloorRequest": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "level": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "level"
+      ]
+    }
+  },
+  "title": "UpdateFloorRequest",
+  "description": "UpdateFloorRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/update-survey-settings-request.schema.json
+++ b/docs/schemas/api/update-survey-settings-request.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/update-survey-settings-request.schema.json",
+  "$ref": "#/$defs/UpdateSurveySettingsRequest",
+  "$defs": {
+    "UpdateSurveySettingsRequest": {
+      "properties": {
+        "surveyType": {
+          "type": "string"
+        },
+        "iperfServer": {
+          "type": "string"
+        },
+        "testDuration": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "surveyType"
+      ]
+    }
+  },
+  "title": "UpdateSurveySettingsRequest",
+  "description": "UpdateSurveySettingsRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/src/types/generated/add-floor-request.ts
+++ b/ui/src/types/generated/add-floor-request.ts
@@ -1,0 +1,11 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface AddFloorRequest {
+  name: string;
+  level: number;
+}

--- a/ui/src/types/generated/add-floor-sample-request.ts
+++ b/ui/src/types/generated/add-floor-sample-request.ts
@@ -1,0 +1,12 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface AddFloorSampleRequest {
+  x: number;
+  y: number;
+  sampleData: unknown;
+}

--- a/ui/src/types/generated/add-sample-request.ts
+++ b/ui/src/types/generated/add-sample-request.ts
@@ -1,0 +1,12 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface AddSampleRequest {
+  x: number;
+  y: number;
+  sampleData: unknown;
+}

--- a/ui/src/types/generated/create-survey-request.ts
+++ b/ui/src/types/generated/create-survey-request.ts
@@ -1,0 +1,13 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface CreateSurveyRequest {
+  name: string;
+  description: string;
+  surveyType: string;
+  interface: string;
+}

--- a/ui/src/types/generated/generate-report-request.ts
+++ b/ui/src/types/generated/generate-report-request.ts
@@ -1,0 +1,14 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface GenerateReportRequest {
+  includeHeatmaps: boolean;
+  includeRawData: boolean;
+  includeRecommendations: boolean;
+  includeExecutiveSummary: boolean;
+  companyName?: string;
+}

--- a/ui/src/types/generated/profile-import-response.ts
+++ b/ui/src/types/generated/profile-import-response.ts
@@ -1,0 +1,13 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface ProfileImportResponse {
+  created: number;
+  updated: number;
+  skipped: number;
+  errors?: string[];
+}

--- a/ui/src/types/generated/set-active-floor-request.ts
+++ b/ui/src/types/generated/set-active-floor-request.ts
@@ -1,0 +1,10 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface SetActiveFloorRequest {
+  floorId: string;
+}

--- a/ui/src/types/generated/update-floor-plan-request.ts
+++ b/ui/src/types/generated/update-floor-plan-request.ts
@@ -1,0 +1,13 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface UpdateFloorPlanRequest {
+  imageData: string;
+  width: number;
+  height: number;
+  scaleM: number;
+}

--- a/ui/src/types/generated/update-floor-request.ts
+++ b/ui/src/types/generated/update-floor-request.ts
@@ -1,0 +1,11 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface UpdateFloorRequest {
+  name: string;
+  level: number;
+}

--- a/ui/src/types/generated/update-survey-settings-request.ts
+++ b/ui/src/types/generated/update-survey-settings-request.ts
@@ -1,0 +1,12 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface UpdateSurveySettingsRequest {
+  surveyType: string;
+  iperfServer?: string;
+  testDuration?: number;
+}


### PR DESCRIPTION
Adds the flat / self-contained Canopy survey request DTOs (create survey, add/
update floor, floor-plan + active-floor, add floor-sample/sample, update survey
settings, generate report) and the profile-import response.

This completes the Phase 2 flat + self-contained widening: coverage 87 -> 97
(28 at the start of the session). The remaining ~25 uncovered DTOs are
deferred to Phase 3 by policy — they put internal domain types on the wire
(discovery.*/dhcp.*/netif.*/logging.*/survey.*), compose other top-level
responses, carry json.RawMessage, or self-recurse (GatewayResponse) — and will
get hand-designed flat transport DTOs then, plus 10 unexported lowercase DTOs
that cannot be referenced from package main.

Verified: no $ref cycles, round-trip guardrail green, schema + types drift
gates clean, lint 0 issues.
