### PR TITLE
feat(schema): publish profile envelope schemas (config as opaque JSON)

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -211,6 +211,20 @@ func schemaTargets() []schemaTarget {
 		{&api.WiFiDiscoveryStatsResponse{}, "wifi-discovery-stats-response.schema.json"},
 		{&api.PathResponse{}, "path-response.schema.json"},
 		{&api.UpdateSurveyImportedDataRequest{}, "update-survey-imported-data-request.schema.json"},
+
+		// Profile envelope DTOs. The backend treats the per-profile Config as an
+		// opaque JSON blob (json.RawMessage) — it only ever inspects the
+		// `interface` block for license gating and otherwise stores/forwards it
+		// verbatim — so the published schema documents config as arbitrary JSON.
+		// Modeling that blob as typed Go structs, and retiring the hand-written
+		// profile.ts/settings.ts TS twins, is deferred to Phase 7 (frontend
+		// re-architecture); here we just complete contract coverage of the
+		// envelope itself.
+		{&api.ProfileRequest{}, "profile-request.schema.json"},
+		{&api.ProfileResponse{}, "profile-response.schema.json"},
+		{&api.ProfileListResponse{}, "profile-list-response.schema.json"},
+		{&api.ProfileImportRequest{}, "profile-import-request.schema.json"},
+		{&api.ProfileExportResponse{}, "profile-export-response.schema.json"},
 	}
 
 	targets := make([]schemaTarget, len(rows))

--- a/cmd/seed-schema/roundtrip_internal_test.go
+++ b/cmd/seed-schema/roundtrip_internal_test.go
@@ -130,6 +130,15 @@ func fillValue(t *testing.T, typ reflect.Type) reflect.Value {
 		return reflect.ValueOf(time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC))
 	}
 
+	// json.RawMessage is a []byte, but it must carry VALID JSON: its MarshalJSON
+	// emits the bytes verbatim and errors on anything else. The generic []byte
+	// path below would fill it with \x01..., so hand it a representative JSON
+	// object. A RawMessage field reflects to an open schema (true), so any
+	// well-formed JSON validates.
+	if typ == reflect.TypeFor[json.RawMessage]() {
+		return reflect.ValueOf(json.RawMessage(`{"sample":true}`))
+	}
+
 	// Every reflect.Kind is listed (no default) so a future field type the
 	// filler can't represent fails the exhaustiveness check at compile-review
 	// time rather than silently producing a bogus sample.

--- a/docs/schemas/api/profile-export-response.schema.json
+++ b/docs/schemas/api/profile-export-response.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/profile-export-response.schema.json",
+  "$ref": "#/$defs/ProfileExportResponse",
+  "$defs": {
+    "ProfileExportResponse": {
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "exported_at": {
+          "type": "string"
+        },
+        "profiles": {
+          "items": {
+            "$ref": "#/$defs/ProfileResponse"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "exported_at",
+        "profiles"
+      ]
+    },
+    "ProfileResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "config": true,
+        "is_default": {
+          "type": "boolean"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "description",
+        "config",
+        "is_default",
+        "created_at",
+        "updated_at"
+      ]
+    }
+  },
+  "title": "ProfileExportResponse",
+  "description": "ProfileExportResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/profile-import-request.schema.json
+++ b/docs/schemas/api/profile-import-request.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/profile-import-request.schema.json",
+  "$ref": "#/$defs/ProfileImportRequest",
+  "$defs": {
+    "ProfileImportRequest": {
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "profiles": {
+          "items": {
+            "$ref": "#/$defs/ProfileRequest"
+          },
+          "type": "array"
+        },
+        "overwrite": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "profiles",
+        "overwrite"
+      ]
+    },
+    "ProfileRequest": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "config": true,
+        "is_default": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "config",
+        "is_default"
+      ]
+    }
+  },
+  "title": "ProfileImportRequest",
+  "description": "ProfileImportRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/profile-list-response.schema.json
+++ b/docs/schemas/api/profile-list-response.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/profile-list-response.schema.json",
+  "$ref": "#/$defs/ProfileListResponse",
+  "$defs": {
+    "ProfileListResponse": {
+      "properties": {
+        "profiles": {
+          "items": {
+            "$ref": "#/$defs/ProfileResponse"
+          },
+          "type": "array"
+        },
+        "total": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "profiles",
+        "total"
+      ]
+    },
+    "ProfileResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "config": true,
+        "is_default": {
+          "type": "boolean"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "description",
+        "config",
+        "is_default",
+        "created_at",
+        "updated_at"
+      ]
+    }
+  },
+  "title": "ProfileListResponse",
+  "description": "ProfileListResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/profile-request.schema.json
+++ b/docs/schemas/api/profile-request.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/profile-request.schema.json",
+  "$ref": "#/$defs/ProfileRequest",
+  "$defs": {
+    "ProfileRequest": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "config": true,
+        "is_default": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "config",
+        "is_default"
+      ]
+    }
+  },
+  "title": "ProfileRequest",
+  "description": "ProfileRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/profile-response.schema.json
+++ b/docs/schemas/api/profile-response.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/profile-response.schema.json",
+  "$ref": "#/$defs/ProfileResponse",
+  "$defs": {
+    "ProfileResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "config": true,
+        "is_default": {
+          "type": "boolean"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "description",
+        "config",
+        "is_default",
+        "created_at",
+        "updated_at"
+      ]
+    }
+  },
+  "title": "ProfileResponse",
+  "description": "ProfileResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/src/types/generated/profile-export-response.ts
+++ b/ui/src/types/generated/profile-export-response.ts
@@ -1,0 +1,21 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface ProfileExportResponse {
+  version: string;
+  exported_at: string;
+  profiles: ProfileResponse[];
+}
+export interface ProfileResponse {
+  id: string;
+  name: string;
+  description: string;
+  config: unknown;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/ui/src/types/generated/profile-import-request.ts
+++ b/ui/src/types/generated/profile-import-request.ts
@@ -1,0 +1,18 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface ProfileImportRequest {
+  version: string;
+  profiles: ProfileRequest[];
+  overwrite: boolean;
+}
+export interface ProfileRequest {
+  name: string;
+  description: string;
+  config: unknown;
+  is_default: boolean;
+}

--- a/ui/src/types/generated/profile-list-response.ts
+++ b/ui/src/types/generated/profile-list-response.ts
@@ -1,0 +1,20 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface ProfileListResponse {
+  profiles: ProfileResponse[];
+  total: number;
+}
+export interface ProfileResponse {
+  id: string;
+  name: string;
+  description: string;
+  config: unknown;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/ui/src/types/generated/profile-request.ts
+++ b/ui/src/types/generated/profile-request.ts
@@ -1,0 +1,13 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface ProfileRequest {
+  name: string;
+  description: string;
+  config: unknown;
+  is_default: boolean;
+}

--- a/ui/src/types/generated/profile-response.ts
+++ b/ui/src/types/generated/profile-response.ts
@@ -1,0 +1,16 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface ProfileResponse {
+  id: string;
+  name: string;
+  description: string;
+  config: unknown;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Phase 2 tail — final slice: profile envelope schemas

Registers the profile envelope DTOs (`ProfileRequest`/`Response`/`ListResponse`/`ImportRequest`/`ExportResponse`). The backend treats per-profile `Config` as an **opaque `json.RawMessage`** — it only inspects the `interface` block for license gating and otherwise stores/forwards it verbatim — so the published schema honestly documents `config` as arbitrary JSON (schema `true` → TS `unknown`).

Modeling that blob as typed Go structs, and retiring the hand-written `profile.ts` (~596L) / `settings.ts` (~757L) TS twins (a **~70-file UI migration**), is **deferred to Phase 7 frontend re-architecture** per owner decision. This slice just completes code-first contract coverage of the envelope.

Also teaches the round-trip guardrail's reflection filler to populate `json.RawMessage` with valid JSON (it marshals bytes verbatim and errors on non-JSON), mirroring the existing `time.Time` special case.

### Closes out Phase 2 tail
Every wire DTO now has a generated schema **except** the deep `EngineDiscoveryResponse`/`DiscoveredDevice` cluster (deferred to Phase 6) and the per-profile config blob (frontend-owned; Phase 7).

### Gates (all green locally)
- round-trip + acyclic guardrails → `ok`
- golden HTTP harness (incl. `profiles-get`) → PASS
- schema/types drift → up to date
- `golangci-lint` → **0 issues**

Purely additive — no handler changes.

Refs: `docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md` Phase 2 tail.