### PR TITLE
feat(platform): add unified async job runner core (ADR-0005)

### DIFF
--- a/internal/platform/jobs/jobs.go
+++ b/internal/platform/jobs/jobs.go
@@ -1,0 +1,405 @@
+// Package jobs is seed's unified async job runner (ADR-0005).
+//
+// Every long-running operation — speedtest, iperf, discovery scan, vuln scan,
+// survey, traceroute, pipeline — used to reinvent run/status/cancel/progress as
+// its own pair of endpoints. This package collapses them into one model: a Job
+// of some Kind, advanced through a fixed lifecycle by a registered Handler, with
+// uniform cancellation, progress, and result capture. The HTTP surface
+// (POST /jobs, GET /jobs/{id}, DELETE /jobs/{id}, the single SSE stream) and the
+// refactor of the real long-ops into job kinds are layered on separately; this
+// is the in-memory core.
+//
+// Lifecycle:
+//
+//	queued ──▶ running ──▶ succeeded   (handler returned nil error)
+//	                  └──▶ failed      (handler returned an error or panicked)
+//	                  └──▶ cancelled   (Cancel or shutdown, handler observed ctx)
+//
+// Semantics:
+//   - Bounded concurrency with a hard cap. Submit rejects with ErrAtCapacity
+//     once the cap of active (queued or running) jobs is reached — appliance
+//     backpressure, never an unbounded queue. ErrAtCapacity is the 503 signal.
+//   - Cancellation via context: Cancel cancels the job's context; a well-behaved
+//     Handler observes ctx.Done() and returns, landing the job in cancelled.
+//   - Progress reporting: a Handler calls its report callback with a fraction in
+//     [0,1]; the value is clamped and visible through Get.
+//   - Result capture: a Handler's return value becomes Job.Result on success.
+//   - Panic isolation: a panicking Handler fails just that job (recovered and
+//     logged) without crashing the runner.
+//   - State-change facts: every transition publishes a JobEvent on the events
+//     bus, so the frontend can follow one job/event stream.
+//   - Retention: terminal jobs are kept in memory until Cleanup removes those
+//     older than the configured retention window (driven by the scheduler).
+//
+// Durability across restarts is the persistence phase's concern; an in-memory
+// store that loses jobs on restart is the correct fail-cleanly v1 (ADR-0005).
+package jobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/krisarmstrong/seed/internal/platform/events"
+)
+
+// defaultMaxConcurrent bounds in-flight jobs when Config leaves it unset. Sized
+// for an appliance: enough parallelism for independent scans, low enough that
+// overload is rejected rather than thrashing.
+const defaultMaxConcurrent = 8
+
+// State is a point in a job's lifecycle.
+type State string
+
+// The five lifecycle states (ADR-0005). queued and running are active; the rest
+// are terminal.
+const (
+	StateQueued    State = "queued"
+	StateRunning   State = "running"
+	StateSucceeded State = "succeeded"
+	StateFailed    State = "failed"
+	StateCancelled State = "cancelled"
+)
+
+// Sentinel errors returned by the runner. Callers match with [errors.Is]; the
+// HTTP layer maps ErrAtCapacity to 503, ErrNotFound to 404, ErrUnknownKind to
+// 400, ErrClosed to 503.
+var (
+	ErrAtCapacity  = errors.New("jobs: runner at capacity")
+	ErrUnknownKind = errors.New("jobs: unknown job kind")
+	ErrNotFound    = errors.New("jobs: job not found")
+	ErrClosed      = errors.New("jobs: runner closed")
+	errPanic       = errors.New("jobs: handler panicked")
+)
+
+// Topic returns the events-bus topic a state change is published on, e.g.
+// "job.running". Subscribers register per state.
+func Topic(s State) string { return "job." + string(s) }
+
+// Job is an immutable snapshot of a unit of work. Get and JobEvent hand out
+// copies; mutating one never affects the runner's state.
+type Job struct {
+	ID       string
+	Kind     string
+	State    State
+	Progress float64 // fraction in [0,1]
+	Result   any     // set on success; nil otherwise
+	Err      string  // failure detail; empty unless State is failed
+}
+
+// JobEvent is the domain fact published on every state change. It carries a
+// snapshot of the job as of that transition.
+type JobEvent struct {
+	Job Job
+}
+
+// Topic routes the event by the job's new state, e.g. "job.succeeded".
+func (e JobEvent) Topic() string { return Topic(e.Job.State) }
+
+// Handler executes one job of a kind. It receives a context cancelled when the
+// job is cancelled or the runner shuts down, the submit-time params, and a
+// report callback for progress in [0,1]. Its return value becomes Job.Result; a
+// non-nil error fails the job. A well-behaved handler returns promptly once ctx
+// is done.
+type Handler func(ctx context.Context, params any, report func(float64)) (any, error)
+
+// Config tunes a Runner. The zero value is valid: an 8-job cap and zero
+// retention (terminal jobs are eligible for Cleanup immediately).
+type Config struct {
+	// MaxConcurrent caps active (queued or running) jobs. <= 0 uses the default.
+	MaxConcurrent int
+	// Retention is how long a terminal job is kept before Cleanup may remove it.
+	Retention time.Duration
+}
+
+// Runner schedules and tracks jobs. The zero value is not usable; call New. A
+// Runner is safe for concurrent use.
+type Runner struct {
+	bus       *events.Bus
+	logger    *slog.Logger
+	cap       int
+	retention time.Duration
+
+	mu       sync.Mutex
+	handlers map[string]Handler
+	jobs     map[string]*entry
+	active   int
+	closed   bool
+	wg       sync.WaitGroup
+}
+
+// entry is a job's mutable state behind the runner's mutex. The job snapshot,
+// its cancel func, and bookkeeping all live here; nothing outside this file
+// touches it without holding Runner.mu.
+type entry struct {
+	job         Job
+	cancel      context.CancelFunc
+	cancelled   bool      // a cancel was requested (vs. a plain handler error)
+	completedAt time.Time // when it reached a terminal state; zero while active
+}
+
+// New returns a runner that publishes state changes to bus and logs handler
+// panics to logger. bus and logger must be non-nil.
+func New(bus *events.Bus, logger *slog.Logger, cfg Config) *Runner {
+	if cfg.MaxConcurrent <= 0 {
+		cfg.MaxConcurrent = defaultMaxConcurrent
+	}
+	return &Runner{
+		bus:       bus,
+		logger:    logger,
+		cap:       cfg.MaxConcurrent,
+		retention: cfg.Retention,
+		handlers:  make(map[string]Handler),
+		jobs:      make(map[string]*entry),
+	}
+}
+
+// Register binds a handler to a job kind. It must be called before Submit of
+// that kind (typically at boot). Re-registering a kind, an empty kind, or a nil
+// handler is an error.
+func (r *Runner) Register(kind string, h Handler) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return ErrClosed
+	}
+	if kind == "" {
+		return errors.New("jobs: empty kind")
+	}
+	if h == nil {
+		return errors.New("jobs: nil handler")
+	}
+	if _, dup := r.handlers[kind]; dup {
+		return fmt.Errorf("jobs: kind %q already registered", kind)
+	}
+	r.handlers[kind] = h
+	return nil
+}
+
+// Submit enqueues a job of kind with params and returns its id. It rejects with
+// ErrUnknownKind if no handler is registered, ErrAtCapacity if the concurrency
+// cap is reached, or ErrClosed after shutdown. The job runs asynchronously.
+func (r *Runner) Submit(kind string, params any) (string, error) {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return "", ErrClosed
+	}
+	h, ok := r.handlers[kind]
+	if !ok {
+		r.mu.Unlock()
+		return "", fmt.Errorf("%w: %q", ErrUnknownKind, kind)
+	}
+	if r.active >= r.cap {
+		r.mu.Unlock()
+		return "", ErrAtCapacity
+	}
+
+	id := uuid.New().String()
+	ctx, cancel := context.WithCancel(context.Background())
+	e := &entry{
+		job:    Job{ID: id, Kind: kind, State: StateQueued},
+		cancel: cancel,
+	}
+	r.jobs[id] = e
+	r.active++
+	r.wg.Add(1)
+	snap := e.job
+	r.mu.Unlock()
+
+	r.bus.Publish(JobEvent{Job: snap})
+	go r.execute(ctx, e, h, params)
+	return id, nil
+}
+
+// Get returns a snapshot of the job and whether it exists.
+func (r *Runner) Get(id string) (Job, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.jobs[id]
+	if !ok {
+		return Job{}, false
+	}
+	return e.job, true
+}
+
+// Cancel requests cancellation of a job, cancelling its context so a
+// well-behaved handler unwinds into the cancelled state. It is idempotent:
+// cancelling a terminal or already-cancelling job is a no-op. An unknown id
+// returns ErrNotFound.
+func (r *Runner) Cancel(id string) error {
+	r.mu.Lock()
+	e, ok := r.jobs[id]
+	if !ok {
+		r.mu.Unlock()
+		return ErrNotFound
+	}
+	if isTerminal(e.job.State) {
+		r.mu.Unlock()
+		return nil
+	}
+	e.cancelled = true
+	cancel := e.cancel
+	r.mu.Unlock()
+
+	cancel()
+	return nil
+}
+
+// Cleanup removes terminal jobs whose age exceeds the retention window and
+// returns the count removed. It is intended to be driven by the scheduler on a
+// retention tick; active jobs are never removed.
+func (r *Runner) Cleanup() int {
+	now := time.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	removed := 0
+	for id, e := range r.jobs {
+		if isTerminal(e.job.State) && now.Sub(e.completedAt) >= r.retention {
+			delete(r.jobs, id)
+			removed++
+		}
+	}
+	return removed
+}
+
+// Close stops accepting new jobs, cancels every in-flight job, and waits for
+// their handlers to return. It returns nil once drained, or ctx.Err() if ctx is
+// cancelled first. Close is idempotent.
+func (r *Runner) Close(ctx context.Context) error {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closed = true
+	cancels := make([]context.CancelFunc, 0, len(r.jobs))
+	for _, e := range r.jobs {
+		if !isTerminal(e.job.State) {
+			e.cancelled = true
+			cancels = append(cancels, e.cancel)
+		}
+	}
+	r.mu.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// execute runs a job's handler to completion and records the terminal state.
+func (r *Runner) execute(ctx context.Context, e *entry, h Handler, params any) {
+	defer r.wg.Done()
+	defer e.cancel()
+
+	r.transition(e, func(j *Job) { j.State = StateRunning })
+
+	report := func(p float64) {
+		r.mu.Lock()
+		e.job.Progress = clamp(p)
+		r.mu.Unlock()
+	}
+
+	result, err := safeRun(ctx, r.logger, h, params, report)
+	r.finish(e, result, err)
+}
+
+// finish records a job's terminal state, frees its slot, and publishes the fact.
+func (r *Runner) finish(e *entry, result any, err error) {
+	r.mu.Lock()
+	switch {
+	case err == nil:
+		e.job.State = StateSucceeded
+		e.job.Result = result
+		e.job.Progress = 1
+	case e.cancelled:
+		e.job.State = StateCancelled
+	default:
+		e.job.State = StateFailed
+		e.job.Err = err.Error()
+	}
+	e.completedAt = time.Now()
+	r.active--
+	snap := e.job
+	r.mu.Unlock()
+
+	r.bus.Publish(JobEvent{Job: snap})
+}
+
+// transition mutates a job's state under the lock and publishes the new fact.
+func (r *Runner) transition(e *entry, mutate func(*Job)) {
+	r.mu.Lock()
+	mutate(&e.job)
+	snap := e.job
+	r.mu.Unlock()
+
+	r.bus.Publish(JobEvent{Job: snap})
+}
+
+// safeRun invokes a handler with panic recovery, converting a panic into a
+// failing error so one bad job never crashes the runner.
+func safeRun(
+	ctx context.Context,
+	logger *slog.Logger,
+	h Handler,
+	params any,
+	report func(float64),
+) (any, error) {
+	var (
+		result any
+		err    error
+	)
+	func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				logger.ErrorContext(ctx, "job handler panicked", "panic", rec)
+				result = nil
+				err = fmt.Errorf("%w: %v", errPanic, rec)
+			}
+		}()
+		result, err = h(ctx, params, report)
+	}()
+	return result, err
+}
+
+// isTerminal reports whether s is a final state.
+func isTerminal(s State) bool {
+	switch s {
+	case StateSucceeded, StateFailed, StateCancelled:
+		return true
+	case StateQueued, StateRunning:
+		return false
+	default:
+		return false
+	}
+}
+
+// clamp bounds a progress fraction to [0,1].
+func clamp(p float64) float64 {
+	switch {
+	case p < 0:
+		return 0
+	case p > 1:
+		return 1
+	default:
+		return p
+	}
+}

--- a/internal/platform/jobs/jobs_test.go
+++ b/internal/platform/jobs/jobs_test.go
@@ -1,0 +1,543 @@
+package jobs_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/platform/events"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+// --- test harness ---------------------------------------------------------
+
+// fixture bundles a runner with the bus it publishes to so a test can both
+// drive jobs and observe the state-change facts they emit.
+type fixture struct {
+	runner *jobs.Runner
+	bus    *events.Bus
+}
+
+func newFixture(t *testing.T, cfg jobs.Config) *fixture {
+	t.Helper()
+	bus := events.New(slog.New(slog.DiscardHandler))
+	runner := jobs.New(bus, slog.New(slog.DiscardHandler), cfg)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := runner.Close(ctx); err != nil {
+			t.Errorf("runner.Close: %v", err)
+		}
+		if err := bus.Close(ctx); err != nil {
+			t.Errorf("bus.Close: %v", err)
+		}
+	})
+	return &fixture{runner: runner, bus: bus}
+}
+
+// watch subscribes to the job event for a single terminal/intermediate state
+// and returns a channel of the jobs seen in that state. It lets tests wait on a
+// concrete fact instead of sleeping.
+func (f *fixture) watch(t *testing.T, state jobs.State) <-chan jobs.Job {
+	t.Helper()
+	ch := make(chan jobs.Job, 16)
+	f.bus.Subscribe(jobs.Topic(state), func(_ context.Context, ev events.Event) {
+		if je, ok := ev.(jobs.JobEvent); ok {
+			ch <- je.Job
+		}
+	})
+	return ch
+}
+
+// awaitJob blocks until a job with id appears on ch, failing on timeout.
+func awaitJob(t *testing.T, ch <-chan jobs.Job, id string) jobs.Job {
+	t.Helper()
+	for {
+		select {
+		case j := <-ch:
+			if j.ID == id {
+				return j
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("job %s never reached the awaited state", id)
+		}
+	}
+}
+
+// okHandler succeeds immediately, returning result.
+func okHandler(result any) jobs.Handler {
+	return func(context.Context, any, func(float64)) (any, error) {
+		return result, nil
+	}
+}
+
+// blockHandler signals on started, then blocks until release is closed or the
+// job's context is cancelled. It reports which happened via the returned error.
+func blockHandler(started chan<- struct{}, release <-chan struct{}) jobs.Handler {
+	return func(ctx context.Context, _ any, _ func(float64)) (any, error) {
+		close(started)
+		select {
+		case <-release:
+			return "released", nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// --- tests ----------------------------------------------------------------
+
+func TestRunnerRunsJobToSuccess(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	if err := f.runner.Register("noop", okHandler("payload")); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	succeeded := f.watch(t, jobs.StateSucceeded)
+
+	id, err := f.runner.Submit("noop", nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	done := awaitJob(t, succeeded, id)
+	if done.State != jobs.StateSucceeded {
+		t.Fatalf("state = %q, want succeeded", done.State)
+	}
+	if done.Result != "payload" {
+		t.Fatalf("result = %v, want payload", done.Result)
+	}
+	if done.Progress != 1 {
+		t.Fatalf("progress = %v, want 1", done.Progress)
+	}
+
+	got, ok := f.runner.Get(id)
+	if !ok || got.State != jobs.StateSucceeded || got.Result != "payload" {
+		t.Fatalf("Get = %+v, ok=%v; want succeeded/payload", got, ok)
+	}
+}
+
+func TestSubmitUnknownKindIsRejected(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	_, err := f.runner.Submit("does-not-exist", nil)
+	if !errors.Is(err, jobs.ErrUnknownKind) {
+		t.Fatalf("Submit err = %v, want ErrUnknownKind", err)
+	}
+}
+
+func TestFailingHandlerMarksJobFailed(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	wantErr := errors.New("disk on fire")
+	_ = f.runner.Register("boom", func(context.Context, any, func(float64)) (any, error) {
+		return nil, wantErr
+	})
+	failed := f.watch(t, jobs.StateFailed)
+
+	id, _ := f.runner.Submit("boom", nil)
+	j := awaitJob(t, failed, id)
+	if j.State != jobs.StateFailed {
+		t.Fatalf("state = %q, want failed", j.State)
+	}
+	if j.Err == "" {
+		t.Fatal("failed job has empty Err, want the handler error message")
+	}
+}
+
+func TestRunnerRejectsAtCapacity(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{MaxConcurrent: 1})
+	started := make(chan struct{})
+	release := make(chan struct{})
+	_ = f.runner.Register("slow", blockHandler(started, release))
+	_ = f.runner.Register("quick", okHandler("done"))
+	succeeded := f.watch(t, jobs.StateSucceeded)
+
+	first, err := f.runner.Submit("slow", nil)
+	if err != nil {
+		t.Fatalf("first Submit: %v", err)
+	}
+
+	// The single slot is now occupied: a second submit must be rejected with a
+	// distinct at-capacity error, not queued.
+	_, err = f.runner.Submit("slow", nil)
+	if !errors.Is(err, jobs.ErrAtCapacity) {
+		t.Fatalf("second Submit err = %v, want ErrAtCapacity", err)
+	}
+
+	close(release)
+	awaitJob(t, succeeded, first) // slot frees only after completion
+
+	// With the slot freed, a fresh submit is accepted and runs to completion;
+	// an at-capacity error here would mean the slot never freed.
+	third, err := f.runner.Submit("quick", nil)
+	if err != nil {
+		t.Fatalf("third Submit after slot freed = %v, want accepted", err)
+	}
+	awaitJob(t, succeeded, third)
+}
+
+func TestCancelStopsRunningJob(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	started := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	_ = f.runner.Register("slow", blockHandler(started, release))
+	cancelled := f.watch(t, jobs.StateCancelled)
+
+	id, _ := f.runner.Submit("slow", nil)
+	<-started // handler is now blocked inside the runner
+
+	if err := f.runner.Cancel(id); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	j := awaitJob(t, cancelled, id)
+	if j.State != jobs.StateCancelled {
+		t.Fatalf("state = %q, want cancelled", j.State)
+	}
+}
+
+func TestCancelUnknownJob(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	if err := f.runner.Cancel("nope"); !errors.Is(err, jobs.ErrNotFound) {
+		t.Fatalf("Cancel err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCancelTerminalJobIsNoop(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	_ = f.runner.Register("noop", okHandler(nil))
+	succeeded := f.watch(t, jobs.StateSucceeded)
+
+	id, _ := f.runner.Submit("noop", nil)
+	awaitJob(t, succeeded, id)
+
+	if err := f.runner.Cancel(id); err != nil {
+		t.Fatalf("Cancel of terminal job = %v, want nil (idempotent no-op)", err)
+	}
+	got, _ := f.runner.Get(id)
+	if got.State != jobs.StateSucceeded {
+		t.Fatalf("state after cancel = %q, want still succeeded", got.State)
+	}
+}
+
+func TestProgressReporting(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	reported := make(chan struct{})
+	release := make(chan struct{})
+	_ = f.runner.Register("progressing", func(_ context.Context, _ any, report func(float64)) (any, error) {
+		report(0.5)
+		close(reported)
+		<-release
+		return "ok", nil
+	})
+	succeeded := f.watch(t, jobs.StateSucceeded)
+
+	id, _ := f.runner.Submit("progressing", nil)
+	<-reported // 0.5 has been recorded, job still running
+
+	mid, ok := f.runner.Get(id)
+	if !ok || mid.Progress != 0.5 {
+		t.Fatalf("mid-flight progress = %v (ok=%v), want 0.5", mid.Progress, ok)
+	}
+
+	close(release)
+	final := awaitJob(t, succeeded, id)
+	if final.Progress != 1 {
+		t.Fatalf("final progress = %v, want 1", final.Progress)
+	}
+}
+
+func TestProgressIsClamped(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	reported := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	_ = f.runner.Register("wild", func(_ context.Context, _ any, report func(float64)) (any, error) {
+		report(-0.5)
+		report(7)
+		close(reported)
+		<-release
+		return "ok", nil
+	})
+
+	id, _ := f.runner.Submit("wild", nil)
+	<-reported
+	got, _ := f.runner.Get(id)
+	if got.Progress != 1 {
+		t.Fatalf("progress = %v, want clamped to 1", got.Progress)
+	}
+}
+
+func TestPanicInHandlerFailsJobCleanly(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	_ = f.runner.Register("panicker", func(context.Context, any, func(float64)) (any, error) {
+		panic("handler boom")
+	})
+	_ = f.runner.Register("noop", okHandler("fine"))
+	failed := f.watch(t, jobs.StateFailed)
+	succeeded := f.watch(t, jobs.StateSucceeded)
+
+	bad, _ := f.runner.Submit("panicker", nil)
+	j := awaitJob(t, failed, bad)
+	if j.State != jobs.StateFailed {
+		t.Fatalf("panicking job state = %q, want failed", j.State)
+	}
+	if j.Err == "" {
+		t.Fatal("panicking job has empty Err, want recovered panic detail")
+	}
+
+	// The runner must still be alive and able to run further jobs.
+	good, err := f.runner.Submit("noop", nil)
+	if err != nil {
+		t.Fatalf("Submit after panic: %v", err)
+	}
+	if done := awaitJob(t, succeeded, good); done.Result != "fine" {
+		t.Fatalf("post-panic job result = %v, want fine", done.Result)
+	}
+}
+
+func TestStateChangeEventsEmitted(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	_ = f.runner.Register("noop", okHandler(nil))
+
+	// A subscriber on each lifecycle topic records which transitions fired. The
+	// bus guarantees order per subscriber, not across these three independent
+	// subscriptions, so this asserts the set of facts emitted, not their
+	// interleaving — lifecycle ordering itself is enforced by the runner.
+	var (
+		mu   sync.Mutex
+		seen = map[jobs.State]bool{}
+	)
+	record := func(_ context.Context, ev events.Event) {
+		if je, ok := ev.(jobs.JobEvent); ok {
+			mu.Lock()
+			seen[je.Job.State] = true
+			mu.Unlock()
+		}
+	}
+	for _, s := range []jobs.State{jobs.StateQueued, jobs.StateRunning, jobs.StateSucceeded} {
+		f.bus.Subscribe(jobs.Topic(s), record)
+	}
+	done := f.watch(t, jobs.StateSucceeded)
+
+	id, _ := f.runner.Submit("noop", nil)
+	awaitJob(t, done, id)
+
+	// Drain the bus so every queued event is delivered before asserting.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := f.bus.Close(ctx); err != nil {
+		t.Fatalf("bus drain: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, s := range []jobs.State{jobs.StateQueued, jobs.StateRunning, jobs.StateSucceeded} {
+		if !seen[s] {
+			t.Fatalf("no %q event emitted; saw %v", s, seen)
+		}
+	}
+}
+
+func TestGracefulShutdownCancelsInFlight(t *testing.T) {
+	t.Parallel()
+
+	bus := events.New(slog.New(slog.DiscardHandler))
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = bus.Close(ctx)
+	}()
+	runner := jobs.New(bus, slog.New(slog.DiscardHandler), jobs.Config{MaxConcurrent: 8})
+
+	const n = 4
+	starts := make([]chan struct{}, n)
+	ids := make([]string, n)
+	for i := range n {
+		starts[i] = make(chan struct{})
+		_ = runner.Register("slow"+string(rune('a'+i)), blockHandler(starts[i], make(chan struct{})))
+		ids[i], _ = runner.Submit("slow"+string(rune('a'+i)), nil)
+		<-starts[i] // ensure all are actually running and blocked on ctx
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := runner.Close(ctx); err != nil {
+		t.Fatalf("Close drained incompletely: %v", err)
+	}
+
+	for _, id := range ids {
+		got, ok := runner.Get(id)
+		if !ok || got.State != jobs.StateCancelled {
+			t.Fatalf("in-flight job %s = %+v (ok=%v), want cancelled after shutdown", id, got, ok)
+		}
+	}
+}
+
+func TestSubmitAfterCloseIsRejected(t *testing.T) {
+	t.Parallel()
+
+	bus := events.New(slog.New(slog.DiscardHandler))
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = bus.Close(ctx)
+	}()
+	runner := jobs.New(bus, slog.New(slog.DiscardHandler), jobs.Config{})
+	_ = runner.Register("noop", okHandler(nil))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := runner.Close(ctx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if _, err := runner.Submit("noop", nil); !errors.Is(err, jobs.ErrClosed) {
+		t.Fatalf("Submit after Close err = %v, want ErrClosed", err)
+	}
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{}) // Cleanup will Close once more
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := f.runner.Close(ctx); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := f.runner.Close(ctx); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func TestRetentionCleanupRemovesTerminalJobs(t *testing.T) {
+	t.Parallel()
+
+	// Retention 0 → every terminal job is immediately eligible for cleanup.
+	f := newFixture(t, jobs.Config{Retention: 0})
+	_ = f.runner.Register("noop", okHandler(nil))
+	succeeded := f.watch(t, jobs.StateSucceeded)
+
+	id, _ := f.runner.Submit("noop", nil)
+	awaitJob(t, succeeded, id)
+
+	if removed := f.runner.Cleanup(); removed != 1 {
+		t.Fatalf("Cleanup removed %d, want 1", removed)
+	}
+	if _, ok := f.runner.Get(id); ok {
+		t.Fatal("terminal job still present after Cleanup with zero retention")
+	}
+}
+
+func TestRetentionKeepsRecentTerminalJobs(t *testing.T) {
+	t.Parallel()
+
+	// A long retention window keeps just-finished jobs around.
+	f := newFixture(t, jobs.Config{Retention: time.Hour})
+	_ = f.runner.Register("noop", okHandler(nil))
+	succeeded := f.watch(t, jobs.StateSucceeded)
+
+	id, _ := f.runner.Submit("noop", nil)
+	awaitJob(t, succeeded, id)
+
+	if removed := f.runner.Cleanup(); removed != 0 {
+		t.Fatalf("Cleanup removed %d, want 0 within retention window", removed)
+	}
+	if _, ok := f.runner.Get(id); !ok {
+		t.Fatal("recent terminal job purged despite long retention window")
+	}
+}
+
+func TestCleanupLeavesActiveJobs(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{Retention: 0})
+	started := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	_ = f.runner.Register("slow", blockHandler(started, release))
+
+	id, _ := f.runner.Submit("slow", nil)
+	<-started
+
+	if removed := f.runner.Cleanup(); removed != 0 {
+		t.Fatalf("Cleanup removed %d active jobs, want 0", removed)
+	}
+	if _, ok := f.runner.Get(id); !ok {
+		t.Fatal("active job purged by Cleanup")
+	}
+}
+
+func TestRegisterValidation(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	if err := f.runner.Register("", okHandler(nil)); err == nil {
+		t.Fatal("Register with empty kind = nil, want error")
+	}
+	if err := f.runner.Register("k", nil); err == nil {
+		t.Fatal("Register with nil handler = nil, want error")
+	}
+	if err := f.runner.Register("dup", okHandler(nil)); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	if err := f.runner.Register("dup", okHandler(nil)); err == nil {
+		t.Fatal("duplicate Register = nil, want error")
+	}
+}
+
+func TestConcurrentSubmitGetCancelIsRaceFree(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{MaxConcurrent: 64})
+	_ = f.runner.Register("fast", okHandler("x"))
+
+	const workers = 16
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := range workers {
+		go func(w int) {
+			defer wg.Done()
+			for i := range 50 {
+				id, err := f.runner.Submit("fast", i)
+				if errors.Is(err, jobs.ErrAtCapacity) {
+					continue
+				}
+				if err != nil {
+					return
+				}
+				_, _ = f.runner.Get(id)
+				_ = f.runner.Cancel(id)
+				_ = w
+			}
+		}(w)
+	}
+	wg.Wait()
+	// Cleanup is exercised concurrently with the tail of in-flight jobs.
+	f.runner.Cleanup()
+}


### PR DESCRIPTION
## Phase 4, Slice 2 — `internal/platform/jobs` unified job-runner core

Adds the in-memory **core** of the unified async job runner from **ADR-0005** / `RE_ARCHITECTURE_BLUEPRINT.md` §8. This is the runner that will replace the ~19 bespoke `run/status/cancel` endpoints (speedtest, iperf, discovery scan, vuln scan, survey, traceroute, pipeline) with one model.

Built the same way as Slice 1 (the events bus, #1466): **additive, isolated, fully TDD'd, nothing wired into hot zones yet.**

### What's here
A `Job{ID, Kind, State, Progress, Result, Err}` advancing `queued → running → {succeeded, failed, cancelled}`, driven by a registered `Handler`, with a `Runner` exposing `Register`, `Submit`, `Get`, `Cancel`, `Cleanup`, `Close`.

Semantics implemented + tested (incl. `-race`):
- **Bounded concurrency, hard cap** — `Submit` rejects with `ErrAtCapacity` (the 503 signal) under overload rather than queuing unboundedly (appliance backpressure).
- **Cancellation via context** — `Cancel` cancels the job ctx; a well-behaved handler unwinds into `cancelled`.
- **Progress reporting** — handler `report(f)` callback, clamped to `[0,1]`, visible via `Get`.
- **Result capture** on success.
- **Panic isolation** — a panicking handler fails just that job (recovered + logged) without crashing the runner; the runner keeps serving.
- **State-change facts** — every transition publishes a `JobEvent` on the **events bus** (`job.*` topics) via the injected `events.Bus` — the integration point with Slice 1.
- **In-memory store + retention** — `Cleanup` removes terminal jobs past the retention window (intended to be driven by the Phase-scheduler tick). In-memory = the correct fail-cleanly-on-restart v1 per ADR-0005; durable persistence is Phase 5.
- **Graceful shutdown** — `Close` cancels in-flight jobs and drains their handlers.

### Deferred (later slices, per the task scope)
HTTP surface (`POST /jobs`, `GET /jobs/{id}`, `DELETE /jobs/{id}`, single SSE stream) + capability-registry/authz wiring; refactoring the real long-ops into job kinds; durable persistence + transactional outbox (Phase 5). This PR is a pure package + tests.

### Gates
- `go test -race ./internal/platform/jobs/` — **18 black-box tests pass, ×3 no flakes**
- `golangci-lint run ./internal/platform/jobs/` — **0 issues**
- `go build` + `go vet` + `gofmt` clean
- Purely additive — no schema/route/handler changes; nothing imports the package yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)