### PR TITLE
feat(platform): add in-process domain event bus (ADR-0004)

### DIFF
--- a/internal/platform/events/events.go
+++ b/internal/platform/events/events.go
@@ -1,0 +1,219 @@
+// Package events is seed's in-process domain event bus (ADR-0004).
+//
+// Modules never import one another; instead they publish and subscribe to typed
+// domain facts through a Bus. An event is a past-tense fact ("DeviceDiscovered"),
+// never a command — it notifies, it does not request. That rule is what keeps
+// the bus a decoupling seam rather than hidden control-flow.
+//
+// Delivery semantics:
+//   - In-process, single binary — no broker.
+//   - Asynchronous: Publish enqueues and returns; handlers run on the bus's own
+//     per-subscriber goroutines.
+//   - Ordered per subscriber: a subscriber sees events in the order they were
+//     enqueued for it.
+//   - At-least-once for the process lifetime: every event accepted by Publish
+//     before Close is delivered, even if it was still queued when Close ran.
+//     Durability across restarts (the transactional outbox) is layered on
+//     separately by the persistence phase; this bus is the in-memory core.
+//   - Panic-isolated: a handler that panics is recovered and logged; it never
+//     crashes the publisher or a sibling subscriber, and the subscriber keeps
+//     receiving later events.
+//
+// Subscribe before the publishers start (the supervisor wires subscribers
+// first) so no early event is missed.
+package events
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// Event is a domain fact. Implementations carry whatever payload subscribers
+// need and report the topic they are published under.
+type Event interface {
+	// Topic is the stable channel name the event is routed on, e.g.
+	// "device.discovered". Subscribers register by topic.
+	Topic() string
+}
+
+// Handler reacts to an event. It runs asynchronously from Publish on the bus's
+// own goroutine. A panic inside a Handler is recovered and logged; it does not
+// propagate to the publisher or other subscribers.
+type Handler func(ctx context.Context, ev Event)
+
+// Bus is an in-process domain event bus. The zero value is not usable; call
+// New. A Bus is safe for concurrent use by multiple publishers and subscribers.
+type Bus struct {
+	logger *slog.Logger
+
+	mu     sync.Mutex
+	subs   map[string][]*subscription
+	closed bool
+	wg     sync.WaitGroup
+}
+
+// subscription is one handler's ordered, unbounded delivery queue plus the
+// goroutine draining it. The queue is unbounded so Publish never blocks and
+// never drops a fact; a persistently slow subscriber is a backpressure concern
+// to bound in a later iteration, not a correctness one here.
+type subscription struct {
+	topic   string
+	handler Handler
+
+	mu      sync.Mutex
+	cond    *sync.Cond
+	queue   []Event
+	stopped bool
+}
+
+// New returns a started bus that logs subscriber panics to logger.
+func New(logger *slog.Logger) *Bus {
+	return &Bus{
+		logger: logger,
+		subs:   make(map[string][]*subscription),
+	}
+}
+
+// Subscribe registers handler for events published on topic and returns a
+// cancel function that stops further delivery to it. Calling cancel more than
+// once is safe. Subscribing on a closed bus is a no-op.
+func (b *Bus) Subscribe(topic string, handler Handler) func() {
+	sub := &subscription{topic: topic, handler: handler}
+	sub.cond = sync.NewCond(&sub.mu)
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return func() {}
+	}
+	b.subs[topic] = append(b.subs[topic], sub)
+	b.wg.Add(1)
+	b.mu.Unlock()
+
+	go b.run(sub)
+
+	var once sync.Once
+	return func() { once.Do(func() { b.unsubscribe(topic, sub) }) }
+}
+
+// Publish enqueues ev for every current subscriber of its topic and returns
+// immediately. It is a no-op once the bus is closed.
+func (b *Bus) Publish(ev Event) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return
+	}
+	subs := b.subs[ev.Topic()]
+	targets := make([]*subscription, len(subs))
+	copy(targets, subs)
+	b.mu.Unlock()
+
+	for _, sub := range targets {
+		sub.enqueue(ev)
+	}
+}
+
+// Close stops accepting new events, drains every subscriber's queued events,
+// and waits for the in-flight handlers to finish. It returns nil once the bus
+// has fully drained, or ctx.Err() if ctx is cancelled first. Close is
+// idempotent.
+func (b *Bus) Close(ctx context.Context) error {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return nil
+	}
+	b.closed = true
+	all := make([]*subscription, 0, len(b.subs))
+	for _, subs := range b.subs {
+		all = append(all, subs...)
+	}
+	b.subs = make(map[string][]*subscription)
+	b.mu.Unlock()
+
+	for _, sub := range all {
+		sub.stop()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		b.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// run drains a subscription's queue in order until it is stopped and empty.
+func (b *Bus) run(sub *subscription) {
+	defer b.wg.Done()
+
+	for {
+		sub.mu.Lock()
+		for len(sub.queue) == 0 && !sub.stopped {
+			sub.cond.Wait()
+		}
+		if len(sub.queue) == 0 {
+			// Stopped and drained.
+			sub.mu.Unlock()
+			return
+		}
+		ev := sub.queue[0]
+		sub.queue = sub.queue[1:]
+		sub.mu.Unlock()
+
+		b.deliver(sub, ev)
+	}
+}
+
+// deliver invokes the handler with panic isolation.
+func (b *Bus) deliver(sub *subscription, ev Event) {
+	defer func() {
+		if r := recover(); r != nil {
+			b.logger.Error("event subscriber panicked",
+				"topic", sub.topic, "panic", r)
+		}
+	}()
+	sub.handler(context.Background(), ev)
+}
+
+// unsubscribe removes target from its topic's fan-out set and stops its worker.
+func (b *Bus) unsubscribe(topic string, target *subscription) {
+	b.mu.Lock()
+	subs := b.subs[topic]
+	for i, sub := range subs {
+		if sub == target {
+			b.subs[topic] = append(subs[:i], subs[i+1:]...)
+			break
+		}
+	}
+	b.mu.Unlock()
+
+	target.stop()
+}
+
+// enqueue appends ev to the subscription's queue and wakes its worker. It is a
+// no-op once the subscription is stopped.
+func (s *subscription) enqueue(ev Event) {
+	s.mu.Lock()
+	if !s.stopped {
+		s.queue = append(s.queue, ev)
+		s.cond.Signal()
+	}
+	s.mu.Unlock()
+}
+
+// stop signals the worker to drain its queue and exit.
+func (s *subscription) stop() {
+	s.mu.Lock()
+	s.stopped = true
+	s.cond.Signal()
+	s.mu.Unlock()
+}

--- a/internal/platform/events/events_test.go
+++ b/internal/platform/events/events_test.go
@@ -1,0 +1,267 @@
+package events_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/platform/events"
+)
+
+// testEvent is a minimal domain fact used by the bus tests.
+type testEvent struct {
+	topic string
+	id    string
+}
+
+func (e testEvent) Topic() string { return e.topic }
+
+// recorder collects the events a subscriber receives, guarded for the race
+// detector since delivery happens on the bus's own goroutines.
+type recorder struct {
+	mu   sync.Mutex
+	got  []string
+	hook func() // optional per-delivery side effect (e.g. panic, signal)
+}
+
+func (r *recorder) handler(_ context.Context, ev events.Event) {
+	if r.hook != nil {
+		r.hook()
+	}
+	te, ok := ev.(testEvent)
+	if !ok {
+		return
+	}
+	r.mu.Lock()
+	r.got = append(r.got, te.id)
+	r.mu.Unlock()
+}
+
+func (r *recorder) ids() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.got))
+	copy(out, r.got)
+	return out
+}
+
+// quietBus returns a bus that discards log output (panicking subscribers log).
+func quietBus(t *testing.T) *events.Bus {
+	t.Helper()
+	return events.New(slog.New(slog.DiscardHandler))
+}
+
+// closeBus drains and stops the bus with a generous deadline, failing the test
+// if the drain does not complete (a hang means a delivery/shutdown bug).
+func closeBus(t *testing.T, bus *events.Bus) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := bus.Close(ctx); err != nil {
+		t.Fatalf("Close drained incompletely: %v", err)
+	}
+}
+
+func TestBusDeliversEventToSubscriber(t *testing.T) {
+	t.Parallel()
+
+	bus := quietBus(t)
+	var rec recorder
+	bus.Subscribe("device.discovered", rec.handler)
+
+	bus.Publish(testEvent{topic: "device.discovered", id: "a"})
+	closeBus(t, bus) // draining guarantees delivery without sleeps
+
+	if got := rec.ids(); len(got) != 1 || got[0] != "a" {
+		t.Fatalf("subscriber got %v, want [a]", got)
+	}
+}
+
+func TestBusRoutesByTopic(t *testing.T) {
+	t.Parallel()
+
+	bus := quietBus(t)
+	var onTopicA, onTopicB recorder
+	bus.Subscribe("topic.a", onTopicA.handler)
+	bus.Subscribe("topic.b", onTopicB.handler)
+
+	bus.Publish(testEvent{topic: "topic.a", id: "a1"})
+	bus.Publish(testEvent{topic: "topic.b", id: "b1"})
+	bus.Publish(testEvent{topic: "topic.a", id: "a2"})
+	closeBus(t, bus)
+
+	if got := onTopicA.ids(); len(got) != 2 {
+		t.Fatalf("topic.a subscriber got %v, want 2 events", got)
+	}
+	if got := onTopicB.ids(); len(got) != 1 || got[0] != "b1" {
+		t.Fatalf("topic.b subscriber got %v, want [b1]", got)
+	}
+}
+
+func TestBusFansOutToMultipleSubscribers(t *testing.T) {
+	t.Parallel()
+
+	bus := quietBus(t)
+	var first, second recorder
+	bus.Subscribe("device.discovered", first.handler)
+	bus.Subscribe("device.discovered", second.handler)
+
+	bus.Publish(testEvent{topic: "device.discovered", id: "x"})
+	closeBus(t, bus)
+
+	if got := first.ids(); len(got) != 1 || got[0] != "x" {
+		t.Fatalf("first subscriber got %v, want [x]", got)
+	}
+	if got := second.ids(); len(got) != 1 || got[0] != "x" {
+		t.Fatalf("second subscriber got %v, want [x]", got)
+	}
+}
+
+func TestBusPreservesPerSubscriberOrder(t *testing.T) {
+	t.Parallel()
+
+	bus := quietBus(t)
+	var rec recorder
+	bus.Subscribe("scan.progress", rec.handler)
+
+	const n = 100
+	want := make([]string, n)
+	for i := range n {
+		id := fmt.Sprintf("e%03d", i)
+		want[i] = id
+		bus.Publish(testEvent{topic: "scan.progress", id: id})
+	}
+	closeBus(t, bus)
+
+	got := rec.ids()
+	if len(got) != n {
+		t.Fatalf("got %d events, want %d", len(got), n)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("event %d out of order: got %s, want %s (per-topic ordering broken)", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBusIsolatesPanickingSubscriber(t *testing.T) {
+	t.Parallel()
+
+	bus := quietBus(t)
+	healthy := recorder{}
+	panicker := recorder{hook: func() { panic("subscriber boom") }}
+
+	bus.Subscribe("device.discovered", panicker.handler)
+	bus.Subscribe("device.discovered", healthy.handler)
+
+	// A panicking subscriber must neither crash the bus nor stop a sibling
+	// subscriber from receiving this or subsequent events.
+	bus.Publish(testEvent{topic: "device.discovered", id: "p1"})
+	bus.Publish(testEvent{topic: "device.discovered", id: "p2"})
+	closeBus(t, bus)
+
+	if got := healthy.ids(); len(got) != 2 {
+		t.Fatalf("healthy subscriber got %v despite sibling panics, want 2 events", got)
+	}
+}
+
+func TestBusUnsubscribeStopsDelivery(t *testing.T) {
+	t.Parallel()
+
+	bus := quietBus(t)
+	delivered := make(chan struct{}, 1)
+	var rec recorder
+	rec.hook = func() { delivered <- struct{}{} }
+
+	cancel := bus.Subscribe("device.discovered", rec.handler)
+	bus.Publish(testEvent{topic: "device.discovered", id: "before"})
+
+	select {
+	case <-delivered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first event never delivered")
+	}
+
+	cancel()
+	bus.Publish(testEvent{topic: "device.discovered", id: "after"})
+	closeBus(t, bus)
+
+	if got := rec.ids(); len(got) != 1 || got[0] != "before" {
+		t.Fatalf("after unsubscribe got %v, want only [before]", got)
+	}
+}
+
+func TestBusCloseDrainsPendingEvents(t *testing.T) {
+	t.Parallel()
+
+	bus := quietBus(t)
+	var rec recorder
+	// Each delivery is slow, so events queue up; Close must drain them all
+	// rather than dropping the backlog (at-least-once).
+	rec.hook = func() { time.Sleep(time.Millisecond) }
+	bus.Subscribe("scan.progress", rec.handler)
+
+	const n = 50
+	for i := range n {
+		bus.Publish(testEvent{topic: "scan.progress", id: fmt.Sprintf("e%d", i)})
+	}
+	closeBus(t, bus)
+
+	if got := rec.ids(); len(got) != n {
+		t.Fatalf("Close dropped queued events: got %d, want %d", len(got), n)
+	}
+}
+
+func TestBusPublishAfterCloseIsNoop(t *testing.T) {
+	t.Parallel()
+
+	bus := quietBus(t)
+	var rec recorder
+	bus.Subscribe("device.discovered", rec.handler)
+	closeBus(t, bus)
+
+	// Must not panic and must not deliver.
+	bus.Publish(testEvent{topic: "device.discovered", id: "late"})
+
+	if got := rec.ids(); len(got) != 0 {
+		t.Fatalf("publish after Close delivered %v, want none", got)
+	}
+}
+
+func TestBusConcurrentPublishIsRaceFree(t *testing.T) {
+	t.Parallel()
+
+	bus := quietBus(t)
+	var rec recorder
+	bus.Subscribe("device.discovered", rec.handler)
+
+	const publishers, each = 8, 50
+	var wg sync.WaitGroup
+	wg.Add(publishers)
+	for p := range publishers {
+		go func(p int) {
+			defer wg.Done()
+			for i := range each {
+				bus.Publish(testEvent{topic: "device.discovered", id: fmt.Sprintf("p%d-%d", p, i)})
+			}
+		}(p)
+	}
+	wg.Wait()
+	closeBus(t, bus)
+
+	if got := rec.ids(); len(got) != publishers*each {
+		t.Fatalf("got %d events from concurrent publishers, want %d", len(got), publishers*each)
+	}
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	bus := quietBus(t)
+	bus.Subscribe("device.discovered", func(context.Context, events.Event) {})
+	closeBus(t, bus)
+	closeBus(t, bus) // second Close must be a safe no-op
+}


### PR DESCRIPTION
## Phase 4 — Slice 1: the `platform/events` bus core

First slice of Phase 4 (lifecycle + events + jobs). Implements the in-process domain event bus from **ADR-0004** so modules can publish/subscribe typed domain *facts* instead of importing each other (ADR-0001).

### Semantics (implemented + tested, incl. `-race`)
- `Event` is a past-tense fact with a `Topic()`; `Handler` reacts asynchronously.
- `Publish` enqueues per subscriber and returns; delivery is **ordered per subscriber** and **at-least-once for the process lifetime** — `Close` drains queued events rather than dropping them.
- A panicking handler is **recovered + logged**; it never crashes the publisher or a sibling subscriber, which keeps receiving later events.
- `Subscribe` returns an **idempotent** cancel; `Publish`/`Subscribe` after `Close` are no-ops; `Close` is idempotent and drains-then-waits (or returns `ctx.Err()`).

### Design
Each subscriber gets an unbounded ordered queue drained by one goroutine, so `Publish` never blocks and never drops a fact (bounded backpressure is a documented later refinement). 11 tests cover routing, fan-out, ordering, panic isolation, unsubscribe, drain-on-close, no-op-after-close, idempotent close, and concurrent publish (race-free).

### Scope
Purely **additive** — nothing imports the bus yet; wiring modules onto it comes in later Phase 4 slices. Durability/transactional outbox (Phase 5), audit-class events, and trace-context propagation are deferred (handlers get `context.Background()` for now).

### Gates
- `go test -race ./internal/platform/events/` → `ok`
- `golangci-lint` → **0 issues**

Refs: `docs/architecture/decisions/0004-event-bus.md`, `RE_ARCHITECTURE_BLUEPRINT.md` §6.