### PR TITLE
feat(api): migrate speedtest to a unified job kind (ADR-0005)

### DIFF
--- a/internal/api/handlers_speedtest.go
+++ b/internal/api/handlers_speedtest.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/krisarmstrong/seed/internal/diagnostics/speedtest"
 	"github.com/krisarmstrong/seed/internal/i18n"
 	"github.com/krisarmstrong/seed/internal/logging"
 )
@@ -149,18 +150,26 @@ func (s *Server) handleSpeedtestStatus(w http.ResponseWriter, r *http.Request) {
 
 	// Include last result if available
 	if lastResult := s.speedtestTester().GetLastResult(); lastResult != nil {
-		resp.Last = &SpeedtestResponse{
-			Download:     lastResult.Download,
-			Upload:       lastResult.Upload,
-			Latency:      lastResult.Latency,
-			Server:       lastResult.Server,
-			Location:     lastResult.Location,
-			Host:         lastResult.Host,
-			Distance:     lastResult.Distance,
-			Timestamp:    lastResult.Timestamp.Format(time.RFC3339),
-			TestDuration: lastResult.TestDuration,
-		}
+		last := toSpeedtestResponse(lastResult)
+		resp.Last = &last
 	}
 
 	sendJSONResponse(w, logger, http.StatusOK, resp)
+}
+
+// toSpeedtestResponse maps a speedtest.Result to the API wire shape. Shared by
+// the status handler and the speedtest job kind so the result shape stays
+// identical across both paths.
+func toSpeedtestResponse(r *speedtest.Result) SpeedtestResponse {
+	return SpeedtestResponse{
+		Download:     r.Download,
+		Upload:       r.Upload,
+		Latency:      r.Latency,
+		Server:       r.Server,
+		Location:     r.Location,
+		Host:         r.Host,
+		Distance:     r.Distance,
+		Timestamp:    r.Timestamp.Format(time.RFC3339),
+		TestDuration: r.TestDuration,
+	}
 }

--- a/internal/api/jobs_speedtest.go
+++ b/internal/api/jobs_speedtest.go
@@ -1,0 +1,87 @@
+package api
+
+// jobs_speedtest.go registers the first real long-op as a unified job kind
+// (ADR-0005): "speedtest". It is the proof that the runner drives a real
+// operation end-to-end — submit, progress, cancel, result — over the /jobs
+// surface. The legacy /telemetry/speedtest + /status endpoints are unchanged and
+// stay until the frontend cuts over to /jobs (Phase 7); this kind is additive.
+
+import (
+	"context"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/diagnostics/speedtest"
+	"github.com/krisarmstrong/seed/internal/logging"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+const (
+	// speedtestJobKind is the registered kind name for a speedtest job.
+	speedtestJobKind = "speedtest"
+
+	// speedtestProgressPoll is how often the kind samples the tester's phase
+	// progress to report it onto the job.
+	speedtestProgressPoll = 250 * time.Millisecond
+
+	// speedtestProgressMax is the tester's progress scale (0–100); the job model
+	// reports a [0,1] fraction.
+	speedtestProgressMax = 100.0
+)
+
+// speedTester is the slice of [speedtest.Tester] behaviour the job kind needs.
+// Depending on an interface keeps the kind unit-testable without the network and
+// leaves room to swap the implementation (e.g. a home-grown tester) without
+// touching the kind, the runner, or the HTTP surface.
+type speedTester interface {
+	RunTest(ctx context.Context) (*speedtest.Result, error)
+	GetStatus() speedtest.Status
+}
+
+// newSpeedtestHandler returns the job Handler for the "speedtest" kind. newTester
+// produces a fresh tester per job so concurrent runs never share singleton
+// state. The handler runs the test, samples its phase progress onto the job, and
+// returns the result as a SpeedtestResponse; a cancelled job context unwinds the
+// underlying run at its next phase boundary.
+func newSpeedtestHandler(newTester func() speedTester) jobs.Handler {
+	return func(ctx context.Context, _ any, report func(float64)) (any, error) {
+		tester := newTester()
+
+		type outcome struct {
+			res *speedtest.Result
+			err error
+		}
+		done := make(chan outcome, 1)
+		go func() {
+			res, err := tester.RunTest(ctx)
+			done <- outcome{res: res, err: err}
+		}()
+
+		ticker := time.NewTicker(speedtestProgressPoll)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				report(tester.GetStatus().Progress / speedtestProgressMax)
+			case out := <-done:
+				if out.err != nil {
+					return nil, out.err
+				}
+				report(1)
+				return toSpeedtestResponse(out.res), nil
+			}
+		}
+	}
+}
+
+// registerJobKinds registers the built-in job kinds on the runner at startup.
+func (s *Server) registerJobKinds() {
+	s.registerSpeedtestKind(func() speedTester { return speedtest.NewTester() })
+}
+
+// registerSpeedtestKind registers the speedtest kind with an injectable tester
+// factory (the seam that makes the wiring testable without the network).
+func (s *Server) registerSpeedtestKind(newTester func() speedTester) {
+	if err := s.jobsRunner().Register(speedtestJobKind, newSpeedtestHandler(newTester)); err != nil {
+		logging.GetLogger().Error("failed to register speedtest job kind", "error", err)
+	}
+}

--- a/internal/api/jobs_speedtest_internal_test.go
+++ b/internal/api/jobs_speedtest_internal_test.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/diagnostics/speedtest"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+// fakeSpeedTester is a controllable speedTester for the kind tests: it never
+// touches the network.
+type fakeSpeedTester struct {
+	result   *speedtest.Result
+	err      error
+	progress float64
+	release  chan struct{} // if non-nil, RunTest blocks until closed or ctx is done
+}
+
+func (f *fakeSpeedTester) GetStatus() speedtest.Status {
+	return speedtest.Status{Running: true, Progress: f.progress}
+}
+
+func (f *fakeSpeedTester) RunTest(ctx context.Context) (*speedtest.Result, error) {
+	if f.release != nil {
+		select {
+		case <-f.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.result, nil
+}
+
+func TestSpeedtestKindRunsToSuccess(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeSpeedTester{
+		result:   &speedtest.Result{Download: 100, Upload: 20, Latency: 5, Server: "s1"},
+		progress: 100,
+	}
+	if err := runner.Register(speedtestJobKind, newSpeedtestHandler(func() speedTester { return fake })); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	id, err := runner.Submit(speedtestJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+
+	j, _ := runner.Get(id)
+	res, ok := j.Result.(SpeedtestResponse)
+	if !ok {
+		t.Fatalf("Result type = %T, want SpeedtestResponse", j.Result)
+	}
+	if res.Download != 100 || res.Upload != 20 || res.Server != "s1" {
+		t.Fatalf("result = %+v, want download 100 / upload 20 / server s1", res)
+	}
+	if j.Progress != 1 {
+		t.Fatalf("progress = %v, want 1", j.Progress)
+	}
+}
+
+func TestSpeedtestKindReportsProgress(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	release := make(chan struct{})
+	defer close(release)
+	fake := &fakeSpeedTester{result: &speedtest.Result{}, progress: 50, release: release}
+	_ = runner.Register(speedtestJobKind, newSpeedtestHandler(func() speedTester { return fake }))
+
+	id, _ := runner.Submit(speedtestJobKind, nil)
+	// The handler samples the tester's phase progress (50/100) onto the job.
+	waitFor(t, "progress sampled to 0.5", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.Progress == 0.5
+	})
+}
+
+func TestSpeedtestKindCancellation(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	// release is never closed: RunTest blocks until the job context is cancelled.
+	fake := &fakeSpeedTester{release: make(chan struct{})}
+	_ = runner.Register(speedtestJobKind, newSpeedtestHandler(func() speedTester { return fake }))
+
+	id, _ := runner.Submit(speedtestJobKind, nil)
+	waitFor(t, "job running", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateRunning
+	})
+
+	if err := runner.Cancel(id); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	waitFor(t, "job cancelled", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateCancelled
+	})
+}
+
+func TestSpeedtestKindFailure(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeSpeedTester{err: errors.New("network down")}
+	_ = runner.Register(speedtestJobKind, newSpeedtestHandler(func() speedTester { return fake }))
+
+	id, _ := runner.Submit(speedtestJobKind, nil)
+	waitFor(t, "job failed", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateFailed
+	})
+	j, _ := runner.Get(id)
+	if j.Err == "" {
+		t.Fatal("failed speedtest job has empty Err, want the tester error")
+	}
+}
+
+// TestRegisterSpeedtestKindWiresRunner exercises the Server-level registration
+// path with an injected fake, proving registerSpeedtestKind makes the kind
+// runnable on the server's own runner without hitting the network.
+func TestRegisterSpeedtestKindWiresRunner(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeSpeedTester{result: &speedtest.Result{Download: 42}, progress: 100}
+	srv.registerSpeedtestKind(func() speedTester { return fake })
+
+	id, err := runner.Submit(speedtestJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit after registerSpeedtestKind: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+	j, _ := runner.Get(id)
+	res, ok := j.Result.(SpeedtestResponse)
+	if !ok || res.Download != 42 {
+		t.Fatalf("result = %+v (ok=%v), want download 42", res, ok)
+	}
+}

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -159,6 +159,7 @@ func (s *Server) initSSEAndLogging(db *database.DB) {
 		s.services.RealTime.EventBus, logging.GetLogger(), jobs.Config{Retention: jobsRetention},
 	)
 	s.services.RealTime.JobIdempotency = newJobIdempotencyCache(jobIdempotencyCapacity)
+	s.registerJobKinds()
 
 	// Wire up database persistence for logs if database is available
 	if db != nil {

--- a/internal/diagnostics/speedtest/speedtest.go
+++ b/internal/diagnostics/speedtest/speedtest.go
@@ -166,6 +166,17 @@ func (t *Tester) setCurrentSpeeds(download, upload float64) {
 	t.status.CurrentUpload = upload
 }
 
+// abortIfCancelled returns ctx.Err() and resets status to idle if ctx is done,
+// so a cancelled run leaves the tester in a clean state. It is the phase-boundary
+// cancellation check used throughout RunTest.
+func (t *Tester) abortIfCancelled(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		t.setStatus("idle", 0)
+		return err
+	}
+	return nil
+}
+
 // findTestServer discovers and selects the best speedtest server.
 func (t *Tester) findTestServer() (*speedtest.Server, error) {
 	speedtestClient := speedtest.New()
@@ -269,8 +280,16 @@ func (t *Tester) buildTestResult(server *speedtest.Server, startTime time.Time) 
 	}
 }
 
-// RunTest performs a complete speedtest.
-func (t *Tester) RunTest(_ context.Context) (*Result, error) {
+// RunTest performs a complete speedtest. It honors ctx at every phase boundary:
+// if ctx is cancelled (or its deadline passes), RunTest stops before the next
+// phase and returns ctx.Err(), rather than running the full ~minute test to
+// completion. The underlying library calls are not themselves interruptible, so
+// cancellation takes effect at the next boundary, not mid-phase.
+func (t *Tester) RunTest(ctx context.Context) (*Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	// Check if already running
 	t.mu.RLock()
 	if t.status.Running {
@@ -285,6 +304,9 @@ func (t *Tester) RunTest(_ context.Context) (*Result, error) {
 	startTime := time.Now()
 
 	// Find servers
+	if cerr := t.abortIfCancelled(ctx); cerr != nil {
+		return nil, cerr
+	}
 	t.setStatus("finding_server", progressFindingServer)
 	server, err := t.findTestServer()
 	if err != nil {
@@ -293,6 +315,9 @@ func (t *Tester) RunTest(_ context.Context) (*Result, error) {
 	}
 
 	// Test latency
+	if cerr := t.abortIfCancelled(ctx); cerr != nil {
+		return nil, cerr
+	}
 	t.setStatus("testing_latency", progressTestingLatency)
 	err = server.PingTest(nil)
 	if err != nil {
@@ -301,6 +326,9 @@ func (t *Tester) RunTest(_ context.Context) (*Result, error) {
 	}
 
 	// Test download with live speed updates
+	if cerr := t.abortIfCancelled(ctx); cerr != nil {
+		return nil, cerr
+	}
 	err = t.runDownloadTest(server)
 	if err != nil {
 		t.setStatus("idle", 0)
@@ -311,6 +339,9 @@ func (t *Tester) RunTest(_ context.Context) (*Result, error) {
 	finalDownload := server.DLSpeed.Mbps()
 
 	// Test upload with live speed updates
+	if cerr := t.abortIfCancelled(ctx); cerr != nil {
+		return nil, cerr
+	}
 	err = t.runUploadTest(server, finalDownload)
 	if err != nil {
 		t.setStatus("idle", 0)

--- a/internal/diagnostics/speedtest/speedtest_cancel_test.go
+++ b/internal/diagnostics/speedtest/speedtest_cancel_test.go
@@ -1,0 +1,43 @@
+package speedtest_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/diagnostics/speedtest"
+)
+
+// TestRunTestHonorsCancelledContext verifies RunTest returns promptly with the
+// context error when its context is already cancelled, instead of ignoring the
+// context and proceeding to hit the network for the full run. The first
+// phase-boundary check fires before any server lookup, so this is fast and
+// hermetic (no network).
+func TestRunTestHonorsCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	tester := speedtest.NewTester()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before the run starts
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := tester.RunTest(ctx)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunTest err = %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("RunTest did not honor the cancelled context (still running)")
+	}
+
+	// The guard must also release the running flag so a later run is possible.
+	if tester.GetStatus().Running {
+		t.Fatal("Running flag stuck true after a cancelled run")
+	}
+}


### PR DESCRIPTION
## Phase 4, Slice 4 — first real long-op as a job kind: speedtest

The first real long-running operation now runs through the unified job runner (ADR-0005). Registers a `speedtest` **kind** so a speedtest can be driven over the `/jobs` surface end-to-end — submit → sampled progress → cancel → captured result — proving the model on a real op and setting the pattern for the remaining long-ops (iperf, vuln scan, survey, …).

**Additive and non-breaking:** the legacy `/telemetry/speedtest` + `/telemetry/speedtest/status` endpoints are unchanged and stay until the frontend cuts over to `/jobs` (Phase 7). Kinds aren't routes, so **no capability-manifest or golden churn**.

### Design
- The kind depends on an **injectable `speedTester` interface** (`RunTest` + `GetStatus`), so it's unit-tested with a fake (no network) and a future **home-grown** tester would swap only the adapter — not the kind, runner, or HTTP surface. Each job gets a **fresh tester** (no shared singleton state across concurrent runs).
- The handler runs the test on a goroutine, **samples the tester's phase progress** (0–100) onto the job as a `[0,1]` fraction every 250ms, and returns the result as the existing `SpeedtestResponse` (mapping extracted into a shared `toSpeedtestResponse` helper, now used by the status handler too).

### Cancellation made meaningful (latent-bug fix)
`speedtest.Tester.RunTest` previously **ignored its context** (`_ context.Context`) — a ~minute test couldn't be cancelled. It now checks ctx at every **phase boundary** (find-server / latency / download / upload) via `abortIfCancelled` and returns `ctx.Err()`, leaving the tester idle. The underlying library calls aren't themselves interruptible, so cancellation lands at the next boundary, not mid-phase.

### Wiring
`registerJobKinds()` wires the kind at startup (`initSSEAndLogging`) with the real `speedtest.NewTester`; `registerSpeedtestKind` takes the factory as a **seam** so the Server-level wiring is testable without the network.

### Gates
- `go test -race ./internal/diagnostics/speedtest/` — full suite + new hermetic ctx-cancellation test
- `go test -race ./internal/api/` (targeted) — 5 white-box kind tests (success/progress/cancel/failure + server registration) + jobs handlers + golden harness all pass
- `golangci-lint` **0 issues**; `go vet`/`gofmt` clean; binary builds
- On the Go 1.26.4 base — Security Scanning stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)