### PR TITLE
refactor(api): flat transport mirrors for 4 domain-nested DTOs

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -193,6 +193,15 @@ func schemaTargets() []schemaTarget {
 		{&api.SNMPSettingsResponse{}, "snmp-settings-response.schema.json"},
 		{&api.TestsSettingsResponse{}, "tests-settings-response.schema.json"},
 		{&api.IperfClientStatusResponse{}, "iperf-client-status-response.schema.json"},
+
+		// Domain-nested DTOs that now carry flat transport mirrors (the handler
+		// maps the discovery/dhcp/netif/logging domain value onto a local
+		// purpose-built sub-struct), so the published schema no longer reaches
+		// into a domain package.
+		{&api.TCPProbeResponse{}, "tcp-probe-response.schema.json"},
+		{&api.RogueServersResponse{}, "rogue-servers-response.schema.json"},
+		{&api.CategorizedInterfacesResponse{}, "categorized-interfaces-response.schema.json"},
+		{&api.LogQueryResponse{}, "log-query-response.schema.json"},
 	}
 
 	targets := make([]schemaTarget, len(rows))

--- a/docs/schemas/api/categorized-interfaces-response.schema.json
+++ b/docs/schemas/api/categorized-interfaces-response.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/categorized-interfaces-response.schema.json",
+  "$ref": "#/$defs/CategorizedInterfacesResponse",
+  "$defs": {
+    "CategorizedInterfacesResponse": {
+      "properties": {
+        "ethernet": {
+          "items": {
+            "$ref": "#/$defs/InterfaceInfo"
+          },
+          "type": "array"
+        },
+        "wifi": {
+          "items": {
+            "$ref": "#/$defs/InterfaceInfo"
+          },
+          "type": "array"
+        },
+        "recommendedEthernet": {
+          "type": "string"
+        },
+        "recommendedWifi": {
+          "type": "string"
+        },
+        "currentInterface": {
+          "type": "string"
+        },
+        "currentType": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ethernet",
+        "wifi",
+        "currentInterface",
+        "currentType"
+      ]
+    },
+    "InterfaceInfo": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "friendlyName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "up": {
+          "type": "boolean"
+        },
+        "running": {
+          "type": "boolean"
+        },
+        "hardwareAddr": {
+          "type": "string"
+        },
+        "mtu": {
+          "type": "integer"
+        },
+        "addresses": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "speed": {
+          "type": "integer"
+        },
+        "speedDisplay": {
+          "type": "string"
+        },
+        "chipsetVendor": {
+          "type": "string"
+        },
+        "chipsetModel": {
+          "type": "string"
+        },
+        "hasTDR": {
+          "type": "boolean"
+        },
+        "hasDOM": {
+          "type": "boolean"
+        },
+        "score": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "type",
+        "up",
+        "running",
+        "hardwareAddr",
+        "mtu",
+        "addresses"
+      ]
+    }
+  },
+  "title": "CategorizedInterfacesResponse",
+  "description": "CategorizedInterfacesResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/log-query-response.schema.json
+++ b/docs/schemas/api/log-query-response.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/log-query-response.schema.json",
+  "$ref": "#/$defs/LogQueryResponse",
+  "$defs": {
+    "LogEntry": {
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "level": {
+          "type": "string"
+        },
+        "layer": {
+          "type": "string"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "session_id": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "component": {
+          "type": "string"
+        },
+        "duration_ms": {
+          "type": "integer"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "stack": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "timestamp",
+        "level",
+        "layer",
+        "message"
+      ]
+    },
+    "LogQueryResponse": {
+      "properties": {
+        "logs": {
+          "items": {
+            "$ref": "#/$defs/LogEntry"
+          },
+          "type": "array"
+        },
+        "total_count": {
+          "type": "integer"
+        },
+        "offset": {
+          "type": "integer"
+        },
+        "limit": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "logs",
+        "total_count",
+        "offset",
+        "limit"
+      ]
+    }
+  },
+  "title": "LogQueryResponse",
+  "description": "LogQueryResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/rogue-servers-response.schema.json
+++ b/docs/schemas/api/rogue-servers-response.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/rogue-servers-response.schema.json",
+  "$ref": "#/$defs/RogueServersResponse",
+  "$defs": {
+    "RogueServer": {
+      "properties": {
+        "ip": {
+          "type": "string"
+        },
+        "mac": {
+          "type": "string"
+        },
+        "firstSeen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastSeen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "offerCount": {
+          "type": "integer"
+        },
+        "isAuthorized": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ip",
+        "mac",
+        "firstSeen",
+        "lastSeen",
+        "offerCount",
+        "isAuthorized"
+      ]
+    },
+    "RogueServersResponse": {
+      "properties": {
+        "servers": {
+          "items": {
+            "$ref": "#/$defs/RogueServer"
+          },
+          "type": "array"
+        },
+        "rogueCount": {
+          "type": "integer"
+        },
+        "authorizedCount": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "servers",
+        "rogueCount",
+        "authorizedCount"
+      ]
+    }
+  },
+  "title": "RogueServersResponse",
+  "description": "RogueServersResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/tcp-probe-response.schema.json
+++ b/docs/schemas/api/tcp-probe-response.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/tcp-probe-response.schema.json",
+  "$ref": "#/$defs/TCPProbeResponse",
+  "$defs": {
+    "TCPProbeResponse": {
+      "properties": {
+        "target": {
+          "type": "string"
+        },
+        "results": {
+          "items": {
+            "$ref": "#/$defs/TCPProbeResult"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "target",
+        "results"
+      ]
+    },
+    "TCPProbeResult": {
+      "properties": {
+        "ip": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "state": {
+          "type": "string"
+        },
+        "ttl": {
+          "type": "integer"
+        },
+        "rtt": {
+          "type": "integer"
+        },
+        "flags": {
+          "type": "integer"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ip",
+        "port",
+        "state",
+        "ttl",
+        "rtt"
+      ]
+    }
+  },
+  "title": "TCPProbeResponse",
+  "description": "TCPProbeResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/internal/api/handlers_logs.go
+++ b/internal/api/handlers_logs.go
@@ -41,10 +41,49 @@ type ClientLogEntry struct {
 
 // LogQueryResponse represents the response for log queries.
 type LogQueryResponse struct {
-	Logs       []*logging.LogEntry `json:"logs"`
-	TotalCount int                 `json:"total_count"`
-	Offset     int                 `json:"offset"`
-	Limit      int                 `json:"limit"`
+	Logs       []LogEntry `json:"logs"`
+	TotalCount int        `json:"total_count"`
+	Offset     int        `json:"offset"`
+	Limit      int        `json:"limit"`
+}
+
+// LogEntry is the flat transport view of a log record, mirroring
+// logging.LogEntry's wire shape so the published schema does not depend on the
+// logging domain package.
+type LogEntry struct {
+	Timestamp  time.Time      `json:"timestamp"`
+	Level      string         `json:"level"`
+	Layer      string         `json:"layer"`
+	RequestID  string         `json:"request_id,omitempty"`
+	SessionID  string         `json:"session_id,omitempty"`
+	Message    string         `json:"message"`
+	Component  string         `json:"component,omitempty"`
+	DurationMs int64          `json:"duration_ms,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+	Stack      string         `json:"stack,omitempty"`
+}
+
+// toLogEntries maps logging records onto their flat transport view.
+func toLogEntries(entries []*logging.LogEntry) []LogEntry {
+	out := make([]LogEntry, 0, len(entries))
+	for _, e := range entries {
+		if e == nil {
+			continue
+		}
+		out = append(out, LogEntry{
+			Timestamp:  e.Timestamp,
+			Level:      e.Level,
+			Layer:      e.Layer,
+			RequestID:  e.RequestID,
+			SessionID:  e.SessionID,
+			Message:    e.Message,
+			Component:  e.Component,
+			DurationMs: e.DurationMs,
+			Metadata:   e.Metadata,
+			Stack:      e.Stack,
+		})
+	}
+	return out
 }
 
 // LogStatsResponse represents log statistics.
@@ -211,7 +250,7 @@ func (s *Server) handleLogsQuery(w http.ResponseWriter, r *http.Request) {
 		dbLogs, err := s.queryLogsFromDB(r.Context(), params)
 		if err == nil {
 			sendJSONResponse(w, logger, http.StatusOK, LogQueryResponse{
-				Logs:       dbLogs,
+				Logs:       toLogEntries(dbLogs),
 				TotalCount: len(dbLogs), // TODO: get actual count from DB
 				Offset:     params.offset,
 				Limit:      params.limit,
@@ -249,7 +288,7 @@ func (s *Server) handleLogsQuery(w http.ResponseWriter, r *http.Request) {
 	filtered = paginateLogs(filtered, params.offset, params.limit)
 
 	sendJSONResponse(w, logger, http.StatusOK, LogQueryResponse{
-		Logs:       filtered,
+		Logs:       toLogEntries(filtered),
 		TotalCount: totalCount,
 		Offset:     params.offset,
 		Limit:      params.limit,

--- a/internal/api/handlers_network.go
+++ b/internal/api/handlers_network.go
@@ -182,12 +182,65 @@ type SetMTURequest struct {
 // CategorizedInterfacesResponse groups interfaces by type for UI display.
 // #756: Interfaces are categorized so WiFi only shows under WiFi, Ethernet under Ethernet.
 type CategorizedInterfacesResponse struct {
-	Ethernet            []*netif.InterfaceInfo `json:"ethernet"`
-	WiFi                []*netif.InterfaceInfo `json:"wifi"`
-	RecommendedEthernet string                 `json:"recommendedEthernet,omitempty"`
-	RecommendedWiFi     string                 `json:"recommendedWifi,omitempty"`
-	CurrentInterface    string                 `json:"currentInterface"`
-	CurrentType         string                 `json:"currentType"`
+	Ethernet            []InterfaceInfo `json:"ethernet"`
+	WiFi                []InterfaceInfo `json:"wifi"`
+	RecommendedEthernet string          `json:"recommendedEthernet,omitempty"`
+	RecommendedWiFi     string          `json:"recommendedWifi,omitempty"`
+	CurrentInterface    string          `json:"currentInterface"`
+	CurrentType         string          `json:"currentType"`
+}
+
+// InterfaceInfo is the flat transport view of a network interface, mirroring
+// netif.InterfaceInfo's wire shape so the published schema does not depend on
+// the netif domain package. Type is a plain string (the domain's InterfaceType
+// is a string enum).
+type InterfaceInfo struct {
+	Name          string   `json:"name"`
+	FriendlyName  string   `json:"friendlyName,omitempty"`
+	Description   string   `json:"description,omitempty"`
+	Type          string   `json:"type"`
+	Up            bool     `json:"up"`
+	Running       bool     `json:"running"`
+	HardwareAddr  string   `json:"hardwareAddr"`
+	MTU           int      `json:"mtu"`
+	Addresses     []string `json:"addresses"`
+	Speed         int64    `json:"speed,omitempty"`
+	SpeedDisplay  string   `json:"speedDisplay,omitempty"`
+	ChipsetVendor string   `json:"chipsetVendor,omitempty"`
+	ChipsetModel  string   `json:"chipsetModel,omitempty"`
+	HasTDR        bool     `json:"hasTDR,omitempty"`
+	HasDOM        bool     `json:"hasDOM,omitempty"`
+	Score         int      `json:"score,omitempty"`
+}
+
+// toInterfaceInfos maps physical interfaces onto their flat transport view. It
+// always returns a non-nil slice so an empty category serializes as [] not null.
+func toInterfaceInfos(ifaces []*netif.InterfaceInfo) []InterfaceInfo {
+	out := make([]InterfaceInfo, 0, len(ifaces))
+	for _, iface := range ifaces {
+		if iface == nil {
+			continue
+		}
+		out = append(out, InterfaceInfo{
+			Name:          iface.Name,
+			FriendlyName:  iface.FriendlyName,
+			Description:   iface.Description,
+			Type:          string(iface.Type),
+			Up:            iface.Up,
+			Running:       iface.Running,
+			HardwareAddr:  iface.HardwareAddr,
+			MTU:           iface.MTU,
+			Addresses:     iface.Addresses,
+			Speed:         iface.Speed,
+			SpeedDisplay:  iface.SpeedDisplay,
+			ChipsetVendor: iface.ChipsetVendor,
+			ChipsetModel:  iface.ChipsetModel,
+			HasTDR:        iface.HasTDR,
+			HasDOM:        iface.HasDOM,
+			Score:         iface.Score,
+		})
+	}
+	return out
 }
 
 func (s *Server) handleInterfaces(w http.ResponseWriter, r *http.Request) {
@@ -264,23 +317,22 @@ func (s *Server) handleCategorizedInterfaces(w http.ResponseWriter, _ *http.Requ
 	interfaces := s.netManager().GetPhysicalInterfaces()
 
 	resp := CategorizedInterfacesResponse{
-		Ethernet:         make([]*netif.InterfaceInfo, 0),
-		WiFi:             make([]*netif.InterfaceInfo, 0),
 		CurrentInterface: s.netManager().GetCurrentInterface(),
 	}
 
 	// Categorize interfaces and find best in each category
+	var ethernet, wifi []*netif.InterfaceInfo
 	var bestEthernet, bestWiFi *netif.InterfaceInfo
 
 	for _, iface := range interfaces {
 		switch iface.Type {
 		case netif.InterfaceTypeEthernet:
-			resp.Ethernet = append(resp.Ethernet, iface)
+			ethernet = append(ethernet, iface)
 			if isBetterInterface(iface, bestEthernet) {
 				bestEthernet = iface
 			}
 		case netif.InterfaceTypeWiFi:
-			resp.WiFi = append(resp.WiFi, iface)
+			wifi = append(wifi, iface)
 			if isBetterInterface(iface, bestWiFi) {
 				bestWiFi = iface
 			}
@@ -289,6 +341,9 @@ func (s *Server) handleCategorizedInterfaces(w http.ResponseWriter, _ *http.Requ
 			continue
 		}
 	}
+
+	resp.Ethernet = toInterfaceInfos(ethernet)
+	resp.WiFi = toInterfaceInfos(wifi)
 
 	// Set recommended interfaces
 	if bestEthernet != nil {

--- a/internal/api/handlers_security.go
+++ b/internal/api/handlers_security.go
@@ -31,9 +31,40 @@ type RogueDHCPResponse struct {
 
 // RogueServersResponse contains the list of detected DHCP servers.
 type RogueServersResponse struct {
-	Servers         []*dhcp.RogueServer `json:"servers"`
-	RogueCount      int                 `json:"rogueCount"`
-	AuthorizedCount int                 `json:"authorizedCount"`
+	Servers         []RogueServer `json:"servers"`
+	RogueCount      int           `json:"rogueCount"`
+	AuthorizedCount int           `json:"authorizedCount"`
+}
+
+// RogueServer is the flat transport view of a detected DHCP server, mirroring
+// dhcp.RogueServer's wire shape so the published schema does not depend on the
+// dhcp domain package.
+type RogueServer struct {
+	IP           string    `json:"ip"`
+	MAC          string    `json:"mac"`
+	FirstSeen    time.Time `json:"firstSeen"`
+	LastSeen     time.Time `json:"lastSeen"`
+	OfferCount   int       `json:"offerCount"`
+	IsAuthorized bool      `json:"isAuthorized"`
+}
+
+// toRogueServers maps detected DHCP servers onto their flat transport view.
+func toRogueServers(servers []*dhcp.RogueServer) []RogueServer {
+	out := make([]RogueServer, 0, len(servers))
+	for _, srv := range servers {
+		if srv == nil {
+			continue
+		}
+		out = append(out, RogueServer{
+			IP:           srv.IP,
+			MAC:          srv.MAC,
+			FirstSeen:    srv.FirstSeen,
+			LastSeen:     srv.LastSeen,
+			OfferCount:   srv.OfferCount,
+			IsAuthorized: srv.IsAuthorized,
+		})
+	}
+	return out
 }
 
 // RogueDHCPConfigResponse contains the rogue DHCP detector configuration.
@@ -160,7 +191,7 @@ func (s *Server) handleRogueDHCPServers(w http.ResponseWriter, r *http.Request) 
 		rogues := s.rogueDetector().GetRogueServers()
 
 		resp := RogueServersResponse{
-			Servers:         servers,
+			Servers:         toRogueServers(servers),
 			RogueCount:      len(rogues),
 			AuthorizedCount: len(servers) - len(rogues),
 		}

--- a/internal/api/handlers_tools.go
+++ b/internal/api/handlers_tools.go
@@ -57,8 +57,42 @@ type TCPProbeRequest struct {
 
 // TCPProbeResponse represents TCP probe results.
 type TCPProbeResponse struct {
-	Target  string                     `json:"target"`
-	Results []discovery.TCPProbeResult `json:"results"`
+	Target  string           `json:"target"`
+	Results []TCPProbeResult `json:"results"`
+}
+
+// TCPProbeResult is the flat transport view of a single TCP probe outcome. It
+// mirrors discovery.TCPProbeResult's wire shape so the published schema stays
+// self-contained instead of reaching into the discovery domain package. State
+// is a plain string (the domain's PortState is a string enum); Error carries
+// the error message (the domain's error field serialized as an opaque "{}").
+type TCPProbeResult struct {
+	IP    string        `json:"ip"`
+	Port  int           `json:"port"`
+	State string        `json:"state"`
+	TTL   int           `json:"ttl"`
+	RTT   time.Duration `json:"rtt"`
+	Flags uint8         `json:"flags,omitempty"`
+	Error string        `json:"error,omitempty"`
+}
+
+// toTCPProbeResults maps discovery probe results onto their flat transport view.
+func toTCPProbeResults(results []discovery.TCPProbeResult) []TCPProbeResult {
+	out := make([]TCPProbeResult, len(results))
+	for i, r := range results {
+		out[i] = TCPProbeResult{
+			IP:    r.IP,
+			Port:  r.Port,
+			State: string(r.State),
+			TTL:   r.TTL,
+			RTT:   r.RTT,
+			Flags: r.Flags,
+		}
+		if r.Error != nil {
+			out[i].Error = r.Error.Error()
+		}
+	}
+	return out
 }
 
 // resolveTargetIP resolves a target string to an IP address.
@@ -183,7 +217,7 @@ func (s *Server) handleTCPProbe(w http.ResponseWriter, r *http.Request) {
 
 	resp := TCPProbeResponse{
 		Target:  req.Target,
-		Results: results,
+		Results: toTCPProbeResults(results),
 	}
 
 	sendJSONResponse(w, logger, http.StatusOK, resp)

--- a/ui/src/types/generated/categorized-interfaces-response.ts
+++ b/ui/src/types/generated/categorized-interfaces-response.ts
@@ -1,0 +1,33 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface CategorizedInterfacesResponse {
+  ethernet: InterfaceInfo[];
+  wifi: InterfaceInfo[];
+  recommendedEthernet?: string;
+  recommendedWifi?: string;
+  currentInterface: string;
+  currentType: string;
+}
+export interface InterfaceInfo {
+  name: string;
+  friendlyName?: string;
+  description?: string;
+  type: string;
+  up: boolean;
+  running: boolean;
+  hardwareAddr: string;
+  mtu: number;
+  addresses: string[];
+  speed?: number;
+  speedDisplay?: string;
+  chipsetVendor?: string;
+  chipsetModel?: string;
+  hasTDR?: boolean;
+  hasDOM?: boolean;
+  score?: number;
+}

--- a/ui/src/types/generated/log-query-response.ts
+++ b/ui/src/types/generated/log-query-response.ts
@@ -1,0 +1,25 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface LogQueryResponse {
+  logs: LogEntry[];
+  total_count: number;
+  offset: number;
+  limit: number;
+}
+export interface LogEntry {
+  timestamp: string;
+  level: string;
+  layer: string;
+  request_id?: string;
+  session_id?: string;
+  message: string;
+  component?: string;
+  duration_ms?: number;
+  metadata?: {};
+  stack?: string;
+}

--- a/ui/src/types/generated/rogue-servers-response.ts
+++ b/ui/src/types/generated/rogue-servers-response.ts
@@ -1,0 +1,20 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface RogueServersResponse {
+  servers: RogueServer[];
+  rogueCount: number;
+  authorizedCount: number;
+}
+export interface RogueServer {
+  ip: string;
+  mac: string;
+  firstSeen: string;
+  lastSeen: string;
+  offerCount: number;
+  isAuthorized: boolean;
+}

--- a/ui/src/types/generated/tcp-probe-response.ts
+++ b/ui/src/types/generated/tcp-probe-response.ts
@@ -1,0 +1,20 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface TCPProbeResponse {
+  target: string;
+  results: TCPProbeResult[];
+}
+export interface TCPProbeResult {
+  ip: string;
+  port: number;
+  state: string;
+  ttl: number;
+  rtt: number;
+  flags?: number;
+  error?: string;
+}


### PR DESCRIPTION
## Phase 2 tail — Slice 3: first batch of domain-nested transport mirrors

Four response DTOs put internal **domain types** directly on the wire, so they were deferred from the code-first contract. This gives each a flat, purpose-built transport sub-struct in `internal/api` and maps domain→transport in the handler, then registers them — so the published schema never reaches into a domain package (best practice: the wire contract owns its own types).

| DTO | mirrors | notes |
|---|---|---|
| `TCPProbeResponse` | `discovery.TCPProbeResult` | `PortState`→`string`; **error field now serializes as its message** instead of the opaque `{}` a non-nil `error` interface produced |
| `RogueServersResponse` | `dhcp.RogueServer` | |
| `CategorizedInterfacesResponse` | `netif.InterfaceInfo` | `InterfaceType`→`string`; handler collects domain interfaces locally then maps once |
| `LogQueryResponse` | `logging.LogEntry` | |

Each published schema's `$defs` now holds **only** the local mirror — no domain package. Wire shape preserved field-for-field (json tags copied exactly).

> Scope note: the deep `EngineDiscoveryResponse`/`DiscoveredDevice` cluster (~20 nested structs in the hot discovery zone) is **deferred to Phase 6** per owner decision — it'll be handled by relocating discovery's data types into a CGO-free shared package, not by hand-duplicating 20 structs.

### Gates (all green locally)
- round-trip + acyclic guardrails (`go test ./cmd/seed-schema/`) → `ok`
- golden HTTP harness (`TestGoldenHTTP`/`AuthChain`, incl. `interfaces` subtest) → PASS
- `check-schema-drift.sh` / `check-types-drift.sh` → up to date
- `golangci-lint run ./cmd/seed-schema/ ./internal/api/` → **0 issues**

Refs: `docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md` Phase 2 tail.