### PR TITLE
chore(deps): bump Go to 1.26.4 (security)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/krisarmstrong/seed
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1


### PR DESCRIPTION
## Bump Go 1.26.3 → 1.26.4 (security)

`govulncheck` is failing CI on two **Go standard-library** vulnerabilities reachable on go1.26.3, both **fixed in go1.26.4**:

- **GO-2026-5037** — `crypto/x509`
- **GO-2026-5039** — `net/textproto`

These are newly-disclosed stdlib CVEs (not introduced by any code change), so `main` and every in-flight PR fail the hard `govulncheck` gate until the toolchain is bumped.

### Change
`go.mod`: `go 1.26.3` → `go 1.26.4`. That's the only pin — CI's `setup-go` composite action uses `go-version-file: go.mod`, so this flows to every workflow; there are no explicit version literals in `.github/`.

### Verification
- `govulncheck ./...` → **No vulnerabilities found** (was 2) on the 1.26.4 toolchain
- Binary builds; no source changes

Per the always-latest policy. **stem** and **niac** get the same bump as follow-ups (harmonization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)