### PR TITLE
feat(api): add unified job runner HTTP surface (ADR-0005)

### DIFF
--- a/internal/api/golden_http_authchain_test.go
+++ b/internal/api/golden_http_authchain_test.go
@@ -56,6 +56,10 @@ func authChainRoutes() []goldenRoute {
 		{name: "settings-link-post", method: http.MethodPost, path: "/api/v1/settings/link"},
 		{name: "survey-create-post", method: http.MethodPost, path: "/api/v1/wifi/survey/create"},
 		{name: "path-get", method: http.MethodGet, path: "/api/v1/path/path"},
+		// Unified job runner (ADR-0005): create is operator-gated/mutating,
+		// inspect is a safe read — both behind the global auth chain.
+		{name: "jobs-create-post", method: http.MethodPost, path: "/api/v1/jobs"},
+		{name: "jobs-get", method: http.MethodGet, path: "/api/v1/jobs/some-id"},
 	}
 }
 

--- a/internal/api/handlers_jobs.go
+++ b/internal/api/handlers_jobs.go
@@ -1,0 +1,391 @@
+package api
+
+// handlers_jobs.go is the HTTP surface of the unified async job runner
+// (ADR-0005, RE_ARCHITECTURE_BLUEPRINT.md §8): create / inspect / cancel a job
+// and a single SSE stream of job state changes. It is a thin adapter over
+// internal/platform/jobs — decode, delegate, map errors, encode — holding no
+// business logic. Job kinds are registered on the runner separately; until the
+// real long-ops are migrated into kinds, an unknown kind is a 400.
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/logging"
+	"github.com/krisarmstrong/seed/internal/platform/events"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+const (
+	// jobsPathPrefix is the /jobs/{id} item-route prefix.
+	jobsPathPrefix = APIVersionPrefix + "/jobs/"
+
+	// jobSSEBuffer bounds a connection's pending event backlog. A consumer that
+	// falls this far behind drops events (it can re-sync with GET /jobs/{id});
+	// the stream favours liveness over guaranteed delivery, like the card hub.
+	jobSSEBuffer = 64
+
+	// jobIdempotencyCapacity bounds the in-memory Idempotency-Key cache. The
+	// oldest key is evicted past this; idempotency is best-effort within that
+	// window, which covers the realistic client-retry case.
+	jobIdempotencyCapacity = 256
+
+	// jobsRetention is how long terminal jobs are kept for inspection before a
+	// retention sweep may remove them.
+	jobsRetention = time.Hour
+
+	// jobsShutdownTimeout bounds the graceful drain of the runner and event bus.
+	jobsShutdownTimeout = 5 * time.Second
+)
+
+// CreateJobRequest is the POST /jobs body: a job kind plus opaque,
+// kind-specific parameters passed through verbatim to the kind's handler.
+type CreateJobRequest struct {
+	Kind   string          `json:"kind"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+// JobResponse is the transport view of a [jobs.Job].
+type JobResponse struct {
+	ID       string  `json:"id"`
+	Kind     string  `json:"kind"`
+	State    string  `json:"state"`
+	Progress float64 `json:"progress"`
+	Result   any     `json:"result,omitempty"`
+	Err      string  `json:"error,omitempty"`
+}
+
+// toJobResponse maps a domain job snapshot to its transport view.
+func toJobResponse(j jobs.Job) JobResponse {
+	return JobResponse{
+		ID:       j.ID,
+		Kind:     j.Kind,
+		State:    string(j.State),
+		Progress: j.Progress,
+		Result:   j.Result,
+		Err:      j.Err,
+	}
+}
+
+// handleJobs is the /jobs collection handler: POST creates a job. The mutating
+// method is operator-gated by writeGated at registration.
+func (s *Server) handleJobs(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+	if r.Method != http.MethodPost {
+		sendErrorResponseWithDetails(w, logger, http.StatusMethodNotAllowed,
+			ErrCodeMethodNotAllowed, "Only POST is supported on /jobs", "")
+		return
+	}
+
+	var req CreateJobRequest
+	if !decodeJSONStrict(w, r, &req, MaxBodySizeJSON) {
+		return
+	}
+	if req.Kind == "" {
+		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
+			ErrCodeValidation, "Job kind is required", "")
+		return
+	}
+
+	// Idempotency: a repeated Idempotency-Key replays the original job rather
+	// than creating a duplicate; the same key with a different body conflicts.
+	key := r.Header.Get("Idempotency-Key")
+	if key != "" {
+		switch res := s.jobIdempotency().check(key, req); res.kind {
+		case idemConflict:
+			sendErrorResponseWithDetails(w, logger, http.StatusConflict, ErrCodeConflict,
+				"Idempotency-Key already used with different parameters", "")
+			return
+		case idemHit:
+			if j, ok := s.jobsRunner().Get(res.id); ok {
+				sendJSONResponse(w, logger, http.StatusOK, toJobResponse(j))
+				return
+			}
+			// Original job was retained-out; fall through and create afresh.
+		case idemMiss:
+		}
+	}
+
+	id, err := s.jobsRunner().Submit(req.Kind, req.Params)
+	if err != nil {
+		writeJobError(w, logger, err)
+		return
+	}
+	if key != "" {
+		s.jobIdempotency().store(key, req, id)
+	}
+
+	j, _ := s.jobsRunner().Get(id)
+	w.Header().Set("Location", jobsPathPrefix+id)
+	sendJSONResponse(w, logger, http.StatusCreated, toJobResponse(j))
+}
+
+// handleJobByID is the /jobs/{id} item handler: GET inspects, DELETE cancels.
+// DELETE is operator-gated by writeGated; GET is a safe read.
+func (s *Server) handleJobByID(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+	id := strings.TrimPrefix(r.URL.Path, jobsPathPrefix)
+	if id == "" || strings.Contains(id, "/") {
+		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
+			ErrCodeValidation, "Missing or invalid job id", "")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		j, ok := s.jobsRunner().Get(id)
+		if !ok {
+			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
+				ErrCodeNotFound, "Job not found", "")
+			return
+		}
+		sendJSONResponse(w, logger, http.StatusOK, toJobResponse(j))
+	case http.MethodDelete:
+		if err := s.jobsRunner().Cancel(id); err != nil {
+			writeJobError(w, logger, err)
+			return
+		}
+		// Cancellation is asynchronous; return the current snapshot with 202.
+		j, _ := s.jobsRunner().Get(id)
+		sendJSONResponse(w, logger, http.StatusAccepted, toJobResponse(j))
+	default:
+		sendErrorResponseWithDetails(w, logger, http.StatusMethodNotAllowed,
+			ErrCodeMethodNotAllowed, "Only GET and DELETE are supported on /jobs/{id}", "")
+	}
+}
+
+// handleJobsEvents streams every job state change to the client as SSE, bridged
+// from the events bus. One stream covers all jobs (clients filter by id),
+// replacing the per-operation status-poll endpoints.
+func (s *Server) handleJobsEvents(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+	if r.Method != http.MethodGet {
+		sendErrorResponseWithDetails(w, logger, http.StatusMethodNotAllowed,
+			ErrCodeMethodNotAllowed, "Only GET is supported on /jobs/events", "")
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, "Streaming unsupported", "")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering
+
+	// Per-connection backlog. The bus delivers on its own goroutine; the push
+	// handler must never block it, so a full buffer drops (re-syncable via GET).
+	ch := make(chan []byte, jobSSEBuffer)
+	unsubscribe := s.subscribeJobEvents(ch)
+	defer unsubscribe()
+
+	// Signal the stream is live: subscriptions are now active, so no state
+	// change from this point is missed.
+	if _, err := w.Write([]byte(": ready\n\n")); err != nil {
+		return
+	}
+	flusher.Flush()
+
+	s.pumpJobSSE(r.Context(), w, flusher, ch, logger)
+}
+
+// subscribeJobEvents fans every job state change into ch and returns a single
+// unsubscribe func. The push never blocks the bus: a full backlog is dropped
+// (the client re-syncs with GET /jobs/{id}).
+func (s *Server) subscribeJobEvents(ch chan<- []byte) func() {
+	push := func(_ context.Context, ev events.Event) {
+		je, isJob := ev.(jobs.JobEvent)
+		if !isJob {
+			return
+		}
+		data, err := json.Marshal(toJobResponse(je.Job))
+		if err != nil {
+			return
+		}
+		select {
+		case ch <- data:
+		default: // consumer too slow; drop this event
+		}
+	}
+
+	bus := s.eventBus()
+	cancels := make([]func(), 0, len(jobs.States()))
+	for _, st := range jobs.States() {
+		cancels = append(cancels, bus.Subscribe(jobs.Topic(st), push))
+	}
+	return func() {
+		for _, cancel := range cancels {
+			cancel()
+		}
+	}
+}
+
+// pumpJobSSE writes queued job frames and periodic heartbeats until the client
+// disconnects (ctx cancelled) or a write fails.
+func (s *Server) pumpJobSSE(
+	ctx context.Context,
+	w http.ResponseWriter,
+	flusher http.Flusher,
+	ch <-chan []byte,
+	logger *slog.Logger,
+) {
+	heartbeat := time.NewTicker(sseHeartbeatInterval)
+	defer heartbeat.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case data := <-ch:
+			if err := writeJobSSE(w, data); err != nil {
+				logger.DebugContext(ctx, "jobs SSE write error", "error", err)
+				return
+			}
+			flusher.Flush()
+		case <-heartbeat.C:
+			if _, err := w.Write([]byte(": heartbeat\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// writeJobSSE writes one `event: job` SSE frame. It uses w.Write (not a
+// value-interpolating Fprintf) so the data — already JSON-marshalled bytes —
+// is emitted verbatim and the output-escaping gate stays satisfied.
+func writeJobSSE(w http.ResponseWriter, data []byte) error {
+	var b bytes.Buffer
+	b.WriteString("event: job\ndata: ")
+	b.Write(data)
+	b.WriteString("\n\n")
+	_, err := w.Write(b.Bytes())
+	return err
+}
+
+// writeJobError maps a runner sentinel error to its HTTP status + ErrCode.
+func writeJobError(w http.ResponseWriter, logger *slog.Logger, err error) {
+	switch {
+	case errors.Is(err, jobs.ErrUnknownKind):
+		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
+			ErrCodeValidation, "Unknown job kind", "")
+	case errors.Is(err, jobs.ErrAtCapacity):
+		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
+			ErrCodeServiceUnavail, "Job runner at capacity, retry later", "")
+	case errors.Is(err, jobs.ErrNotFound):
+		sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
+			ErrCodeNotFound, "Job not found", "")
+	case errors.Is(err, jobs.ErrClosed):
+		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
+			ErrCodeServiceUnavail, "Job runner unavailable", "")
+	default:
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, "Failed to process job", "")
+	}
+}
+
+// jobsRoutes returns the unified job-runner routes (ADR-0005). POST (create)
+// and DELETE (cancel) are mutating -> operator-gated via writeGated; GET
+// (status) and the SSE stream are safe reads. The exact /jobs/events pattern
+// out-ranks the /jobs/ subtree in net/http's ServeMux (longest match wins).
+func (s *Server) jobsRoutes() []route {
+	op := database.RoleOperator
+	return []route{
+		{path: APIVersionPrefix + "/jobs", handler: s.handleJobs, minRole: op, rateLimited: true},
+		{path: APIVersionPrefix + "/jobs/events", handler: s.handleJobsEvents},
+		{path: APIVersionPrefix + "/jobs/", handler: s.handleJobByID, minRole: op},
+	}
+}
+
+// --- idempotency cache ----------------------------------------------------
+
+// idemKind is the outcome of an idempotency-key lookup.
+type idemKind int
+
+const (
+	idemMiss     idemKind = iota // unseen key — caller should create
+	idemHit                      // same key + same request — replay the job
+	idemConflict                 // same key, different request — reject
+)
+
+// idemResult is a lookup outcome plus the prior job id when it is a hit.
+type idemResult struct {
+	id   string
+	kind idemKind
+}
+
+// idemEntry binds an Idempotency-Key to the job it created and a hash of the
+// request, so reuse with a different body can be detected as a conflict.
+type idemEntry struct {
+	jobID string
+	hash  string
+}
+
+// jobIdempotencyCache is a bounded, in-memory Idempotency-Key store. It is
+// best-effort: keys evict in FIFO order past the capacity, and two genuinely
+// simultaneous identical submits may both create (the realistic case is a
+// sequential client retry, which is deduplicated). Durable idempotency arrives
+// with persistence in Phase 5.
+type jobIdempotencyCache struct {
+	mu    sync.Mutex
+	byKey map[string]idemEntry
+	order []string
+	cap   int
+}
+
+func newJobIdempotencyCache(capacity int) *jobIdempotencyCache {
+	return &jobIdempotencyCache{byKey: make(map[string]idemEntry), cap: capacity}
+}
+
+// requestHash fingerprints the kind + params so a reused key with a changed
+// body is detectable.
+func requestHash(req CreateJobRequest) string {
+	h := sha256.New()
+	h.Write([]byte(req.Kind))
+	h.Write([]byte{0})
+	h.Write(req.Params)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// check classifies a key against a request without recording anything.
+func (c *jobIdempotencyCache) check(key string, req CreateJobRequest) idemResult {
+	h := requestHash(req)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.byKey[key]
+	if !ok {
+		return idemResult{kind: idemMiss}
+	}
+	if e.hash != h {
+		return idemResult{kind: idemConflict}
+	}
+	return idemResult{id: e.jobID, kind: idemHit}
+}
+
+// store records the job a key created, evicting the oldest key past capacity.
+func (c *jobIdempotencyCache) store(key string, req CreateJobRequest, jobID string) {
+	h := requestHash(req)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.byKey[key]; !exists {
+		c.order = append(c.order, key)
+		if len(c.order) > c.cap {
+			oldest := c.order[0]
+			c.order = c.order[1:]
+			delete(c.byKey, oldest)
+		}
+	}
+	c.byKey[key] = idemEntry{jobID: jobID, hash: h}
+}

--- a/internal/api/handlers_jobs_internal_test.go
+++ b/internal/api/handlers_jobs_internal_test.go
@@ -1,0 +1,446 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/platform/events"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+// --- harness --------------------------------------------------------------
+
+// newJobsTestServer builds a Server populated with only the fields the jobs
+// handlers touch (runner, bus, idempotency cache). The middleware chain — auth,
+// CSRF, the operator role gate — is applied at registration and exercised by
+// the authchain golden harness, not here; these tests drive the handlers
+// directly to characterize their own logic.
+func newJobsTestServer(t *testing.T, cfg jobs.Config) (*Server, *jobs.Runner) {
+	t.Helper()
+	bus := events.New(slog.New(slog.DiscardHandler))
+	runner := jobs.New(bus, slog.New(slog.DiscardHandler), cfg)
+	srv := &Server{services: &ServiceContainer{RealTime: &RealTimeServices{
+		EventBus:       bus,
+		Jobs:           runner,
+		JobIdempotency: newJobIdempotencyCache(16),
+	}}}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = runner.Close(ctx)
+		_ = bus.Close(ctx)
+	})
+	return srv, runner
+}
+
+func okKind(result any) jobs.Handler {
+	return func(context.Context, any, func(float64)) (any, error) { return result, nil }
+}
+
+// blockKind blocks until release is closed or the job ctx is cancelled.
+func blockKind(release <-chan struct{}) jobs.Handler {
+	return func(ctx context.Context, _ any, _ func(float64)) (any, error) {
+		select {
+		case <-release:
+			return "released", nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func decodeJob(t *testing.T, body *bytes.Buffer) JobResponse {
+	t.Helper()
+	var jr JobResponse
+	if err := json.Unmarshal(body.Bytes(), &jr); err != nil {
+		t.Fatalf("decode JobResponse: %v (body=%q)", err, body.String())
+	}
+	return jr
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within deadline: %s", what)
+}
+
+// --- create (POST /jobs) --------------------------------------------------
+
+func TestHandleJobsCreate(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{})
+	if err := runner.Register("echo", okKind(map[string]any{"ok": true})); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	body := `{"kind":"echo","params":{"x":1}}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleJobs(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (body=%q)", w.Code, w.Body.String())
+	}
+	jr := decodeJob(t, w.Body)
+	if jr.ID == "" || jr.Kind != "echo" {
+		t.Fatalf("JobResponse = %+v, want id set + kind echo", jr)
+	}
+	if loc := w.Header().Get("Location"); loc != "/api/v1/jobs/"+jr.ID {
+		t.Fatalf("Location = %q, want /api/v1/jobs/%s", loc, jr.ID)
+	}
+}
+
+func TestHandleJobsCreateUnknownKind(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newJobsTestServer(t, jobs.Config{})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"kind":"nope"}`))
+	w := httptest.NewRecorder()
+	srv.handleJobs(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for unknown kind", w.Code)
+	}
+}
+
+func TestHandleJobsCreateMissingKind(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newJobsTestServer(t, jobs.Config{})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"params":{}}`))
+	w := httptest.NewRecorder()
+	srv.handleJobs(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for missing kind", w.Code)
+	}
+}
+
+func TestHandleJobsCreateBadJSON(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newJobsTestServer(t, jobs.Config{})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{not json`))
+	w := httptest.NewRecorder()
+	srv.handleJobs(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for malformed JSON", w.Code)
+	}
+}
+
+func TestHandleJobsMethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newJobsTestServer(t, jobs.Config{})
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs", nil)
+	w := httptest.NewRecorder()
+	srv.handleJobs(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405 for GET /jobs", w.Code)
+	}
+}
+
+func TestHandleJobsAtCapacity(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{MaxConcurrent: 1})
+	release := make(chan struct{})
+	defer close(release)
+	_ = runner.Register("slow", blockKind(release))
+
+	// Occupy the only slot.
+	first := httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"kind":"slow"}`))
+	fw := httptest.NewRecorder()
+	srv.handleJobs(fw, first)
+	if fw.Code != http.StatusCreated {
+		t.Fatalf("first create status = %d, want 201", fw.Code)
+	}
+
+	// A second create must be rejected with 503 (appliance backpressure).
+	second := httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"kind":"slow"}`))
+	sw := httptest.NewRecorder()
+	srv.handleJobs(sw, second)
+	if sw.Code != http.StatusServiceUnavailable {
+		t.Fatalf("second create status = %d, want 503 at capacity", sw.Code)
+	}
+}
+
+// --- idempotency ----------------------------------------------------------
+
+func TestHandleJobsIdempotentReplay(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{Retention: time.Hour})
+	_ = runner.Register("echo", okKind("done"))
+
+	post := func() *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"kind":"echo","params":{"a":1}}`))
+		r.Header.Set("Idempotency-Key", "key-123")
+		w := httptest.NewRecorder()
+		srv.handleJobs(w, r)
+		return w
+	}
+
+	first := post()
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first status = %d, want 201", first.Code)
+	}
+	id1 := decodeJob(t, first.Body).ID
+
+	second := post()
+	if second.Code != http.StatusOK {
+		t.Fatalf("replay status = %d, want 200 (not a new 201)", second.Code)
+	}
+	if id2 := decodeJob(t, second.Body).ID; id2 != id1 {
+		t.Fatalf("replay id = %s, want same job %s", id2, id1)
+	}
+}
+
+func TestHandleJobsIdempotentConflict(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{Retention: time.Hour})
+	_ = runner.Register("echo", okKind("done"))
+	_ = runner.Register("other", okKind("done"))
+
+	r1 := httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"kind":"echo"}`))
+	r1.Header.Set("Idempotency-Key", "dup")
+	w1 := httptest.NewRecorder()
+	srv.handleJobs(w1, r1)
+	if w1.Code != http.StatusCreated {
+		t.Fatalf("first status = %d, want 201", w1.Code)
+	}
+
+	// Same key, different request body -> conflict.
+	r2 := httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"kind":"other"}`))
+	r2.Header.Set("Idempotency-Key", "dup")
+	w2 := httptest.NewRecorder()
+	srv.handleJobs(w2, r2)
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("conflicting reuse status = %d, want 409", w2.Code)
+	}
+}
+
+// --- inspect / cancel (/jobs/{id}) ----------------------------------------
+
+func TestHandleJobByIDGet(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{Retention: time.Hour})
+	_ = runner.Register("echo", okKind("payload"))
+	id, err := runner.Submit("echo", nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	waitFor(t, "job terminal", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/"+id, nil)
+	w := httptest.NewRecorder()
+	srv.handleJobByID(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if jr := decodeJob(t, w.Body); jr.ID != id || jr.State != string(jobs.StateSucceeded) {
+		t.Fatalf("JobResponse = %+v, want id %s succeeded", jr, id)
+	}
+}
+
+func TestHandleJobByIDNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newJobsTestServer(t, jobs.Config{})
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/missing", nil)
+	w := httptest.NewRecorder()
+	srv.handleJobByID(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleJobByIDInvalidID(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newJobsTestServer(t, jobs.Config{})
+	// A nested path segment is not a valid job id.
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/a/b", nil)
+	w := httptest.NewRecorder()
+	srv.handleJobByID(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for invalid id", w.Code)
+	}
+}
+
+func TestHandleJobByIDCancel(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{Retention: time.Hour})
+	release := make(chan struct{})
+	defer close(release)
+	_ = runner.Register("slow", blockKind(release))
+	id, _ := runner.Submit("slow", nil)
+	waitFor(t, "job running", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateRunning
+	})
+
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/jobs/"+id, nil)
+	w := httptest.NewRecorder()
+	srv.handleJobByID(w, r)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("cancel status = %d, want 202", w.Code)
+	}
+	waitFor(t, "job cancelled", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateCancelled
+	})
+}
+
+func TestHandleJobByIDCancelNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newJobsTestServer(t, jobs.Config{})
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/jobs/ghost", nil)
+	w := httptest.NewRecorder()
+	srv.handleJobByID(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleJobByIDMethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newJobsTestServer(t, jobs.Config{})
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/jobs/x", nil)
+	w := httptest.NewRecorder()
+	srv.handleJobByID(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- SSE (/jobs/events) ---------------------------------------------------
+
+// syncRecorder is a flushable, mutex-guarded ResponseWriter so the test can
+// read the streamed body while the handler writes it concurrently.
+type syncRecorder struct {
+	mu     sync.Mutex
+	header http.Header
+	buf    bytes.Buffer
+}
+
+func newSyncRecorder() *syncRecorder { return &syncRecorder{header: make(http.Header)} }
+
+func (r *syncRecorder) Header() http.Header { return r.header }
+
+func (r *syncRecorder) WriteHeader(int) {}
+
+func (r *syncRecorder) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.buf.Write(p)
+}
+
+func (r *syncRecorder) Flush() {}
+
+func (r *syncRecorder) snapshot() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.buf.String()
+}
+
+func TestHandleJobsEventsStreamsStateChanges(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{Retention: time.Hour})
+	_ = runner.Register("echo", okKind("payload"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/events", nil).WithContext(ctx)
+	rec := newSyncRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		srv.handleJobsEvents(rec, r)
+		close(done)
+	}()
+
+	// Wait until the handler signals the stream is live (subscriptions active),
+	// so the job we submit next cannot race ahead of them.
+	waitFor(t, "stream ready", func() bool { return strings.Contains(rec.snapshot(), ": ready") })
+
+	id, err := runner.Submit("echo", nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	waitFor(t, "job event streamed", func() bool {
+		s := rec.snapshot()
+		return strings.Contains(s, "event: job") && strings.Contains(s, id) &&
+			strings.Contains(s, string(jobs.StateSucceeded))
+	})
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not return after context cancel")
+	}
+}
+
+func TestHandleJobsEventsRejectsNonGet(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newJobsTestServer(t, jobs.Config{})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/jobs/events", nil)
+	w := httptest.NewRecorder()
+	srv.handleJobsEvents(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", w.Code)
+	}
+}
+
+// plainWriter implements [http.ResponseWriter] but NOT [http.Flusher].
+type plainWriter struct {
+	header http.Header
+	status int
+	buf    bytes.Buffer
+}
+
+func (p *plainWriter) Header() http.Header {
+	if p.header == nil {
+		p.header = make(http.Header)
+	}
+	return p.header
+}
+func (p *plainWriter) Write(b []byte) (int, error) { return p.buf.Write(b) }
+func (p *plainWriter) WriteHeader(s int)           { p.status = s }
+
+func TestHandleJobsEventsRequiresFlusher(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newJobsTestServer(t, jobs.Config{})
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/events", nil)
+	pw := &plainWriter{}
+	srv.handleJobsEvents(pw, r)
+	if pw.status != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 when streaming unsupported", pw.status)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -35,6 +35,8 @@ import (
 	"github.com/krisarmstrong/seed/internal/oauth"
 	"github.com/krisarmstrong/seed/internal/paths"
 	"github.com/krisarmstrong/seed/internal/pipeline/publicip"
+	"github.com/krisarmstrong/seed/internal/platform/events"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
 	snmporchestrator "github.com/krisarmstrong/seed/internal/polling/snmp/orchestrator"
 	"github.com/krisarmstrong/seed/internal/polling/snmp/snmpclient"
 	"github.com/krisarmstrong/seed/internal/probe"
@@ -698,6 +700,9 @@ func (s *Server) wifiScanner() *wifi.Scanner               { return s.services.W
 func (s *Server) surveyManager() *survey.Manager           { return s.services.Wireless.Survey }
 func (s *Server) sseHub() *SSEHub                          { return s.services.RealTime.SSEHub }
 func (s *Server) logBroadcaster() *logging.LogBroadcaster  { return s.services.RealTime.LogBroadcaster }
+func (s *Server) eventBus() *events.Bus                    { return s.services.RealTime.EventBus }
+func (s *Server) jobsRunner() *jobs.Runner                 { return s.services.RealTime.Jobs }
+func (s *Server) jobIdempotency() *jobIdempotencyCache     { return s.services.RealTime.JobIdempotency }
 func (s *Server) db() *database.DB                         { return s.services.Database.DB }
 
 // webAuthnConfigFromServer derives the relying-party config for the

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -15,6 +15,8 @@ import (
 	"github.com/krisarmstrong/seed/internal/diagnostics/dns"
 	"github.com/krisarmstrong/seed/internal/logging"
 	"github.com/krisarmstrong/seed/internal/mibdb"
+	"github.com/krisarmstrong/seed/internal/platform/events"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
 	"github.com/krisarmstrong/seed/internal/services/discovery"
 	"github.com/krisarmstrong/seed/internal/wifi/survey"
 )
@@ -146,6 +148,17 @@ func (s *Server) initSSEAndLogging(db *database.DB) {
 	// Initialize log broadcaster for real-time log streaming
 	s.services.RealTime.LogBroadcaster = logging.InitBroadcaster(logBroadcasterBufferSize)
 	s.logBroadcaster().SetBroadcaster(&sseLogBroadcastAdapter{hub: s.sseHub()})
+
+	// Initialize the in-process event bus and the unified job runner (ADR-0004 /
+	// ADR-0005). The runner publishes job state changes onto the bus; the
+	// /api/v1/jobs surface (POST/GET/DELETE + the /jobs/events SSE stream)
+	// adapts it. No job kinds are registered yet — they arrive as the real
+	// long-ops are migrated in a later slice; both Close() on shutdown.
+	s.services.RealTime.EventBus = events.New(logging.GetLogger())
+	s.services.RealTime.Jobs = jobs.New(
+		s.services.RealTime.EventBus, logging.GetLogger(), jobs.Config{Retention: jobsRetention},
+	)
+	s.services.RealTime.JobIdempotency = newJobIdempotencyCache(jobIdempotencyCapacity)
 
 	// Wire up database persistence for logs if database is available
 	if db != nil {

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -28,6 +28,7 @@ func (s *Server) setupRoutes() {
 	s.setupWiFiRoutes()
 	s.setupReportingRoutes()
 	s.setupTopologyRoutes()
+	s.registerAll(s.jobsRoutes())
 	s.setupSSEAndStatic()
 }
 

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+
 	"github.com/krisarmstrong/seed/internal/alerts"
 	"github.com/krisarmstrong/seed/internal/auth"
 	"github.com/krisarmstrong/seed/internal/database"
@@ -19,6 +21,8 @@ import (
 	"github.com/krisarmstrong/seed/internal/netif"
 	"github.com/krisarmstrong/seed/internal/oauth"
 	"github.com/krisarmstrong/seed/internal/pipeline/publicip"
+	"github.com/krisarmstrong/seed/internal/platform/events"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
 	"github.com/krisarmstrong/seed/internal/probe"
 	"github.com/krisarmstrong/seed/internal/scheduler"
 	"github.com/krisarmstrong/seed/internal/services/discovery"
@@ -170,6 +174,9 @@ type WiFiServices struct {
 type RealTimeServices struct {
 	SSEHub         *SSEHub                 // SSE hub for real-time updates
 	LogBroadcaster *logging.LogBroadcaster // Log streaming
+	EventBus       *events.Bus             // in-process domain event bus (ADR-0004)
+	Jobs           *jobs.Runner            // unified async job runner (ADR-0005)
+	JobIdempotency *jobIdempotencyCache    // Idempotency-Key dedup for POST /jobs
 }
 
 // DatabaseServices groups database-related services.
@@ -204,9 +211,20 @@ func (sc *ServiceContainer) Stop() {
 		sc.Auth.CSRF.Stop()
 	}
 
-	// Stop real-time services
+	// Stop real-time services. Close the job runner first (it stops publishing
+	// state changes), then drain the event bus.
 	if sc.RealTime.SSEHub != nil {
 		sc.RealTime.SSEHub.Shutdown()
+	}
+	if sc.RealTime.Jobs != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), jobsShutdownTimeout)
+		_ = sc.RealTime.Jobs.Close(ctx)
+		cancel()
+	}
+	if sc.RealTime.EventBus != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), jobsShutdownTimeout)
+		_ = sc.RealTime.EventBus.Close(ctx)
+		cancel()
 	}
 
 	// Stop network services

--- a/internal/api/testdata/golden/authchain/jobs-create-post.txt
+++ b/internal/api/testdata/golden/authchain/jobs-create-post.txt
@@ -1,0 +1,12 @@
+status: 401
+headers:
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Xss-Protection: 1; mode=block
+body:
+{
+  "code": "UNAUTHORIZED",
+  "error": "Unauthorized"
+}

--- a/internal/api/testdata/golden/authchain/jobs-get.txt
+++ b/internal/api/testdata/golden/authchain/jobs-get.txt
@@ -1,0 +1,12 @@
+status: 401
+headers:
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Xss-Protection: 1; mode=block
+body:
+{
+  "code": "UNAUTHORIZED",
+  "error": "Unauthorized"
+}

--- a/internal/api/testdata/golden/capabilities.txt
+++ b/internal/api/testdata/golden/capabilities.txt
@@ -620,6 +620,18 @@ body:
     "path": "/api/v1/alert-rules/"
   },
   {
+    "minRole": "operator",
+    "path": "/api/v1/jobs",
+    "rateLimited": true
+  },
+  {
+    "path": "/api/v1/jobs/events"
+  },
+  {
+    "minRole": "operator",
+    "path": "/api/v1/jobs/"
+  },
+  {
     "feature": "live_telemetry",
     "path": "/api/v1/events"
   }

--- a/internal/platform/jobs/jobs.go
+++ b/internal/platform/jobs/jobs.go
@@ -81,6 +81,13 @@ var (
 // "job.running". Subscribers register per state.
 func Topic(s State) string { return "job." + string(s) }
 
+// States returns the five lifecycle states in canonical order. A consumer that
+// must observe every transition — an SSE bridge, an audit sink — subscribes to
+// Topic(s) for each, rather than hardcoding the set at the call site.
+func States() []State {
+	return []State{StateQueued, StateRunning, StateSucceeded, StateFailed, StateCancelled}
+}
+
 // Job is an immutable snapshot of a unit of work. Get and JobEvent hand out
 // copies; mutating one never affects the runner's state.
 type Job struct {

--- a/internal/platform/jobs/jobs_test.go
+++ b/internal/platform/jobs/jobs_test.go
@@ -493,6 +493,24 @@ func TestCleanupLeavesActiveJobs(t *testing.T) {
 	}
 }
 
+func TestStatesIsCanonicalAndComplete(t *testing.T) {
+	t.Parallel()
+
+	got := jobs.States()
+	want := []jobs.State{
+		jobs.StateQueued, jobs.StateRunning,
+		jobs.StateSucceeded, jobs.StateFailed, jobs.StateCancelled,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("States() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("States()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestRegisterValidation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Phase 4, Slice 3 — jobs HTTP surface (isolated)

Exposes `internal/platform/jobs` (the runner core, #1467) over HTTP — the transport adapter from **ADR-0005** / `RE_ARCHITECTURE_BLUEPRINT.md` §8. One uniform model that will replace the ~19 bespoke `run/status/cancel` endpoint pairs.

This is the **isolated** slice (the option chosen): additive routes + SSE only. No hot zones, no long-op code touched.

### Surface
| Method | Path | Purpose | Gate |
|---|---|---|---|
| POST | `/api/v1/jobs` | create (kind + opaque params) | operator (writeGated) + rate-limited |
| GET | `/api/v1/jobs/{id}` | inspect snapshot | safe read |
| DELETE | `/api/v1/jobs/{id}` | cancel (async, 202) | operator (writeGated) |
| GET | `/api/v1/jobs/events` | one SSE stream of all job state changes | safe read |

All four go through the **capability registry** (ADR-0002) and sit behind the global auth chain — the regenerated authchain golden fixtures pin unauth → **401**. The capabilities manifest golden pins the policy (operator+rate-limit on create, operator on item, open read-stream).

### SSE bridge (events bus, #1466)
The stream subscribes to every `job.*` topic, writes `event: job` frames, and emits a `: ready` marker once subscriptions are live so no early transition is missed. Per-connection backlog is bounded and drops under backpressure (client re-syncs via `GET /jobs/{id}`), mirroring the existing card-data hub. Frames use `w.Write` (not value-interpolating `Fprintf`) so the output-escaping gate stays satisfied.

### Idempotency
`Idempotency-Key` on POST replays the original job (**200**, not a new 201); the same key with a different body **conflicts (409)**. Bounded, in-memory, best-effort within that window (sequential client retries are deduplicated). Durable idempotency lands with persistence in Phase 5.

### Error mapping
`ErrAtCapacity`/`ErrClosed` → 503 (appliance backpressure), `ErrUnknownKind` → 400, `ErrNotFound` → 404.

### Wiring
Bus + runner + idempotency cache constructed in `initSSEAndLogging`, `Close()`d on shutdown (runner first, then the bus drains). `jobs.States()` added to the core as the single source of the canonical topic set the SSE bridge fans over.

### Deferred (by scope)
- **No job kinds registered yet** — an unknown kind is a 400 until the real long-ops (speedtest/iperf/discovery.scan/vuln.scan/survey/traceroute/pipeline) become kinds in a later slice.
- `JobResponse`/`CreateJobRequest` are **not yet in the code-first schema** — they join it when the frontend consumes the surface.

### Gates
- `go test -race ./internal/platform/jobs/ ./internal/api/` (targeted) — **18 jobs-core + 17 HTTP/SSE tests pass**, race-clean (incl. a synchronized streaming recorder)
- golden capabilities + authchain fixtures regenerated and verified
- `check-route-policy.sh`, `check-output-escaping.sh` pass; `golangci-lint` **0 issues**; `go vet`/`gofmt` clean; binary builds
- CI **Backend (Go)** is the authoritative full-suite gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)