### PR TITLE
feat(api): migrate vulnerability scan to a job kind (ADR-0005)

### DIFF
--- a/internal/api/jobs_speedtest.go
+++ b/internal/api/jobs_speedtest.go
@@ -78,6 +78,9 @@ func newSpeedtestHandler(newTester func() speedTester) jobs.Handler {
 func (s *Server) registerJobKinds() {
 	s.registerSpeedtestKind(func() speedTester { return speedtest.NewTester() })
 	s.registerIperfKind(func() iperfClient { return iperf.NewManager() })
+	s.registerVulnScanKind(func() vulnScanService {
+		return serverVulnScanService{scanner: s.vulnScanner(), devices: s.deviceDiscovery()}
+	})
 }
 
 // registerSpeedtestKind registers the speedtest kind with an injectable tester

--- a/internal/api/jobs_vuln.go
+++ b/internal/api/jobs_vuln.go
@@ -1,0 +1,136 @@
+package api
+
+// jobs_vuln.go registers the vulnerability scan as a unified job kind
+// (ADR-0005), the first discovery-coupled long-op on the runner. It is a thin
+// additive wrapper over the EXISTING public scanner + device-registry methods
+// (both already ctx-aware) behind an interface seam — no discovery-internal
+// refactor. The legacy /security/vulnerabilities/scan + /status + /results
+// endpoints are unchanged (retire at the Phase-7 frontend cutover).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/krisarmstrong/seed/internal/logging"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+	"github.com/krisarmstrong/seed/internal/services/discovery"
+)
+
+// vulnScanJobKind is the registered kind name for a vulnerability scan.
+const vulnScanJobKind = "vuln-scan"
+
+// VulnScanParams is the job params for a vulnerability scan. An empty IP scans
+// every discovered device; a set IP scans just that one.
+type VulnScanParams struct {
+	IP string `json:"ip,omitempty"`
+}
+
+// VulnScanJobResult is the job Result for a vulnerability scan: the aggregated
+// per-device vulnerabilities plus how many devices were scanned and how many
+// failed (surfaced, not silently dropped, unlike the legacy log-and-continue).
+type VulnScanJobResult struct {
+	Results []*discovery.DeviceVulnerabilities `json:"results"`
+	Count   int                                `json:"count"`
+	Scanned int                                `json:"scanned"`
+	Failed  int                                `json:"failed"`
+}
+
+// vulnScanService is the slice of behaviour the vuln-scan kind needs:
+// enumerate target devices, scan one (ctx-aware), and read aggregated results.
+// The Server adapts its scanner + device registry into this seam, which also
+// keeps the kind unit-testable without the real discovery services.
+type vulnScanService interface {
+	Devices(targetIP string) []*discovery.DiscoveredDevice
+	ScanDevice(ctx context.Context, device *discovery.DiscoveredDevice) (*discovery.DeviceVulnerabilities, error)
+	Results() []*discovery.DeviceVulnerabilities
+}
+
+// newVulnScanHandler returns the job Handler for the "vuln-scan" kind. It scans
+// each target device in turn, reports per-device progress onto the job, and
+// returns the aggregated results. Per-device errors are counted (not fatal) so
+// one offline device does not fail the whole scan; a cancelled context unwinds
+// the scan between (or during) devices.
+func newVulnScanHandler(newSvc func() vulnScanService) jobs.Handler {
+	return func(ctx context.Context, params any, report func(float64)) (any, error) {
+		p, err := decodeVulnScanParams(params)
+		if err != nil {
+			return nil, err
+		}
+
+		svc := newSvc()
+		devices := svc.Devices(p.IP)
+		total := len(devices)
+
+		var result VulnScanJobResult
+		for i, device := range devices {
+			if cerr := ctx.Err(); cerr != nil {
+				return nil, cerr
+			}
+			if _, scanErr := svc.ScanDevice(ctx, device); scanErr != nil {
+				// A cancelled scan unwinds the job; any other per-device error is
+				// counted and the scan continues.
+				if cerr := ctx.Err(); cerr != nil {
+					return nil, cerr
+				}
+				result.Failed++
+			} else {
+				result.Scanned++
+			}
+			report(float64(i+1) / float64(total))
+		}
+
+		result.Results = svc.Results()
+		result.Count = len(result.Results)
+		return result, nil
+	}
+}
+
+// decodeVulnScanParams parses the optional job params; absent params scan all
+// devices.
+func decodeVulnScanParams(params any) (VulnScanParams, error) {
+	raw, ok := params.(json.RawMessage)
+	if !ok || len(raw) == 0 {
+		return VulnScanParams{}, nil
+	}
+	var p VulnScanParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return VulnScanParams{}, fmt.Errorf("invalid vuln-scan params: %w", err)
+	}
+	return p, nil
+}
+
+// serverVulnScanService adapts the Server's scanner + device registry to the
+// vulnScanService seam.
+type serverVulnScanService struct {
+	scanner *discovery.VulnerabilityScanner
+	devices *discovery.DeviceDiscovery
+}
+
+func (a serverVulnScanService) Devices(targetIP string) []*discovery.DiscoveredDevice {
+	if targetIP != "" {
+		if d := a.devices.GetDeviceByIP(targetIP); d != nil {
+			return []*discovery.DiscoveredDevice{d}
+		}
+		return nil
+	}
+	return a.devices.GetDevices()
+}
+
+func (a serverVulnScanService) ScanDevice(
+	ctx context.Context, device *discovery.DiscoveredDevice,
+) (*discovery.DeviceVulnerabilities, error) {
+	return a.scanner.ScanDevice(ctx, device)
+}
+
+func (a serverVulnScanService) Results() []*discovery.DeviceVulnerabilities {
+	return a.scanner.GetAllVulnerabilities()
+}
+
+// registerVulnScanKind registers the vuln-scan kind with an injectable service
+// factory (the seam that makes the wiring testable without the real scanner).
+func (s *Server) registerVulnScanKind(newSvc func() vulnScanService) {
+	if err := s.jobsRunner().Register(vulnScanJobKind, newVulnScanHandler(newSvc)); err != nil {
+		logging.GetLogger().Error("failed to register vuln-scan job kind", "error", err)
+	}
+}

--- a/internal/api/jobs_vuln_internal_test.go
+++ b/internal/api/jobs_vuln_internal_test.go
@@ -1,0 +1,208 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+	"github.com/krisarmstrong/seed/internal/services/discovery"
+)
+
+// fakeVulnScanService is a controllable vulnScanService for the kind tests: it
+// never touches the real scanner or device registry.
+type fakeVulnScanService struct {
+	devices []*discovery.DiscoveredDevice
+	results []*discovery.DeviceVulnerabilities
+	scanErr error
+	gate    chan struct{} // if non-nil, each ScanDevice waits for one token (or ctx)
+}
+
+func (f *fakeVulnScanService) Devices(targetIP string) []*discovery.DiscoveredDevice {
+	if targetIP == "" {
+		return f.devices
+	}
+	for _, d := range f.devices {
+		if d.IP == targetIP {
+			return []*discovery.DiscoveredDevice{d}
+		}
+	}
+	return nil
+}
+
+func (f *fakeVulnScanService) ScanDevice(
+	ctx context.Context, device *discovery.DiscoveredDevice,
+) (*discovery.DeviceVulnerabilities, error) {
+	if f.gate != nil {
+		select {
+		case <-f.gate:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.scanErr != nil {
+		return nil, f.scanErr
+	}
+	return &discovery.DeviceVulnerabilities{DeviceIP: device.IP}, nil
+}
+
+func (f *fakeVulnScanService) Results() []*discovery.DeviceVulnerabilities {
+	return f.results
+}
+
+func devicesAt(ips ...string) []*discovery.DiscoveredDevice {
+	out := make([]*discovery.DiscoveredDevice, len(ips))
+	for i, ip := range ips {
+		out[i] = &discovery.DiscoveredDevice{IP: ip}
+	}
+	return out
+}
+
+func TestVulnScanKindScansAllDevices(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeVulnScanService{
+		devices: devicesAt("10.0.0.1", "10.0.0.2", "10.0.0.3"),
+		results: []*discovery.DeviceVulnerabilities{{DeviceIP: "10.0.0.1"}, {DeviceIP: "10.0.0.2"}},
+	}
+	if err := runner.Register(vulnScanJobKind, newVulnScanHandler(func() vulnScanService { return fake })); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	id, err := runner.Submit(vulnScanJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+
+	j, _ := runner.Get(id)
+	res, ok := j.Result.(VulnScanJobResult)
+	if !ok {
+		t.Fatalf("Result type = %T, want VulnScanJobResult", j.Result)
+	}
+	if res.Scanned != 3 || res.Failed != 0 || res.Count != 2 {
+		t.Fatalf("result = %+v, want scanned 3 / failed 0 / count 2", res)
+	}
+}
+
+func TestVulnScanKindTargetsSingleDevice(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeVulnScanService{devices: devicesAt("10.0.0.1", "10.0.0.2")}
+	_ = runner.Register(vulnScanJobKind, newVulnScanHandler(func() vulnScanService { return fake }))
+
+	id, _ := runner.Submit(vulnScanJobKind, json.RawMessage(`{"ip":"10.0.0.2"}`))
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+	j, _ := runner.Get(id)
+	if res := j.Result.(VulnScanJobResult); res.Scanned != 1 {
+		t.Fatalf("scanned = %d, want 1 (single-device target)", res.Scanned)
+	}
+}
+
+func TestVulnScanKindReportsProgress(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	gate := make(chan struct{})
+	fake := &fakeVulnScanService{devices: devicesAt("10.0.0.1", "10.0.0.2"), gate: gate}
+	_ = runner.Register(vulnScanJobKind, newVulnScanHandler(func() vulnScanService { return fake }))
+
+	id, _ := runner.Submit(vulnScanJobKind, nil)
+	gate <- struct{}{} // let the first of two devices complete -> progress 0.5
+	waitFor(t, "progress 0.5 after first device", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.Progress == 0.5
+	})
+	gate <- struct{}{} // release the second device
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+}
+
+func TestVulnScanKindCancellation(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	// gate never receives tokens: ScanDevice blocks until the job ctx is cancelled.
+	fake := &fakeVulnScanService{devices: devicesAt("10.0.0.1"), gate: make(chan struct{})}
+	_ = runner.Register(vulnScanJobKind, newVulnScanHandler(func() vulnScanService { return fake }))
+
+	id, _ := runner.Submit(vulnScanJobKind, nil)
+	waitFor(t, "job running", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateRunning
+	})
+	if err := runner.Cancel(id); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	waitFor(t, "job cancelled", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateCancelled
+	})
+}
+
+func TestVulnScanKindCountsPerDeviceFailures(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	// Every device errors (but not via cancellation), so the scan completes with
+	// a non-zero failed count rather than failing the whole job.
+	fake := &fakeVulnScanService{devices: devicesAt("10.0.0.1", "10.0.0.2"), scanErr: errors.New("offline")}
+	_ = runner.Register(vulnScanJobKind, newVulnScanHandler(func() vulnScanService { return fake }))
+
+	id, _ := runner.Submit(vulnScanJobKind, nil)
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+	j, _ := runner.Get(id)
+	res := j.Result.(VulnScanJobResult)
+	if res.Failed != 2 || res.Scanned != 0 {
+		t.Fatalf("result = %+v, want failed 2 / scanned 0", res)
+	}
+}
+
+func TestVulnScanKindNoDevices(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeVulnScanService{} // no devices
+	_ = runner.Register(vulnScanJobKind, newVulnScanHandler(func() vulnScanService { return fake }))
+
+	id, _ := runner.Submit(vulnScanJobKind, nil)
+	waitFor(t, "job succeeded with no devices", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+	j, _ := runner.Get(id)
+	if res := j.Result.(VulnScanJobResult); res.Scanned != 0 || res.Count != 0 {
+		t.Fatalf("result = %+v, want empty", res)
+	}
+}
+
+func TestRegisterVulnScanKindWiresRunner(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeVulnScanService{devices: devicesAt("10.0.0.1")}
+	srv.registerVulnScanKind(func() vulnScanService { return fake })
+
+	id, err := runner.Submit(vulnScanJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit after registerVulnScanKind: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+}


### PR DESCRIPTION
## Phase 4, Slice 6 — first discovery-coupled long-op as a job kind: vuln-scan

Registers a `vuln-scan` **kind** so a vulnerability scan runs over the `/jobs` surface end-to-end — submit → per-device progress → cancel → aggregated result. Follows speedtest (#1470) and iperf (#1471).

**Safe by construction:** the kind is a thin **additive wrapper** over the *existing public* scanner + device-registry methods (`VulnerabilityScanner.ScanDevice`, `DeviceDiscovery.GetDevices/GetDeviceByIP`, `GetAllVulnerabilities`) — all already ctx-aware — behind a `vulnScanService` interface seam. **No discovery-internal refactor.** Legacy `/security/vulnerabilities/scan` + `/status` + `/results` are unchanged (retire at Phase-7 cutover); kinds aren't routes → **no manifest/golden churn**.

### Design
- Job params (`VulnScanParams`) optionally target a single device by IP; absent params scan every discovered device.
- The handler scans each device in turn, reporting **per-device progress** (i/N) onto the job, and returns a `VulnScanJobResult`: aggregated per-device vulnerabilities + **scanned/failed counts**. Per-device errors are **counted, not silently dropped** (an improvement over the legacy log-and-continue); a cancelled context unwinds the scan between or during devices.
- `serverVulnScanService` adapts the Server's scanner + device registry to the seam; `registerVulnScanKind` wires it at startup behind the same factory pattern as the other kinds.

### Gates
- `go test -race ./internal/api/` (targeted) — 7 white-box kind tests (scan-all / single-device / per-device progress / cancel / per-device-failure counting / no-devices / registration) + golden harness, all pass
- `golangci-lint` **0 issues**; `go vet`/`gofmt` clean; binary builds; 1.26.4 base (Security green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)