### PR TITLE
refactor(api): split GatewayResponse into a flat non-recursive transport DTO

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -56,10 +56,12 @@ type reg struct {
 // POLICY (RE_ARCHITECTURE_BLUEPRINT.md Phase 2 — flat + self-contained): a DTO
 // belongs here iff it is flat or nests only local, purpose-built transport
 // sub-structs in internal/api. DTOs that put an internal domain type on the
-// wire (discovery.*/dhcp.*/netif.*/logging.*/survey.*/config), compose another
-// top-level *Response/*Request, carry [json.RawMessage], or self-recurse
-// (GatewayResponse.ipv6) are deferred to Phase 3, where they get hand-designed
-// flat transport DTOs. Unexported lowercase DTOs cannot be referenced here.
+// wire (discovery.*/dhcp.*/netif.*/logging.*/survey.*/config), carry
+// [json.RawMessage], or self-recurse (a field typed as the DTO itself) are
+// deferred to Phase 3, where they get hand-designed flat transport DTOs — e.g.
+// GatewayResponse's recursive ipv6 field was split out into the flat
+// GatewayPingResult value object so the published schema stays acyclic.
+// Unexported lowercase DTOs cannot be referenced here.
 //
 // Function rather than a package-level var to keep gochecknoglobals happy and
 // so `go run` doesn't pull internal/api into an init side effect.
@@ -98,6 +100,7 @@ func schemaTargets() []schemaTarget {
 		{&api.DiscoveryResponse{}, "discovery-response.schema.json"},
 		{&api.NetworkProblemsResponse{}, "network-problems-response.schema.json"},
 		{&api.ProblemScanResponse{}, "problem-scan-response.schema.json"},
+		{&api.GatewayResponse{}, "gateway-response.schema.json"},
 
 		// telemetry / network settings.
 		{&api.IPSettingsRequest{}, "ip-settings-request.schema.json"},

--- a/docs/schemas/api/gateway-response.schema.json
+++ b/docs/schemas/api/gateway-response.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/gateway-response.schema.json",
+  "$ref": "#/$defs/GatewayResponse",
+  "$defs": {
+    "GatewayPingResult": {
+      "properties": {
+        "gateway": {
+          "type": "string"
+        },
+        "reachable": {
+          "type": "boolean"
+        },
+        "sent": {
+          "type": "integer"
+        },
+        "received": {
+          "type": "integer"
+        },
+        "lossPercent": {
+          "type": "number"
+        },
+        "minTime": {
+          "type": "number"
+        },
+        "maxTime": {
+          "type": "number"
+        },
+        "avgTime": {
+          "type": "number"
+        },
+        "lastTime": {
+          "type": "number"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "gateway",
+        "reachable",
+        "sent",
+        "received",
+        "lossPercent",
+        "minTime",
+        "maxTime",
+        "avgTime",
+        "lastTime",
+        "status"
+      ]
+    },
+    "GatewayResponse": {
+      "properties": {
+        "gateway": {
+          "type": "string"
+        },
+        "reachable": {
+          "type": "boolean"
+        },
+        "sent": {
+          "type": "integer"
+        },
+        "received": {
+          "type": "integer"
+        },
+        "lossPercent": {
+          "type": "number"
+        },
+        "minTime": {
+          "type": "number"
+        },
+        "maxTime": {
+          "type": "number"
+        },
+        "avgTime": {
+          "type": "number"
+        },
+        "lastTime": {
+          "type": "number"
+        },
+        "status": {
+          "type": "string"
+        },
+        "ipv6": {
+          "$ref": "#/$defs/GatewayPingResult"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "gateway",
+        "reachable",
+        "sent",
+        "received",
+        "lossPercent",
+        "minTime",
+        "maxTime",
+        "avgTime",
+        "lastTime",
+        "status"
+      ]
+    }
+  },
+  "title": "GatewayResponse",
+  "description": "GatewayResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/internal/api/handlers_security.go
+++ b/internal/api/handlers_security.go
@@ -266,19 +266,31 @@ func (s *Server) handleRogueDHCPConfig(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// GatewayResponse represents the gateway ping test results for the API.
+// GatewayPingResult is the ping outcome for a single gateway. It is the flat,
+// self-contained value object shared by the IPv4 and IPv6 sides of a gateway
+// test, so the transport contract never has to reference itself.
+type GatewayPingResult struct {
+	Gateway     string  `json:"gateway"`
+	Reachable   bool    `json:"reachable"`
+	Sent        int     `json:"sent"`
+	Received    int     `json:"received"`
+	LossPercent float64 `json:"lossPercent"`
+	MinTime     float64 `json:"minTime"`
+	MaxTime     float64 `json:"maxTime"`
+	AvgTime     float64 `json:"avgTime"`
+	LastTime    float64 `json:"lastTime"`
+	Status      string  `json:"status"`
+}
+
+// GatewayResponse represents the gateway ping test results for the API: the
+// IPv4 gateway result (promoted to the top level) plus the IPv6 gateway result
+// when one is detected. It is non-recursive — the IPv6 sibling is a flat
+// GatewayPingResult and carries no further nesting — which keeps the published
+// schema acyclic.
 type GatewayResponse struct {
-	Gateway     string           `json:"gateway"`
-	Reachable   bool             `json:"reachable"`
-	Sent        int              `json:"sent"`
-	Received    int              `json:"received"`
-	LossPercent float64          `json:"lossPercent"`
-	MinTime     float64          `json:"minTime"`
-	MaxTime     float64          `json:"maxTime"`
-	AvgTime     float64          `json:"avgTime"`
-	LastTime    float64          `json:"lastTime"`
-	Status      string           `json:"status"`
-	IPv6        *GatewayResponse `json:"ipv6,omitempty"`
+	GatewayPingResult
+
+	IPv6 *GatewayPingResult `json:"ipv6,omitempty"`
 }
 
 // handleGateway performs gateway ping testing and returns results.
@@ -316,9 +328,11 @@ func (s *Server) handleGateway(w http.ResponseWriter, r *http.Request) {
 		// If link is down, return disconnected status
 		if !s.linkMonitor().IsUp() {
 			resp := GatewayResponse{
-				Gateway:   "",
-				Reachable: false,
-				Status:    "disconnected",
+				GatewayPingResult: GatewayPingResult{
+					Gateway:   "",
+					Reachable: false,
+					Status:    "disconnected",
+				},
 			}
 			sendJSONResponse(w, logger, http.StatusOK, resp)
 			return
@@ -329,16 +343,18 @@ func (s *Server) handleGateway(w http.ResponseWriter, r *http.Request) {
 	stats := s.gatewayTester().Test()
 
 	resp := GatewayResponse{
-		Gateway:     stats.Gateway,
-		Reachable:   stats.Reachable,
-		Sent:        stats.Sent,
-		Received:    stats.Received,
-		LossPercent: stats.LossPercent,
-		MinTime:     stats.MinTime,
-		MaxTime:     stats.MaxTime,
-		AvgTime:     stats.AvgTime,
-		LastTime:    stats.LastTime,
-		Status:      string(stats.Status),
+		GatewayPingResult: GatewayPingResult{
+			Gateway:     stats.Gateway,
+			Reachable:   stats.Reachable,
+			Sent:        stats.Sent,
+			Received:    stats.Received,
+			LossPercent: stats.LossPercent,
+			MinTime:     stats.MinTime,
+			MaxTime:     stats.MaxTime,
+			AvgTime:     stats.AvgTime,
+			LastTime:    stats.LastTime,
+			Status:      string(stats.Status),
+		},
 	}
 
 	// Detect and ping IPv6 gateway if available
@@ -349,7 +365,7 @@ func (s *Server) handleGateway(w http.ResponseWriter, r *http.Request) {
 		ipv6Tester.SetGateway(ipv6Gateway)
 		ipv6Stats := ipv6Tester.Test()
 
-		resp.IPv6 = &GatewayResponse{
+		resp.IPv6 = &GatewayPingResult{
 			Gateway:     ipv6Stats.Gateway,
 			Reachable:   ipv6Stats.Reachable,
 			Sent:        ipv6Stats.Sent,

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -634,16 +634,18 @@ func TestDNSLookupResult(t *testing.T) {
 
 func TestGatewayResponse(t *testing.T) {
 	resp := api.GatewayResponse{
-		Gateway:     "192.168.1.1",
-		Reachable:   true,
-		Sent:        5,
-		Received:    5,
-		LossPercent: 0,
-		MinTime:     10.5,
-		MaxTime:     25.3,
-		AvgTime:     15.2,
-		LastTime:    12.1,
-		Status:      "success",
+		GatewayPingResult: api.GatewayPingResult{
+			Gateway:     "192.168.1.1",
+			Reachable:   true,
+			Sent:        5,
+			Received:    5,
+			LossPercent: 0,
+			MinTime:     10.5,
+			MaxTime:     25.3,
+			AvgTime:     15.2,
+			LastTime:    12.1,
+			Status:      "success",
+		},
 	}
 
 	if !resp.Reachable && resp.LossPercent < 100 {

--- a/ui/src/types/generated/gateway-response.ts
+++ b/ui/src/types/generated/gateway-response.ts
@@ -1,0 +1,32 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface GatewayResponse {
+  gateway: string;
+  reachable: boolean;
+  sent: number;
+  received: number;
+  lossPercent: number;
+  minTime: number;
+  maxTime: number;
+  avgTime: number;
+  lastTime: number;
+  status: string;
+  ipv6?: GatewayPingResult;
+}
+export interface GatewayPingResult {
+  gateway: string;
+  reachable: boolean;
+  sent: number;
+  received: number;
+  lossPercent: number;
+  minTime: number;
+  maxTime: number;
+  avgTime: number;
+  lastTime: number;
+  status: string;
+}


### PR DESCRIPTION
## Phase 2 tail — Slice 2: retire the last self-recursive DTO

`GatewayResponse` carried a self-referential `IPv6 *GatewayResponse` field — a `$ref` cycle in the published schema and a recursive shape leaking onto the wire. The recursion was only ever **one level deep** (the IPv6 sibling's own `IPv6` was never set), so this models it honestly instead of suppressing it:

- Extract the ten ping-result scalars into a shared **`GatewayPingResult`** value object.
- `GatewayResponse` **embeds** it (Go field promotion preserves the wire bytes **exactly** — top-level `gateway/reachable/.../status` unchanged) plus `IPv6 *GatewayPingResult`.

### Result (best-practice, not a hack)
Generated schema flattens the embed; `$defs` graph is acyclic (`GatewayResponse → GatewayPingResult → ∅`). Generated TS is clean (`ipv6?: GatewayPingResult`). This was the last self-recursive transport DTO, so the acyclic guardrail now holds for a fully-registered contract surface.

### Gates (all green locally)
- round-trip + acyclic guardrails (`go test ./cmd/seed-schema/`) → `ok`
- golden HTTP harness (`TestGoldenHTTP`, `TestGoldenHTTPAuthChain`) + `TestGatewayResponse` → PASS
- full `internal/api` suite → `ok 156s`
- `check-schema-drift.sh` / `check-types-drift.sh` → up to date
- `golangci-lint run ./cmd/seed-schema/ ./internal/api/` → **0 issues**

Wire behavior unchanged (field-promotion-preserving refactor + 3 mechanical literal sites + 1 test).

Refs: `docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md` Phase 2 tail.