### PR TITLE
docs(arch): record reconcile execution status (checkpoint)

### DIFF
--- a/docs/architecture/PHASE3_EXTRACTION_PLAN.md
+++ b/docs/architecture/PHASE3_EXTRACTION_PLAN.md
@@ -1,6 +1,17 @@
 # Phase 3 — Domain Core / Hexagon Extraction Plan
 
-**Status:** Proposed — 2026-06-01
+> ⛔ **SUPERSEDED (2026-06-01) — DO NOT FOLLOW THE "extract every feature into a
+> Module" DIRECTION BELOW.** Execution proved the module facades were *dead
+> parallel wiring* the HTTP request path never consumes (the api uses fat
+> handlers + `internal/api/services.go` groupings → feature packages directly).
+> The plan of record is now **`PHASE3_RECONCILE_PROPOSAL.md`**: delete the dead
+> facades, one composition root, capability-first descriptive names, ports only
+> at real I/O seams. The harvest pilot (1a–1b-v) is retained as the ports/repo
+> exemplar but `internal/modules/harvest` itself becomes `internal/reporting`.
+> This doc is kept for history (the pilot mechanics + the audit that exposed the
+> dead facades). See the RECONCILE proposal §0 for live status.
+
+**Status:** SUPERSEDED by PHASE3_RECONCILE_PROPOSAL.md — 2026-06-01
 **Owner:** re-architecture workstream
 **Scope:** Implements Phase 3 of `RE_ARCHITECTURE_BLUEPRINT.md` (§16) under ADR-0001
 (modulith hexagon). Phases 0–2 are complete (registry + code-first contract,

--- a/docs/architecture/PHASE3_RECONCILE_PROPOSAL.md
+++ b/docs/architecture/PHASE3_RECONCILE_PROPOSAL.md
@@ -1,8 +1,54 @@
 # Phase 3 — Reconcile Proposal: right-sized modular monolith + descriptive names
 
-**Status:** PROPOSED — 2026-06-01 — *awaiting owner decision, no code moves yet*
-**Supersedes (if approved):** the "extract every feature into a Module" framing of
+**Status:** APPROVED & IN PROGRESS — 2026-06-01.
+**Supersedes:** the "extract every feature into a Module" framing of
 `PHASE3_EXTRACTION_PLAN.md` (the harvest pilot under it is retained — see §6).
+
+---
+
+## 0. Execution status (2026-06-01 checkpoint) — RESUME HERE
+
+Owner approved Reconcile + **capability-first** layout + descriptive **code**
+names (botanical names OK for *marketing*, separate brand call). `main` is clean
+and green; all items below are merged.
+
+**Done:**
+- R1/R2 — all four dead facades deleted: roots (#1439), shell (#1441, kept
+  `guestaudit`), canopy (#1442, kept wifi/survey), sap (#1443, kept all
+  diagnostic subpkgs; its "monitors" were no-ops / a duplicate LinkMonitor).
+  `api.Modules` now holds only the report scheduler.
+- R4a reorg (capability-first, golden-gated each):
+  - `internal/canopy/{wifi,survey}` → `internal/wifi/{,survey}` (#1444)
+  - `internal/services/{dns,dhcp,gateway,vlan,speedtest,iperf,cable,link,snmp,
+    performance,telemetry}` → `internal/diagnostics/*` (#1445)
+  - `internal/services/shell/guestaudit` → `internal/security/guestaudit` (#1446)
+  - api `ServiceContainer`: `SapServices`→`DiagnosticsServices` (`.Sap`→
+    `.Diagnostics`), `CanopyServices`→`WiFiServices` (`.Canopy`→`.Wireless`),
+    delete dead `RootsServices` (commit `52a83718`).
+  - `internal/services/` now holds **only `discovery`** (HOT — promote to
+    `internal/discovery` in Phase 6, coordinated with the discovery workstream).
+
+**Remaining:**
+1. **harvest → reporting** (last R4a internal piece; its own careful PR — it
+   reworks depguard). Moves: `internal/modules/harvest` → `internal/reporting`;
+   `internal/adapters/store/harvest_*_repo.go` → `internal/reporting/store/`;
+   `internal/app/harvest.go` → `app/reporting.go` (`NewHarvest`→`NewReporting`);
+   `api.Modules.Harvest` → `Reporting`; cmd `app.NewHarvest`→`NewReporting`.
+   **depguard:** `harvest-no-database` / `harvest-module-independence` /
+   `modules-domain-purity` / `modules-no-adapter-import` are hexagon-ring
+   artifacts keyed on `internal/modules/**` + `internal/adapters/**` — repurpose
+   or drop (keep the `ReportRepo` *port* for testability; a light
+   `internal/reporting/store` boundary is optional). Afterward `internal/modules/`
+   and `internal/adapters/` are empty → remove.
+2. **R4b — customer-facing rename — GATED on the marketing-name decision
+   (pending).** Route prefixes `/api/v1/{sap,roots,shell,canopy,harvest}/*`
+   (28 groups, called by the UI + API clients) + UI `themeColors`/`pageRegistry`/
+   i18n (~60 files). Breaking → needs a versioned route alias / 308 deprecation
+   window if going descriptive. May be KEPT as decorative brand. Confirm.
+
+**Also open:** CI design-token gate is red on `main` (~108 pre-existing whole-repo
+violations — issue #1437); the Frontend job fails for every PR, so UI PRs land via
+`--admin`. Admin-merge is owner-authorized for this workstream.
 
 ---
 

--- a/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
+++ b/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
@@ -1,9 +1,21 @@
 # Seed Re-Architecture Blueprint
 
+> ⚠️ **AMENDED 2026-06-01 — Phase 3 pivoted.** The "modulith hexagon" with one
+> `internal/modules/<botanical>` package per product module (Roots/Canopy/Shell/
+> Sap/Harvest) proved, during execution, to be *dead parallel wiring* the HTTP
+> request path never consumed. Phase 3's live plan of record is now
+> **`PHASE3_RECONCILE_PROPOSAL.md`**: a right-sized modular monolith — fat
+> handlers + api `ServiceContainer` groupings → **capability-first** feature
+> packages (`internal/wifi`, `internal/diagnostics`, `internal/security`,
+> `internal/reporting`), one composition root, ports only at real I/O seams, and
+> **descriptive code names** (botanical names retained for *marketing* only). The
+> module facades have been deleted. Phases 0–2 (registry, code-first contract,
+> golden harness) stand. Read the RECONCILE proposal for current direction.
+
 **Product:** Seed (Network Diagnostics + Wi-Fi Troubleshooting + Security + Compliance)
 **Owner:** Mustard Seed Networks
-**Status:** Plan of record — approved direction, not yet implemented
-**Updated:** 2026-05-31
+**Status:** AMENDED — Phase 3 superseded by PHASE3_RECONCILE_PROPOSAL.md (2026-06-01)
+**Updated:** 2026-06-01
 **Companion ADRs:** [`decisions/`](decisions/)
 **Supersedes (structure):** the legacy seed/cross-repo structure plans in msn-docs — see [§17](#17-documentation-alignment-per-phase-gate)
 

--- a/docs/architecture/decisions/0001-modulith-hexagon.md
+++ b/docs/architecture/decisions/0001-modulith-hexagon.md
@@ -1,6 +1,19 @@
 # ADR-0001: Modulith hexagon structure
 
-**Status:** Accepted — 2026-05-31
+**Status:** AMENDED — 2026-06-01 (see `PHASE3_RECONCILE_PROPOSAL.md`)
+
+> **Amendment (2026-06-01):** the `internal/modules/<botanical>` + `internal/
+> adapters/` rings this ADR proposed were found to be dead parallel wiring (the
+> api consumes feature packages directly, not the module facades). The structural
+> intent — *dependencies point inward, infra behind ports, depguard-enforced
+> direction* — is **retained**, but realized as a **capability-first modular
+> monolith**: flat `internal/<feature>` packages (`wifi`, `diagnostics`,
+> `security`, `reporting`), one composition root, **ports as a technique at real
+> I/O seams** (not a dedicated `adapters/` folder ring). The botanical module
+> facades + the `modules/`/`adapters/` rings are being removed. depguard now
+> enforces *direction*, not folder layout.
+
+**Status (original):** Accepted — 2026-05-31
 
 ## Context
 


### PR DESCRIPTION
Adds Execution-status section to PHASE3_RECONCILE_PROPOSAL.md so work can resume cleanly. R1/R2 + R4a done; harvest->reporting + R4b remain. Docs-only.