### PR TITLE
refactor(api): flat transport mirrors for PathResponse + survey-import

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -209,6 +209,8 @@ func schemaTargets() []schemaTarget {
 		{&api.WiFiDiscoveryNetworksResponse{}, "wifi-discovery-networks-response.schema.json"},
 		{&api.WiFiDiscoveryAPsResponse{}, "wifi-discovery-aps-response.schema.json"},
 		{&api.WiFiDiscoveryStatsResponse{}, "wifi-discovery-stats-response.schema.json"},
+		{&api.PathResponse{}, "path-response.schema.json"},
+		{&api.UpdateSurveyImportedDataRequest{}, "update-survey-imported-data-request.schema.json"},
 	}
 
 	targets := make([]schemaTarget, len(rows))

--- a/docs/schemas/api/path-response.schema.json
+++ b/docs/schemas/api/path-response.schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/path-response.schema.json",
+  "$ref": "#/$defs/PathResponse",
+  "$defs": {
+    "L2Hop": {
+      "properties": {
+        "device": {
+          "type": "string"
+        },
+        "deviceIp": {
+          "type": "string"
+        },
+        "ingressPort": {
+          "$ref": "#/$defs/PortInfo"
+        },
+        "egressPort": {
+          "$ref": "#/$defs/PortInfo"
+        },
+        "source": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "device",
+        "deviceIp",
+        "ingressPort",
+        "egressPort",
+        "source"
+      ]
+    },
+    "L2PathResult": {
+      "properties": {
+        "hops": {
+          "items": {
+            "$ref": "#/$defs/L2Hop"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "hops"
+      ]
+    },
+    "PathResponse": {
+      "properties": {
+        "l3Path": {
+          "$ref": "#/$defs/TracerouteResult"
+        },
+        "l2Path": {
+          "$ref": "#/$defs/L2PathResult"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PortInfo": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "index": {
+          "type": "integer"
+        },
+        "speed": {
+          "type": "string"
+        },
+        "duplex": {
+          "type": "string"
+        },
+        "vlans": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "isTrunk": {
+          "type": "boolean"
+        },
+        "connectedTo": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "index",
+        "speed",
+        "duplex",
+        "vlans",
+        "isTrunk",
+        "connectedTo"
+      ]
+    },
+    "TracerouteHop": {
+      "properties": {
+        "ttl": {
+          "type": "integer"
+        },
+        "ip": {
+          "type": "string"
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "rtt": {
+          "type": "integer"
+        },
+        "state": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ttl",
+        "rtt",
+        "state"
+      ]
+    },
+    "TracerouteResult": {
+      "properties": {
+        "target": {
+          "type": "string"
+        },
+        "targetIp": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "hops": {
+          "items": {
+            "$ref": "#/$defs/TracerouteHop"
+          },
+          "type": "array"
+        },
+        "completed": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "target",
+        "targetIp",
+        "protocol",
+        "hops",
+        "completed"
+      ]
+    }
+  },
+  "title": "PathResponse",
+  "description": "PathResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/update-survey-imported-data-request.schema.json
+++ b/docs/schemas/api/update-survey-imported-data-request.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/update-survey-imported-data-request.schema.json",
+  "$ref": "#/$defs/UpdateSurveyImportedDataRequest",
+  "$defs": {
+    "APLocation": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "x": {
+          "type": "integer"
+        },
+        "y": {
+          "type": "integer"
+        },
+        "label": {
+          "type": "string"
+        },
+        "bssid": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "imported": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "x",
+        "y"
+      ]
+    },
+    "ClientLocation": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "x": {
+          "type": "integer"
+        },
+        "y": {
+          "type": "integer"
+        },
+        "label": {
+          "type": "string"
+        },
+        "mac": {
+          "type": "string"
+        },
+        "imported": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "x",
+        "y"
+      ]
+    },
+    "PassFailCriterion": {
+      "properties": {
+        "option": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "number"
+        },
+        "suffix": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "ap": {
+          "type": "integer"
+        },
+        "imported": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "option",
+        "limit",
+        "enabled"
+      ]
+    },
+    "UpdateSurveyImportedDataRequest": {
+      "properties": {
+        "apLocations": {
+          "items": {
+            "$ref": "#/$defs/APLocation"
+          },
+          "type": "array"
+        },
+        "clientLocations": {
+          "items": {
+            "$ref": "#/$defs/ClientLocation"
+          },
+          "type": "array"
+        },
+        "passFailCriteria": {
+          "items": {
+            "$ref": "#/$defs/PassFailCriterion"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "apLocations",
+        "clientLocations",
+        "passFailCriteria"
+      ]
+    }
+  },
+  "title": "UpdateSurveyImportedDataRequest",
+  "description": "UpdateSurveyImportedDataRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/internal/api/handlers_path.go
+++ b/internal/api/handlers_path.go
@@ -43,8 +43,120 @@ type PathRequest struct {
 
 // PathResponse contains both L2 and L3 path information.
 type PathResponse struct {
-	L3Path *discovery.TracerouteResult `json:"l3Path,omitempty"`
-	L2Path *discovery.L2PathResult     `json:"l2Path,omitempty"`
+	L3Path *TracerouteResult `json:"l3Path,omitempty"`
+	L2Path *L2PathResult     `json:"l2Path,omitempty"`
+}
+
+// TracerouteResult is the flat transport view of discovery.TracerouteResult
+// (an L3 path), mirroring its wire shape so the published schema does not
+// depend on the discovery domain package.
+type TracerouteResult struct {
+	Target    string          `json:"target"`
+	TargetIP  string          `json:"targetIp"`
+	Protocol  string          `json:"protocol"`
+	Port      int             `json:"port,omitempty"`
+	Hops      []TracerouteHop `json:"hops"`
+	Completed bool            `json:"completed"`
+	Error     string          `json:"error,omitempty"`
+}
+
+// TracerouteHop is the flat transport view of a single L3 traceroute hop.
+type TracerouteHop struct {
+	TTL      int           `json:"ttl"`
+	IP       string        `json:"ip,omitempty"`
+	Hostname string        `json:"hostname,omitempty"`
+	RTT      time.Duration `json:"rtt"`
+	State    string        `json:"state"`
+}
+
+// L2PathResult is the flat transport view of discovery.L2PathResult (an L2
+// switch path).
+type L2PathResult struct {
+	Hops []L2Hop `json:"hops"`
+}
+
+// L2Hop is the flat transport view of a single L2 hop. IngressPort/EgressPort
+// keep pointer semantics (no omitempty) so an unknown port stays null on the
+// wire, matching the domain shape.
+type L2Hop struct {
+	Device      string    `json:"device"`
+	DeviceIP    string    `json:"deviceIp"`
+	IngressPort *PortInfo `json:"ingressPort"`
+	EgressPort  *PortInfo `json:"egressPort"`
+	Source      string    `json:"source"`
+}
+
+// PortInfo is the flat transport view of a switch port on an L2 hop.
+type PortInfo struct {
+	Name        string `json:"name"`
+	Index       int    `json:"index"`
+	Speed       string `json:"speed"`
+	Duplex      string `json:"duplex"`
+	VLANs       []int  `json:"vlans"`
+	IsTrunk     bool   `json:"isTrunk"`
+	ConnectedTo string `json:"connectedTo"`
+}
+
+// toTracerouteResult maps an L3 traceroute result onto its flat transport view,
+// preserving nil so an absent L3 path stays omitted.
+func toTracerouteResult(result *discovery.TracerouteResult) *TracerouteResult {
+	if result == nil {
+		return nil
+	}
+	hops := make([]TracerouteHop, 0, len(result.Hops))
+	for _, h := range result.Hops {
+		hops = append(hops, TracerouteHop{
+			TTL:      h.TTL,
+			IP:       h.IP,
+			Hostname: h.Hostname,
+			RTT:      h.RTT,
+			State:    h.State,
+		})
+	}
+	return &TracerouteResult{
+		Target:    result.Target,
+		TargetIP:  result.TargetIP,
+		Protocol:  result.Protocol,
+		Port:      result.Port,
+		Hops:      hops,
+		Completed: result.Completed,
+		Error:     result.Error,
+	}
+}
+
+// toL2PathResult maps an L2 switch path onto its flat transport view,
+// preserving nil so an absent L2 path stays omitted.
+func toL2PathResult(result *discovery.L2PathResult) *L2PathResult {
+	if result == nil {
+		return nil
+	}
+	hops := make([]L2Hop, 0, len(result.Hops))
+	for _, h := range result.Hops {
+		hops = append(hops, L2Hop{
+			Device:      h.Device,
+			DeviceIP:    h.DeviceIP,
+			IngressPort: toPortInfo(h.IngressPort),
+			EgressPort:  toPortInfo(h.EgressPort),
+			Source:      h.Source,
+		})
+	}
+	return &L2PathResult{Hops: hops}
+}
+
+// toPortInfo maps a switch port onto its flat transport view, preserving nil.
+func toPortInfo(port *discovery.PortInfo) *PortInfo {
+	if port == nil {
+		return nil
+	}
+	return &PortInfo{
+		Name:        port.Name,
+		Index:       port.Index,
+		Speed:       port.Speed,
+		Duplex:      port.Duplex,
+		VLANs:       port.VLANs,
+		IsTrunk:     port.IsTrunk,
+		ConnectedTo: port.ConnectedTo,
+	}
 }
 
 // handlePath performs L2 and/or L3 path discovery between two endpoints.
@@ -192,7 +304,7 @@ func (s *Server) performPathDiscovery(
 				return nil
 			}
 		}
-		response.L3Path = l3Path
+		response.L3Path = toTracerouteResult(l3Path)
 	}
 
 	// Perform L2 path discovery if requested
@@ -214,7 +326,7 @@ func (s *Server) performPathDiscovery(
 				return nil
 			}
 		} else {
-			response.L2Path = l2Path
+			response.L2Path = toL2PathResult(l2Path)
 		}
 	}
 

--- a/internal/api/handlers_survey_floorplan.go
+++ b/internal/api/handlers_survey_floorplan.go
@@ -194,9 +194,111 @@ func (s *Server) updateSurveySettings(w http.ResponseWriter, r *http.Request) {
 // endpoint. Any field left nil is left unchanged on the survey; an empty
 // slice clears the corresponding list.
 type UpdateSurveyImportedDataRequest struct {
-	APLocations      []survey.APLocation        `json:"apLocations"`
-	ClientLocations  []survey.ClientLocation    `json:"clientLocations"`
-	PassFailCriteria []survey.PassFailCriterion `json:"passFailCriteria"`
+	APLocations      []APLocation        `json:"apLocations"`
+	ClientLocations  []ClientLocation    `json:"clientLocations"`
+	PassFailCriteria []PassFailCriterion `json:"passFailCriteria"`
+}
+
+// APLocation is the flat transport view of survey.APLocation. It and its
+// siblings (ClientLocation, PassFailCriterion) mirror the survey domain's
+// imported-data value objects so the published request schema does not depend
+// on the survey package.
+type APLocation struct {
+	ID       string `json:"id"`
+	X        int    `json:"x"`
+	Y        int    `json:"y"`
+	Label    string `json:"label,omitempty"`
+	BSSID    string `json:"bssid,omitempty"`
+	Vendor   string `json:"vendor,omitempty"`
+	Notes    string `json:"notes,omitempty"`
+	Imported bool   `json:"imported,omitempty"`
+}
+
+// ClientLocation is the flat transport view of survey.ClientLocation.
+type ClientLocation struct {
+	ID       string `json:"id"`
+	X        int    `json:"x"`
+	Y        int    `json:"y"`
+	Label    string `json:"label,omitempty"`
+	MAC      string `json:"mac,omitempty"`
+	Imported bool   `json:"imported,omitempty"`
+}
+
+// PassFailCriterion is the flat transport view of survey.PassFailCriterion.
+type PassFailCriterion struct {
+	Option   string  `json:"option"`
+	Name     string  `json:"name,omitempty"`
+	Limit    float64 `json:"limit"`
+	Suffix   string  `json:"suffix,omitempty"`
+	Enabled  bool    `json:"enabled"`
+	Mode     string  `json:"mode,omitempty"`
+	APCount  int     `json:"ap,omitempty"`
+	Imported bool    `json:"imported,omitempty"`
+}
+
+// toSurveyAPLocations maps inbound AP placements onto the survey domain type.
+// A nil input stays nil (the field is left unchanged); a non-nil input maps
+// element-for-element (an empty slice clears the list) — see the request doc.
+func toSurveyAPLocations(in []APLocation) []survey.APLocation {
+	if in == nil {
+		return nil
+	}
+	out := make([]survey.APLocation, len(in))
+	for i, l := range in {
+		out[i] = survey.APLocation{
+			ID:       l.ID,
+			X:        l.X,
+			Y:        l.Y,
+			Label:    l.Label,
+			BSSID:    l.BSSID,
+			Vendor:   l.Vendor,
+			Notes:    l.Notes,
+			Imported: l.Imported,
+		}
+	}
+	return out
+}
+
+// toSurveyClientLocations maps inbound client placements onto the survey type,
+// preserving nil-vs-empty semantics.
+func toSurveyClientLocations(in []ClientLocation) []survey.ClientLocation {
+	if in == nil {
+		return nil
+	}
+	out := make([]survey.ClientLocation, len(in))
+	for i, l := range in {
+		out[i] = survey.ClientLocation{
+			ID:       l.ID,
+			X:        l.X,
+			Y:        l.Y,
+			Label:    l.Label,
+			MAC:      l.MAC,
+			Imported: l.Imported,
+		}
+	}
+	return out
+}
+
+// toSurveyPassFailCriteria maps inbound pass/fail criteria onto the survey
+// type, preserving nil-vs-empty semantics.
+func toSurveyPassFailCriteria(in []PassFailCriterion) []survey.PassFailCriterion {
+	if in == nil {
+		return nil
+	}
+	out := make([]survey.PassFailCriterion, len(in))
+	for i, c := range in {
+		out[i] = survey.PassFailCriterion{
+			Option:   c.Option,
+			Name:     c.Name,
+			Limit:    c.Limit,
+			Suffix:   c.Suffix,
+			Enabled:  c.Enabled,
+			Mode:     c.Mode,
+			APCount:  c.APCount,
+			Imported: c.Imported,
+		}
+	}
+	return out
 }
 
 // updateSurveyImportedData handles PUT /api/wifi/survey/imported-data?id=xxx.
@@ -225,9 +327,9 @@ func (s *Server) updateSurveyImportedData(w http.ResponseWriter, r *http.Request
 	}
 
 	update := survey.ImportedDataUpdate{
-		APLocations:      req.APLocations,
-		ClientLocations:  req.ClientLocations,
-		PassFailCriteria: req.PassFailCriteria,
+		APLocations:      toSurveyAPLocations(req.APLocations),
+		ClientLocations:  toSurveyClientLocations(req.ClientLocations),
+		PassFailCriteria: toSurveyPassFailCriteria(req.PassFailCriteria),
 	}
 	if err := s.surveyManager().UpdateImportedData(id, update); err != nil {
 		logger.ErrorContext(r.Context(), "Failed to update imported data", "error", err)

--- a/ui/src/types/generated/path-response.ts
+++ b/ui/src/types/generated/path-response.ts
@@ -1,0 +1,46 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface PathResponse {
+  l3Path?: TracerouteResult;
+  l2Path?: L2PathResult;
+}
+export interface TracerouteResult {
+  target: string;
+  targetIp: string;
+  protocol: string;
+  port?: number;
+  hops: TracerouteHop[];
+  completed: boolean;
+  error?: string;
+}
+export interface TracerouteHop {
+  ttl: number;
+  ip?: string;
+  hostname?: string;
+  rtt: number;
+  state: string;
+}
+export interface L2PathResult {
+  hops: L2Hop[];
+}
+export interface L2Hop {
+  device: string;
+  deviceIp: string;
+  ingressPort: PortInfo;
+  egressPort: PortInfo;
+  source: string;
+}
+export interface PortInfo {
+  name: string;
+  index: number;
+  speed: string;
+  duplex: string;
+  vlans: number[];
+  isTrunk: boolean;
+  connectedTo: string;
+}

--- a/ui/src/types/generated/update-survey-imported-data-request.ts
+++ b/ui/src/types/generated/update-survey-imported-data-request.ts
@@ -1,0 +1,40 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface UpdateSurveyImportedDataRequest {
+  apLocations: APLocation[];
+  clientLocations: ClientLocation[];
+  passFailCriteria: PassFailCriterion[];
+}
+export interface APLocation {
+  id: string;
+  x: number;
+  y: number;
+  label?: string;
+  bssid?: string;
+  vendor?: string;
+  notes?: string;
+  imported?: boolean;
+}
+export interface ClientLocation {
+  id: string;
+  x: number;
+  y: number;
+  label?: string;
+  mac?: string;
+  imported?: boolean;
+}
+export interface PassFailCriterion {
+  option: string;
+  name?: string;
+  limit: number;
+  suffix?: string;
+  enabled: boolean;
+  mode?: string;
+  ap?: number;
+  imported?: boolean;
+}


### PR DESCRIPTION
## Phase 2 tail — Slice 6: closes the domain-nested DTO group

Two remaining DTOs put internal domain types on the wire:

- **`PathResponse`** wrapped `discovery.TracerouteResult` (→`TracerouteHop`) and `discovery.L2PathResult` (→`L2Hop`→`PortInfo`). Adds flat transport mirrors and maps domain→transport. `L2Hop` keeps pointer `IngressPort`/`EgressPort` (no `omitempty`) so an unknown port stays `null` exactly as before.
- **`UpdateSurveyImportedDataRequest`** accepted `survey.APLocation`/`ClientLocation`/`PassFailCriterion` inbound. Adds flat mirrors and maps transport→domain when building `survey.ImportedDataUpdate`. The mappers **preserve nil-vs-empty**, so a `nil` field still means "leave unchanged" and an empty slice still clears the list (per the endpoint contract).

Published schemas are self-contained (`$defs` hold only local mirrors) and acyclic despite the nested `L2Hop→PortInfo` pointers. Wire shape preserved field-for-field; the golden authchain `path-get` fixture is unchanged.

> With this, every domain-nested DTO except the deep `EngineDiscoveryResponse`/`DiscoveredDevice` cluster (deferred to Phase 6 by owner decision) now has a self-contained schema. Remaining Phase 2 tail work: the `json.RawMessage` profile DTOs + retiring the `profile.ts`/`settings.ts` hand twins.

### Gates (all green locally)
- round-trip + acyclic guardrails → `ok`
- golden HTTP harness (incl. `path-get`) → PASS
- schema/types drift → up to date
- `golangci-lint` → **0 issues**

Refs: `docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md` Phase 2 tail.