### PR TITLE
fix(help): add HelpDrawer sections for alerts, polling-targets, topology

### DIFF
--- a/internal/i18n/locales/en/help.json
+++ b/internal/i18n/locales/en/help.json
@@ -27,7 +27,10 @@
     "glossary": "Glossary",
     "path": "Path Analysis",
     "reports": "Reports",
-    "logs": "Logs"
+    "logs": "Logs",
+    "alerts": "Alerts",
+    "pollingTargets": "Polling Targets",
+    "topology": "Topology"
   },
   "instructions": {
     "runTests": "Tap the play button to run all tests.",

--- a/internal/i18n/locales/es/help.json
+++ b/internal/i18n/locales/es/help.json
@@ -27,7 +27,10 @@
     "glossary": "Glosario",
     "path": "Análisis de ruta",
     "reports": "Informes",
-    "logs": "Logs"
+    "logs": "Logs",
+    "alerts": "Alertas",
+    "pollingTargets": "Objetivos de sondeo",
+    "topology": "Topología"
   },
   "instructions": {
     "runTests": "Toque el botón de reproducir para ejecutar todas las pruebas.",

--- a/ui/src/components/help/helpDrawerContent.tsx
+++ b/ui/src/components/help/helpDrawerContent.tsx
@@ -1067,6 +1067,107 @@ export const helpSections: HelpSection[] = [
     ],
   },
   {
+    id: 'alerts',
+    titleKey: 'sections.alerts',
+    icon: <AlertTriangle className={ICON} />,
+    keywords: ['alerts', 'alert', 'acknowledge', 'resolve', 'severity', 'notification', 'incident'],
+    blocks: [
+      {
+        kind: 'paragraph',
+        text: 'Alerts lists the conditions the monitoring pipelines have raised — for example a polled device going unreachable or an interface changing state. Filter by severity, acknowledged, or resolved, then act on each row: acknowledge marks it seen, resolve marks it fixed. The person who clicks is recorded against the alert.',
+      },
+      {
+        kind: 'terms',
+        heading: 'Terms',
+        items: [
+          {
+            term: 'Severity',
+            description:
+              'How urgent the condition is. Filter to focus on the most important alerts first.',
+          },
+          {
+            term: 'Acknowledge',
+            description:
+              'Marks an alert as seen without closing it — signals someone is looking into it.',
+          },
+          {
+            term: 'Resolve',
+            description: 'Marks an alert as fixed and removes it from the default unresolved view.',
+          },
+          {
+            term: 'Acknowledged by',
+            description:
+              'The operator who acknowledged the alert, taken from the signed-in identity.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'pollingTargets',
+    titleKey: 'sections.pollingTargets',
+    icon: <Server className={ICON} />,
+    keywords: ['polling', 'targets', 'snmp', 'monitor', 'device', 'collector', 'add', 'edit'],
+    blocks: [
+      {
+        kind: 'paragraph',
+        text: 'Polling targets is the list of devices Seed polls over SNMP. Add a target to start monitoring it, edit one to change its settings, or remove one you no longer track. A new target picks up the default collector chain and begins polling on the next cycle; the devices and links it discovers appear on the Topology page, and state changes surface as alerts.',
+      },
+      {
+        kind: 'terms',
+        heading: 'Terms',
+        items: [
+          {
+            term: 'Target',
+            description: 'A device (by address) that Seed polls on a recurring interval.',
+          },
+          {
+            term: 'Collector chain',
+            description:
+              'The set of SNMP collectors run against a target (system info, interface table, LLDP, ARP, and forwarding-database neighbors).',
+          },
+          {
+            term: 'SNMP',
+            description:
+              'Simple Network Management Protocol — the standard used to read device state and tables.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'topology',
+    titleKey: 'sections.topology',
+    icon: <Network className={ICON} />,
+    keywords: ['topology', 'graph', 'nodes', 'links', 'neighbors', 'map', 'interfaces'],
+    blocks: [
+      {
+        kind: 'paragraph',
+        text: 'Topology shows the network graph reconciled from discovery and SNMP polling: every node visible to your session, with its interfaces and the links between nodes. Select a node to open a detail panel listing its interfaces and discovered links. The graph is built from the same observations that drive polling targets and alerts.',
+      },
+      {
+        kind: 'terms',
+        heading: 'Terms',
+        items: [
+          {
+            term: 'Node',
+            description:
+              'A discovered device in the graph — switch, router, host, or access point.',
+          },
+          {
+            term: 'Link',
+            description:
+              'A neighbor relationship between two nodes, learned from LLDP/CDP or forwarding tables.',
+          },
+          {
+            term: 'Interface',
+            description: 'A port on a node, with its status and any links observed on it.',
+          },
+        ],
+      },
+    ],
+  },
+  {
     id: 'glossary',
     titleKey: 'sections.glossary',
     icon: <BookOpen className={ICON} />,

--- a/ui/src/components/help/helpRouteCoverage.test.ts
+++ b/ui/src/components/help/helpRouteCoverage.test.ts
@@ -21,6 +21,9 @@ const ROUTE_TO_HELP: Record<string, string> = {
   '/performance': 'performance',
   '/reports': 'reports',
   '/logs': 'logs',
+  '/alerts': 'alerts',
+  '/polling-targets': 'pollingTargets',
+  '/topology': 'topology',
 };
 
 describe('GUI help — route coverage', () => {


### PR DESCRIPTION
The alerts page (#1363), polling-targets CRUD (#1361), and topology page
shipped without HelpDrawer coverage, leaving helpRouteCoverage.test.ts red on
main (every route in pageRegistry must have an explicit help mapping + a
section). This adds the three missing sections with factual, on-feature copy:

- alerts: severity filtering, acknowledge ("seen") / resolve ("fixed"), and the
  acknowledged-by identity recorded from the signed-in user.
- pollingTargets: SNMP polling CRUD, the default collector chain, and how new
  targets feed the topology graph and alert pipelines.
- topology: the reconciled node/link graph, node detail (interfaces + links),
  built from discovery + SNMP observations.

Wires the three routes into ROUTE_TO_HELP and adds sections.alerts/
pollingTargets/topology to en + es help.json (Spanish translates prose only;
SNMP/LLDP/ARP and other standard terms stay verbatim). HelpTranslations derives
from en/help.json so the titleKey type picks the keys up automatically.

Verified: helpRouteCoverage + i18n parity green, full UI suite 158/158 (was
156 + 2 failing), Go i18n tests pass, tsc + biome clean.
