### PR TITLE
refactor(contract): retire hand-maintained TS twins for 6 generated DTOs

### DIFF
--- a/ui/src/components/settings/sections/UpdateSettings.tsx
+++ b/ui/src/components/settings/sections/UpdateSettings.tsx
@@ -225,7 +225,7 @@ export const UpdateSettings: React.NamedExoticComponent<UpdateSettingsProps> = m
                 </div>
               ) : null}
 
-              {updateInfo.downloadSize > 0 ? (
+              {updateInfo.downloadSize ? (
                 <div className="body-small text-text-secondary">
                   {t('updates.downloadSize', 'Size')}: {formatBytes(updateInfo.downloadSize)}
                 </div>

--- a/ui/src/contexts/profileContext.tsx
+++ b/ui/src/contexts/profileContext.tsx
@@ -40,6 +40,7 @@ import {
   useVulnerabilitySettings,
   useWifiSettings,
 } from '../stores/profileStore';
+import type { ProfileImportResponse } from '../types/generated/profile-import-response';
 import type {
   AppearanceConfig,
   CableTestConfig,
@@ -52,7 +53,6 @@ import type {
   Profile,
   ProfileExportResponse,
   ProfileImportRequest,
-  ProfileImportResponse,
   ProfileInterfaceSelection,
   ProfileRequest,
   ProfileSettings,

--- a/ui/src/contexts/useProfileApi.ts
+++ b/ui/src/contexts/useProfileApi.ts
@@ -20,11 +20,11 @@ import {
   useSwitchProfileMutation,
   useUpdateProfileMutation,
 } from '../stores/profileQueries';
+import type { ProfileImportResponse } from '../types/generated/profile-import-response';
 import type {
   Profile,
   ProfileExportResponse,
   ProfileImportRequest,
-  ProfileImportResponse,
   ProfileRequest,
 } from '../types/profile';
 

--- a/ui/src/hooks/useUpdates.ts
+++ b/ui/src/hooks/useUpdates.ts
@@ -27,13 +27,10 @@
 import { useCallback, useState } from 'react';
 import { api } from '../api';
 import { LogComponents, logger } from '../lib/logger';
-import type {
-  UpdateActionResponse,
-  UpdateCheckResponse,
-  UpdateConfig,
-  UpdateConfigRequest,
-  UpdateStatusResponse,
-} from '../types/update';
+import type { UpdateCheckResponse } from '../types/generated/update-check-response';
+import type { UpdateConfigRequest } from '../types/generated/update-config-request';
+import type { UpdateStatusResponse } from '../types/generated/update-status-response';
+import type { UpdateActionResponse, UpdateConfig } from '../types/update';
 
 /**
  * Custom hook for managing application updates.

--- a/ui/src/stores/profileQueries.ts
+++ b/ui/src/stores/profileQueries.ts
@@ -23,11 +23,11 @@ import { useEffect } from 'react';
 import { api } from '../api';
 import { LogComponents, logger } from '../lib/logger';
 import type { DefaultSettings } from '../types/defaults';
+import type { ProfileImportResponse } from '../types/generated/profile-import-response';
 import type {
   Profile,
   ProfileExportResponse,
   ProfileImportRequest,
-  ProfileImportResponse,
   ProfileListResponse,
   ProfileRequest,
 } from '../types/profile';

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -143,13 +143,11 @@ export interface Settings {
 // Traceroute Types
 // ============================================================================
 
-export interface TracerouteRequest {
-  target: string;
-  protocol: 'icmp' | 'udp' | 'tcp';
-  port?: number;
-  maxHops?: number;
-  timeout?: number;
-}
+// TracerouteRequest and PathRequest now come from the generated schema
+// (code-first contract): src/types/generated/traceroute-request.ts and path.ts.
+// The result/view-model types below (TracerouteResult, L2PathResult,
+// PathResponse) stay hand-maintained — PathResponse is a Phase-3-deferred DTO
+// (it nests discovery.* domain types) and the others are its building blocks.
 
 export interface TracerouteHop {
   ttl: number;
@@ -193,14 +191,6 @@ export interface L2Hop {
 
 export interface L2PathResult {
   hops: L2Hop[];
-}
-
-export interface PathRequest {
-  source: string; // IP or "self"
-  destination: string; // IP or hostname
-  method: 'l3' | 'l2' | 'both';
-  protocol: 'icmp' | 'udp' | 'tcp';
-  port?: number;
 }
 
 export interface PathResponse {

--- a/ui/src/types/profile.ts
+++ b/ui/src/types/profile.ts
@@ -555,15 +555,10 @@ export interface ProfileImportRequest {
   overwrite?: boolean;
 }
 
-/**
- * ProfileImportResponse is returned after importing profiles.
- */
-export interface ProfileImportResponse {
-  created: number;
-  updated: number;
-  skipped: number;
-  errors?: string[];
-}
+// ProfileImportResponse now comes from the generated schema (code-first
+// contract): src/types/generated/profile-import-response.ts. ProfileImportRequest
+// stays here until Phase 3 — it carries an opaque json.RawMessage config that
+// has no generated transport DTO yet.
 
 /**
  * ProfileExportResponse is returned when exporting profiles.

--- a/ui/src/types/update.ts
+++ b/ui/src/types/update.ts
@@ -39,19 +39,13 @@ export interface UpdateStatus {
   startedAt: string;
 }
 
-/** Combined status response from the API */
-export interface UpdateStatusResponse {
-  state: UpdateState;
-  progress: number;
-  message: string;
-  error: string;
-  downloadedBytes: number;
-  totalBytes: number;
-  startedAt: string;
-  lastCheck: string;
-  updateReady: boolean;
-  requiresAction: boolean;
-}
+// UpdateStatusResponse, UpdateConfigRequest, and UpdateCheckResponse now come
+// from the generated schema (code-first contract) under
+// src/types/generated/. The hand-maintained twins had already drifted from the
+// backend DTO (e.g. downloadURL vs the real downloadUrl, missing canAutoUpdate/
+// requiresRestart) — the generated types are the source of truth. The
+// remaining types here (UpdateState, UpdateInfo, UpdateStatus, UpdateConfig,
+// UpdateActionResponse) have no generated DTO and stay hand-maintained.
 
 /** Update configuration */
 export interface UpdateConfig {
@@ -60,27 +54,6 @@ export interface UpdateConfig {
   autoDownload: boolean;
   autoApply: boolean;
   includePrerelease: boolean;
-}
-
-/** Request to update configuration */
-export interface UpdateConfigRequest {
-  enabled?: boolean;
-  checkInterval?: string;
-  autoDownload?: boolean;
-  autoApply?: boolean;
-  includePrerelease?: boolean;
-}
-
-/** API response for check/info endpoints */
-export interface UpdateCheckResponse {
-  available: boolean;
-  currentVersion: string;
-  latestVersion: string;
-  releaseNotes: string;
-  publishedAt: string;
-  downloadURL: string;
-  downloadSize: number;
-  checksumURL: string;
 }
 
 /** API response for action endpoints */


### PR DESCRIPTION
Migrates the six hand-written TypeScript interfaces that now have a generated
code-first equivalent over to the generated types, and deletes the duplicates:

- UpdateCheckResponse, UpdateConfigRequest, UpdateStatusResponse (types/update.ts
  -> types/generated/*) — useUpdates.ts now imports the generated types. The
  hand twins had already DRIFTED from the backend DTO (downloadURL vs the real
  downloadUrl, missing canAutoUpdate/requiresRestart), so this also corrects a
  latent contract mismatch. The generated UpdateCheckResponse.downloadSize is
  optional (omitempty), which surfaced an unguarded access in UpdateSettings.tsx
  — fixed to a truthy check.
- ProfileImportResponse (types/profile.ts -> generated) — byte-identical shape;
  3 consumers repointed. ProfileImportRequest stays hand-maintained (deferred:
  carries json.RawMessage, no generated transport DTO until Phase 3).
- TracerouteRequest, PathRequest (types/index.ts) — dead duplicates (0
  consumers); generated traceroute-request.ts / path.ts supersede them. The
  view-model result types (TracerouteResult, PathResponse, L2PathResult) stay —
  PathResponse is a Phase-3-deferred DTO that nests discovery.* domain types.

No schema/generated changes. Verified: tsc clean, biome clean, 156/156 related
unit tests pass. (Pre-existing unrelated failure in helpRouteCoverage.test.ts
for the /alerts route is a separate workstream, untouched here.)
