### PR TITLE
refactor(harvest): extract ReportRepo port into adapters/store ring (Phase 3 1b-iv)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -239,6 +239,10 @@ linters:
         # no transport, no SQL driver, no infra ring. Applies to every package
         # under internal/modules/ as it is extracted (harvest first). This makes
         # "dependencies point inward" a CI gate, not a hope.
+        #
+        # The no-transport / no-SQL-driver ban holds for ALL files (production
+        # AND tests): module code, even in tests, talks to I/O through ports and
+        # the internal/database wrapper, never net/http or a raw database/sql.
         "modules-domain-purity":
           files:
             - "**/internal/modules/**"
@@ -247,6 +251,16 @@ linters:
               desc: "modules are pure — define a port, implement it in adapters/http"
             - pkg: database/sql
               desc: "modules are pure — define a Repo port, implement it in adapters/store"
+        # The infra-ring ban is production-only: a module's own code must never
+        # import internal/adapters (inward-only direction). Test files are
+        # exempt because they are mini composition roots — they wire the real
+        # store/http adapter to exercise the module end-to-end (e.g. harvest's
+        # tests build store.NewReportRepo(db)). $test = all _test.go files.
+        "modules-no-adapter-import":
+          files:
+            - "**/internal/modules/**"
+            - "!$test"
+          deny:
             - pkg: github.com/krisarmstrong/seed/internal/adapters
               desc: "inward-only — adapters depend on modules, never the reverse"
         # Module independence: each module is an island; cross-module talk goes

--- a/cmd/seed/cmd_serve.go
+++ b/cmd/seed/cmd_serve.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/krisarmstrong/seed/internal/adapters/store"
 	api "github.com/krisarmstrong/seed/internal/api"
 	"github.com/krisarmstrong/seed/internal/auth"
 	"github.com/krisarmstrong/seed/internal/canopy"
@@ -130,7 +131,7 @@ func initializeModules(cfg *config.Config, db *database.DB) *api.Modules {
 	logging.GetLogger().Info("Roots module initialized")
 
 	// Harvest: Reporting (report generation, templates, scheduling)
-	modules.Harvest = harvest.New(cfg, db)
+	modules.Harvest = harvest.New(cfg, db, store.NewReportRepo(db))
 	logging.GetLogger().Info("Harvest module initialized")
 
 	return modules

--- a/cmd/seed/cmd_service_windows.go
+++ b/cmd/seed/cmd_service_windows.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kardianos/service"
 	"github.com/spf13/cobra"
 
+	"github.com/krisarmstrong/seed/internal/adapters/store"
 	api "github.com/krisarmstrong/seed/internal/api"
 	"github.com/krisarmstrong/seed/internal/auth"
 	"github.com/krisarmstrong/seed/internal/canopy"
@@ -248,7 +249,7 @@ func initializeModulesForService(cfg *config.Config, db *database.DB) *api.Modul
 	modules.Shell = shell.New(cfg, db)
 	modules.Canopy = canopy.New(cfg, db)
 	modules.Roots = pipeline.New(cfg, db)
-	modules.Harvest = harvest.New(cfg, db)
+	modules.Harvest = harvest.New(cfg, db, store.NewReportRepo(db))
 
 	return modules
 }

--- a/docs/architecture/PHASE3_EXTRACTION_PLAN.md
+++ b/docs/architecture/PHASE3_EXTRACTION_PLAN.md
@@ -130,8 +130,11 @@ deny `net/http`, `database/sql`, `internal/adapters/**`, and the other four
 - [ ] `go test ./...` green; **harvest report/export golden snapshots unchanged**.
 - [ ] `internal/modules/harvest` imports no `net/http`, no `database/sql`, no
       `internal/adapters/**`, no sibling `internal/modules/*` — `depguard` at `deny`.
-- [ ] harvest's logic has table-driven unit tests that run with **fake ports**
-      (no DB, no filesystem) — the payoff the phase exists for.
+- [~] harvest's logic has table-driven unit tests that run with **fake ports**
+      (no DB, no filesystem) — the payoff the phase exists for. Started in
+      1b-iv: `report_repo_test.go` exercises `GeneratorService` report CRUD with
+      a fake `ReportRepo` and nil db/templates/aggregator. Completes as the
+      remaining repos (1b-v) land.
 - [ ] `internal/app/harvest.go` builds the module from `Deps`; `internal/api/modules.go`
       consumes the module through the same surface (no behavior change).
 - [x] The harvest→health coupling is gone (it was dead code — deleted, #1428).
@@ -149,9 +152,18 @@ Resliced during execution into atomic PRs:
 3. ✅ **1b-iii enforce purity** (#1429): `depguard` `modules-domain-purity`
    (deny `net/http`/`database/sql`/`internal/adapters` on `internal/modules/**`)
    + `harvest-module-independence` (deny sibling module roots). RED-proven.
-4. ⏳ **1b-iv ReportRepo** — NEXT (see §4.7). Relocate reports SQL into the
-   `adapters/store` ring behind a port.
-5. ⏳ **1b-v** — `ScheduleRepo` (scheduler) + `MetricsRepo`/`ExportRepo`
+4. ✅ **1b-iv ReportRepo** (see §4.7): report-record SQL (`GetReport`/
+   `ListReports`/`scanReport`/`saveReport`/`DeleteReport` row) lifted verbatim
+   into `internal/adapters/store/harvest_repo.go` behind the `harvest.ReportRepo`
+   port (`ports.go`). `GeneratorService` delegates and keeps `db` for export
+   (1b-v). Rewired `harvest.New`/`NewGeneratorService` + the 2 prod callers
+   (`cmd_serve.go`, `cmd_service_windows.go`) + all test sites. `depguard`
+   `modules-domain-purity` split: the transport/SQL-driver ban stays universal,
+   the infra-ring ban is now production-only (`!$test`) so test files can wire
+   the real store adapter (`modules-no-adapter-import`). Golden HTTP suite
+   unchanged; lint 0; `go test ./...` green. Added a DB-free `GeneratorService`
+   unit test via a fake `ReportRepo`.
+5. ⏳ **1b-v** — NEXT: `ScheduleRepo` (scheduler) + `MetricsRepo`/`ExportRepo`
    (aggregator + export device/vuln queries), then ban `internal/database` from
    `modules/harvest` in `depguard` and seed `internal/app/harvest.go`.
 

--- a/internal/adapters/store/harvest_repo.go
+++ b/internal/adapters/store/harvest_repo.go
@@ -1,0 +1,129 @@
+// Package store holds persistence adapters: concrete SQLite implementations of
+// the repository ports declared by the domain modules. Adapters depend on
+// modules (importing their types and satisfying their ports), never the
+// reverse — the inward-only direction enforced by depguard.
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/modules/harvest"
+)
+
+// ReportRepo implements harvest.ReportRepo over the SQLite reports table. The
+// SQL and row scanning were lifted verbatim from the harvest module
+// (services_reports.go + services.go:saveReport) when the module was made
+// I/O-free — Phase 3 slice 1b-iv.
+type ReportRepo struct {
+	db *database.DB
+}
+
+// NewReportRepo constructs a ReportRepo backed by db.
+func NewReportRepo(db *database.DB) *ReportRepo {
+	return &ReportRepo{db: db}
+}
+
+// Compile-time assertion that the adapter satisfies the module's port.
+var _ harvest.ReportRepo = (*ReportRepo)(nil)
+
+// GetReport retrieves a report by ID.
+func (r *ReportRepo) GetReport(ctx context.Context, id string) (*harvest.Report, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, name, type, format, template, status, file_path, file_size, parameters_json, error, created_at, completed_at, expires_at
+		FROM reports WHERE id = ?
+	`, id)
+
+	return scanReport(row)
+}
+
+// ListReports returns all generated reports.
+func (r *ReportRepo) ListReports(ctx context.Context) ([]harvest.Report, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, name, type, format, template, status, file_path, file_size, parameters_json, error, created_at, completed_at, expires_at
+		FROM reports ORDER BY created_at DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying reports: %w", err)
+	}
+	defer rows.Close()
+
+	var reports []harvest.Report
+	for rows.Next() {
+		report, scanErr := scanReport(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		reports = append(reports, *report)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("iterating reports: %w", rowsErr)
+	}
+
+	return reports, nil
+}
+
+// SaveReport upserts a report record.
+func (r *ReportRepo) SaveReport(ctx context.Context, report *harvest.Report) error {
+	paramsJSON, _ := json.Marshal(report.Parameters)
+
+	var completedAt, expiresAt *string
+	if report.CompletedAt != nil {
+		t := report.CompletedAt.Format(time.RFC3339)
+		completedAt = &t
+	}
+	if report.ExpiresAt != nil {
+		t := report.ExpiresAt.Format(time.RFC3339)
+		expiresAt = &t
+	}
+
+	_, err := r.db.Exec(ctx, `
+		INSERT OR REPLACE INTO reports (id, name, type, format, template, status, file_path, file_size, parameters_json, error, created_at, completed_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, report.ID, report.Name, report.Type, report.Format, report.Template, report.Status,
+		report.FilePath, report.FileSize, string(paramsJSON), report.Error,
+		report.CreatedAt.Format(time.RFC3339), completedAt, expiresAt)
+	if err != nil {
+		return fmt.Errorf("saving report to database: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteReport removes the report row (the file is removed by the service).
+func (r *ReportRepo) DeleteReport(ctx context.Context, id string) error {
+	_, err := r.db.Exec(ctx, "DELETE FROM reports WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("deleting report from database: %w", err)
+	}
+	return nil
+}
+
+// scanReport materializes a Report from a QueryRow or Rows scanner.
+func scanReport(row interface{ Scan(...any) error }) (*harvest.Report, error) {
+	var r harvest.Report
+	var paramsJSON, completedAt, expiresAt *string
+
+	err := row.Scan(&r.ID, &r.Name, &r.Type, &r.Format, &r.Template, &r.Status,
+		&r.FilePath, &r.FileSize, &paramsJSON, &r.Error, &r.CreatedAt, &completedAt, &expiresAt)
+	if err != nil {
+		return nil, fmt.Errorf("scanning report: %w", err)
+	}
+
+	if paramsJSON != nil {
+		_ = json.Unmarshal([]byte(*paramsJSON), &r.Parameters)
+	}
+	if completedAt != nil {
+		t, _ := time.Parse(time.RFC3339, *completedAt)
+		r.CompletedAt = &t
+	}
+	if expiresAt != nil {
+		t, _ := time.Parse(time.RFC3339, *expiresAt)
+		r.ExpiresAt = &t
+	}
+
+	return &r, nil
+}

--- a/internal/modules/harvest/internal_test.go
+++ b/internal/modules/harvest/internal_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/krisarmstrong/seed/internal/adapters/store"
 	"github.com/krisarmstrong/seed/internal/config"
 	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/modules/harvest"
@@ -142,7 +143,7 @@ func TestGenerateHTML_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	report := &harvest.Report{
 		ID:   "test-html",
@@ -189,7 +190,7 @@ func TestGenerateCSV_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	report := &harvest.Report{
 		ID:   "test-csv",
@@ -235,7 +236,7 @@ func TestGenerateJSON_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	report := &harvest.Report{
 		ID:   "test-json",
@@ -281,7 +282,7 @@ func TestGeneratePDF_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	tests := []struct {
 		name       string
@@ -348,7 +349,7 @@ func TestDataToCSV_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	tests := []struct {
 		name      string
@@ -416,7 +417,7 @@ func TestSaveReportFile_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	gs.SetReportsPath(tmpDir)
 
 	tests := []struct {
@@ -550,7 +551,7 @@ func TestCheckSchedules_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -590,7 +591,7 @@ func TestRunScheduledReport_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -626,7 +627,7 @@ func TestLoadSchedules_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -672,7 +673,7 @@ func TestSaveSchedule_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -745,7 +746,7 @@ func TestExportDevices_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	req := &harvest.ExportRequest{
 		Type:   "devices",
@@ -772,7 +773,7 @@ func TestExportVulnerabilities_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	req := &harvest.ExportRequest{
 		Type:   "vulnerabilities",
@@ -800,7 +801,7 @@ func TestFailReport_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -833,7 +834,7 @@ func TestSaveReport_Internal(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 	now := time.Now()
@@ -941,7 +942,7 @@ func TestReportsPath_Internal(t *testing.T) {
 	cfg := testConfigHelper()
 	ts := harvest.NewTemplateService(cfg)
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	// Default path
 	defaultPath := gs.GetReportsPath()
@@ -1123,7 +1124,7 @@ func TestGeneratorService_GenerateWithDateRanges(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -1168,7 +1169,7 @@ func TestGeneratorService_Export_Formats(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	gs.SetReportsPath(tmpDir)
 
 	tests := []struct {
@@ -1206,7 +1207,7 @@ func TestSchedulerService_ScheduleVariations(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -1341,7 +1342,7 @@ func TestModuleStart_TemplateLoadError(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfigHelper()
-	module := harvest.New(cfg, db)
+	module := harvest.New(cfg, db, store.NewReportRepo(db))
 
 	// Start should succeed (templates load without error)
 	ctx := context.Background()

--- a/internal/modules/harvest/module.go
+++ b/internal/modules/harvest/module.go
@@ -21,8 +21,11 @@ type Module struct {
 	aggregator *AggregatorService
 }
 
-// New creates a new Harvest module instance.
-func New(cfg *config.Config, db *database.DB) *Module {
+// New creates a new Harvest module instance. The report-record persistence
+// adapter is injected (ReportRepo port) so the module stays free of SQL for
+// report CRUD; aggregator/scheduler still take db directly until their own
+// repos are extracted (slice 1b-v).
+func New(cfg *config.Config, db *database.DB, reports ReportRepo) *Module {
 	m := &Module{
 		cfg: cfg,
 		db:  db,
@@ -31,11 +34,11 @@ func New(cfg *config.Config, db *database.DB) *Module {
 	// Create services in dependency order:
 	// 1. Templates (no dependencies)
 	// 2. Aggregator (needs db)
-	// 3. Generator (needs templates + aggregator)
+	// 3. Generator (needs report repo + templates + aggregator)
 	// 4. Scheduler (needs generator)
 	m.templates = NewTemplateService(cfg)
 	m.aggregator = NewAggregatorService(cfg, db)
-	m.generator = NewGeneratorService(cfg, db, m.templates, m.aggregator)
+	m.generator = NewGeneratorService(cfg, reports, db, m.templates, m.aggregator)
 	m.scheduler = NewSchedulerService(cfg, db, m.generator)
 
 	return m

--- a/internal/modules/harvest/ports.go
+++ b/internal/modules/harvest/ports.go
@@ -1,0 +1,23 @@
+package harvest
+
+import "context"
+
+// ports.go declares the infrastructure interfaces the harvest module depends
+// on. The module is pure: it owns these ports, and the concrete I/O lives in
+// internal/adapters/* (inward-only — an adapter imports harvest, never the
+// reverse). See docs/architecture/PHASE3_EXTRACTION_PLAN.md §4.7.
+
+// ReportRepo persists report records. The SQLite implementation lives in
+// internal/adapters/store. The service depends on this interface so report
+// orchestration can be unit-tested with a fake repo (no database).
+type ReportRepo interface {
+	// GetReport returns the report row with the given id.
+	GetReport(ctx context.Context, id string) (*Report, error)
+	// ListReports returns all report rows, newest first.
+	ListReports(ctx context.Context) ([]Report, error)
+	// SaveReport upserts a report row.
+	SaveReport(ctx context.Context, r *Report) error
+	// DeleteReport removes the report row only; file cleanup is the service's
+	// orchestration concern.
+	DeleteReport(ctx context.Context, id string) error
+}

--- a/internal/modules/harvest/report_repo_test.go
+++ b/internal/modules/harvest/report_repo_test.go
@@ -1,0 +1,100 @@
+package harvest_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/krisarmstrong/seed/internal/modules/harvest"
+)
+
+// fakeReportRepo is an in-memory harvest.ReportRepo. It is the payoff of the
+// ReportRepo port (PHASE3_EXTRACTION_PLAN.md §4.5): GeneratorService's
+// report-record orchestration can now be exercised with no database and no
+// filesystem.
+type fakeReportRepo struct {
+	reports map[string]*harvest.Report
+	saveErr error
+}
+
+func newFakeReportRepo() *fakeReportRepo {
+	return &fakeReportRepo{reports: make(map[string]*harvest.Report)}
+}
+
+func (f *fakeReportRepo) GetReport(_ context.Context, id string) (*harvest.Report, error) {
+	r, ok := f.reports[id]
+	if !ok {
+		return nil, fmt.Errorf("report not found: %s", id)
+	}
+	clone := *r
+	return &clone, nil
+}
+
+func (f *fakeReportRepo) ListReports(_ context.Context) ([]harvest.Report, error) {
+	out := make([]harvest.Report, 0, len(f.reports))
+	for _, r := range f.reports {
+		out = append(out, *r)
+	}
+	return out, nil
+}
+
+func (f *fakeReportRepo) SaveReport(_ context.Context, r *harvest.Report) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	clone := *r
+	f.reports[r.ID] = &clone
+	return nil
+}
+
+func (f *fakeReportRepo) DeleteReport(_ context.Context, id string) error {
+	delete(f.reports, id)
+	return nil
+}
+
+// TestGeneratorService_ReportCRUD_NoDB exercises save → get → list → delete
+// against a fake repo. db/templates/aggregator are nil: report-record CRUD
+// touches none of them, which is the whole point of the port.
+func TestGeneratorService_ReportCRUD_NoDB(t *testing.T) {
+	repo := newFakeReportRepo()
+	gs := harvest.NewGeneratorService(testConfig(), repo, nil, nil, nil)
+	ctx := context.Background()
+
+	rep := &harvest.Report{
+		ID:        "r1",
+		Name:      "Quarterly",
+		Type:      harvest.ReportTypeExecutive,
+		Format:    harvest.FormatJSON,
+		Status:    harvest.StatusComplete,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, gs.ExportSaveReport(ctx, rep))
+
+	got, err := gs.GetReport(ctx, "r1")
+	require.NoError(t, err)
+	assert.Equal(t, "Quarterly", got.Name)
+
+	list, err := gs.ListReports(ctx)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+
+	require.NoError(t, gs.DeleteReport(ctx, "r1"))
+	_, err = gs.GetReport(ctx, "r1")
+	require.Error(t, err)
+}
+
+// TestGeneratorService_SaveReportError surfaces a repo write failure through
+// the service unchanged.
+func TestGeneratorService_SaveReportError(t *testing.T) {
+	repo := newFakeReportRepo()
+	repo.saveErr = errors.New("disk full")
+	gs := harvest.NewGeneratorService(testConfig(), repo, nil, nil, nil)
+
+	err := gs.ExportSaveReport(context.Background(), &harvest.Report{ID: "r1", CreatedAt: time.Now()})
+	require.ErrorContains(t, err, "disk full")
+}

--- a/internal/modules/harvest/scheduler/scheduler_test.go
+++ b/internal/modules/harvest/scheduler/scheduler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/krisarmstrong/seed/internal/adapters/store"
 	"github.com/krisarmstrong/seed/internal/config"
 	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/modules/harvest"
@@ -53,7 +54,7 @@ func setupSchedulerService(t *testing.T) (
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	return ss, cleanup

--- a/internal/modules/harvest/services.go
+++ b/internal/modules/harvest/services.go
@@ -9,7 +9,6 @@ package harvest
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -98,8 +97,13 @@ const (
 )
 
 // GeneratorService generates reports in various formats.
+//
+// It depends on a ReportRepo port for report-record persistence; db is
+// retained only for the bulk-export queries in services_export.go (devices /
+// device_vulnerabilities), which move behind an ExportRepo in slice 1b-v.
 type GeneratorService struct {
 	cfg         *config.Config
+	reports     ReportRepo
 	db          *database.DB
 	templates   *TemplateService
 	aggregator  *AggregatorService
@@ -110,12 +114,14 @@ type GeneratorService struct {
 // NewGeneratorService creates a new generator service.
 func NewGeneratorService(
 	cfg *config.Config,
+	reports ReportRepo,
 	db *database.DB,
 	templates *TemplateService,
 	aggregator *AggregatorService,
 ) *GeneratorService {
 	return &GeneratorService{
 		cfg:         cfg,
+		reports:     reports,
 		db:          db,
 		templates:   templates,
 		aggregator:  aggregator,
@@ -258,27 +264,5 @@ func (s *GeneratorService) failReport(ctx context.Context, report *Report, errMs
 }
 
 func (s *GeneratorService) saveReport(ctx context.Context, report *Report) error {
-	paramsJSON, _ := json.Marshal(report.Parameters)
-
-	var completedAt, expiresAt *string
-	if report.CompletedAt != nil {
-		t := report.CompletedAt.Format(time.RFC3339)
-		completedAt = &t
-	}
-	if report.ExpiresAt != nil {
-		t := report.ExpiresAt.Format(time.RFC3339)
-		expiresAt = &t
-	}
-
-	_, err := s.db.Exec(ctx, `
-		INSERT OR REPLACE INTO reports (id, name, type, format, template, status, file_path, file_size, parameters_json, error, created_at, completed_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, report.ID, report.Name, report.Type, report.Format, report.Template, report.Status,
-		report.FilePath, report.FileSize, string(paramsJSON), report.Error,
-		report.CreatedAt.Format(time.RFC3339), completedAt, expiresAt)
-	if err != nil {
-		return fmt.Errorf("saving report to database: %w", err)
-	}
-
-	return nil
+	return s.reports.SaveReport(ctx, report)
 }

--- a/internal/modules/harvest/services_reports.go
+++ b/internal/modules/harvest/services_reports.go
@@ -6,13 +6,11 @@ package harvest
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"slices"
-	"time"
 )
 
 // GenerateFromTemplate creates a report using a template.
@@ -38,69 +36,12 @@ func (s *GeneratorService) GenerateFromTemplate(
 
 // GetReport retrieves a report by ID.
 func (s *GeneratorService) GetReport(ctx context.Context, id string) (*Report, error) {
-	row := s.db.QueryRow(ctx, `
-		SELECT id, name, type, format, template, status, file_path, file_size, parameters_json, error, created_at, completed_at, expires_at
-		FROM reports WHERE id = ?
-	`, id)
-
-	return s.scanReport(row)
+	return s.reports.GetReport(ctx, id)
 }
 
 // ListReports returns all generated reports.
 func (s *GeneratorService) ListReports(ctx context.Context) ([]Report, error) {
-	rows, err := s.db.Query(ctx, `
-		SELECT id, name, type, format, template, status, file_path, file_size, parameters_json, error, created_at, completed_at, expires_at
-		FROM reports ORDER BY created_at DESC
-	`)
-	if err != nil {
-		return nil, fmt.Errorf("querying reports: %w", err)
-	}
-	defer rows.Close()
-
-	var reports []Report
-	for rows.Next() {
-		report, scanErr := s.scanReportFromRows(rows)
-		if scanErr != nil {
-			return nil, scanErr
-		}
-		reports = append(reports, *report)
-	}
-	if rowsErr := rows.Err(); rowsErr != nil {
-		return nil, fmt.Errorf("iterating reports: %w", rowsErr)
-	}
-
-	return reports, nil
-}
-
-func (s *GeneratorService) scanReport(row interface{ Scan(...any) error }) (*Report, error) {
-	var r Report
-	var paramsJSON, completedAt, expiresAt *string
-
-	err := row.Scan(&r.ID, &r.Name, &r.Type, &r.Format, &r.Template, &r.Status,
-		&r.FilePath, &r.FileSize, &paramsJSON, &r.Error, &r.CreatedAt, &completedAt, &expiresAt)
-	if err != nil {
-		return nil, fmt.Errorf("scanning report: %w", err)
-	}
-
-	if paramsJSON != nil {
-		_ = json.Unmarshal([]byte(*paramsJSON), &r.Parameters)
-	}
-	if completedAt != nil {
-		t, _ := time.Parse(time.RFC3339, *completedAt)
-		r.CompletedAt = &t
-	}
-	if expiresAt != nil {
-		t, _ := time.Parse(time.RFC3339, *expiresAt)
-		r.ExpiresAt = &t
-	}
-
-	return &r, nil
-}
-
-func (s *GeneratorService) scanReportFromRows(
-	rows interface{ Scan(...any) error },
-) (*Report, error) {
-	return s.scanReport(rows)
+	return s.reports.ListReports(ctx)
 }
 
 // DownloadReport returns the report file content.
@@ -134,9 +75,5 @@ func (s *GeneratorService) DeleteReport(ctx context.Context, id string) error {
 		_ = os.Remove(report.FilePath)
 	}
 
-	_, err = s.db.Exec(ctx, "DELETE FROM reports WHERE id = ?", id)
-	if err != nil {
-		return fmt.Errorf("deleting report from database: %w", err)
-	}
-	return nil
+	return s.reports.DeleteReport(ctx, id)
 }

--- a/internal/modules/harvest/services_test.go
+++ b/internal/modules/harvest/services_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/krisarmstrong/seed/internal/adapters/store"
 	"github.com/krisarmstrong/seed/internal/config"
 	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/modules/harvest"
@@ -474,7 +475,7 @@ func TestSchedulerService_Create(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -570,7 +571,7 @@ func TestSchedulerService_Get(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -629,7 +630,7 @@ func TestSchedulerService_List(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -670,7 +671,7 @@ func TestSchedulerService_Update(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -755,7 +756,7 @@ func TestSchedulerService_Delete(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -800,7 +801,7 @@ func TestSchedulerService_StartStop(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -828,7 +829,7 @@ func TestCalculateNextRun(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -900,7 +901,7 @@ func TestGeneratorService_Generate(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -984,7 +985,7 @@ func TestGeneratorService_GenerateFromTemplate(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -1051,7 +1052,7 @@ func TestGeneratorService_Export(t *testing.T) {
 	as := harvest.NewAggregatorService(cfg, db)
 
 	// Create generator with a temp directory for reports
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -1138,7 +1139,7 @@ func TestGeneratorService_ListReports(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -1171,7 +1172,7 @@ func TestGeneratorService_GetReport(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -1206,7 +1207,7 @@ func TestGeneratorService_DeleteReport(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -1238,7 +1239,7 @@ func TestModule_New(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfig()
-	module := harvest.New(cfg, db)
+	module := harvest.New(cfg, db, store.NewReportRepo(db))
 
 	require.NotNil(t, module)
 	assert.NotNil(t, module.Generator())
@@ -1252,7 +1253,7 @@ func TestModule_StartStop(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfig()
-	module := harvest.New(cfg, db)
+	module := harvest.New(cfg, db, store.NewReportRepo(db))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -1275,7 +1276,7 @@ func TestModule_Accessors(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfig()
-	module := harvest.New(cfg, db)
+	module := harvest.New(cfg, db, store.NewReportRepo(db))
 
 	// Multiple calls should return the same instance
 	gen1 := module.Generator()
@@ -1300,7 +1301,7 @@ func TestModule_ConcurrentAccess(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfig()
-	module := harvest.New(cfg, db)
+	module := harvest.New(cfg, db, store.NewReportRepo(db))
 
 	ctx := context.Background()
 	require.NoError(t, module.Start(ctx))
@@ -1356,7 +1357,7 @@ func TestGeneratorService_UnsupportedFormats(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -1436,7 +1437,7 @@ func TestSchedulerService_InvalidTimezone(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 	ss := harvest.NewSchedulerService(cfg, db, gs)
 
 	ctx := context.Background()
@@ -1468,7 +1469,7 @@ func TestReportParams_DateRangeCalculation(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -1508,7 +1509,7 @@ func TestExportResult_Fields(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -1544,7 +1545,7 @@ func TestDatabaseInteraction_Reports(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 
@@ -1650,7 +1651,7 @@ func TestGeneratorService_DownloadReport(t *testing.T) {
 	require.NoError(t, ts.Load())
 
 	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
## Phase 3 — slice 1b-iv: ReportRepo

Per `docs/architecture/PHASE3_EXTRACTION_PLAN.md` §4.7. Moves harvest's
report-record SQL out of the pure domain module behind a port; the SQL lands in
the **new `internal/adapters/store` ring**. Inward-only: the adapter imports
`harvest`, never the reverse (the Go compiler enforces this for `store` — a
production harvest file importing it is a hard import cycle).

### What changed
- **`internal/modules/harvest/ports.go`** — new `harvest.ReportRepo` interface
  (`GetReport`/`ListReports`/`SaveReport`/`DeleteReport` row-only).
- **`internal/adapters/store/harvest_repo.go`** — SQL + row scanning **lifted
  verbatim** from `services_reports.go` + `services.go:saveReport`
  (move-and-preserve, not a rewrite). `var _ harvest.ReportRepo` assertion.
- **`GeneratorService`** delegates report CRUD to the port; keeps
  `DeleteReport`'s `os.Remove` orchestration and keeps `db` for the bulk-export
  queries (those become an `ExportRepo` in 1b-v).
- **Wiring** — `harvest.New` / `NewGeneratorService` take the repo; the 2 prod
  callers (`cmd_serve.go`, `cmd_service_windows.go`) + all test sites build
  `store.NewReportRepo(db)`.
- **depguard** — split `modules-domain-purity`: the `net/http` + `database/sql`
  ban stays universal (prod **and** tests); the `internal/adapters` ban is now
  production-only (`!$test`, new `modules-no-adapter-import` rule) so test files
  can legitimately wire the real store adapter (tests are mini composition
  roots). RED-proven both halves.
- **`report_repo_test.go`** — DB-free `GeneratorService` unit test via a fake
  `ReportRepo` (the §4.5 payoff).

### Gates
- ✅ **Golden HTTP suite unchanged** (behavior gate)
- ✅ `go test ./...` green
- ✅ `golangci-lint` 0 issues; depguard green
- ✅ `check-route-policy.sh`, `check-output-escaping.sh` pass

### Next
1b-v: `ScheduleRepo` + `MetricsRepo`/`ExportRepo`, then ban `internal/database`
from `modules/harvest` and seed `internal/app/harvest.go`.