### PR TITLE
feat(schema): publish self-contained composer DTO schemas

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -179,6 +179,17 @@ func schemaTargets() []schemaTarget {
 		{&api.UpdateSurveySettingsRequest{}, "update-survey-settings-request.schema.json"},
 		{&api.GenerateReportRequest{}, "generate-report-request.schema.json"},
 		{&api.ProfileImportResponse{}, "profile-import-response.schema.json"},
+
+		// Settings composers: top-level DTOs whose entire transitive closure is
+		// flat, local transport sub-structs in internal/api (every composed
+		// *Response is itself registered above). They compose, but never reach a
+		// domain type, json.RawMessage, or a self-reference, so the published
+		// schema stays self-contained and acyclic.
+		{&api.NetworkDiscoverySettingsResponse{}, "network-discovery-settings-response.schema.json"},
+		{&api.OptionsResponse{}, "options-response.schema.json"},
+		{&api.SNMPSettingsResponse{}, "snmp-settings-response.schema.json"},
+		{&api.TestsSettingsResponse{}, "tests-settings-response.schema.json"},
+		{&api.IperfClientStatusResponse{}, "iperf-client-status-response.schema.json"},
 	}
 
 	targets := make([]schemaTarget, len(rows))

--- a/docs/schemas/api/iperf-client-status-response.schema.json
+++ b/docs/schemas/api/iperf-client-status-response.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/iperf-client-status-response.schema.json",
+  "$ref": "#/$defs/IperfClientStatusResponse",
+  "$defs": {
+    "IperfClientStatusResponse": {
+      "properties": {
+        "running": {
+          "type": "boolean"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "progress": {
+          "type": "number"
+        },
+        "last": {
+          "$ref": "#/$defs/IperfResultResponse"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "running",
+        "phase",
+        "progress"
+      ]
+    },
+    "IperfResultResponse": {
+      "properties": {
+        "bandwidth": {
+          "type": "number"
+        },
+        "transfer": {
+          "type": "number"
+        },
+        "retransmits": {
+          "type": "integer"
+        },
+        "jitter": {
+          "type": "number"
+        },
+        "lostPackets": {
+          "type": "integer"
+        },
+        "lostPercent": {
+          "type": "number"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "direction": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "number"
+        },
+        "server": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "timestamp": {
+          "type": "string"
+        },
+        "downloadBandwidth": {
+          "type": "number"
+        },
+        "uploadBandwidth": {
+          "type": "number"
+        },
+        "downloadTransfer": {
+          "type": "number"
+        },
+        "uploadTransfer": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "bandwidth",
+        "transfer",
+        "retransmits",
+        "jitter",
+        "lostPackets",
+        "lostPercent",
+        "protocol",
+        "direction",
+        "duration",
+        "server",
+        "port",
+        "timestamp"
+      ]
+    }
+  },
+  "title": "IperfClientStatusResponse",
+  "description": "IperfClientStatusResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/network-discovery-settings-response.schema.json
+++ b/docs/schemas/api/network-discovery-settings-response.schema.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/network-discovery-settings-response.schema.json",
+  "$ref": "#/$defs/NetworkDiscoverySettingsResponse",
+  "$defs": {
+    "FingerprintingResponse": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "osDetection": {
+          "type": "boolean"
+        },
+        "serviceProbes": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled",
+        "osDetection",
+        "serviceProbes"
+      ]
+    },
+    "NetworkDiscoverySettingsResponse": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "arpScanWorkers": {
+          "type": "integer"
+        },
+        "pingTimeoutMs": {
+          "type": "integer"
+        },
+        "scanTimeoutMs": {
+          "type": "integer"
+        },
+        "autoScan": {
+          "type": "boolean"
+        },
+        "scanIntervalMs": {
+          "type": "integer"
+        },
+        "ouiFilePath": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/$defs/OptionsResponse"
+        },
+        "timing": {
+          "$ref": "#/$defs/TimingResponse"
+        },
+        "profiler": {
+          "$ref": "#/$defs/ProfilerResponse"
+        },
+        "fingerprinting": {
+          "$ref": "#/$defs/FingerprintingResponse"
+        },
+        "ipv6Enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled",
+        "arpScanWorkers",
+        "pingTimeoutMs",
+        "scanTimeoutMs",
+        "autoScan",
+        "scanIntervalMs",
+        "ouiFilePath",
+        "options",
+        "timing",
+        "profiler",
+        "fingerprinting",
+        "ipv6Enabled"
+      ]
+    },
+    "OptionsResponse": {
+      "properties": {
+        "passiveProtocols": {
+          "$ref": "#/$defs/PassiveProtocolResponse"
+        },
+        "arpScan": {
+          "type": "boolean"
+        },
+        "icmpScan": {
+          "type": "boolean"
+        },
+        "portScan": {
+          "$ref": "#/$defs/PortScanResponse"
+        },
+        "tcpProbe": {
+          "$ref": "#/$defs/TCPProbeSettingsResponse"
+        },
+        "traceroute": {
+          "type": "boolean"
+        },
+        "snmpQuery": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "passiveProtocols",
+        "arpScan",
+        "icmpScan",
+        "portScan",
+        "tcpProbe",
+        "traceroute",
+        "snmpQuery"
+      ]
+    },
+    "PassiveProtocolResponse": {
+      "properties": {
+        "lldp": {
+          "type": "boolean"
+        },
+        "cdp": {
+          "type": "boolean"
+        },
+        "edp": {
+          "type": "boolean"
+        },
+        "ndp": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "lldp",
+        "cdp",
+        "edp",
+        "ndp"
+      ]
+    },
+    "PortScanResponse": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "tcpPorts": {
+          "type": "string"
+        },
+        "udpPorts": {
+          "type": "string"
+        },
+        "bannerTimeoutMs": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled",
+        "tcpPorts",
+        "udpPorts",
+        "bannerTimeoutMs"
+      ]
+    },
+    "ProfilerResponse": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "timeoutMs": {
+          "type": "integer"
+        },
+        "maxConcurrent": {
+          "type": "integer"
+        },
+        "quickPorts": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled",
+        "timeoutMs",
+        "maxConcurrent",
+        "quickPorts"
+      ]
+    },
+    "TCPProbeSettingsResponse": {
+      "properties": {
+        "timeoutMs": {
+          "type": "integer"
+        },
+        "workers": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "timeoutMs",
+        "workers"
+      ]
+    },
+    "TimingResponse": {
+      "properties": {
+        "probeIntervalMs": {
+          "type": "integer"
+        },
+        "rescanIntervalMs": {
+          "type": "integer"
+        },
+        "workers": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "probeIntervalMs",
+        "rescanIntervalMs",
+        "workers"
+      ]
+    }
+  },
+  "title": "NetworkDiscoverySettingsResponse",
+  "description": "NetworkDiscoverySettingsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/options-response.schema.json
+++ b/docs/schemas/api/options-response.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/options-response.schema.json",
+  "$ref": "#/$defs/OptionsResponse",
+  "$defs": {
+    "OptionsResponse": {
+      "properties": {
+        "passiveProtocols": {
+          "$ref": "#/$defs/PassiveProtocolResponse"
+        },
+        "arpScan": {
+          "type": "boolean"
+        },
+        "icmpScan": {
+          "type": "boolean"
+        },
+        "portScan": {
+          "$ref": "#/$defs/PortScanResponse"
+        },
+        "tcpProbe": {
+          "$ref": "#/$defs/TCPProbeSettingsResponse"
+        },
+        "traceroute": {
+          "type": "boolean"
+        },
+        "snmpQuery": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "passiveProtocols",
+        "arpScan",
+        "icmpScan",
+        "portScan",
+        "tcpProbe",
+        "traceroute",
+        "snmpQuery"
+      ]
+    },
+    "PassiveProtocolResponse": {
+      "properties": {
+        "lldp": {
+          "type": "boolean"
+        },
+        "cdp": {
+          "type": "boolean"
+        },
+        "edp": {
+          "type": "boolean"
+        },
+        "ndp": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "lldp",
+        "cdp",
+        "edp",
+        "ndp"
+      ]
+    },
+    "PortScanResponse": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "tcpPorts": {
+          "type": "string"
+        },
+        "udpPorts": {
+          "type": "string"
+        },
+        "bannerTimeoutMs": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled",
+        "tcpPorts",
+        "udpPorts",
+        "bannerTimeoutMs"
+      ]
+    },
+    "TCPProbeSettingsResponse": {
+      "properties": {
+        "timeoutMs": {
+          "type": "integer"
+        },
+        "workers": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "timeoutMs",
+        "workers"
+      ]
+    }
+  },
+  "title": "OptionsResponse",
+  "description": "OptionsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/snmp-settings-response.schema.json
+++ b/docs/schemas/api/snmp-settings-response.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/snmp-settings-response.schema.json",
+  "$ref": "#/$defs/SNMPSettingsResponse",
+  "$defs": {
+    "SNMPSettingsResponse": {
+      "properties": {
+        "communities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "v3Credentials": {
+          "items": {
+            "$ref": "#/$defs/SNMPv3CredentialResponse"
+          },
+          "type": "array"
+        },
+        "timeout": {
+          "type": "integer"
+        },
+        "retries": {
+          "type": "integer"
+        },
+        "port": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "communities",
+        "v3Credentials",
+        "timeout",
+        "retries",
+        "port"
+      ]
+    },
+    "SNMPv3CredentialResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "authProtocol": {
+          "type": "string"
+        },
+        "authPassword": {
+          "type": "string"
+        },
+        "privProtocol": {
+          "type": "string"
+        },
+        "privPassword": {
+          "type": "string"
+        },
+        "contextName": {
+          "type": "string"
+        },
+        "securityLevel": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "username",
+        "authProtocol",
+        "authPassword",
+        "privProtocol",
+        "privPassword",
+        "contextName",
+        "securityLevel"
+      ]
+    }
+  },
+  "title": "SNMPSettingsResponse",
+  "description": "SNMPSettingsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/tests-settings-response.schema.json
+++ b/docs/schemas/api/tests-settings-response.schema.json
@@ -1,0 +1,647 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/tests-settings-response.schema.json",
+  "$ref": "#/$defs/TestsSettingsResponse",
+  "$defs": {
+    "DICOMEndpointResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "calledAe": {
+          "type": "string"
+        },
+        "callingAe": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "host",
+        "port",
+        "calledAe",
+        "callingAe",
+        "enabled"
+      ]
+    },
+    "DNSServerResponse": {
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "address",
+        "enabled"
+      ]
+    },
+    "FHIREndpointResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "baseUrl": {
+          "type": "string"
+        },
+        "authType": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "criticality": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "baseUrl",
+        "authType",
+        "enabled",
+        "criticality"
+      ]
+    },
+    "FileShareEndpointResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "share": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "testReadPerformance": {
+          "type": "boolean"
+        },
+        "testWritePerformance": {
+          "type": "boolean"
+        },
+        "testFileSizeMb": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "criticality": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "protocol",
+        "host",
+        "share",
+        "enabled",
+        "criticality"
+      ]
+    },
+    "HL7EndpointResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "sendingApp": {
+          "type": "string"
+        },
+        "sendingFacility": {
+          "type": "string"
+        },
+        "receivingApp": {
+          "type": "string"
+        },
+        "receivingFacility": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "criticality": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "host",
+        "port",
+        "sendingApp",
+        "sendingFacility",
+        "receivingApp",
+        "receivingFacility",
+        "enabled",
+        "criticality"
+      ]
+    },
+    "HTTPEndpointResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "expectedStatus": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "bodyMatch": {
+          "type": "string"
+        },
+        "bodyMatchIsRegex": {
+          "type": "boolean"
+        },
+        "checkSecurityHeaders": {
+          "type": "boolean"
+        },
+        "followRedirects": {
+          "type": "boolean"
+        },
+        "maxRedirects": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "url",
+        "expectedStatus",
+        "enabled"
+      ]
+    },
+    "IperfSettingsResponse": {
+      "properties": {
+        "autoRunOnLink": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "autoRunOnLink"
+      ]
+    },
+    "LDAPEndpointResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "useTls": {
+          "type": "boolean"
+        },
+        "startTls": {
+          "type": "boolean"
+        },
+        "baseDn": {
+          "type": "string"
+        },
+        "searchFilter": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "criticality": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "host",
+        "port",
+        "useTls",
+        "startTls",
+        "baseDn",
+        "enabled",
+        "criticality"
+      ]
+    },
+    "LTIEndpointResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "launchUrl": {
+          "type": "string"
+        },
+        "ltiVersion": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "criticality": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "launchUrl",
+        "enabled",
+        "criticality"
+      ]
+    },
+    "ModbusEndpointResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "unitId": {
+          "type": "integer"
+        },
+        "testRegister": {
+          "type": "integer"
+        },
+        "registerType": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "criticality": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "host",
+        "port",
+        "unitId",
+        "testRegister",
+        "enabled",
+        "criticality"
+      ]
+    },
+    "OPCUAEndpointResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "endpointUrl": {
+          "type": "string"
+        },
+        "securityMode": {
+          "type": "string"
+        },
+        "securityPolicy": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "criticality": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "endpointUrl",
+        "enabled",
+        "criticality"
+      ]
+    },
+    "PingTargetResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "host",
+        "enabled"
+      ]
+    },
+    "RTSPEndpointResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "url",
+        "enabled"
+      ]
+    },
+    "SQLEndpointResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "driver": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "database": {
+          "type": "string"
+        },
+        "sslMode": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "criticality": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "driver",
+        "host",
+        "port",
+        "database",
+        "enabled",
+        "criticality"
+      ]
+    },
+    "SpeedtestSettingsResponse": {
+      "properties": {
+        "serverId": {
+          "type": "string"
+        },
+        "autoRunOnLink": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "serverId",
+        "autoRunOnLink"
+      ]
+    },
+    "TCPPortResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "host",
+        "port",
+        "enabled"
+      ]
+    },
+    "TestsSettingsResponse": {
+      "properties": {
+        "dnsHostname": {
+          "type": "string"
+        },
+        "dnsServers": {
+          "items": {
+            "$ref": "#/$defs/DNSServerResponse"
+          },
+          "type": "array"
+        },
+        "pingTargets": {
+          "items": {
+            "$ref": "#/$defs/PingTargetResponse"
+          },
+          "type": "array"
+        },
+        "tcpPorts": {
+          "items": {
+            "$ref": "#/$defs/TCPPortResponse"
+          },
+          "type": "array"
+        },
+        "udpPorts": {
+          "items": {
+            "$ref": "#/$defs/UDPPortResponse"
+          },
+          "type": "array"
+        },
+        "httpEndpoints": {
+          "items": {
+            "$ref": "#/$defs/HTTPEndpointResponse"
+          },
+          "type": "array"
+        },
+        "rtspEndpoints": {
+          "items": {
+            "$ref": "#/$defs/RTSPEndpointResponse"
+          },
+          "type": "array"
+        },
+        "dicomEndpoints": {
+          "items": {
+            "$ref": "#/$defs/DICOMEndpointResponse"
+          },
+          "type": "array"
+        },
+        "hl7Endpoints": {
+          "items": {
+            "$ref": "#/$defs/HL7EndpointResponse"
+          },
+          "type": "array"
+        },
+        "fhirEndpoints": {
+          "items": {
+            "$ref": "#/$defs/FHIREndpointResponse"
+          },
+          "type": "array"
+        },
+        "sqlEndpoints": {
+          "items": {
+            "$ref": "#/$defs/SQLEndpointResponse"
+          },
+          "type": "array"
+        },
+        "fileShareEndpoints": {
+          "items": {
+            "$ref": "#/$defs/FileShareEndpointResponse"
+          },
+          "type": "array"
+        },
+        "ldapEndpoints": {
+          "items": {
+            "$ref": "#/$defs/LDAPEndpointResponse"
+          },
+          "type": "array"
+        },
+        "ltiEndpoints": {
+          "items": {
+            "$ref": "#/$defs/LTIEndpointResponse"
+          },
+          "type": "array"
+        },
+        "opcuaEndpoints": {
+          "items": {
+            "$ref": "#/$defs/OPCUAEndpointResponse"
+          },
+          "type": "array"
+        },
+        "modbusEndpoints": {
+          "items": {
+            "$ref": "#/$defs/ModbusEndpointResponse"
+          },
+          "type": "array"
+        },
+        "speedtest": {
+          "$ref": "#/$defs/SpeedtestSettingsResponse"
+        },
+        "iperf": {
+          "$ref": "#/$defs/IperfSettingsResponse"
+        },
+        "runPerformance": {
+          "type": "boolean"
+        },
+        "runSpeedtest": {
+          "type": "boolean"
+        },
+        "runIperf": {
+          "type": "boolean"
+        },
+        "runDiscovery": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "dnsHostname",
+        "dnsServers",
+        "pingTargets",
+        "tcpPorts",
+        "udpPorts",
+        "httpEndpoints",
+        "rtspEndpoints",
+        "dicomEndpoints",
+        "hl7Endpoints",
+        "fhirEndpoints",
+        "sqlEndpoints",
+        "fileShareEndpoints",
+        "ldapEndpoints",
+        "ltiEndpoints",
+        "opcuaEndpoints",
+        "modbusEndpoints",
+        "speedtest",
+        "iperf",
+        "runPerformance",
+        "runSpeedtest",
+        "runIperf",
+        "runDiscovery"
+      ]
+    },
+    "UDPPortResponse": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "host",
+        "port",
+        "enabled"
+      ]
+    }
+  },
+  "title": "TestsSettingsResponse",
+  "description": "TestsSettingsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/src/types/generated/iperf-client-status-response.ts
+++ b/ui/src/types/generated/iperf-client-status-response.ts
@@ -1,0 +1,31 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface IperfClientStatusResponse {
+  running: boolean;
+  phase: string;
+  progress: number;
+  last?: IperfResultResponse;
+}
+export interface IperfResultResponse {
+  bandwidth: number;
+  transfer: number;
+  retransmits: number;
+  jitter: number;
+  lostPackets: number;
+  lostPercent: number;
+  protocol: string;
+  direction: string;
+  duration: number;
+  server: string;
+  port: number;
+  timestamp: string;
+  downloadBandwidth?: number;
+  uploadBandwidth?: number;
+  downloadTransfer?: number;
+  uploadTransfer?: number;
+}

--- a/ui/src/types/generated/network-discovery-settings-response.ts
+++ b/ui/src/types/generated/network-discovery-settings-response.ts
@@ -1,0 +1,62 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface NetworkDiscoverySettingsResponse {
+  enabled: boolean;
+  arpScanWorkers: number;
+  pingTimeoutMs: number;
+  scanTimeoutMs: number;
+  autoScan: boolean;
+  scanIntervalMs: number;
+  ouiFilePath: string;
+  options: OptionsResponse;
+  timing: TimingResponse;
+  profiler: ProfilerResponse;
+  fingerprinting: FingerprintingResponse;
+  ipv6Enabled: boolean;
+}
+export interface OptionsResponse {
+  passiveProtocols: PassiveProtocolResponse;
+  arpScan: boolean;
+  icmpScan: boolean;
+  portScan: PortScanResponse;
+  tcpProbe: TCPProbeSettingsResponse;
+  traceroute: boolean;
+  snmpQuery: boolean;
+}
+export interface PassiveProtocolResponse {
+  lldp: boolean;
+  cdp: boolean;
+  edp: boolean;
+  ndp: boolean;
+}
+export interface PortScanResponse {
+  enabled: boolean;
+  tcpPorts: string;
+  udpPorts: string;
+  bannerTimeoutMs: number;
+}
+export interface TCPProbeSettingsResponse {
+  timeoutMs: number;
+  workers: number;
+}
+export interface TimingResponse {
+  probeIntervalMs: number;
+  rescanIntervalMs: number;
+  workers: number;
+}
+export interface ProfilerResponse {
+  enabled: boolean;
+  timeoutMs: number;
+  maxConcurrent: number;
+  quickPorts: number[];
+}
+export interface FingerprintingResponse {
+  enabled: boolean;
+  osDetection: boolean;
+  serviceProbes: boolean;
+}

--- a/ui/src/types/generated/options-response.ts
+++ b/ui/src/types/generated/options-response.ts
@@ -1,0 +1,32 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface OptionsResponse {
+  passiveProtocols: PassiveProtocolResponse;
+  arpScan: boolean;
+  icmpScan: boolean;
+  portScan: PortScanResponse;
+  tcpProbe: TCPProbeSettingsResponse;
+  traceroute: boolean;
+  snmpQuery: boolean;
+}
+export interface PassiveProtocolResponse {
+  lldp: boolean;
+  cdp: boolean;
+  edp: boolean;
+  ndp: boolean;
+}
+export interface PortScanResponse {
+  enabled: boolean;
+  tcpPorts: string;
+  udpPorts: string;
+  bannerTimeoutMs: number;
+}
+export interface TCPProbeSettingsResponse {
+  timeoutMs: number;
+  workers: number;
+}

--- a/ui/src/types/generated/snmp-settings-response.ts
+++ b/ui/src/types/generated/snmp-settings-response.ts
@@ -1,0 +1,24 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface SNMPSettingsResponse {
+  communities: string[];
+  v3Credentials: SNMPv3CredentialResponse[];
+  timeout: number;
+  retries: number;
+  port: number;
+}
+export interface SNMPv3CredentialResponse {
+  name: string;
+  username: string;
+  authProtocol: string;
+  authPassword: string;
+  privProtocol: string;
+  privPassword: string;
+  contextName: string;
+  securityLevel: string;
+}

--- a/ui/src/types/generated/tests-settings-response.ts
+++ b/ui/src/types/generated/tests-settings-response.ts
@@ -1,0 +1,159 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface TestsSettingsResponse {
+  dnsHostname: string;
+  dnsServers: DNSServerResponse[];
+  pingTargets: PingTargetResponse[];
+  tcpPorts: TCPPortResponse[];
+  udpPorts: UDPPortResponse[];
+  httpEndpoints: HTTPEndpointResponse[];
+  rtspEndpoints: RTSPEndpointResponse[];
+  dicomEndpoints: DICOMEndpointResponse[];
+  hl7Endpoints: HL7EndpointResponse[];
+  fhirEndpoints: FHIREndpointResponse[];
+  sqlEndpoints: SQLEndpointResponse[];
+  fileShareEndpoints: FileShareEndpointResponse[];
+  ldapEndpoints: LDAPEndpointResponse[];
+  ltiEndpoints: LTIEndpointResponse[];
+  opcuaEndpoints: OPCUAEndpointResponse[];
+  modbusEndpoints: ModbusEndpointResponse[];
+  speedtest: SpeedtestSettingsResponse;
+  iperf: IperfSettingsResponse;
+  runPerformance: boolean;
+  runSpeedtest: boolean;
+  runIperf: boolean;
+  runDiscovery: boolean;
+}
+export interface DNSServerResponse {
+  address: string;
+  enabled: boolean;
+}
+export interface PingTargetResponse {
+  name: string;
+  host: string;
+  enabled: boolean;
+}
+export interface TCPPortResponse {
+  name: string;
+  host: string;
+  port: number;
+  enabled: boolean;
+}
+export interface UDPPortResponse {
+  name: string;
+  host: string;
+  port: number;
+  enabled: boolean;
+}
+export interface HTTPEndpointResponse {
+  name: string;
+  url: string;
+  expectedStatus: number;
+  enabled: boolean;
+  bodyMatch?: string;
+  bodyMatchIsRegex?: boolean;
+  checkSecurityHeaders?: boolean;
+  followRedirects?: boolean;
+  maxRedirects?: number;
+}
+export interface RTSPEndpointResponse {
+  name: string;
+  url: string;
+  enabled: boolean;
+}
+export interface DICOMEndpointResponse {
+  name: string;
+  host: string;
+  port: number;
+  calledAe: string;
+  callingAe: string;
+  enabled: boolean;
+}
+export interface HL7EndpointResponse {
+  name: string;
+  host: string;
+  port: number;
+  sendingApp: string;
+  sendingFacility: string;
+  receivingApp: string;
+  receivingFacility: string;
+  enabled: boolean;
+  criticality: number;
+}
+export interface FHIREndpointResponse {
+  name: string;
+  baseUrl: string;
+  authType: string;
+  enabled: boolean;
+  criticality: number;
+}
+export interface SQLEndpointResponse {
+  name: string;
+  driver: string;
+  host: string;
+  port: number;
+  database: string;
+  sslMode?: string;
+  enabled: boolean;
+  criticality: number;
+}
+export interface FileShareEndpointResponse {
+  name: string;
+  protocol: string;
+  host: string;
+  share: string;
+  path?: string;
+  testReadPerformance?: boolean;
+  testWritePerformance?: boolean;
+  testFileSizeMb?: number;
+  enabled: boolean;
+  criticality: number;
+}
+export interface LDAPEndpointResponse {
+  name: string;
+  host: string;
+  port: number;
+  useTls: boolean;
+  startTls: boolean;
+  baseDn: string;
+  searchFilter?: string;
+  enabled: boolean;
+  criticality: number;
+}
+export interface LTIEndpointResponse {
+  name: string;
+  launchUrl: string;
+  ltiVersion?: string;
+  enabled: boolean;
+  criticality: number;
+}
+export interface OPCUAEndpointResponse {
+  name: string;
+  endpointUrl: string;
+  securityMode?: string;
+  securityPolicy?: string;
+  enabled: boolean;
+  criticality: number;
+}
+export interface ModbusEndpointResponse {
+  name: string;
+  host: string;
+  port: number;
+  unitId: number;
+  testRegister: number;
+  registerType?: string;
+  enabled: boolean;
+  criticality: number;
+}
+export interface SpeedtestSettingsResponse {
+  serverId: string;
+  autoRunOnLink: boolean;
+}
+export interface IperfSettingsResponse {
+  autoRunOnLink: boolean;
+}


### PR DESCRIPTION
## Phase 2 tail — Slice 1 of the code-first contract close-out

Registers the five **settings-composer DTOs** whose entire transitive closure is flat, local transport sub-structs in `internal/api` (every composed `*Response` is already published):

- `NetworkDiscoverySettingsResponse` → Options/Timing/Profiler/Fingerprinting
- `OptionsResponse` → PassiveProtocol/PortScan/TCPProbeSettings
- `SNMPSettingsResponse` → SNMPv3Credential
- `TestsSettingsResponse` → all DNS/Ping/TCP/UDP/HTTP/RTSP/DICOM/HL7/FHIR/SQL/FileShare/LDAP/LTI/OPCUA/Modbus endpoint + Speedtest/Iperf settings
- `IperfClientStatusResponse` → IperfResult

### Why now (best-practice, not a hack)
These were held back only by the conservative *flat + self-contained* Phase 2 policy flag for "composes another top-level `*Response`". None of them reaches a domain type, `json.RawMessage`, or a self-reference, so each published schema is self-contained and **acyclic** — confirmed by the cycle gate. Publishing them gives each a real generated schema + TS type, which is exactly the code-first contract goal.

### Gates (all green locally)
- `go run ./cmd/seed-schema` → 5 new schema files
- cycle check → `No $ref cycles`
- round-trip guardrail (`go test ./cmd/seed-schema/`) → `ok`
- `check-schema-drift.sh` / `check-types-drift.sh` → up to date
- `golangci-lint run ./cmd/seed-schema/` → **0 issues**
- regenerated TS twins under `ui/src/types/generated/`

No handler changes; wire behavior unchanged.

Refs: `docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md` Phase 2 tail.