### PR TITLE
refactor(harvest): Schedule/Metrics/Export repos — module persistence-free (Phase 3 1b-v)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -267,6 +267,17 @@ linters:
         # through platform/events, never a direct import. One rule per module
         # (a module may import its OWN sub-packages, so only sibling module roots
         # are denied). Sibling roots are listed ahead of their extraction.
+        # harvest is fully persistence-free (Phase 3 slice 1b-v): all SQL lives
+        # behind repo ports in adapters/store. Production code must not import
+        # internal/database. Test files are exempt (!$test) — they open real
+        # SQLite DBs via database.Open to back the store adapters under test.
+        "harvest-no-database":
+          files:
+            - "**/internal/modules/harvest/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/krisarmstrong/seed/internal/database
+              desc: "harvest is persistence-free — define a Repo port, implement it in adapters/store"
         "harvest-module-independence":
           files:
             - "**/internal/modules/harvest/**"

--- a/cmd/seed/cmd_serve.go
+++ b/cmd/seed/cmd_serve.go
@@ -12,14 +12,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/krisarmstrong/seed/internal/adapters/store"
 	api "github.com/krisarmstrong/seed/internal/api"
+	"github.com/krisarmstrong/seed/internal/app"
 	"github.com/krisarmstrong/seed/internal/auth"
 	"github.com/krisarmstrong/seed/internal/canopy"
 	"github.com/krisarmstrong/seed/internal/config"
 	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/logging"
-	"github.com/krisarmstrong/seed/internal/modules/harvest"
 	"github.com/krisarmstrong/seed/internal/netif"
 	"github.com/krisarmstrong/seed/internal/paths"
 	"github.com/krisarmstrong/seed/internal/pipeline"
@@ -131,7 +130,7 @@ func initializeModules(cfg *config.Config, db *database.DB) *api.Modules {
 	logging.GetLogger().Info("Roots module initialized")
 
 	// Harvest: Reporting (report generation, templates, scheduling)
-	modules.Harvest = harvest.New(cfg, db, store.NewReportRepo(db))
+	modules.Harvest = app.NewHarvest(cfg, db)
 	logging.GetLogger().Info("Harvest module initialized")
 
 	return modules

--- a/cmd/seed/cmd_service_windows.go
+++ b/cmd/seed/cmd_service_windows.go
@@ -13,14 +13,13 @@ import (
 	"github.com/kardianos/service"
 	"github.com/spf13/cobra"
 
-	"github.com/krisarmstrong/seed/internal/adapters/store"
 	api "github.com/krisarmstrong/seed/internal/api"
+	"github.com/krisarmstrong/seed/internal/app"
 	"github.com/krisarmstrong/seed/internal/auth"
 	"github.com/krisarmstrong/seed/internal/canopy"
 	"github.com/krisarmstrong/seed/internal/config"
 	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/logging"
-	"github.com/krisarmstrong/seed/internal/modules/harvest"
 	"github.com/krisarmstrong/seed/internal/netif"
 	"github.com/krisarmstrong/seed/internal/paths"
 	"github.com/krisarmstrong/seed/internal/pipeline"
@@ -249,7 +248,7 @@ func initializeModulesForService(cfg *config.Config, db *database.DB) *api.Modul
 	modules.Shell = shell.New(cfg, db)
 	modules.Canopy = canopy.New(cfg, db)
 	modules.Roots = pipeline.New(cfg, db)
-	modules.Harvest = harvest.New(cfg, db, store.NewReportRepo(db))
+	modules.Harvest = app.NewHarvest(cfg, db)
 
 	return modules
 }

--- a/docs/architecture/PHASE3_EXTRACTION_PLAN.md
+++ b/docs/architecture/PHASE3_EXTRACTION_PLAN.md
@@ -127,15 +127,15 @@ deny `net/http`, `database/sql`, `internal/adapters/**`, and the other four
 
 ### 4.5 Acceptance criteria (pilot done when all true)
 
-- [ ] `go test ./...` green; **harvest report/export golden snapshots unchanged**.
-- [ ] `internal/modules/harvest` imports no `net/http`, no `database/sql`, no
-      `internal/adapters/**`, no sibling `internal/modules/*` — `depguard` at `deny`.
-- [~] harvest's logic has table-driven unit tests that run with **fake ports**
-      (no DB, no filesystem) — the payoff the phase exists for. Started in
-      1b-iv: `report_repo_test.go` exercises `GeneratorService` report CRUD with
-      a fake `ReportRepo` and nil db/templates/aggregator. Completes as the
-      remaining repos (1b-v) land.
-- [ ] `internal/app/harvest.go` builds the module from `Deps`; `internal/api/modules.go`
+- [x] `go test ./...` green; **harvest report/export golden snapshots unchanged**.
+- [x] `internal/modules/harvest` imports no `net/http`, no `database/sql`, no
+      `internal/adapters/**`, no `internal/database`, no sibling
+      `internal/modules/*` — `depguard` at `deny` (1b-v completed the
+      `internal/database` ban, prod-only via `harvest-no-database`).
+- [x] harvest's logic has table-driven unit tests that run with **fake ports**
+      (no DB, no filesystem) — `report_repo_test.go` (fake `ReportRepo`) and
+      `aggregator_repo_test.go` (fake `MetricsRepo`).
+- [x] `internal/app/harvest.go` builds the module from `Deps`; `internal/api/modules.go`
       consumes the module through the same surface (no behavior change).
 - [x] The harvest→health coupling is gone (it was dead code — deleted, #1428).
 - [ ] Docs synced (§7): `THE_SEED_ARCHITECTURE` harvest section + folder-tree + ring diagram.
@@ -163,9 +163,20 @@ Resliced during execution into atomic PRs:
    the real store adapter (`modules-no-adapter-import`). Golden HTTP suite
    unchanged; lint 0; `go test ./...` green. Added a DB-free `GeneratorService`
    unit test via a fake `ReportRepo`.
-5. ⏳ **1b-v** — NEXT: `ScheduleRepo` (scheduler) + `MetricsRepo`/`ExportRepo`
-   (aggregator + export device/vuln queries), then ban `internal/database` from
-   `modules/harvest` in `depguard` and seed `internal/app/harvest.go`.
+5. ✅ **1b-v ScheduleRepo + MetricsRepo + ExportRepo** — all remaining harvest
+   SQL lifted into `internal/adapters/store` (`harvest_schedule_repo.go`,
+   `harvest_metrics_repo.go`, `harvest_export_repo.go`), behind three new ports
+   in `ports.go`. The aggregator keeps severity-bucket / category semantics
+   (the meaning of `statusCritical` stays in the domain; `MetricsRepo` returns a
+   raw `severity → count` map); `sqliteDateFormat` moved to the adapter (a SQL
+   concern). `GeneratorService`/`AggregatorService`/`SchedulerService` no longer
+   hold `*database.DB`. `harvest.New` now takes a **`Deps`** struct; the new
+   `internal/app/harvest.go` composition root wires the store adapters and is
+   called by both prod callers (`app.NewHarvest(cfg, db)`). `depguard`
+   `harvest-no-database` bans `internal/database` in harvest production code
+   (`!$test`; tests still open real SQLite). Golden HTTP suite unchanged; lint 0;
+   `go test ./...` green. Added `aggregator_repo_test.go` (DB-free aggregator via
+   a fake `MetricsRepo`). **The harvest module is now fully persistence-free.**
 
 (Clock/IDGen ports: optional/low-value — `time.Now()` sprawls 7 files, mostly
 presentational PDF/CSV stamps. Skip unless determinism is needed.)

--- a/internal/adapters/store/harvest_export_repo.go
+++ b/internal/adapters/store/harvest_export_repo.go
@@ -1,0 +1,101 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/modules/harvest"
+)
+
+// ExportRepo implements harvest.ExportRepo over the devices and
+// device_vulnerabilities tables. The SQL and scanning were lifted verbatim from
+// the harvest module (services_export.go) when the module was made I/O-free —
+// Phase 3 slice 1b-v.
+type ExportRepo struct {
+	db *database.DB
+}
+
+// NewExportRepo constructs an ExportRepo backed by db.
+func NewExportRepo(db *database.DB) *ExportRepo {
+	return &ExportRepo{db: db}
+}
+
+// Compile-time assertion that the adapter satisfies the module's port.
+var _ harvest.ExportRepo = (*ExportRepo)(nil)
+
+// ExportDevices returns all device rows, newest-seen first.
+func (r *ExportRepo) ExportDevices(ctx context.Context) ([]map[string]any, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, ip_address, mac_address, hostname, vendor, device_type, first_seen, last_seen
+		FROM devices ORDER BY last_seen DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying devices: %w", err)
+	}
+	defer rows.Close()
+
+	var devices []map[string]any
+	for rows.Next() {
+		var id, ip, mac, hostname, vendor, deviceType, firstSeen, lastSeen string
+		if scanErr := rows.Scan(
+			&id,
+			&ip,
+			&mac,
+			&hostname,
+			&vendor,
+			&deviceType,
+			&firstSeen,
+			&lastSeen,
+		); scanErr != nil {
+			continue
+		}
+		devices = append(devices, map[string]any{
+			"id":          id,
+			"ip_address":  ip,
+			"mac_address": mac,
+			"hostname":    hostname,
+			"vendor":      vendor,
+			"device_type": deviceType,
+			"first_seen":  firstSeen,
+			"last_seen":   lastSeen,
+		})
+	}
+
+	return devices, nil
+}
+
+// ExportVulnerabilities returns all vulnerability rows joined to device IPs.
+func (r *ExportRepo) ExportVulnerabilities(ctx context.Context) ([]map[string]any, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT dv.id, dv.device_id, dv.cve_id, dv.severity, dv.description, dv.discovered_at, d.ip_address
+		FROM device_vulnerabilities dv
+		LEFT JOIN devices d ON dv.device_id = d.id
+		ORDER BY dv.severity DESC, dv.discovered_at DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying vulnerabilities: %w", err)
+	}
+	defer rows.Close()
+
+	var vulns []map[string]any
+	for rows.Next() {
+		var id int
+		var deviceID, cveID, severity, desc, discoveredAt string
+		var ipAddr *string
+		if scanErr := rows.Scan(&id, &deviceID, &cveID, &severity, &desc, &discoveredAt, &ipAddr); scanErr != nil {
+			continue
+		}
+		vulns = append(vulns, map[string]any{
+			"id":            id,
+			"device_id":     deviceID,
+			"cve_id":        cveID,
+			"severity":      severity,
+			"description":   desc,
+			"discovered_at": discoveredAt,
+			"device_ip":     ipAddr,
+		})
+	}
+
+	return vulns, nil
+}

--- a/internal/adapters/store/harvest_metrics_repo.go
+++ b/internal/adapters/store/harvest_metrics_repo.go
@@ -1,0 +1,244 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/modules/harvest"
+)
+
+// sqliteDateFormat is the strftime grouping format for trend buckets. It is a
+// SQLite-dialect concern, so it lives with the SQL in the adapter.
+const sqliteDateFormat = "%Y-%m-%d"
+
+// MetricsRepo implements harvest.MetricsRepo over the diagnostics tables. The
+// SQL and scanning were lifted verbatim from the harvest module
+// (services_aggregator.go) when the module was made I/O-free — Phase 3 slice
+// 1b-v. The repo returns raw results (e.g. severity → count); the domain owns
+// the severity-bucket and category semantics.
+type MetricsRepo struct {
+	db *database.DB
+}
+
+// NewMetricsRepo constructs a MetricsRepo backed by db.
+func NewMetricsRepo(db *database.DB) *MetricsRepo {
+	return &MetricsRepo{db: db}
+}
+
+// Compile-time assertion that the adapter satisfies the module's port.
+var _ harvest.MetricsRepo = (*MetricsRepo)(nil)
+
+// CountDevices returns the total device count.
+func (r *MetricsRepo) CountDevices(ctx context.Context) (int, error) {
+	var count int
+	row := r.db.QueryRow(ctx, "SELECT COUNT(*) FROM devices")
+	if err := row.Scan(&count); err != nil {
+		return 0, fmt.Errorf("counting devices: %w", err)
+	}
+	return count, nil
+}
+
+// VulnerabilitySeverityCounts returns severity → count discovered since `since`.
+func (r *MetricsRepo) VulnerabilitySeverityCounts(
+	ctx context.Context,
+	since time.Time,
+) (map[string]int, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT severity, COUNT(*) as count
+		FROM device_vulnerabilities
+		WHERE discovered_at >= ?
+		GROUP BY severity
+	`, since.Format(time.RFC3339))
+	if err != nil {
+		return nil, fmt.Errorf("querying vulnerability counts: %w", err)
+	}
+	defer rows.Close()
+
+	counts := make(map[string]int)
+	for rows.Next() {
+		var severity string
+		var count int
+		if scanErr := rows.Scan(&severity, &count); scanErr != nil {
+			continue
+		}
+		counts[severity] = count
+	}
+
+	return counts, nil
+}
+
+// PerformanceMetrics returns averaged latency / packet-loss / bandwidth /
+// uptime since `since`. Defaults (notably 100% uptime with no data) are
+// preserved from the original aggregator.
+func (r *MetricsRepo) PerformanceMetrics(
+	ctx context.Context,
+	since time.Time,
+) (harvest.PerformanceMetrics, error) {
+	var perf harvest.PerformanceMetrics
+
+	// Get average latency from gateway results
+	row := r.db.QueryRow(ctx, `
+		SELECT AVG(latency_ms), AVG(packet_loss)
+		FROM gateway_results
+		WHERE timestamp >= ?
+	`, since.Format(time.RFC3339))
+
+	var avgLatency, avgPacketLoss *float64
+	_ = row.Scan(&avgLatency, &avgPacketLoss)
+
+	if avgLatency != nil {
+		perf.AvgLatencyMs = *avgLatency
+	}
+	if avgPacketLoss != nil {
+		perf.AvgPacketLoss = *avgPacketLoss
+	}
+
+	// Get average bandwidth from speedtest results
+	row = r.db.QueryRow(ctx, `
+		SELECT AVG((download_mbps + upload_mbps) / 2)
+		FROM speedtest_results
+		WHERE timestamp >= ?
+	`, since.Format(time.RFC3339))
+
+	var avgBandwidth *float64
+	_ = row.Scan(&avgBandwidth)
+	if avgBandwidth != nil {
+		perf.AvgBandwidthMbps = *avgBandwidth
+	}
+
+	// Calculate uptime (simplified: based on successful gateway checks)
+	row = r.db.QueryRow(ctx, `
+		SELECT
+			COUNT(CASE WHEN success = 1 THEN 1 END) * 100.0 / COUNT(*)
+		FROM gateway_results
+		WHERE timestamp >= ?
+	`, since.Format(time.RFC3339))
+
+	var uptime *float64
+	_ = row.Scan(&uptime)
+	if uptime != nil {
+		perf.UptimePercent = *uptime
+	} else {
+		perf.UptimePercent = 100.0 // Default to 100% if no data
+	}
+
+	return perf, nil
+}
+
+// TopIssues returns the highest-impact vulnerability issues.
+func (r *MetricsRepo) TopIssues(ctx context.Context) ([]harvest.IssueSummary, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT severity, description, COUNT(*) as count
+		FROM device_vulnerabilities
+		GROUP BY description
+		ORDER BY
+			CASE severity
+				WHEN 'critical' THEN 1
+				WHEN 'high' THEN 2
+				WHEN 'medium' THEN 3
+				ELSE 4
+			END,
+			count DESC
+		LIMIT 10
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying top issues: %w", err)
+	}
+	defer rows.Close()
+
+	var issues []harvest.IssueSummary
+	for rows.Next() {
+		var issue harvest.IssueSummary
+		if scanErr := rows.Scan(&issue.Severity, &issue.Description, &issue.Count); scanErr != nil {
+			continue
+		}
+		issue.Category = "vulnerability"
+		issues = append(issues, issue)
+	}
+
+	return issues, nil
+}
+
+// Trends returns time-series points for a metric over a period.
+func (r *MetricsRepo) Trends(
+	ctx context.Context,
+	metric, period string,
+) ([]harvest.DataPoint, error) {
+	// Determine time range and grouping
+	now := time.Now()
+	var startDate time.Time
+	var groupFormat string
+
+	switch period {
+	case harvest.PeriodDaily:
+		startDate = now.AddDate(0, 0, -1)
+		groupFormat = "%Y-%m-%d %H:00"
+	case harvest.PeriodWeekly:
+		startDate = now.AddDate(0, 0, -7)
+		groupFormat = sqliteDateFormat
+	case harvest.PeriodMonthly:
+		startDate = now.AddDate(0, -1, 0)
+		groupFormat = sqliteDateFormat
+	default:
+		startDate = now.AddDate(0, 0, -7)
+		groupFormat = sqliteDateFormat
+	}
+
+	var query string
+	switch metric {
+	case "latency":
+		query = fmt.Sprintf(`
+			SELECT strftime('%s', timestamp) as period, AVG(latency_ms)
+			FROM gateway_results
+			WHERE timestamp >= ?
+			GROUP BY period
+			ORDER BY period
+		`, groupFormat)
+	case "bandwidth":
+		query = fmt.Sprintf(`
+			SELECT strftime('%s', timestamp) as period, AVG(download_mbps)
+			FROM speedtest_results
+			WHERE timestamp >= ?
+			GROUP BY period
+			ORDER BY period
+		`, groupFormat)
+	case "devices":
+		query = fmt.Sprintf(`
+			SELECT strftime('%s', last_seen) as period, COUNT(*)
+			FROM devices
+			WHERE last_seen >= ?
+			GROUP BY period
+			ORDER BY period
+		`, groupFormat)
+	default:
+		return nil, fmt.Errorf("unsupported metric: %s", metric)
+	}
+
+	rows, err := r.db.Query(ctx, query, startDate.Format(time.RFC3339))
+	if err != nil {
+		return nil, fmt.Errorf("querying trends: %w", err)
+	}
+	defer rows.Close()
+
+	var points []harvest.DataPoint
+	for rows.Next() {
+		var periodStr string
+		var value float64
+		if scanErr := rows.Scan(&periodStr, &value); scanErr != nil {
+			continue
+		}
+
+		t, _ := time.Parse("2006-01-02", periodStr)
+		points = append(points, harvest.DataPoint{
+			Timestamp: t,
+			Value:     value,
+		})
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("iterating trend data: %w", rowsErr)
+	}
+
+	return points, nil
+}

--- a/internal/adapters/store/harvest_schedule_repo.go
+++ b/internal/adapters/store/harvest_schedule_repo.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/modules/harvest"
+)
+
+// ScheduleRepo implements harvest.ScheduleRepo over the scheduled_reports table.
+// The SQL and row scanning were lifted verbatim from the harvest module
+// (services_scheduler.go) when the module was made I/O-free — Phase 3 slice 1b-v.
+type ScheduleRepo struct {
+	db *database.DB
+}
+
+// NewScheduleRepo constructs a ScheduleRepo backed by db.
+func NewScheduleRepo(db *database.DB) *ScheduleRepo {
+	return &ScheduleRepo{db: db}
+}
+
+// Compile-time assertion that the adapter satisfies the module's port.
+var _ harvest.ScheduleRepo = (*ScheduleRepo)(nil)
+
+// ListSchedules returns every persisted scheduled report. Rows that fail to
+// scan are skipped (best-effort load, preserved from the original loader).
+func (r *ScheduleRepo) ListSchedules(ctx context.Context) ([]harvest.ScheduledReport, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, name, template, format, schedule_json, parameters_json, recipients_json, enabled, last_run, next_run, created_at, updated_at
+		FROM scheduled_reports
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying scheduled reports: %w", err)
+	}
+	defer rows.Close()
+
+	var schedules []harvest.ScheduledReport
+	for rows.Next() {
+		var sr harvest.ScheduledReport
+		var scheduleJSON, paramsJSON, recipientsJSON string
+		var lastRun, nextRun *string
+
+		scanErr := rows.Scan(
+			&sr.ID,
+			&sr.Name,
+			&sr.Template,
+			&sr.Format,
+			&scheduleJSON,
+			&paramsJSON,
+			&recipientsJSON,
+			&sr.Enabled,
+			&lastRun,
+			&nextRun,
+			&sr.CreatedAt,
+			&sr.UpdatedAt,
+		)
+		if scanErr != nil {
+			continue
+		}
+
+		_ = json.Unmarshal([]byte(scheduleJSON), &sr.Schedule)
+		_ = json.Unmarshal([]byte(paramsJSON), &sr.Parameters)
+		_ = json.Unmarshal([]byte(recipientsJSON), &sr.Recipients)
+
+		if lastRun != nil {
+			t, _ := time.Parse(time.RFC3339, *lastRun)
+			sr.LastRun = &t
+		}
+		if nextRun != nil {
+			t, _ := time.Parse(time.RFC3339, *nextRun)
+			sr.NextRun = &t
+		}
+
+		schedules = append(schedules, sr)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("iterating scheduled reports: %w", rowsErr)
+	}
+
+	return schedules, nil
+}
+
+// SaveSchedule upserts a scheduled-report row.
+func (r *ScheduleRepo) SaveSchedule(ctx context.Context, sr *harvest.ScheduledReport) error {
+	scheduleJSON, _ := json.Marshal(sr.Schedule)
+	paramsJSON, _ := json.Marshal(sr.Parameters)
+	recipientsJSON, _ := json.Marshal(sr.Recipients)
+
+	var lastRun, nextRun *string
+	if sr.LastRun != nil {
+		t := sr.LastRun.Format(time.RFC3339)
+		lastRun = &t
+	}
+	if sr.NextRun != nil {
+		t := sr.NextRun.Format(time.RFC3339)
+		nextRun = &t
+	}
+
+	_, err := r.db.Exec(
+		ctx,
+		`
+		INSERT OR REPLACE INTO scheduled_reports (id, name, template, format, schedule_json, parameters_json, recipients_json, enabled, last_run, next_run, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		sr.ID,
+		sr.Name,
+		sr.Template,
+		sr.Format,
+		string(scheduleJSON),
+		string(paramsJSON),
+		string(recipientsJSON),
+		sr.Enabled,
+		lastRun,
+		nextRun,
+		sr.CreatedAt.Format(time.RFC3339),
+		sr.UpdatedAt.Format(time.RFC3339),
+	)
+	if err != nil {
+		return fmt.Errorf("saving scheduled report: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteSchedule removes a scheduled-report row.
+func (r *ScheduleRepo) DeleteSchedule(ctx context.Context, id string) error {
+	_, err := r.db.Exec(ctx, "DELETE FROM scheduled_reports WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("deleting scheduled report: %w", err)
+	}
+	return nil
+}

--- a/internal/app/harvest.go
+++ b/internal/app/harvest.go
@@ -1,0 +1,23 @@
+// Package app is the composition root: it wires domain modules
+// (internal/modules/*) to their infrastructure adapters (internal/adapters/*)
+// and hands the assembled modules to the API layer. It is the one place that
+// may depend on both a module and its adapters, keeping that knowledge out of
+// the pure module cores.
+package app
+
+import (
+	"github.com/krisarmstrong/seed/internal/adapters/store"
+	"github.com/krisarmstrong/seed/internal/config"
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/modules/harvest"
+)
+
+// NewHarvest builds the Harvest module backed by the SQLite store adapters.
+func NewHarvest(cfg *config.Config, db *database.DB) *harvest.Module {
+	return harvest.New(cfg, harvest.Deps{
+		Reports:  store.NewReportRepo(db),
+		Schedule: store.NewScheduleRepo(db),
+		Metrics:  store.NewMetricsRepo(db),
+		Export:   store.NewExportRepo(db),
+	})
+}

--- a/internal/modules/harvest/aggregator_repo_test.go
+++ b/internal/modules/harvest/aggregator_repo_test.go
@@ -1,0 +1,84 @@
+package harvest_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/krisarmstrong/seed/internal/modules/harvest"
+)
+
+// fakeMetricsRepo is an in-memory harvest.MetricsRepo. It lets the aggregator's
+// severity-bucket and category mapping be tested with no database — the payoff
+// of the MetricsRepo port (PHASE3_EXTRACTION_PLAN.md §4.5).
+type fakeMetricsRepo struct {
+	devices   int
+	vulns     map[string]int
+	perf      harvest.PerformanceMetrics
+	topIssues []harvest.IssueSummary
+	trends    []harvest.DataPoint
+}
+
+func (f *fakeMetricsRepo) CountDevices(context.Context) (int, error) { return f.devices, nil }
+
+func (f *fakeMetricsRepo) VulnerabilitySeverityCounts(
+	context.Context, time.Time,
+) (map[string]int, error) {
+	return f.vulns, nil
+}
+
+func (f *fakeMetricsRepo) PerformanceMetrics(
+	context.Context, time.Time,
+) (harvest.PerformanceMetrics, error) {
+	return f.perf, nil
+}
+
+func (f *fakeMetricsRepo) TopIssues(context.Context) ([]harvest.IssueSummary, error) {
+	return f.topIssues, nil
+}
+
+func (f *fakeMetricsRepo) Trends(context.Context, string, string) ([]harvest.DataPoint, error) {
+	return f.trends, nil
+}
+
+// TestAggregatorService_Aggregate_NoDB verifies the domain maps raw severity
+// counts onto VulnCounts — known severities bucket; every severity (including
+// unknown ones) still contributes to Total — without touching a database.
+func TestAggregatorService_Aggregate_NoDB(t *testing.T) {
+	metrics := &fakeMetricsRepo{
+		devices: 12,
+		vulns:   map[string]int{"critical": 2, "high": 3, "medium": 5, "low": 1, "unknown": 4},
+		perf:    harvest.PerformanceMetrics{AvgLatencyMs: 10, UptimePercent: 99.5},
+		topIssues: []harvest.IssueSummary{
+			{Category: "vulnerability", Description: "CVE-X", Severity: "critical", Count: 2},
+		},
+	}
+	as := harvest.NewAggregatorService(testConfig(), metrics)
+
+	data, err := as.Aggregate(context.Background(), harvest.PeriodWeekly, "", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, 12, data.DeviceCount)
+	assert.Equal(t, 2, data.VulnCount.Critical)
+	assert.Equal(t, 3, data.VulnCount.High)
+	assert.Equal(t, 5, data.VulnCount.Medium)
+	assert.Equal(t, 1, data.VulnCount.Low)
+	assert.Equal(t, 15, data.VulnCount.Total) // 2+3+5+1+4 — unknown counts toward total
+	assert.InEpsilon(t, 99.5, data.Performance.UptimePercent, 0.0001)
+	assert.Len(t, data.TopIssues, 1)
+}
+
+// TestAggregatorService_GetTrends_NoDB confirms GetTrends delegates straight to
+// the metrics port.
+func TestAggregatorService_GetTrends_NoDB(t *testing.T) {
+	metrics := &fakeMetricsRepo{trends: []harvest.DataPoint{{Value: 1.5}}}
+	as := harvest.NewAggregatorService(testConfig(), metrics)
+
+	points, err := as.GetTrends(context.Background(), "latency", harvest.PeriodDaily)
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.InEpsilon(t, 1.5, points[0].Value, 0.0001)
+}

--- a/internal/modules/harvest/internal_test.go
+++ b/internal/modules/harvest/internal_test.go
@@ -142,8 +142,8 @@ func TestGenerateHTML_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	report := &harvest.Report{
 		ID:   "test-html",
@@ -189,8 +189,8 @@ func TestGenerateCSV_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	report := &harvest.Report{
 		ID:   "test-csv",
@@ -235,8 +235,8 @@ func TestGenerateJSON_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	report := &harvest.Report{
 		ID:   "test-json",
@@ -281,8 +281,8 @@ func TestGeneratePDF_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	tests := []struct {
 		name       string
@@ -348,8 +348,8 @@ func TestDataToCSV_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	tests := []struct {
 		name      string
@@ -416,8 +416,8 @@ func TestSaveReportFile_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 	gs.SetReportsPath(tmpDir)
 
 	tests := []struct {
@@ -488,7 +488,7 @@ func TestAggregateVulnerabilities_Internal(t *testing.T) {
 	setupVulnerabilityData(t, ctx, db)
 
 	cfg := testConfigHelper()
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 
 	data := &harvest.AggregatedData{}
 	since := time.Now().AddDate(0, 0, -7)
@@ -509,7 +509,7 @@ func TestAggregatePerformance_Internal(t *testing.T) {
 	setupPerformanceData(t, ctx, db)
 
 	cfg := testConfigHelper()
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 
 	data := &harvest.AggregatedData{}
 	since := time.Now().AddDate(0, 0, -7)
@@ -530,7 +530,7 @@ func TestAggregateTopIssues_Internal(t *testing.T) {
 	setupVulnerabilityData(t, ctx, db)
 
 	cfg := testConfigHelper()
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 
 	data := &harvest.AggregatedData{
 		TopIssues: make([]harvest.IssueSummary, 0), // Initialize to empty slice
@@ -550,9 +550,9 @@ func TestCheckSchedules_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 
@@ -590,9 +590,9 @@ func TestRunScheduledReport_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 
@@ -626,9 +626,9 @@ func TestLoadSchedules_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 
@@ -652,7 +652,7 @@ func TestLoadSchedules_Internal(t *testing.T) {
 	}
 
 	// Create a new scheduler service and load schedules
-	ss2 := harvest.NewSchedulerService(cfg, db, gs)
+	ss2 := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 	err := ss2.ExportLoadSchedules(ctx)
 	require.NoError(t, err)
 
@@ -672,9 +672,9 @@ func TestSaveSchedule_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 
@@ -711,7 +711,7 @@ func TestSaveSchedule_Internal(t *testing.T) {
 	// To retrieve it, we need to use Create which also adds it to the in-memory map
 	// Or alternatively, create using Create method which handles both
 	// Let's use Create instead since ExportSaveSchedule only saves to DB
-	ss2 := harvest.NewSchedulerService(cfg, db, gs)
+	ss2 := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 	schedule2 := &harvest.ScheduledReport{
 		Name:     "Save Schedule Test 2",
 		Template: "executive",
@@ -745,8 +745,8 @@ func TestExportDevices_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	req := &harvest.ExportRequest{
 		Type:   "devices",
@@ -772,8 +772,8 @@ func TestExportVulnerabilities_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	req := &harvest.ExportRequest{
 		Type:   "vulnerabilities",
@@ -800,8 +800,8 @@ func TestFailReport_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -833,8 +833,8 @@ func TestSaveReport_Internal(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 	now := time.Now()
@@ -941,8 +941,8 @@ func TestReportsPath_Internal(t *testing.T) {
 
 	cfg := testConfigHelper()
 	ts := harvest.NewTemplateService(cfg)
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	// Default path
 	defaultPath := gs.GetReportsPath()
@@ -1074,7 +1074,7 @@ func TestGetTrends_AllMetrics(t *testing.T) {
 	setupDeviceData(t, ctx, db)
 
 	cfg := testConfigHelper()
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 
 	tests := []struct {
 		name   string
@@ -1107,7 +1107,7 @@ func TestGetTrends_UnsupportedMetric(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfigHelper()
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 
 	ctx := context.Background()
 	_, err := as.GetTrends(ctx, "unsupported_metric", harvest.PeriodWeekly)
@@ -1123,8 +1123,8 @@ func TestGeneratorService_GenerateWithDateRanges(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -1168,8 +1168,8 @@ func TestGeneratorService_Export_Formats(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 	gs.SetReportsPath(tmpDir)
 
 	tests := []struct {
@@ -1206,9 +1206,9 @@ func TestSchedulerService_ScheduleVariations(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 
@@ -1281,7 +1281,7 @@ func TestAggregateVulnerabilities_WithData(t *testing.T) {
 	setupVulnerabilityData(t, ctx, db)
 
 	cfg := testConfigHelper()
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 
 	// Test with different date ranges
 	testRanges := []time.Duration{
@@ -1312,7 +1312,7 @@ func TestAggregatePerformance_AllScenarios(t *testing.T) {
 	setupPerformanceData(t, ctx, db)
 
 	cfg := testConfigHelper()
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 
 	tests := []struct {
 		name     string
@@ -1342,7 +1342,15 @@ func TestModuleStart_TemplateLoadError(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfigHelper()
-	module := harvest.New(cfg, db, store.NewReportRepo(db))
+	module := harvest.New(
+		cfg,
+		harvest.Deps{
+			Reports:  store.NewReportRepo(db),
+			Schedule: store.NewScheduleRepo(db),
+			Metrics:  store.NewMetricsRepo(db),
+			Export:   store.NewExportRepo(db),
+		},
+	)
 
 	// Start should succeed (templates load without error)
 	ctx := context.Background()

--- a/internal/modules/harvest/module.go
+++ b/internal/modules/harvest/module.go
@@ -7,39 +7,41 @@ import (
 	"sync"
 
 	"github.com/krisarmstrong/seed/internal/config"
-	"github.com/krisarmstrong/seed/internal/database"
 )
 
 // Module is the main Harvest module providing reporting services.
 type Module struct {
 	mu         sync.RWMutex
 	cfg        *config.Config
-	db         *database.DB
 	generator  *GeneratorService
 	templates  *TemplateService
 	scheduler  *SchedulerService
 	aggregator *AggregatorService
 }
 
-// New creates a new Harvest module instance. The report-record persistence
-// adapter is injected (ReportRepo port) so the module stays free of SQL for
-// report CRUD; aggregator/scheduler still take db directly until their own
-// repos are extracted (slice 1b-v).
-func New(cfg *config.Config, db *database.DB, reports ReportRepo) *Module {
-	m := &Module{
-		cfg: cfg,
-		db:  db,
-	}
+// Deps holds the persistence adapters the Harvest module depends on. The
+// composition root (internal/app) implements these ports with the SQLite
+// adapters in internal/adapters/store; the module itself is persistence-free.
+type Deps struct {
+	Reports  ReportRepo
+	Schedule ScheduleRepo
+	Metrics  MetricsRepo
+	Export   ExportRepo
+}
+
+// New creates a new Harvest module instance from its port dependencies.
+func New(cfg *config.Config, deps Deps) *Module {
+	m := &Module{cfg: cfg}
 
 	// Create services in dependency order:
 	// 1. Templates (no dependencies)
-	// 2. Aggregator (needs db)
-	// 3. Generator (needs report repo + templates + aggregator)
-	// 4. Scheduler (needs generator)
+	// 2. Aggregator (needs the metrics repo)
+	// 3. Generator (needs report + export repos + templates + aggregator)
+	// 4. Scheduler (needs the schedule repo + generator)
 	m.templates = NewTemplateService(cfg)
-	m.aggregator = NewAggregatorService(cfg, db)
-	m.generator = NewGeneratorService(cfg, reports, db, m.templates, m.aggregator)
-	m.scheduler = NewSchedulerService(cfg, db, m.generator)
+	m.aggregator = NewAggregatorService(cfg, deps.Metrics)
+	m.generator = NewGeneratorService(cfg, deps.Reports, deps.Export, m.templates, m.aggregator)
+	m.scheduler = NewSchedulerService(cfg, deps.Schedule, m.generator)
 
 	return m
 }

--- a/internal/modules/harvest/ports.go
+++ b/internal/modules/harvest/ports.go
@@ -1,6 +1,9 @@
 package harvest
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // ports.go declares the infrastructure interfaces the harvest module depends
 // on. The module is pure: it owns these ports, and the concrete I/O lives in
@@ -20,4 +23,42 @@ type ReportRepo interface {
 	// DeleteReport removes the report row only; file cleanup is the service's
 	// orchestration concern.
 	DeleteReport(ctx context.Context, id string) error
+}
+
+// ScheduleRepo persists scheduled-report records. The scheduler keeps its
+// in-memory map and tick loop; only the row CRUD crosses this port.
+type ScheduleRepo interface {
+	// ListSchedules returns every persisted scheduled report.
+	ListSchedules(ctx context.Context) ([]ScheduledReport, error)
+	// SaveSchedule upserts a scheduled-report row.
+	SaveSchedule(ctx context.Context, sr *ScheduledReport) error
+	// DeleteSchedule removes a scheduled-report row.
+	DeleteSchedule(ctx context.Context, id string) error
+}
+
+// MetricsRepo reads the aggregate metrics that feed reports. It returns raw
+// query results; the domain (AggregatorService) owns the severity-bucket and
+// category semantics so the meaning of "critical" stays in the module.
+type MetricsRepo interface {
+	// CountDevices returns the total device count.
+	CountDevices(ctx context.Context) (int, error)
+	// VulnerabilitySeverityCounts returns severity → count discovered since the
+	// given time. The domain maps these onto VulnCounts.
+	VulnerabilitySeverityCounts(ctx context.Context, since time.Time) (map[string]int, error)
+	// PerformanceMetrics returns averaged latency / packet-loss / bandwidth /
+	// uptime since the given time.
+	PerformanceMetrics(ctx context.Context, since time.Time) (PerformanceMetrics, error)
+	// TopIssues returns the highest-impact vulnerability issues.
+	TopIssues(ctx context.Context) ([]IssueSummary, error)
+	// Trends returns time-series points for a metric over a period.
+	Trends(ctx context.Context, metric, period string) ([]DataPoint, error)
+}
+
+// ExportRepo reads raw rows for bulk data export. Rows are returned as generic
+// maps because the export serializers (JSON/CSV) are schema-agnostic.
+type ExportRepo interface {
+	// ExportDevices returns all device rows, newest-seen first.
+	ExportDevices(ctx context.Context) ([]map[string]any, error)
+	// ExportVulnerabilities returns all vulnerability rows joined to device IPs.
+	ExportVulnerabilities(ctx context.Context) ([]map[string]any, error)
 }

--- a/internal/modules/harvest/scheduler/scheduler_test.go
+++ b/internal/modules/harvest/scheduler/scheduler_test.go
@@ -53,9 +53,9 @@ func setupSchedulerService(t *testing.T) (
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	return ss, cleanup
 }

--- a/internal/modules/harvest/services.go
+++ b/internal/modules/harvest/services.go
@@ -18,7 +18,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/krisarmstrong/seed/internal/config"
-	"github.com/krisarmstrong/seed/internal/database"
 )
 
 // DefaultReportsPath is the default directory for storing generated reports.
@@ -33,9 +32,6 @@ const (
 	PeriodWeekly  = "weekly"
 	PeriodMonthly = "monthly"
 )
-
-// SQLite date format for grouping.
-const sqliteDateFormat = "%Y-%m-%d"
 
 // PDF layout and formatting constants.
 const (
@@ -96,15 +92,13 @@ const (
 	sectionOrderRemediation = 6 // Order for remediation section
 )
 
-// GeneratorService generates reports in various formats.
-//
-// It depends on a ReportRepo port for report-record persistence; db is
-// retained only for the bulk-export queries in services_export.go (devices /
-// device_vulnerabilities), which move behind an ExportRepo in slice 1b-v.
+// GeneratorService generates reports in various formats. It is persistence-free:
+// report records go through the ReportRepo port and bulk export through the
+// ExportRepo port.
 type GeneratorService struct {
 	cfg         *config.Config
 	reports     ReportRepo
-	db          *database.DB
+	export      ExportRepo
 	templates   *TemplateService
 	aggregator  *AggregatorService
 	reportsPath string
@@ -115,14 +109,14 @@ type GeneratorService struct {
 func NewGeneratorService(
 	cfg *config.Config,
 	reports ReportRepo,
-	db *database.DB,
+	export ExportRepo,
 	templates *TemplateService,
 	aggregator *AggregatorService,
 ) *GeneratorService {
 	return &GeneratorService{
 		cfg:         cfg,
 		reports:     reports,
-		db:          db,
+		export:      export,
 		templates:   templates,
 		aggregator:  aggregator,
 		reportsPath: DefaultReportsPath,

--- a/internal/modules/harvest/services_aggregator.go
+++ b/internal/modules/harvest/services_aggregator.go
@@ -6,24 +6,23 @@ package harvest
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/config"
-	"github.com/krisarmstrong/seed/internal/database"
 )
 
-// AggregatorService aggregates data for reports.
+// AggregatorService aggregates data for reports. It reads metrics through the
+// MetricsRepo port and owns the severity-bucket / category semantics.
 type AggregatorService struct {
-	cfg *config.Config
-	db  *database.DB
+	cfg     *config.Config
+	metrics MetricsRepo
 }
 
 // NewAggregatorService creates a new aggregator service.
-func NewAggregatorService(cfg *config.Config, db *database.DB) *AggregatorService {
+func NewAggregatorService(cfg *config.Config, metrics MetricsRepo) *AggregatorService {
 	return &AggregatorService{
-		cfg: cfg,
-		db:  db,
+		cfg:     cfg,
+		metrics: metrics,
 	}
 }
 
@@ -53,9 +52,8 @@ func (s *AggregatorService) Aggregate(
 		EndDate:   now,
 	}
 
-	// Aggregate device count
-	row := s.db.QueryRow(ctx, "SELECT COUNT(*) FROM devices")
-	_ = row.Scan(&data.DeviceCount)
+	// Aggregate device count (best-effort: a query error leaves the zero value)
+	data.DeviceCount, _ = s.metrics.CountDevices(ctx)
 
 	// Aggregate vulnerability counts
 	s.aggregateVulnerabilities(ctx, data, startDate)
@@ -74,24 +72,10 @@ func (s *AggregatorService) aggregateVulnerabilities(
 	data *AggregatedData,
 	since time.Time,
 ) {
-	rows, err := s.db.Query(ctx, `
-		SELECT severity, COUNT(*) as count
-		FROM device_vulnerabilities
-		WHERE discovered_at >= ?
-		GROUP BY severity
-	`, since.Format(time.RFC3339))
-	if err != nil {
-		return
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var severity string
-		var count int
-		if scanErr := rows.Scan(&severity, &count); scanErr != nil {
-			continue
-		}
-
+	// The domain owns the meaning of each severity bucket; the repo returns the
+	// raw severity → count. A query error leaves VulnCount at its zero value.
+	counts, _ := s.metrics.VulnerabilitySeverityCounts(ctx, since)
+	for severity, count := range counts {
 		switch severity {
 		case statusCritical:
 			data.VulnCount.Critical = count
@@ -111,81 +95,12 @@ func (s *AggregatorService) aggregatePerformance(
 	data *AggregatedData,
 	since time.Time,
 ) {
-	// Get average latency from gateway results
-	row := s.db.QueryRow(ctx, `
-		SELECT AVG(latency_ms), AVG(packet_loss)
-		FROM gateway_results
-		WHERE timestamp >= ?
-	`, since.Format(time.RFC3339))
-
-	var avgLatency, avgPacketLoss *float64
-	_ = row.Scan(&avgLatency, &avgPacketLoss)
-
-	if avgLatency != nil {
-		data.Performance.AvgLatencyMs = *avgLatency
-	}
-	if avgPacketLoss != nil {
-		data.Performance.AvgPacketLoss = *avgPacketLoss
-	}
-
-	// Get average bandwidth from speedtest results
-	row = s.db.QueryRow(ctx, `
-		SELECT AVG((download_mbps + upload_mbps) / 2)
-		FROM speedtest_results
-		WHERE timestamp >= ?
-	`, since.Format(time.RFC3339))
-
-	var avgBandwidth *float64
-	_ = row.Scan(&avgBandwidth)
-	if avgBandwidth != nil {
-		data.Performance.AvgBandwidthMbps = *avgBandwidth
-	}
-
-	// Calculate uptime (simplified: based on successful gateway checks)
-	row = s.db.QueryRow(ctx, `
-		SELECT
-			COUNT(CASE WHEN success = 1 THEN 1 END) * 100.0 / COUNT(*)
-		FROM gateway_results
-		WHERE timestamp >= ?
-	`, since.Format(time.RFC3339))
-
-	var uptime *float64
-	_ = row.Scan(&uptime)
-	if uptime != nil {
-		data.Performance.UptimePercent = *uptime
-	} else {
-		data.Performance.UptimePercent = 100.0 // Default to 100% if no data
-	}
+	data.Performance, _ = s.metrics.PerformanceMetrics(ctx, since)
 }
 
 func (s *AggregatorService) aggregateTopIssues(ctx context.Context, data *AggregatedData) {
-	rows, err := s.db.Query(ctx, `
-		SELECT severity, description, COUNT(*) as count
-		FROM device_vulnerabilities
-		GROUP BY description
-		ORDER BY
-			CASE severity
-				WHEN 'critical' THEN 1
-				WHEN 'high' THEN 2
-				WHEN 'medium' THEN 3
-				ELSE 4
-			END,
-			count DESC
-		LIMIT 10
-	`)
-	if err != nil {
-		return
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var issue IssueSummary
-		if scanErr := rows.Scan(&issue.Severity, &issue.Description, &issue.Count); scanErr != nil {
-			continue
-		}
-		issue.Category = "vulnerability"
-		data.TopIssues = append(data.TopIssues, issue)
-	}
+	issues, _ := s.metrics.TopIssues(ctx)
+	data.TopIssues = append(data.TopIssues, issues...)
 }
 
 // GetTrends retrieves trend data for a metric.
@@ -193,79 +108,5 @@ func (s *AggregatorService) GetTrends(
 	ctx context.Context,
 	metric, period string,
 ) ([]DataPoint, error) {
-	// Determine time range and grouping
-	now := time.Now()
-	var startDate time.Time
-	var groupFormat string
-
-	switch period {
-	case PeriodDaily:
-		startDate = now.AddDate(0, 0, -1)
-		groupFormat = "%Y-%m-%d %H:00"
-	case PeriodWeekly:
-		startDate = now.AddDate(0, 0, -7)
-		groupFormat = sqliteDateFormat
-	case PeriodMonthly:
-		startDate = now.AddDate(0, -1, 0)
-		groupFormat = sqliteDateFormat
-	default:
-		startDate = now.AddDate(0, 0, -7)
-		groupFormat = sqliteDateFormat
-	}
-
-	var query string
-	switch metric {
-	case "latency":
-		query = fmt.Sprintf(`
-			SELECT strftime('%s', timestamp) as period, AVG(latency_ms)
-			FROM gateway_results
-			WHERE timestamp >= ?
-			GROUP BY period
-			ORDER BY period
-		`, groupFormat)
-	case "bandwidth":
-		query = fmt.Sprintf(`
-			SELECT strftime('%s', timestamp) as period, AVG(download_mbps)
-			FROM speedtest_results
-			WHERE timestamp >= ?
-			GROUP BY period
-			ORDER BY period
-		`, groupFormat)
-	case entityDevices:
-		query = fmt.Sprintf(`
-			SELECT strftime('%s', last_seen) as period, COUNT(*)
-			FROM devices
-			WHERE last_seen >= ?
-			GROUP BY period
-			ORDER BY period
-		`, groupFormat)
-	default:
-		return nil, fmt.Errorf("unsupported metric: %s", metric)
-	}
-
-	rows, err := s.db.Query(ctx, query, startDate.Format(time.RFC3339))
-	if err != nil {
-		return nil, fmt.Errorf("querying trends: %w", err)
-	}
-	defer rows.Close()
-
-	var points []DataPoint
-	for rows.Next() {
-		var periodStr string
-		var value float64
-		if scanErr := rows.Scan(&periodStr, &value); scanErr != nil {
-			continue
-		}
-
-		t, _ := time.Parse("2006-01-02", periodStr)
-		points = append(points, DataPoint{
-			Timestamp: t,
-			Value:     value,
-		})
-	}
-	if rowsErr := rows.Err(); rowsErr != nil {
-		return nil, fmt.Errorf("iterating trend data: %w", rowsErr)
-	}
-
-	return points, nil
+	return s.metrics.Trends(ctx, metric, period)
 }

--- a/internal/modules/harvest/services_export.go
+++ b/internal/modules/harvest/services_export.go
@@ -87,42 +87,10 @@ func (s *GeneratorService) Export(ctx context.Context, req *ExportRequest) (*Exp
 }
 
 func (s *GeneratorService) exportDevices(ctx context.Context, _ *ExportRequest) (any, int, error) {
-	rows, err := s.db.Query(ctx, `
-		SELECT id, ip_address, mac_address, hostname, vendor, device_type, first_seen, last_seen
-		FROM devices ORDER BY last_seen DESC
-	`)
+	devices, err := s.export.ExportDevices(ctx)
 	if err != nil {
-		return nil, 0, fmt.Errorf("querying devices: %w", err)
+		return nil, 0, err
 	}
-	defer rows.Close()
-
-	var devices []map[string]any
-	for rows.Next() {
-		var id, ip, mac, hostname, vendor, deviceType, firstSeen, lastSeen string
-		if scanErr := rows.Scan(
-			&id,
-			&ip,
-			&mac,
-			&hostname,
-			&vendor,
-			&deviceType,
-			&firstSeen,
-			&lastSeen,
-		); scanErr != nil {
-			continue
-		}
-		devices = append(devices, map[string]any{
-			"id":          id,
-			"ip_address":  ip,
-			"mac_address": mac,
-			"hostname":    hostname,
-			"vendor":      vendor,
-			"device_type": deviceType,
-			"first_seen":  firstSeen,
-			"last_seen":   lastSeen,
-		})
-	}
-
 	return devices, len(devices), nil
 }
 
@@ -130,36 +98,10 @@ func (s *GeneratorService) exportVulnerabilities(
 	ctx context.Context,
 	_ *ExportRequest,
 ) (any, int, error) {
-	rows, err := s.db.Query(ctx, `
-		SELECT dv.id, dv.device_id, dv.cve_id, dv.severity, dv.description, dv.discovered_at, d.ip_address
-		FROM device_vulnerabilities dv
-		LEFT JOIN devices d ON dv.device_id = d.id
-		ORDER BY dv.severity DESC, dv.discovered_at DESC
-	`)
+	vulns, err := s.export.ExportVulnerabilities(ctx)
 	if err != nil {
-		return nil, 0, fmt.Errorf("querying vulnerabilities: %w", err)
+		return nil, 0, err
 	}
-	defer rows.Close()
-
-	var vulns []map[string]any
-	for rows.Next() {
-		var id int
-		var deviceID, cveID, severity, desc, discoveredAt string
-		var ipAddr *string
-		if scanErr := rows.Scan(&id, &deviceID, &cveID, &severity, &desc, &discoveredAt, &ipAddr); scanErr != nil {
-			continue
-		}
-		vulns = append(vulns, map[string]any{
-			"id":            id,
-			"device_id":     deviceID,
-			"cve_id":        cveID,
-			"severity":      severity,
-			"description":   desc,
-			"discovered_at": discoveredAt,
-			"device_ip":     ipAddr,
-		})
-	}
-
 	return vulns, len(vulns), nil
 }
 

--- a/internal/modules/harvest/services_scheduler.go
+++ b/internal/modules/harvest/services_scheduler.go
@@ -6,7 +6,6 @@ package harvest
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -15,13 +14,13 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/krisarmstrong/seed/internal/config"
-	"github.com/krisarmstrong/seed/internal/database"
 )
 
-// SchedulerService manages scheduled reports.
+// SchedulerService manages scheduled reports. It keeps schedules in memory and
+// ticks once per minute; row persistence goes through the ScheduleRepo port.
 type SchedulerService struct {
 	cfg       *config.Config
-	db        *database.DB
+	repo      ScheduleRepo
 	generator *GeneratorService
 	cancel    context.CancelFunc
 	mu        sync.RWMutex
@@ -31,12 +30,12 @@ type SchedulerService struct {
 // NewSchedulerService creates a new scheduler service.
 func NewSchedulerService(
 	cfg *config.Config,
-	db *database.DB,
+	repo ScheduleRepo,
 	generator *GeneratorService,
 ) *SchedulerService {
 	return &SchedulerService{
 		cfg:       cfg,
-		db:        db,
+		repo:      repo,
 		generator: generator,
 		schedules: make(map[string]*ScheduledReport),
 	}
@@ -58,58 +57,16 @@ func (s *SchedulerService) Start(ctx context.Context) error {
 }
 
 func (s *SchedulerService) loadSchedules(ctx context.Context) error {
-	rows, err := s.db.Query(ctx, `
-		SELECT id, name, template, format, schedule_json, parameters_json, recipients_json, enabled, last_run, next_run, created_at, updated_at
-		FROM scheduled_reports
-	`)
+	schedules, err := s.repo.ListSchedules(ctx)
 	if err != nil {
-		return fmt.Errorf("querying scheduled reports: %w", err)
+		return err
 	}
-	defer rows.Close()
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for rows.Next() {
-		var sr ScheduledReport
-		var scheduleJSON, paramsJSON, recipientsJSON string
-		var lastRun, nextRun *string
-
-		scanErr := rows.Scan(
-			&sr.ID,
-			&sr.Name,
-			&sr.Template,
-			&sr.Format,
-			&scheduleJSON,
-			&paramsJSON,
-			&recipientsJSON,
-			&sr.Enabled,
-			&lastRun,
-			&nextRun,
-			&sr.CreatedAt,
-			&sr.UpdatedAt,
-		)
-		if scanErr != nil {
-			continue
-		}
-
-		_ = json.Unmarshal([]byte(scheduleJSON), &sr.Schedule)
-		_ = json.Unmarshal([]byte(paramsJSON), &sr.Parameters)
-		_ = json.Unmarshal([]byte(recipientsJSON), &sr.Recipients)
-
-		if lastRun != nil {
-			t, _ := time.Parse(time.RFC3339, *lastRun)
-			sr.LastRun = &t
-		}
-		if nextRun != nil {
-			t, _ := time.Parse(time.RFC3339, *nextRun)
-			sr.NextRun = &t
-		}
-
-		s.schedules[sr.ID] = &sr
-	}
-	if rowsErr := rows.Err(); rowsErr != nil {
-		return fmt.Errorf("iterating scheduled reports: %w", rowsErr)
+	for i := range schedules {
+		s.schedules[schedules[i].ID] = &schedules[i]
 	}
 
 	return nil
@@ -248,44 +205,7 @@ func (s *SchedulerService) Create(ctx context.Context, sr *ScheduledReport) erro
 }
 
 func (s *SchedulerService) saveSchedule(ctx context.Context, sr *ScheduledReport) error {
-	scheduleJSON, _ := json.Marshal(sr.Schedule)
-	paramsJSON, _ := json.Marshal(sr.Parameters)
-	recipientsJSON, _ := json.Marshal(sr.Recipients)
-
-	var lastRun, nextRun *string
-	if sr.LastRun != nil {
-		t := sr.LastRun.Format(time.RFC3339)
-		lastRun = &t
-	}
-	if sr.NextRun != nil {
-		t := sr.NextRun.Format(time.RFC3339)
-		nextRun = &t
-	}
-
-	_, err := s.db.Exec(
-		ctx,
-		`
-		INSERT OR REPLACE INTO scheduled_reports (id, name, template, format, schedule_json, parameters_json, recipients_json, enabled, last_run, next_run, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`,
-		sr.ID,
-		sr.Name,
-		sr.Template,
-		sr.Format,
-		string(scheduleJSON),
-		string(paramsJSON),
-		string(recipientsJSON),
-		sr.Enabled,
-		lastRun,
-		nextRun,
-		sr.CreatedAt.Format(time.RFC3339),
-		sr.UpdatedAt.Format(time.RFC3339),
-	)
-	if err != nil {
-		return fmt.Errorf("saving scheduled report: %w", err)
-	}
-
-	return nil
+	return s.repo.SaveSchedule(ctx, sr)
 }
 
 // Get retrieves a scheduled report.
@@ -342,9 +262,5 @@ func (s *SchedulerService) Delete(ctx context.Context, id string) error {
 	}
 
 	delete(s.schedules, id)
-	_, err := s.db.Exec(ctx, "DELETE FROM scheduled_reports WHERE id = ?", id)
-	if err != nil {
-		return fmt.Errorf("deleting scheduled report: %w", err)
-	}
-	return nil
+	return s.repo.DeleteSchedule(ctx, id)
 }

--- a/internal/modules/harvest/services_test.go
+++ b/internal/modules/harvest/services_test.go
@@ -365,7 +365,7 @@ func TestAggregatorService_Aggregate(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfig()
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 
 	tests := []struct {
 		name   string
@@ -414,7 +414,7 @@ func TestAggregatorService_AggregateWithData(t *testing.T) {
 	setupTestData(t, ctx, db)
 
 	cfg := testConfig()
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 
 	data, err := as.Aggregate(ctx, harvest.PeriodWeekly, "", "")
 	require.NoError(t, err)
@@ -429,7 +429,7 @@ func TestAggregatorService_GetTrends(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfig()
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 	ctx := context.Background()
 
 	tests := []struct {
@@ -474,9 +474,9 @@ func TestSchedulerService_Create(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 
@@ -570,9 +570,9 @@ func TestSchedulerService_Get(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 
@@ -629,9 +629,9 @@ func TestSchedulerService_List(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 
@@ -670,9 +670,9 @@ func TestSchedulerService_Update(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 
@@ -755,9 +755,9 @@ func TestSchedulerService_Delete(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 
@@ -800,9 +800,9 @@ func TestSchedulerService_StartStop(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -828,9 +828,9 @@ func TestCalculateNextRun(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 	now := time.Now()
@@ -900,8 +900,8 @@ func TestGeneratorService_Generate(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -984,8 +984,8 @@ func TestGeneratorService_GenerateFromTemplate(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -1049,10 +1049,10 @@ func TestGeneratorService_Export(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 
 	// Create generator with a temp directory for reports
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -1138,8 +1138,8 @@ func TestGeneratorService_ListReports(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -1171,8 +1171,8 @@ func TestGeneratorService_GetReport(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -1206,8 +1206,8 @@ func TestGeneratorService_DeleteReport(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -1239,7 +1239,15 @@ func TestModule_New(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfig()
-	module := harvest.New(cfg, db, store.NewReportRepo(db))
+	module := harvest.New(
+		cfg,
+		harvest.Deps{
+			Reports:  store.NewReportRepo(db),
+			Schedule: store.NewScheduleRepo(db),
+			Metrics:  store.NewMetricsRepo(db),
+			Export:   store.NewExportRepo(db),
+		},
+	)
 
 	require.NotNil(t, module)
 	assert.NotNil(t, module.Generator())
@@ -1253,7 +1261,15 @@ func TestModule_StartStop(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfig()
-	module := harvest.New(cfg, db, store.NewReportRepo(db))
+	module := harvest.New(
+		cfg,
+		harvest.Deps{
+			Reports:  store.NewReportRepo(db),
+			Schedule: store.NewScheduleRepo(db),
+			Metrics:  store.NewMetricsRepo(db),
+			Export:   store.NewExportRepo(db),
+		},
+	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -1276,7 +1292,15 @@ func TestModule_Accessors(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfig()
-	module := harvest.New(cfg, db, store.NewReportRepo(db))
+	module := harvest.New(
+		cfg,
+		harvest.Deps{
+			Reports:  store.NewReportRepo(db),
+			Schedule: store.NewScheduleRepo(db),
+			Metrics:  store.NewMetricsRepo(db),
+			Export:   store.NewExportRepo(db),
+		},
+	)
 
 	// Multiple calls should return the same instance
 	gen1 := module.Generator()
@@ -1301,7 +1325,15 @@ func TestModule_ConcurrentAccess(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfig()
-	module := harvest.New(cfg, db, store.NewReportRepo(db))
+	module := harvest.New(
+		cfg,
+		harvest.Deps{
+			Reports:  store.NewReportRepo(db),
+			Schedule: store.NewScheduleRepo(db),
+			Metrics:  store.NewMetricsRepo(db),
+			Export:   store.NewExportRepo(db),
+		},
+	)
 
 	ctx := context.Background()
 	require.NoError(t, module.Start(ctx))
@@ -1356,8 +1388,8 @@ func TestGeneratorService_UnsupportedFormats(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -1392,7 +1424,7 @@ func TestAggregatorService_EmptyDatabase(t *testing.T) {
 	defer cleanup()
 
 	cfg := testConfig()
-	as := harvest.NewAggregatorService(cfg, db)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
 
 	ctx := context.Background()
 	data, err := as.Aggregate(ctx, harvest.PeriodWeekly, "", "")
@@ -1436,9 +1468,9 @@ func TestSchedulerService_InvalidTimezone(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
-	ss := harvest.NewSchedulerService(cfg, db, gs)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
+	ss := harvest.NewSchedulerService(cfg, store.NewScheduleRepo(db), gs)
 
 	ctx := context.Background()
 
@@ -1468,8 +1500,8 @@ func TestReportParams_DateRangeCalculation(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -1508,8 +1540,8 @@ func TestExportResult_Fields(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -1544,8 +1576,8 @@ func TestDatabaseInteraction_Reports(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 
@@ -1650,8 +1682,8 @@ func TestGeneratorService_DownloadReport(t *testing.T) {
 	ts := harvest.NewTemplateService(cfg)
 	require.NoError(t, ts.Load())
 
-	as := harvest.NewAggregatorService(cfg, db)
-	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), db, ts, as)
+	as := harvest.NewAggregatorService(cfg, store.NewMetricsRepo(db))
+	gs := harvest.NewGeneratorService(cfg, store.NewReportRepo(db), store.NewExportRepo(db), ts, as)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
## Phase 3 — slice 1b-v: finish harvest persistence extraction

Completes the harvest pilot. Lifts **all remaining SQL** out of the module into
`internal/adapters/store` behind three new ports, so the harvest domain core is
now **fully persistence-free** — no `*database.DB`, enforced by depguard.

### Ports (`internal/modules/harvest/ports.go`)
`ScheduleRepo`, `MetricsRepo`, `ExportRepo`.

### Adapters (SQL lifted verbatim — move-and-preserve)
- `store/harvest_schedule_repo.go` — `scheduled_reports` CRUD
- `store/harvest_metrics_repo.go` — device count, vuln/perf/top-issue aggregation, trends
- `store/harvest_export_repo.go` — `devices` / `device_vulnerabilities` export rows

### Domain stays meaningful
- `AggregatorService` keeps the severity-bucket + category semantics: the meaning
  of `statusCritical` stays in the module, and `MetricsRepo` returns a raw
  `severity → count` map that the domain maps onto `VulnCounts`.
- `sqliteDateFormat` moved to the adapter (a SQLite-dialect concern).
- Generator/Aggregator/Scheduler services no longer hold `*database.DB`.

### Composition root
- `harvest.New` now takes a `Deps{Reports, Schedule, Metrics, Export}` struct.
- **new `internal/app/harvest.go`** wires the SQLite store adapters; both prod
  callers (`cmd_serve.go`, `cmd_service_windows.go`) call `app.NewHarvest(cfg, db)`
  and drop their `harvest`/`store` imports.

### depguard
- new **`harvest-no-database`** rule bans `internal/database` in harvest
  production code (`!$test`; tests still open real SQLite to back the adapters
  under test). RED-proven (fires on a real import).

### Tests
- ~120 construction sites rewired to build the store adapters.
- `aggregator_repo_test.go` — DB-free `AggregatorService` test via a fake
  `MetricsRepo` (verifies unknown severities count toward `Total` but don't bucket).

### Gates
- ✅ Golden HTTP suite **unchanged** (behavior gate)
- ✅ `go build ./...` + `GOOS=windows go build ./cmd/seed/` — exit 0
- ✅ `go test ./...` — exit 0
- ✅ `golangci-lint` 0 issues; `harvest-no-database` RED-proven
- ✅ `check-route-policy.sh`, `check-output-escaping.sh` pass

Pilot (harvest) acceptance criteria in `PHASE3_EXTRACTION_PLAN.md` §4.5 now all
green except the §7 docs sync (THE_SEED_ARCHITECTURE diagrams), tracked separately.