### PR TITLE
refactor(api): flat transport mirrors for the Wi-Fi discovery DTOs

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -205,6 +205,10 @@ func schemaTargets() []schemaTarget {
 		{&api.BluetoothScanResponse{}, "bluetooth-scan-response.schema.json"},
 		{&api.BluetoothDevicesResponse{}, "bluetooth-devices-response.schema.json"},
 		{&api.BluetoothStatsResponse{}, "bluetooth-stats-response.schema.json"},
+		{&api.WiFiDiscoveryScanResponse{}, "wifi-discovery-scan-response.schema.json"},
+		{&api.WiFiDiscoveryNetworksResponse{}, "wifi-discovery-networks-response.schema.json"},
+		{&api.WiFiDiscoveryAPsResponse{}, "wifi-discovery-aps-response.schema.json"},
+		{&api.WiFiDiscoveryStatsResponse{}, "wifi-discovery-stats-response.schema.json"},
 	}
 
 	targets := make([]schemaTarget, len(rows))

--- a/docs/schemas/api/wifi-discovery-aps-response.schema.json
+++ b/docs/schemas/api/wifi-discovery-aps-response.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/wifi-discovery-aps-response.schema.json",
+  "$ref": "#/$defs/WiFiDiscoveryAPsResponse",
+  "$defs": {
+    "WiFiAccessPoint": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "device_id": {
+          "type": "string"
+        },
+        "bssid": {
+          "type": "string"
+        },
+        "ssid_id": {
+          "type": "string"
+        },
+        "ssid_name": {
+          "type": "string"
+        },
+        "ap_name": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "integer"
+        },
+        "channel_width": {
+          "type": "integer"
+        },
+        "frequency_mhz": {
+          "type": "integer"
+        },
+        "band": {
+          "type": "string"
+        },
+        "wifi_standard": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "signal_dbm": {
+          "type": "integer"
+        },
+        "noise_dbm": {
+          "type": "integer"
+        },
+        "client_count": {
+          "type": "integer"
+        },
+        "max_clients": {
+          "type": "integer"
+        },
+        "is_authorized": {
+          "type": "boolean"
+        },
+        "first_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "bssid",
+        "channel",
+        "channel_width",
+        "frequency_mhz",
+        "band",
+        "signal_dbm",
+        "client_count",
+        "is_authorized",
+        "first_seen",
+        "last_seen"
+      ]
+    },
+    "WiFiDiscoveryAPsResponse": {
+      "properties": {
+        "accessPoints": {
+          "items": {
+            "$ref": "#/$defs/WiFiAccessPoint"
+          },
+          "type": "array"
+        },
+        "total": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "accessPoints",
+        "total"
+      ]
+    }
+  },
+  "title": "WiFiDiscoveryAPsResponse",
+  "description": "WiFiDiscoveryAPsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/wifi-discovery-networks-response.schema.json
+++ b/docs/schemas/api/wifi-discovery-networks-response.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/wifi-discovery-networks-response.schema.json",
+  "$ref": "#/$defs/WiFiDiscoveryNetworksResponse",
+  "$defs": {
+    "WiFiDiscoveryNetworksResponse": {
+      "properties": {
+        "networks": {
+          "items": {
+            "$ref": "#/$defs/WiFiNetwork"
+          },
+          "type": "array"
+        },
+        "total": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "networks",
+        "total"
+      ]
+    },
+    "WiFiNetwork": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "ssid": {
+          "type": "string"
+        },
+        "is_hidden": {
+          "type": "boolean"
+        },
+        "security_type": {
+          "type": "string"
+        },
+        "authorization_status": {
+          "type": "string"
+        },
+        "first_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ap_count": {
+          "type": "integer"
+        },
+        "best_signal": {
+          "type": "integer"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "ssid",
+        "is_hidden",
+        "security_type",
+        "authorization_status",
+        "first_seen",
+        "last_seen"
+      ]
+    }
+  },
+  "title": "WiFiDiscoveryNetworksResponse",
+  "description": "WiFiDiscoveryNetworksResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/wifi-discovery-scan-response.schema.json
+++ b/docs/schemas/api/wifi-discovery-scan-response.schema.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/wifi-discovery-scan-response.schema.json",
+  "$ref": "#/$defs/WiFiDiscoveryScanResponse",
+  "$defs": {
+    "ChannelUtilization": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "integer"
+        },
+        "band": {
+          "type": "string"
+        },
+        "frequency_mhz": {
+          "type": "integer"
+        },
+        "utilization_percent": {
+          "type": "number"
+        },
+        "non_wifi_percent": {
+          "type": "number"
+        },
+        "retry_percent": {
+          "type": "number"
+        },
+        "ap_count": {
+          "type": "integer"
+        },
+        "client_count": {
+          "type": "integer"
+        },
+        "recorded_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "channel",
+        "band",
+        "frequency_mhz",
+        "utilization_percent",
+        "non_wifi_percent",
+        "retry_percent",
+        "ap_count",
+        "client_count",
+        "recorded_at"
+      ]
+    },
+    "WiFiAccessPoint": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "device_id": {
+          "type": "string"
+        },
+        "bssid": {
+          "type": "string"
+        },
+        "ssid_id": {
+          "type": "string"
+        },
+        "ssid_name": {
+          "type": "string"
+        },
+        "ap_name": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "integer"
+        },
+        "channel_width": {
+          "type": "integer"
+        },
+        "frequency_mhz": {
+          "type": "integer"
+        },
+        "band": {
+          "type": "string"
+        },
+        "wifi_standard": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "signal_dbm": {
+          "type": "integer"
+        },
+        "noise_dbm": {
+          "type": "integer"
+        },
+        "client_count": {
+          "type": "integer"
+        },
+        "max_clients": {
+          "type": "integer"
+        },
+        "is_authorized": {
+          "type": "boolean"
+        },
+        "first_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "bssid",
+        "channel",
+        "channel_width",
+        "frequency_mhz",
+        "band",
+        "signal_dbm",
+        "client_count",
+        "is_authorized",
+        "first_seen",
+        "last_seen"
+      ]
+    },
+    "WiFiDiscoveryScanResponse": {
+      "properties": {
+        "networks": {
+          "items": {
+            "$ref": "#/$defs/WiFiNetwork"
+          },
+          "type": "array"
+        },
+        "accessPoints": {
+          "items": {
+            "$ref": "#/$defs/WiFiAccessPoint"
+          },
+          "type": "array"
+        },
+        "channelUtilization": {
+          "items": {
+            "$ref": "#/$defs/ChannelUtilization"
+          },
+          "type": "array"
+        },
+        "scanTime": {
+          "type": "string"
+        },
+        "interface": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "networks",
+        "accessPoints",
+        "channelUtilization",
+        "scanTime",
+        "interface"
+      ]
+    },
+    "WiFiNetwork": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "ssid": {
+          "type": "string"
+        },
+        "is_hidden": {
+          "type": "boolean"
+        },
+        "security_type": {
+          "type": "string"
+        },
+        "authorization_status": {
+          "type": "string"
+        },
+        "first_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_seen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ap_count": {
+          "type": "integer"
+        },
+        "best_signal": {
+          "type": "integer"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "ssid",
+        "is_hidden",
+        "security_type",
+        "authorization_status",
+        "first_seen",
+        "last_seen"
+      ]
+    }
+  },
+  "title": "WiFiDiscoveryScanResponse",
+  "description": "WiFiDiscoveryScanResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/wifi-discovery-stats-response.schema.json
+++ b/docs/schemas/api/wifi-discovery-stats-response.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/wifi-discovery-stats-response.schema.json",
+  "$ref": "#/$defs/WiFiDiscoveryStatsResponse",
+  "$defs": {
+    "WiFiDiscoveryStats": {
+      "properties": {
+        "total_networks": {
+          "type": "integer"
+        },
+        "hidden_networks": {
+          "type": "integer"
+        },
+        "total_aps": {
+          "type": "integer"
+        },
+        "authorized_aps": {
+          "type": "integer"
+        },
+        "unauthorized_aps": {
+          "type": "integer"
+        },
+        "total_clients": {
+          "type": "integer"
+        },
+        "channels_by_band": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "security_breakdown": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "vendor_breakdown": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "last_scan_time": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "total_networks",
+        "hidden_networks",
+        "total_aps",
+        "authorized_aps",
+        "unauthorized_aps",
+        "total_clients",
+        "channels_by_band",
+        "security_breakdown",
+        "vendor_breakdown",
+        "last_scan_time"
+      ]
+    },
+    "WiFiDiscoveryStatsResponse": {
+      "properties": {
+        "stats": {
+          "$ref": "#/$defs/WiFiDiscoveryStats"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "stats"
+      ]
+    }
+  },
+  "title": "WiFiDiscoveryStatsResponse",
+  "description": "WiFiDiscoveryStatsResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/internal/api/handlers_wifi.go
+++ b/internal/api/handlers_wifi.go
@@ -6,6 +6,7 @@ package api
 import (
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/krisarmstrong/seed/internal/i18n"
 	"github.com/krisarmstrong/seed/internal/logging"
@@ -673,28 +674,191 @@ func (s *Server) wifiBridge() *discovery.WiFiBridge {
 
 // WiFiDiscoveryScanResponse contains enhanced WiFi scan results.
 type WiFiDiscoveryScanResponse struct {
-	Networks    []discovery.WiFiNetwork        `json:"networks"`
-	APs         []discovery.WiFiAccessPoint    `json:"accessPoints"`
-	Utilization []discovery.ChannelUtilization `json:"channelUtilization"`
-	ScanTime    string                         `json:"scanTime"`
-	Interface   string                         `json:"interface"`
+	Networks    []WiFiNetwork        `json:"networks"`
+	APs         []WiFiAccessPoint    `json:"accessPoints"`
+	Utilization []ChannelUtilization `json:"channelUtilization"`
+	ScanTime    string               `json:"scanTime"`
+	Interface   string               `json:"interface"`
 }
 
 // WiFiDiscoveryNetworksResponse contains discovered WiFi networks.
 type WiFiDiscoveryNetworksResponse struct {
-	Networks []discovery.WiFiNetwork `json:"networks"`
-	Total    int                     `json:"total"`
+	Networks []WiFiNetwork `json:"networks"`
+	Total    int           `json:"total"`
 }
 
 // WiFiDiscoveryAPsResponse contains discovered access points.
 type WiFiDiscoveryAPsResponse struct {
-	AccessPoints []discovery.WiFiAccessPoint `json:"accessPoints"`
-	Total        int                         `json:"total"`
+	AccessPoints []WiFiAccessPoint `json:"accessPoints"`
+	Total        int               `json:"total"`
 }
 
 // WiFiDiscoveryStatsResponse contains WiFi discovery statistics.
 type WiFiDiscoveryStatsResponse struct {
-	Stats *discovery.WiFiDiscoveryStats `json:"stats"`
+	Stats *WiFiDiscoveryStats `json:"stats"`
+}
+
+// WiFiNetwork is the flat transport view of discovery.WiFiNetwork. It and its
+// siblings (WiFiAccessPoint, ChannelUtilization, WiFiDiscoveryStats) mirror the
+// discovery domain's Wi-Fi types so the published schemas do not depend on the
+// discovery package; named string enums (security/authorization/band) collapse
+// to string.
+type WiFiNetwork struct {
+	ID                  string         `json:"id"`
+	SSID                string         `json:"ssid"`
+	IsHidden            bool           `json:"is_hidden"`
+	SecurityType        string         `json:"security_type"`
+	AuthorizationStatus string         `json:"authorization_status"`
+	FirstSeen           time.Time      `json:"first_seen"`
+	LastSeen            time.Time      `json:"last_seen"`
+	APCount             int            `json:"ap_count,omitempty"`
+	BestSignal          int            `json:"best_signal,omitempty"`
+	Metadata            map[string]any `json:"metadata,omitempty"`
+}
+
+// WiFiAccessPoint is the flat transport view of discovery.WiFiAccessPoint.
+type WiFiAccessPoint struct {
+	ID           string         `json:"id"`
+	DeviceID     string         `json:"device_id,omitempty"`
+	BSSID        string         `json:"bssid"`
+	SSIDID       string         `json:"ssid_id,omitempty"`
+	SSIDName     string         `json:"ssid_name,omitempty"`
+	APName       string         `json:"ap_name,omitempty"`
+	Vendor       string         `json:"vendor,omitempty"`
+	Channel      int            `json:"channel"`
+	ChannelWidth int            `json:"channel_width"`
+	FrequencyMHz int            `json:"frequency_mhz"`
+	Band         string         `json:"band"`
+	WiFiStandard []string       `json:"wifi_standard,omitempty"`
+	SignalDBm    int            `json:"signal_dbm"`
+	NoiseDBm     int            `json:"noise_dbm,omitempty"`
+	ClientCount  int            `json:"client_count"`
+	MaxClients   int            `json:"max_clients,omitempty"`
+	IsAuthorized bool           `json:"is_authorized"`
+	FirstSeen    time.Time      `json:"first_seen"`
+	LastSeen     time.Time      `json:"last_seen"`
+	Metadata     map[string]any `json:"metadata,omitempty"`
+}
+
+// ChannelUtilization is the flat transport view of discovery.ChannelUtilization.
+type ChannelUtilization struct {
+	ID                 string    `json:"id"`
+	Channel            int       `json:"channel"`
+	Band               string    `json:"band"`
+	FrequencyMHz       int       `json:"frequency_mhz"`
+	UtilizationPercent float64   `json:"utilization_percent"`
+	NonWiFiPercent     float64   `json:"non_wifi_percent"`
+	RetryPercent       float64   `json:"retry_percent"`
+	APCount            int       `json:"ap_count"`
+	ClientCount        int       `json:"client_count"`
+	RecordedAt         time.Time `json:"recorded_at"`
+}
+
+// WiFiDiscoveryStats is the flat transport view of discovery.WiFiDiscoveryStats.
+type WiFiDiscoveryStats struct {
+	TotalNetworks     int            `json:"total_networks"`
+	HiddenNetworks    int            `json:"hidden_networks"`
+	TotalAPs          int            `json:"total_aps"`
+	AuthorizedAPs     int            `json:"authorized_aps"`
+	UnauthorizedAPs   int            `json:"unauthorized_aps"`
+	TotalClients      int            `json:"total_clients"`
+	ChannelsByBand    map[string]int `json:"channels_by_band"`
+	SecurityBreakdown map[string]int `json:"security_breakdown"`
+	VendorBreakdown   map[string]int `json:"vendor_breakdown"`
+	LastScanTime      time.Time      `json:"last_scan_time"`
+}
+
+// toWiFiNetworks maps discovered Wi-Fi networks onto their flat transport view,
+// always returning a non-nil slice so an empty result serializes as [].
+func toWiFiNetworks(networks []discovery.WiFiNetwork) []WiFiNetwork {
+	out := make([]WiFiNetwork, 0, len(networks))
+	for _, n := range networks {
+		out = append(out, WiFiNetwork{
+			ID:                  n.ID,
+			SSID:                n.SSID,
+			IsHidden:            n.IsHidden,
+			SecurityType:        string(n.SecurityType),
+			AuthorizationStatus: string(n.AuthorizationStatus),
+			FirstSeen:           n.FirstSeen,
+			LastSeen:            n.LastSeen,
+			APCount:             n.APCount,
+			BestSignal:          n.BestSignal,
+			Metadata:            n.Metadata,
+		})
+	}
+	return out
+}
+
+// toWiFiAccessPoints maps discovered access points onto their flat transport
+// view, always returning a non-nil slice.
+func toWiFiAccessPoints(aps []discovery.WiFiAccessPoint) []WiFiAccessPoint {
+	out := make([]WiFiAccessPoint, 0, len(aps))
+	for _, ap := range aps {
+		out = append(out, WiFiAccessPoint{
+			ID:           ap.ID,
+			DeviceID:     ap.DeviceID,
+			BSSID:        ap.BSSID,
+			SSIDID:       ap.SSIDID,
+			SSIDName:     ap.SSIDName,
+			APName:       ap.APName,
+			Vendor:       ap.Vendor,
+			Channel:      ap.Channel,
+			ChannelWidth: ap.ChannelWidth,
+			FrequencyMHz: ap.FrequencyMHz,
+			Band:         string(ap.Band),
+			WiFiStandard: ap.WiFiStandard,
+			SignalDBm:    ap.SignalDBm,
+			NoiseDBm:     ap.NoiseDBm,
+			ClientCount:  ap.ClientCount,
+			MaxClients:   ap.MaxClients,
+			IsAuthorized: ap.IsAuthorized,
+			FirstSeen:    ap.FirstSeen,
+			LastSeen:     ap.LastSeen,
+			Metadata:     ap.Metadata,
+		})
+	}
+	return out
+}
+
+// toChannelUtilizations maps channel-utilization records onto their flat
+// transport view, always returning a non-nil slice.
+func toChannelUtilizations(utils []discovery.ChannelUtilization) []ChannelUtilization {
+	out := make([]ChannelUtilization, 0, len(utils))
+	for _, u := range utils {
+		out = append(out, ChannelUtilization{
+			ID:                 u.ID,
+			Channel:            u.Channel,
+			Band:               string(u.Band),
+			FrequencyMHz:       u.FrequencyMHz,
+			UtilizationPercent: u.UtilizationPercent,
+			NonWiFiPercent:     u.NonWiFiPercent,
+			RetryPercent:       u.RetryPercent,
+			APCount:            u.APCount,
+			ClientCount:        u.ClientCount,
+			RecordedAt:         u.RecordedAt,
+		})
+	}
+	return out
+}
+
+// toWiFiDiscoveryStats maps Wi-Fi discovery statistics onto their flat
+// transport view, preserving nil so an absent stats block stays omitted.
+func toWiFiDiscoveryStats(stats *discovery.WiFiDiscoveryStats) *WiFiDiscoveryStats {
+	if stats == nil {
+		return nil
+	}
+	return &WiFiDiscoveryStats{
+		TotalNetworks:     stats.TotalNetworks,
+		HiddenNetworks:    stats.HiddenNetworks,
+		TotalAPs:          stats.TotalAPs,
+		AuthorizedAPs:     stats.AuthorizedAPs,
+		UnauthorizedAPs:   stats.UnauthorizedAPs,
+		TotalClients:      stats.TotalClients,
+		ChannelsByBand:    stats.ChannelsByBand,
+		SecurityBreakdown: stats.SecurityBreakdown,
+		VendorBreakdown:   stats.VendorBreakdown,
+		LastScanTime:      stats.LastScanTime,
+	}
 }
 
 // handleWiFiDiscoveryScan performs an enhanced WiFi scan using the WiFiBridge.
@@ -749,9 +913,9 @@ func (s *Server) handleWiFiDiscoveryScan(w http.ResponseWriter, r *http.Request)
 	}
 
 	resp := WiFiDiscoveryScanResponse{
-		Networks:    result.Networks,
-		APs:         result.APs,
-		Utilization: result.Utilization,
+		Networks:    toWiFiNetworks(result.Networks),
+		APs:         toWiFiAccessPoints(result.APs),
+		Utilization: toChannelUtilizations(result.Utilization),
 		ScanTime:    result.ScanTime.Format("2006-01-02T15:04:05Z07:00"),
 		Interface:   result.Interface,
 	}
@@ -797,7 +961,7 @@ func (s *Server) handleWiFiDiscoveryNetworks(w http.ResponseWriter, r *http.Requ
 
 	networks := bridge.GetNetworks()
 	sendJSONResponse(w, logger, http.StatusOK, WiFiDiscoveryNetworksResponse{
-		Networks: networks,
+		Networks: toWiFiNetworks(networks),
 		Total:    len(networks),
 	})
 }
@@ -840,7 +1004,7 @@ func (s *Server) handleWiFiDiscoveryAPs(w http.ResponseWriter, r *http.Request) 
 
 	aps := bridge.GetAccessPoints()
 	sendJSONResponse(w, logger, http.StatusOK, WiFiDiscoveryAPsResponse{
-		AccessPoints: aps,
+		AccessPoints: toWiFiAccessPoints(aps),
 		Total:        len(aps),
 	})
 }
@@ -883,6 +1047,6 @@ func (s *Server) handleWiFiDiscoveryStats(w http.ResponseWriter, r *http.Request
 
 	stats := bridge.GetStats()
 	sendJSONResponse(w, logger, http.StatusOK, WiFiDiscoveryStatsResponse{
-		Stats: stats,
+		Stats: toWiFiDiscoveryStats(stats),
 	})
 }

--- a/ui/src/types/generated/wifi-discovery-aps-response.ts
+++ b/ui/src/types/generated/wifi-discovery-aps-response.ts
@@ -1,0 +1,33 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface WiFiDiscoveryAPsResponse {
+  accessPoints: WiFiAccessPoint[];
+  total: number;
+}
+export interface WiFiAccessPoint {
+  id: string;
+  device_id?: string;
+  bssid: string;
+  ssid_id?: string;
+  ssid_name?: string;
+  ap_name?: string;
+  vendor?: string;
+  channel: number;
+  channel_width: number;
+  frequency_mhz: number;
+  band: string;
+  wifi_standard?: string[];
+  signal_dbm: number;
+  noise_dbm?: number;
+  client_count: number;
+  max_clients?: number;
+  is_authorized: boolean;
+  first_seen: string;
+  last_seen: string;
+  metadata?: {};
+}

--- a/ui/src/types/generated/wifi-discovery-networks-response.ts
+++ b/ui/src/types/generated/wifi-discovery-networks-response.ts
@@ -1,0 +1,23 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface WiFiDiscoveryNetworksResponse {
+  networks: WiFiNetwork[];
+  total: number;
+}
+export interface WiFiNetwork {
+  id: string;
+  ssid: string;
+  is_hidden: boolean;
+  security_type: string;
+  authorization_status: string;
+  first_seen: string;
+  last_seen: string;
+  ap_count?: number;
+  best_signal?: number;
+  metadata?: {};
+}

--- a/ui/src/types/generated/wifi-discovery-scan-response.ts
+++ b/ui/src/types/generated/wifi-discovery-scan-response.ts
@@ -1,0 +1,60 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface WiFiDiscoveryScanResponse {
+  networks: WiFiNetwork[];
+  accessPoints: WiFiAccessPoint[];
+  channelUtilization: ChannelUtilization[];
+  scanTime: string;
+  interface: string;
+}
+export interface WiFiNetwork {
+  id: string;
+  ssid: string;
+  is_hidden: boolean;
+  security_type: string;
+  authorization_status: string;
+  first_seen: string;
+  last_seen: string;
+  ap_count?: number;
+  best_signal?: number;
+  metadata?: {};
+}
+export interface WiFiAccessPoint {
+  id: string;
+  device_id?: string;
+  bssid: string;
+  ssid_id?: string;
+  ssid_name?: string;
+  ap_name?: string;
+  vendor?: string;
+  channel: number;
+  channel_width: number;
+  frequency_mhz: number;
+  band: string;
+  wifi_standard?: string[];
+  signal_dbm: number;
+  noise_dbm?: number;
+  client_count: number;
+  max_clients?: number;
+  is_authorized: boolean;
+  first_seen: string;
+  last_seen: string;
+  metadata?: {};
+}
+export interface ChannelUtilization {
+  id: string;
+  channel: number;
+  band: string;
+  frequency_mhz: number;
+  utilization_percent: number;
+  non_wifi_percent: number;
+  retry_percent: number;
+  ap_count: number;
+  client_count: number;
+  recorded_at: string;
+}

--- a/ui/src/types/generated/wifi-discovery-stats-response.ts
+++ b/ui/src/types/generated/wifi-discovery-stats-response.ts
@@ -1,0 +1,28 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface WiFiDiscoveryStatsResponse {
+  stats: WiFiDiscoveryStats;
+}
+export interface WiFiDiscoveryStats {
+  total_networks: number;
+  hidden_networks: number;
+  total_aps: number;
+  authorized_aps: number;
+  unauthorized_aps: number;
+  total_clients: number;
+  channels_by_band: {
+    [k: string]: number;
+  };
+  security_breakdown: {
+    [k: string]: number;
+  };
+  vendor_breakdown: {
+    [k: string]: number;
+  };
+  last_scan_time: string;
+}


### PR DESCRIPTION
## Phase 2 tail — Slice 5: Wi-Fi discovery transport mirrors

`WiFiDiscoveryScanResponse`, `WiFiDiscoveryNetworksResponse`, `WiFiDiscoveryAPsResponse`, `WiFiDiscoveryStatsResponse` put `discovery.WiFiNetwork` / `WiFiAccessPoint` / `ChannelUtilization` / `WiFiDiscoveryStats` directly on the wire. Adds flat transport mirrors in `internal/api` (security/authorization/band string enums → `string`) and maps domain→transport in the handlers:
- slice mappers return non-nil so empty results stay `[]`
- the stats mapper preserves `nil`

Each published schema's `$defs` now holds only the local mirrors; wire shape preserved field-for-field.

### Gates (all green locally)
- round-trip + acyclic guardrails → `ok`
- golden HTTP harness → PASS
- schema/types drift → up to date
- `golangci-lint` (cmd/seed-schema + internal/api) → **0 issues**

Refs: `docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md` Phase 2 tail.