### PR TITLE
refactor(api): flat transport mirrors for the Bluetooth DTOs

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -202,6 +202,9 @@ func schemaTargets() []schemaTarget {
 		{&api.RogueServersResponse{}, "rogue-servers-response.schema.json"},
 		{&api.CategorizedInterfacesResponse{}, "categorized-interfaces-response.schema.json"},
 		{&api.LogQueryResponse{}, "log-query-response.schema.json"},
+		{&api.BluetoothScanResponse{}, "bluetooth-scan-response.schema.json"},
+		{&api.BluetoothDevicesResponse{}, "bluetooth-devices-response.schema.json"},
+		{&api.BluetoothStatsResponse{}, "bluetooth-stats-response.schema.json"},
 	}
 
 	targets := make([]schemaTarget, len(rows))

--- a/docs/schemas/api/bluetooth-devices-response.schema.json
+++ b/docs/schemas/api/bluetooth-devices-response.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/bluetooth-devices-response.schema.json",
+  "$ref": "#/$defs/BluetoothDevicesResponse",
+  "$defs": {
+    "BluetoothDevice": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "device_id": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "alias": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "is_connected": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "device_class": {
+          "type": "string"
+        },
+        "appearance": {
+          "type": "integer"
+        },
+        "class_of_device": {
+          "type": "integer"
+        },
+        "rssi": {
+          "type": "integer"
+        },
+        "tx_power": {
+          "type": "integer"
+        },
+        "est_distance_m": {
+          "type": "number"
+        },
+        "is_connectable": {
+          "type": "boolean"
+        },
+        "service_uuids": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "manufacturer_id": {
+          "type": "integer"
+        },
+        "manufacturer_data": {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "is_authorized": {
+          "type": "boolean"
+        },
+        "is_trusted": {
+          "type": "boolean"
+        },
+        "is_paired": {
+          "type": "boolean"
+        },
+        "is_blocked": {
+          "type": "boolean"
+        },
+        "first_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "address",
+        "name",
+        "alias",
+        "vendor",
+        "is_connected",
+        "type",
+        "device_class",
+        "appearance",
+        "rssi",
+        "tx_power",
+        "est_distance_m",
+        "is_connectable",
+        "is_authorized",
+        "is_trusted",
+        "is_paired",
+        "is_blocked",
+        "first_seen",
+        "last_seen"
+      ]
+    },
+    "BluetoothDevicesResponse": {
+      "properties": {
+        "devices": {
+          "items": {
+            "$ref": "#/$defs/BluetoothDevice"
+          },
+          "type": "array"
+        },
+        "total": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "devices",
+        "total"
+      ]
+    }
+  },
+  "title": "BluetoothDevicesResponse",
+  "description": "BluetoothDevicesResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/bluetooth-scan-response.schema.json
+++ b/docs/schemas/api/bluetooth-scan-response.schema.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/bluetooth-scan-response.schema.json",
+  "$ref": "#/$defs/BluetoothScanResponse",
+  "$defs": {
+    "BluetoothDevice": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "device_id": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "alias": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "is_connected": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "device_class": {
+          "type": "string"
+        },
+        "appearance": {
+          "type": "integer"
+        },
+        "class_of_device": {
+          "type": "integer"
+        },
+        "rssi": {
+          "type": "integer"
+        },
+        "tx_power": {
+          "type": "integer"
+        },
+        "est_distance_m": {
+          "type": "number"
+        },
+        "is_connectable": {
+          "type": "boolean"
+        },
+        "service_uuids": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "manufacturer_id": {
+          "type": "integer"
+        },
+        "manufacturer_data": {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "is_authorized": {
+          "type": "boolean"
+        },
+        "is_trusted": {
+          "type": "boolean"
+        },
+        "is_paired": {
+          "type": "boolean"
+        },
+        "is_blocked": {
+          "type": "boolean"
+        },
+        "first_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "address",
+        "name",
+        "alias",
+        "vendor",
+        "is_connected",
+        "type",
+        "device_class",
+        "appearance",
+        "rssi",
+        "tx_power",
+        "est_distance_m",
+        "is_connectable",
+        "is_authorized",
+        "is_trusted",
+        "is_paired",
+        "is_blocked",
+        "first_seen",
+        "last_seen"
+      ]
+    },
+    "BluetoothDiscoveryStats": {
+      "properties": {
+        "total_devices": {
+          "type": "integer"
+        },
+        "classic_devices": {
+          "type": "integer"
+        },
+        "ble_devices": {
+          "type": "integer"
+        },
+        "dual_devices": {
+          "type": "integer"
+        },
+        "connected_devices": {
+          "type": "integer"
+        },
+        "authorized_count": {
+          "type": "integer"
+        },
+        "unauthorized_count": {
+          "type": "integer"
+        },
+        "devices_by_class": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "vendor_breakdown": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "last_scan_time": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "total_devices",
+        "classic_devices",
+        "ble_devices",
+        "dual_devices",
+        "connected_devices",
+        "authorized_count",
+        "unauthorized_count",
+        "devices_by_class",
+        "vendor_breakdown",
+        "last_scan_time"
+      ]
+    },
+    "BluetoothScanResponse": {
+      "properties": {
+        "devices": {
+          "items": {
+            "$ref": "#/$defs/BluetoothDevice"
+          },
+          "type": "array"
+        },
+        "adapterName": {
+          "type": "string"
+        },
+        "scanType": {
+          "type": "string"
+        },
+        "scanTime": {
+          "type": "string"
+        },
+        "scanDurationMs": {
+          "type": "integer"
+        },
+        "stats": {
+          "$ref": "#/$defs/BluetoothDiscoveryStats"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "devices",
+        "adapterName",
+        "scanType",
+        "scanTime",
+        "scanDurationMs"
+      ]
+    }
+  },
+  "title": "BluetoothScanResponse",
+  "description": "BluetoothScanResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/bluetooth-stats-response.schema.json
+++ b/docs/schemas/api/bluetooth-stats-response.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/bluetooth-stats-response.schema.json",
+  "$ref": "#/$defs/BluetoothStatsResponse",
+  "$defs": {
+    "BluetoothDiscoveryStats": {
+      "properties": {
+        "total_devices": {
+          "type": "integer"
+        },
+        "classic_devices": {
+          "type": "integer"
+        },
+        "ble_devices": {
+          "type": "integer"
+        },
+        "dual_devices": {
+          "type": "integer"
+        },
+        "connected_devices": {
+          "type": "integer"
+        },
+        "authorized_count": {
+          "type": "integer"
+        },
+        "unauthorized_count": {
+          "type": "integer"
+        },
+        "devices_by_class": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "vendor_breakdown": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "last_scan_time": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "total_devices",
+        "classic_devices",
+        "ble_devices",
+        "dual_devices",
+        "connected_devices",
+        "authorized_count",
+        "unauthorized_count",
+        "devices_by_class",
+        "vendor_breakdown",
+        "last_scan_time"
+      ]
+    },
+    "BluetoothStatsResponse": {
+      "properties": {
+        "stats": {
+          "$ref": "#/$defs/BluetoothDiscoveryStats"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "stats"
+      ]
+    }
+  },
+  "title": "BluetoothStatsResponse",
+  "description": "BluetoothStatsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/internal/api/handlers_bluetooth.go
+++ b/internal/api/handlers_bluetooth.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/krisarmstrong/seed/internal/i18n"
 	"github.com/krisarmstrong/seed/internal/logging"
@@ -16,23 +17,127 @@ import (
 
 // BluetoothScanResponse contains Bluetooth scan results.
 type BluetoothScanResponse struct {
-	Devices      []discovery.BluetoothDevice        `json:"devices"`
-	AdapterName  string                             `json:"adapterName"`
-	ScanType     string                             `json:"scanType"`
-	ScanTime     string                             `json:"scanTime"`
-	ScanDuration int64                              `json:"scanDurationMs"`
-	Stats        *discovery.BluetoothDiscoveryStats `json:"stats,omitempty"`
+	Devices      []BluetoothDevice        `json:"devices"`
+	AdapterName  string                   `json:"adapterName"`
+	ScanType     string                   `json:"scanType"`
+	ScanTime     string                   `json:"scanTime"`
+	ScanDuration int64                    `json:"scanDurationMs"`
+	Stats        *BluetoothDiscoveryStats `json:"stats,omitempty"`
 }
 
 // BluetoothDevicesResponse contains Bluetooth devices.
 type BluetoothDevicesResponse struct {
-	Devices []discovery.BluetoothDevice `json:"devices"`
-	Total   int                         `json:"total"`
+	Devices []BluetoothDevice `json:"devices"`
+	Total   int               `json:"total"`
 }
 
 // BluetoothStatsResponse contains Bluetooth statistics.
 type BluetoothStatsResponse struct {
-	Stats *discovery.BluetoothDiscoveryStats `json:"stats"`
+	Stats *BluetoothDiscoveryStats `json:"stats"`
+}
+
+// BluetoothDevice is the flat transport view of a discovered Bluetooth device,
+// mirroring discovery.BluetoothDevice's wire shape so the published schema does
+// not depend on the discovery domain package. Type and DeviceClass are plain
+// strings (the domain's BluetoothType/BluetoothDeviceClass are string enums).
+type BluetoothDevice struct {
+	ID               string         `json:"id"`
+	DeviceID         string         `json:"device_id,omitempty"`
+	Address          string         `json:"address"`
+	Name             string         `json:"name"`
+	Alias            string         `json:"alias"`
+	Vendor           string         `json:"vendor"`
+	IsConnected      bool           `json:"is_connected"`
+	Type             string         `json:"type"`
+	DeviceClass      string         `json:"device_class"`
+	Appearance       uint16         `json:"appearance"`
+	ClassOfDev       uint32         `json:"class_of_device,omitempty"`
+	RSSI             int            `json:"rssi"`
+	TxPower          int            `json:"tx_power"`
+	EstDistanceM     float64        `json:"est_distance_m"`
+	IsConnectable    bool           `json:"is_connectable"`
+	ServiceUUIDs     []string       `json:"service_uuids,omitempty"`
+	ManufacturerID   uint16         `json:"manufacturer_id,omitempty"`
+	ManufacturerData []byte         `json:"manufacturer_data,omitempty"`
+	IsAuthorized     bool           `json:"is_authorized"`
+	IsTrusted        bool           `json:"is_trusted"`
+	IsPaired         bool           `json:"is_paired"`
+	IsBlocked        bool           `json:"is_blocked"`
+	FirstSeen        time.Time      `json:"first_seen"`
+	LastSeen         time.Time      `json:"last_seen"`
+	Metadata         map[string]any `json:"metadata,omitempty"`
+}
+
+// BluetoothDiscoveryStats is the flat transport view of Bluetooth scan
+// statistics, mirroring discovery.BluetoothDiscoveryStats's wire shape.
+type BluetoothDiscoveryStats struct {
+	TotalDevices      int            `json:"total_devices"`
+	ClassicDevices    int            `json:"classic_devices"`
+	BLEDevices        int            `json:"ble_devices"`
+	DualDevices       int            `json:"dual_devices"`
+	ConnectedDevices  int            `json:"connected_devices"`
+	AuthorizedCount   int            `json:"authorized_count"`
+	UnauthorizedCount int            `json:"unauthorized_count"`
+	DevicesByClass    map[string]int `json:"devices_by_class"`
+	VendorBreakdown   map[string]int `json:"vendor_breakdown"`
+	LastScanTime      time.Time      `json:"last_scan_time"`
+}
+
+// toBluetoothDevices maps discovered Bluetooth devices onto their flat
+// transport view. It always returns a non-nil slice so an empty scan
+// serializes as [] not null.
+func toBluetoothDevices(devices []discovery.BluetoothDevice) []BluetoothDevice {
+	out := make([]BluetoothDevice, 0, len(devices))
+	for _, d := range devices {
+		out = append(out, BluetoothDevice{
+			ID:               d.ID,
+			DeviceID:         d.DeviceID,
+			Address:          d.Address,
+			Name:             d.Name,
+			Alias:            d.Alias,
+			Vendor:           d.Vendor,
+			IsConnected:      d.IsConnected,
+			Type:             string(d.Type),
+			DeviceClass:      string(d.DeviceClass),
+			Appearance:       d.Appearance,
+			ClassOfDev:       d.ClassOfDev,
+			RSSI:             d.RSSI,
+			TxPower:          d.TxPower,
+			EstDistanceM:     d.EstDistanceM,
+			IsConnectable:    d.IsConnectable,
+			ServiceUUIDs:     d.ServiceUUIDs,
+			ManufacturerID:   d.ManufacturerID,
+			ManufacturerData: d.ManufacturerData,
+			IsAuthorized:     d.IsAuthorized,
+			IsTrusted:        d.IsTrusted,
+			IsPaired:         d.IsPaired,
+			IsBlocked:        d.IsBlocked,
+			FirstSeen:        d.FirstSeen,
+			LastSeen:         d.LastSeen,
+			Metadata:         d.Metadata,
+		})
+	}
+	return out
+}
+
+// toBluetoothStats maps Bluetooth scan statistics onto their flat transport
+// view, preserving nil so an absent stats block stays omitted.
+func toBluetoothStats(stats *discovery.BluetoothDiscoveryStats) *BluetoothDiscoveryStats {
+	if stats == nil {
+		return nil
+	}
+	return &BluetoothDiscoveryStats{
+		TotalDevices:      stats.TotalDevices,
+		ClassicDevices:    stats.ClassicDevices,
+		BLEDevices:        stats.BLEDevices,
+		DualDevices:       stats.DualDevices,
+		ConnectedDevices:  stats.ConnectedDevices,
+		AuthorizedCount:   stats.AuthorizedCount,
+		UnauthorizedCount: stats.UnauthorizedCount,
+		DevicesByClass:    stats.DevicesByClass,
+		VendorBreakdown:   stats.VendorBreakdown,
+		LastScanTime:      stats.LastScanTime,
+	}
 }
 
 // handleBluetoothScan triggers a Bluetooth scan and returns results.
@@ -87,12 +192,12 @@ func (s *Server) handleBluetoothScan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := BluetoothScanResponse{
-		Devices:      result.Devices,
+		Devices:      toBluetoothDevices(result.Devices),
 		AdapterName:  result.AdapterName,
 		ScanType:     result.ScanType,
 		ScanTime:     result.ScanTime.Format("2006-01-02T15:04:05Z07:00"),
 		ScanDuration: result.ScanDuration.Milliseconds(),
-		Stats:        btScanner.GetStats(),
+		Stats:        toBluetoothStats(btScanner.GetStats()),
 	}
 
 	sendJSONResponse(w, logger, http.StatusOK, resp)
@@ -137,14 +242,14 @@ func (s *Server) handleBluetoothDevices(w http.ResponseWriter, r *http.Request) 
 	lastScan := btScanner.GetLastScan()
 	if lastScan == nil {
 		sendJSONResponse(w, logger, http.StatusOK, BluetoothDevicesResponse{
-			Devices: []discovery.BluetoothDevice{},
+			Devices: []BluetoothDevice{},
 			Total:   0,
 		})
 		return
 	}
 
 	sendJSONResponse(w, logger, http.StatusOK, BluetoothDevicesResponse{
-		Devices: lastScan.Devices,
+		Devices: toBluetoothDevices(lastScan.Devices),
 		Total:   len(lastScan.Devices),
 	})
 }
@@ -187,7 +292,7 @@ func (s *Server) handleBluetoothStats(w http.ResponseWriter, r *http.Request) {
 
 	stats := btScanner.GetStats()
 	sendJSONResponse(w, logger, http.StatusOK, BluetoothStatsResponse{
-		Stats: stats,
+		Stats: toBluetoothStats(stats),
 	})
 }
 

--- a/ui/src/types/generated/bluetooth-devices-response.ts
+++ b/ui/src/types/generated/bluetooth-devices-response.ts
@@ -1,0 +1,38 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface BluetoothDevicesResponse {
+  devices: BluetoothDevice[];
+  total: number;
+}
+export interface BluetoothDevice {
+  id: string;
+  device_id?: string;
+  address: string;
+  name: string;
+  alias: string;
+  vendor: string;
+  is_connected: boolean;
+  type: string;
+  device_class: string;
+  appearance: number;
+  class_of_device?: number;
+  rssi: number;
+  tx_power: number;
+  est_distance_m: number;
+  is_connectable: boolean;
+  service_uuids?: string[];
+  manufacturer_id?: number;
+  manufacturer_data?: string;
+  is_authorized: boolean;
+  is_trusted: boolean;
+  is_paired: boolean;
+  is_blocked: boolean;
+  first_seen: string;
+  last_seen: string;
+  metadata?: {};
+}

--- a/ui/src/types/generated/bluetooth-scan-response.ts
+++ b/ui/src/types/generated/bluetooth-scan-response.ts
@@ -1,0 +1,58 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface BluetoothScanResponse {
+  devices: BluetoothDevice[];
+  adapterName: string;
+  scanType: string;
+  scanTime: string;
+  scanDurationMs: number;
+  stats?: BluetoothDiscoveryStats;
+}
+export interface BluetoothDevice {
+  id: string;
+  device_id?: string;
+  address: string;
+  name: string;
+  alias: string;
+  vendor: string;
+  is_connected: boolean;
+  type: string;
+  device_class: string;
+  appearance: number;
+  class_of_device?: number;
+  rssi: number;
+  tx_power: number;
+  est_distance_m: number;
+  is_connectable: boolean;
+  service_uuids?: string[];
+  manufacturer_id?: number;
+  manufacturer_data?: string;
+  is_authorized: boolean;
+  is_trusted: boolean;
+  is_paired: boolean;
+  is_blocked: boolean;
+  first_seen: string;
+  last_seen: string;
+  metadata?: {};
+}
+export interface BluetoothDiscoveryStats {
+  total_devices: number;
+  classic_devices: number;
+  ble_devices: number;
+  dual_devices: number;
+  connected_devices: number;
+  authorized_count: number;
+  unauthorized_count: number;
+  devices_by_class: {
+    [k: string]: number;
+  };
+  vendor_breakdown: {
+    [k: string]: number;
+  };
+  last_scan_time: string;
+}

--- a/ui/src/types/generated/bluetooth-stats-response.ts
+++ b/ui/src/types/generated/bluetooth-stats-response.ts
@@ -1,0 +1,26 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface BluetoothStatsResponse {
+  stats: BluetoothDiscoveryStats;
+}
+export interface BluetoothDiscoveryStats {
+  total_devices: number;
+  classic_devices: number;
+  ble_devices: number;
+  dual_devices: number;
+  connected_devices: number;
+  authorized_count: number;
+  unauthorized_count: number;
+  devices_by_class: {
+    [k: string]: number;
+  };
+  vendor_breakdown: {
+    [k: string]: number;
+  };
+  last_scan_time: string;
+}


### PR DESCRIPTION
## Phase 2 tail — Slice 4: Bluetooth transport mirrors

`BluetoothScanResponse`, `BluetoothDevicesResponse`, `BluetoothStatsResponse` put `discovery.BluetoothDevice` / `discovery.BluetoothDiscoveryStats` directly on the wire. Adds flat transport mirrors (`BluetoothDevice`, `BluetoothDiscoveryStats`) in `internal/api` (`BluetoothType`/`BluetoothDeviceClass`→`string`) and maps domain→transport in the handlers:
- `toBluetoothDevices` returns a non-nil slice so an empty scan stays `[]`
- `toBluetoothStats` preserves `nil` so an absent stats block stays omitted

Each published schema's `$defs` now holds only the local mirrors. `[]byte` `ManufacturerData` serializes as a base64 string exactly as before; wire shape preserved field-for-field.

### Gates (all green locally)
- round-trip + acyclic guardrails → `ok`
- golden HTTP harness → PASS
- schema/types drift → up to date
- `golangci-lint` (cmd/seed-schema + internal/api) → **0 issues**

Refs: `docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md` Phase 2 tail.