### PR TITLE
feat(api): migrate iperf3 client test to a job kind (ADR-0005)

### DIFF
--- a/internal/api/handlers_iperf.go
+++ b/internal/api/handlers_iperf.go
@@ -265,27 +265,35 @@ func (s *Server) handleIperfClientStatus(w http.ResponseWriter, r *http.Request)
 	}
 
 	if lastResult := s.iperfManager().GetLastResult(); lastResult != nil {
-		resp.Last = &IperfResultResponse{
-			Bandwidth:         lastResult.Bandwidth,
-			Transfer:          lastResult.Transfer,
-			Retransmits:       lastResult.Retransmits,
-			Jitter:            lastResult.Jitter,
-			LostPackets:       lastResult.LostPackets,
-			LostPercent:       lastResult.LostPercent,
-			Protocol:          lastResult.Protocol,
-			Direction:         lastResult.Direction,
-			Duration:          lastResult.Duration,
-			Server:            lastResult.Server,
-			Port:              lastResult.Port,
-			Timestamp:         lastResult.Timestamp.Format(time.RFC3339),
-			DownloadBandwidth: lastResult.DownloadBandwidth,
-			UploadBandwidth:   lastResult.UploadBandwidth,
-			DownloadTransfer:  lastResult.DownloadTransfer,
-			UploadTransfer:    lastResult.UploadTransfer,
-		}
+		last := toIperfResultResponse(lastResult)
+		resp.Last = &last
 	}
 
 	sendJSONResponse(w, logger, http.StatusOK, resp)
+}
+
+// toIperfResultResponse maps an iperf.Result to the API wire shape. Shared by
+// the status handler and the iperf job kind so the result shape stays identical
+// across both paths.
+func toIperfResultResponse(r *iperf.Result) IperfResultResponse {
+	return IperfResultResponse{
+		Bandwidth:         r.Bandwidth,
+		Transfer:          r.Transfer,
+		Retransmits:       r.Retransmits,
+		Jitter:            r.Jitter,
+		LostPackets:       r.LostPackets,
+		LostPercent:       r.LostPercent,
+		Protocol:          r.Protocol,
+		Direction:         r.Direction,
+		Duration:          r.Duration,
+		Server:            r.Server,
+		Port:              r.Port,
+		Timestamp:         r.Timestamp.Format(time.RFC3339),
+		DownloadBandwidth: r.DownloadBandwidth,
+		UploadBandwidth:   r.UploadBandwidth,
+		DownloadTransfer:  r.DownloadTransfer,
+		UploadTransfer:    r.UploadTransfer,
+	}
 }
 
 // handleIperfServer starts or stops the iperf3 server.

--- a/internal/api/jobs_iperf.go
+++ b/internal/api/jobs_iperf.go
@@ -1,0 +1,118 @@
+package api
+
+// jobs_iperf.go registers the iperf3 client test as a unified job kind
+// (ADR-0005), the second real long-op on the runner after speedtest. iperf3 has
+// no native Go protocol library, so the existing wrapper drives the bundled
+// binary via exec.CommandContext — which already gives real subprocess
+// cancellation through the job's context. The legacy /telemetry/iperf/client +
+// /status endpoints are unchanged (retire at the Phase-7 frontend cutover); this
+// kind is additive and adds no routes.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/diagnostics/iperf"
+	"github.com/krisarmstrong/seed/internal/logging"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+const (
+	// iperfJobKind is the registered kind name for an iperf3 client test.
+	iperfJobKind = "iperf"
+
+	// iperfProgressPoll is how often the kind samples the client's phase
+	// progress to report it onto the job.
+	iperfProgressPoll = 250 * time.Millisecond
+
+	// iperfProgressMax is the client's progress scale (0–100); the job model
+	// reports a [0,1] fraction.
+	iperfProgressMax = 100.0
+)
+
+// iperfClient is the slice of [iperf.Manager] behaviour the job kind needs.
+// Depending on an interface keeps the kind unit-testable without launching the
+// iperf3 binary and isolates the kind from the wrapper's other concerns.
+type iperfClient interface {
+	RunClient(ctx context.Context, config *iperf.ClientConfig) (*iperf.Result, error)
+	GetClientStatus() iperf.ClientStatus
+}
+
+// newIperfHandler returns the job Handler for the "iperf" kind. The job params
+// are an IperfClientRequest (the same shape the legacy endpoint accepts);
+// newClient produces a fresh manager per job so concurrent runs never share
+// singleton client state. The handler runs the test, samples its phase progress
+// onto the job, and returns the result as an IperfResultResponse.
+func newIperfHandler(newClient func() iperfClient) jobs.Handler {
+	return func(ctx context.Context, params any, report func(float64)) (any, error) {
+		req, err := decodeIperfParams(params)
+		if err != nil {
+			return nil, err
+		}
+		// Semantic validation lives with the domain, not the generic /jobs
+		// surface: a bad request surfaces as a failed job, not a panic.
+		if verr := validateIperfClientRequest(&req); verr != nil {
+			return nil, verr
+		}
+
+		config := iperf.ClientConfig{
+			Server:    req.Server,
+			Port:      req.Port,
+			Protocol:  req.Protocol,
+			Reverse:   req.Reverse,
+			Direction: req.Direction,
+			Duration:  req.Duration,
+			Parallel:  req.Parallel,
+		}
+
+		client := newClient()
+		type outcome struct {
+			res *iperf.Result
+			err error
+		}
+		done := make(chan outcome, 1)
+		go func() {
+			res, runErr := client.RunClient(ctx, &config)
+			done <- outcome{res: res, err: runErr}
+		}()
+
+		ticker := time.NewTicker(iperfProgressPoll)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				report(client.GetClientStatus().Progress / iperfProgressMax)
+			case out := <-done:
+				if out.err != nil {
+					return nil, out.err
+				}
+				report(1)
+				return toIperfResultResponse(out.res), nil
+			}
+		}
+	}
+}
+
+// decodeIperfParams parses the opaque job params into an IperfClientRequest.
+func decodeIperfParams(params any) (IperfClientRequest, error) {
+	raw, ok := params.(json.RawMessage)
+	if !ok || len(raw) == 0 {
+		return IperfClientRequest{}, errors.New("iperf job requires params")
+	}
+	var req IperfClientRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return IperfClientRequest{}, fmt.Errorf("invalid iperf params: %w", err)
+	}
+	return req, nil
+}
+
+// registerIperfKind registers the iperf kind with an injectable client factory
+// (the seam that makes the wiring testable without the binary).
+func (s *Server) registerIperfKind(newClient func() iperfClient) {
+	if err := s.jobsRunner().Register(iperfJobKind, newIperfHandler(newClient)); err != nil {
+		logging.GetLogger().Error("failed to register iperf job kind", "error", err)
+	}
+}

--- a/internal/api/jobs_iperf_internal_test.go
+++ b/internal/api/jobs_iperf_internal_test.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/diagnostics/iperf"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+// fakeIperfClient is a controllable iperfClient for the kind tests: it never
+// launches the iperf3 binary.
+type fakeIperfClient struct {
+	result   *iperf.Result
+	err      error
+	progress float64
+	release  chan struct{} // if non-nil, RunClient blocks until closed or ctx is done
+}
+
+func (f *fakeIperfClient) GetClientStatus() iperf.ClientStatus {
+	return iperf.ClientStatus{Running: true, Progress: f.progress}
+}
+
+func (f *fakeIperfClient) RunClient(ctx context.Context, _ *iperf.ClientConfig) (*iperf.Result, error) {
+	if f.release != nil {
+		select {
+		case <-f.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.result, nil
+}
+
+// iperfParams builds valid job params for a client run (the server value only
+// needs to pass validation; results come from the fake).
+func iperfParams() json.RawMessage {
+	return json.RawMessage(`{"server":"10.0.0.2","protocol":"tcp","direction":"upload","duration":5}`)
+}
+
+func TestIperfKindRunsToSuccess(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeIperfClient{
+		result:   &iperf.Result{Bandwidth: 940, Protocol: "tcp", Direction: "upload", Server: "10.0.0.2"},
+		progress: 100,
+	}
+	if err := runner.Register(iperfJobKind, newIperfHandler(func() iperfClient { return fake })); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	id, err := runner.Submit(iperfJobKind, iperfParams())
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+
+	j, _ := runner.Get(id)
+	res, ok := j.Result.(IperfResultResponse)
+	if !ok {
+		t.Fatalf("Result type = %T, want IperfResultResponse", j.Result)
+	}
+	if res.Bandwidth != 940 || res.Protocol != "tcp" || res.Server != "10.0.0.2" {
+		t.Fatalf("result = %+v, want bandwidth 940 / tcp / server 10.0.0.2", res)
+	}
+	if j.Progress != 1 {
+		t.Fatalf("progress = %v, want 1", j.Progress)
+	}
+}
+
+func TestIperfKindReportsProgress(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	release := make(chan struct{})
+	defer close(release)
+	fake := &fakeIperfClient{result: &iperf.Result{}, progress: 60, release: release}
+	_ = runner.Register(iperfJobKind, newIperfHandler(func() iperfClient { return fake }))
+
+	id, _ := runner.Submit(iperfJobKind, iperfParams())
+	waitFor(t, "progress sampled to 0.6", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.Progress == 0.6
+	})
+}
+
+func TestIperfKindCancellation(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeIperfClient{release: make(chan struct{})} // never closed; cancel via ctx
+	_ = runner.Register(iperfJobKind, newIperfHandler(func() iperfClient { return fake }))
+
+	id, _ := runner.Submit(iperfJobKind, iperfParams())
+	waitFor(t, "job running", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateRunning
+	})
+
+	if err := runner.Cancel(id); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	waitFor(t, "job cancelled", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateCancelled
+	})
+}
+
+func TestIperfKindFailure(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeIperfClient{err: errors.New("connection refused")}
+	_ = runner.Register(iperfJobKind, newIperfHandler(func() iperfClient { return fake }))
+
+	id, _ := runner.Submit(iperfJobKind, iperfParams())
+	waitFor(t, "job failed", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateFailed
+	})
+	j, _ := runner.Get(id)
+	if j.Err == "" {
+		t.Fatal("failed iperf job has empty Err, want the client error")
+	}
+}
+
+func TestIperfKindRejectsMissingServer(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeIperfClient{result: &iperf.Result{}}
+	_ = runner.Register(iperfJobKind, newIperfHandler(func() iperfClient { return fake }))
+
+	// Empty params (no server) must fail validation inside the handler -> failed
+	// job, not a panic or a success.
+	id, _ := runner.Submit(iperfJobKind, json.RawMessage(`{}`))
+	waitFor(t, "job failed on missing server", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateFailed
+	})
+}
+
+func TestRegisterIperfKindWiresRunner(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeIperfClient{result: &iperf.Result{Bandwidth: 100}, progress: 100}
+	srv.registerIperfKind(func() iperfClient { return fake })
+
+	id, err := runner.Submit(iperfJobKind, iperfParams())
+	if err != nil {
+		t.Fatalf("Submit after registerIperfKind: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+	j, _ := runner.Get(id)
+	res, ok := j.Result.(IperfResultResponse)
+	if !ok || res.Bandwidth != 100 {
+		t.Fatalf("result = %+v (ok=%v), want bandwidth 100", res, ok)
+	}
+}

--- a/internal/api/jobs_speedtest.go
+++ b/internal/api/jobs_speedtest.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/krisarmstrong/seed/internal/diagnostics/iperf"
 	"github.com/krisarmstrong/seed/internal/diagnostics/speedtest"
 	"github.com/krisarmstrong/seed/internal/logging"
 	"github.com/krisarmstrong/seed/internal/platform/jobs"
@@ -76,6 +77,7 @@ func newSpeedtestHandler(newTester func() speedTester) jobs.Handler {
 // registerJobKinds registers the built-in job kinds on the runner at startup.
 func (s *Server) registerJobKinds() {
 	s.registerSpeedtestKind(func() speedTester { return speedtest.NewTester() })
+	s.registerIperfKind(func() iperfClient { return iperf.NewManager() })
 }
 
 // registerSpeedtestKind registers the speedtest kind with an injectable tester


### PR DESCRIPTION
## Phase 4, Slice 5 — second long-op as a job kind: iperf

Registers an `iperf` **kind** so an iperf3 client test runs over the `/jobs` surface end-to-end — submit → sampled progress → cancel → captured result. Follows the speedtest kind (#1470).

iperf3 has **no native Go protocol library**, so the existing wrapper (`internal/diagnostics/iperf`) drives the bundled binary via `exec.CommandContext` — which **already** gives real subprocess cancellation through the job's context, so unlike speedtest no underlying fix was needed.

### Design (mirrors speedtest)
- Depends on an injectable **`iperfClient` interface** (`RunClient` + `GetClientStatus`) → unit-tested with a fake (the iperf3 binary is never launched), **fresh manager per job** (no shared singleton client state).
- Job **params are an `IperfClientRequest`** (same shape the legacy endpoint accepts), decoded + validated **inside the handler** — kind-specific validation lives with the domain, so a bad request is a *failed job*, not a panic on the generic surface.
- Samples the client's phase progress (0–100) onto the job every 250ms; returns `IperfResultResponse` (mapping extracted into a shared `toIperfResultResponse` helper, now used by the status handler too).
- `registerIperfKind` wires it at startup alongside speedtest, behind the same factory seam used for tests.

### Additive / non-breaking
Legacy `/telemetry/iperf/client` + `/status` unchanged (retire at Phase-7 frontend cutover). Kinds aren't routes → **no capability-manifest or golden churn**.

### Gates
- `go test -race ./internal/api/` (targeted) — 6 white-box kind tests (success/progress/cancel/failure + missing-server validation + registration) + golden harness, all pass
- `golangci-lint` **0 issues**; `go vet`/`gofmt` clean; binary builds; on the 1.26.4 base (Security green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)