### PR TITLE
feat(api): migrate discovery engine scan to a job kind (ADR-0005)

### DIFF
--- a/internal/api/handlers_engine.go
+++ b/internal/api/handlers_engine.go
@@ -92,6 +92,28 @@ func (s *Server) handleEngineDiscovery(w http.ResponseWriter, r *http.Request) {
 	sendJSONResponse(w, logger, http.StatusOK, resp)
 }
 
+// scanOptsFromRequest builds discovery scan options from a request: the
+// quick/full default plus the per-feature overrides. Shared by the engine-scan
+// handler and the engine-scan job kind so both produce identical options.
+func scanOptsFromRequest(req EngineScanRequest) *discovery.ScanOptions {
+	var opts *discovery.ScanOptions
+	if req.ScanType == "full" {
+		opts = discovery.DefaultFullScanOpts()
+	} else {
+		opts = discovery.DefaultQuickScanOpts()
+	}
+	opts.IncludeWired = req.IncludeWired
+	opts.IncludeWiFi = req.IncludeWiFi
+	opts.IncludeBluetooth = req.IncludeBluetooth
+	opts.IncludeSNMP = req.IncludeSNMP
+	opts.IncludePortScan = req.IncludePortScan
+	opts.IncludeVulnScan = req.IncludeVulnScan
+	opts.FreshWiredScan = req.FreshWiredScan
+	opts.FreshWiFiScan = req.FreshWiFiScan
+	opts.FreshBluetoothScan = req.FreshBluetoothScan
+	return opts
+}
+
 // handleEngineScan triggers a discovery engine scan.
 //
 // POST /api/v1/discovery/engine/scan triggers a new scan.
@@ -167,23 +189,7 @@ func (s *Server) handleEngineScan(w http.ResponseWriter, r *http.Request) {
 		if !decodeJSONStrict(w, r, &req, MaxBodySizeJSON) {
 			return
 		}
-
-		if req.ScanType == "full" {
-			opts = discovery.DefaultFullScanOpts()
-		} else {
-			opts = discovery.DefaultQuickScanOpts()
-		}
-
-		// Override with request values
-		opts.IncludeWired = req.IncludeWired
-		opts.IncludeWiFi = req.IncludeWiFi
-		opts.IncludeBluetooth = req.IncludeBluetooth
-		opts.IncludeSNMP = req.IncludeSNMP
-		opts.IncludePortScan = req.IncludePortScan
-		opts.IncludeVulnScan = req.IncludeVulnScan
-		opts.FreshWiredScan = req.FreshWiredScan
-		opts.FreshWiFiScan = req.FreshWiFiScan
-		opts.FreshBluetoothScan = req.FreshBluetoothScan
+		opts = scanOptsFromRequest(req)
 	} else {
 		opts = discovery.DefaultQuickScanOpts()
 	}

--- a/internal/api/jobs_engine.go
+++ b/internal/api/jobs_engine.go
@@ -1,0 +1,80 @@
+package api
+
+// jobs_engine.go registers the discovery engine scan as a unified job kind
+// (ADR-0005). Like the vuln-scan kind it is a thin additive wrapper over the
+// existing ctx-aware engine methods behind an interface seam — no
+// discovery-internal refactor. engine.Scan is synchronous and exposes no
+// progress fraction (only IsScanning), so the kind reports no granular progress;
+// the runner's queued->running->succeeded transitions carry status. The legacy
+// /discovery/engine/scan endpoint is unchanged (retire at the Phase-7 cutover).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/krisarmstrong/seed/internal/logging"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+	"github.com/krisarmstrong/seed/internal/services/discovery"
+)
+
+// engineScanJobKind is the registered kind name for a discovery engine scan.
+const engineScanJobKind = "engine-scan"
+
+// engineScanner is the slice of *discovery.Engine behaviour the kind needs.
+// The real engine satisfies it; a fake drives the tests.
+type engineScanner interface {
+	Scan(ctx context.Context, opts *discovery.ScanOptions) (*discovery.ScanResult, error)
+	GetDevices() []*discovery.DiscoveredDevice
+	GetStats() *discovery.EngineStats
+	GetCapabilities() map[string]bool
+}
+
+// newEngineScanHandler returns the job Handler for the "engine-scan" kind. It
+// runs one scan (cancellable via the job context) and returns the same
+// EngineDiscoveryResponse the legacy endpoint produces. The report callback is
+// unused: the engine surfaces no progress fraction, only running/idle.
+func newEngineScanHandler(newEngine func() engineScanner) jobs.Handler {
+	return func(ctx context.Context, params any, _ func(float64)) (any, error) {
+		opts, err := engineScanOptsFromParams(params)
+		if err != nil {
+			return nil, err
+		}
+
+		engine := newEngine()
+		result, scanErr := engine.Scan(ctx, opts)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		return EngineDiscoveryResponse{
+			Devices:      engine.GetDevices(),
+			Stats:        engine.GetStats(),
+			ScanResult:   result,
+			Capabilities: engine.GetCapabilities(),
+		}, nil
+	}
+}
+
+// engineScanOptsFromParams parses the optional job params into scan options.
+// Absent params default to a quick scan (matching the legacy no-body behaviour);
+// malformed params are an error so the job fails rather than silently running a
+// different scan.
+func engineScanOptsFromParams(params any) (*discovery.ScanOptions, error) {
+	raw, ok := params.(json.RawMessage)
+	if !ok || len(raw) == 0 {
+		return discovery.DefaultQuickScanOpts(), nil
+	}
+	var req EngineScanRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return nil, fmt.Errorf("invalid engine-scan params: %w", err)
+	}
+	return scanOptsFromRequest(req), nil
+}
+
+// registerEngineScanKind registers the engine-scan kind with an injectable
+// engine factory (the seam that makes the wiring testable without the engine).
+func (s *Server) registerEngineScanKind(newEngine func() engineScanner) {
+	if err := s.jobsRunner().Register(engineScanJobKind, newEngineScanHandler(newEngine)); err != nil {
+		logging.GetLogger().Error("failed to register engine-scan job kind", "error", err)
+	}
+}

--- a/internal/api/jobs_engine_internal_test.go
+++ b/internal/api/jobs_engine_internal_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+	"github.com/krisarmstrong/seed/internal/services/discovery"
+)
+
+// fakeEngineScanner is a controllable engineScanner for the kind tests: it never
+// runs the real discovery engine.
+type fakeEngineScanner struct {
+	result  *discovery.ScanResult
+	err     error
+	devices []*discovery.DiscoveredDevice
+	gotOpts *discovery.ScanOptions // captures the opts Scan was called with
+	release chan struct{}          // if non-nil, Scan blocks until closed or ctx is done
+}
+
+func (f *fakeEngineScanner) Scan(
+	ctx context.Context, opts *discovery.ScanOptions,
+) (*discovery.ScanResult, error) {
+	f.gotOpts = opts
+	if f.release != nil {
+		select {
+		case <-f.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.result, nil
+}
+
+func (f *fakeEngineScanner) GetDevices() []*discovery.DiscoveredDevice { return f.devices }
+func (f *fakeEngineScanner) GetStats() *discovery.EngineStats          { return &discovery.EngineStats{} }
+func (f *fakeEngineScanner) GetCapabilities() map[string]bool          { return map[string]bool{"wired": true} }
+
+func TestEngineScanKindRunsToSuccess(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeEngineScanner{
+		result:  &discovery.ScanResult{},
+		devices: devicesAt("10.0.0.1", "10.0.0.2"),
+	}
+	handler := newEngineScanHandler(func() engineScanner { return fake })
+	if err := runner.Register(engineScanJobKind, handler); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	id, err := runner.Submit(engineScanJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+
+	j, _ := runner.Get(id)
+	res, ok := j.Result.(EngineDiscoveryResponse)
+	if !ok {
+		t.Fatalf("Result type = %T, want EngineDiscoveryResponse", j.Result)
+	}
+	if len(res.Devices) != 2 || res.Capabilities["wired"] != true {
+		t.Fatalf("result = %+v, want 2 devices + wired capability", res)
+	}
+}
+
+func TestEngineScanKindAppliesParams(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeEngineScanner{result: &discovery.ScanResult{}}
+	_ = runner.Register(engineScanJobKind, newEngineScanHandler(func() engineScanner { return fake }))
+
+	id, _ := runner.Submit(engineScanJobKind, json.RawMessage(`{"scanType":"full","includeVulnScan":true}`))
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+	if fake.gotOpts == nil || !fake.gotOpts.IncludeVulnScan {
+		t.Fatalf("Scan opts = %+v, want IncludeVulnScan true from params", fake.gotOpts)
+	}
+}
+
+func TestEngineScanKindCancellation(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeEngineScanner{release: make(chan struct{})} // never closed; cancel via ctx
+	_ = runner.Register(engineScanJobKind, newEngineScanHandler(func() engineScanner { return fake }))
+
+	id, _ := runner.Submit(engineScanJobKind, nil)
+	waitFor(t, "job running", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateRunning
+	})
+	if err := runner.Cancel(id); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	waitFor(t, "job cancelled", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateCancelled
+	})
+}
+
+func TestEngineScanKindFailure(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeEngineScanner{err: errors.New("scan failed")}
+	_ = runner.Register(engineScanJobKind, newEngineScanHandler(func() engineScanner { return fake }))
+
+	id, _ := runner.Submit(engineScanJobKind, nil)
+	waitFor(t, "job failed", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateFailed
+	})
+	j, _ := runner.Get(id)
+	if j.Err == "" {
+		t.Fatal("failed engine-scan job has empty Err, want the engine error")
+	}
+}
+
+func TestEngineScanKindRejectsMalformedParams(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeEngineScanner{result: &discovery.ScanResult{}}
+	_ = runner.Register(engineScanJobKind, newEngineScanHandler(func() engineScanner { return fake }))
+
+	id, _ := runner.Submit(engineScanJobKind, json.RawMessage(`{not json`))
+	waitFor(t, "job failed on malformed params", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateFailed
+	})
+}
+
+func TestRegisterEngineScanKindWiresRunner(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeEngineScanner{result: &discovery.ScanResult{}, devices: devicesAt("10.0.0.9")}
+	srv.registerEngineScanKind(func() engineScanner { return fake })
+
+	id, err := runner.Submit(engineScanJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit after registerEngineScanKind: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+}

--- a/internal/api/jobs_speedtest.go
+++ b/internal/api/jobs_speedtest.go
@@ -81,6 +81,7 @@ func (s *Server) registerJobKinds() {
 	s.registerVulnScanKind(func() vulnScanService {
 		return serverVulnScanService{scanner: s.vulnScanner(), devices: s.deviceDiscovery()}
 	})
+	s.registerEngineScanKind(func() engineScanner { return s.services.Discovery.Engine })
 }
 
 // registerSpeedtestKind registers the speedtest kind with an injectable tester


### PR DESCRIPTION
## Phase 4, Slice 7 — discovery engine scan as a job kind: engine-scan

Registers an `engine-scan` **kind** so the discovery engine scan runs over the `/jobs` surface end-to-end. Follows speedtest (#1470), iperf (#1471), vuln-scan (#1472).

Thin **additive wrapper** over the existing ctx-aware engine methods (`Engine.Scan/GetDevices/GetStats/GetCapabilities`) behind an `engineScanner` interface seam — **no discovery-internal refactor**. Legacy `/discovery/engine/scan` unchanged (retire at Phase-7 cutover); kinds aren't routes → **no manifest/golden churn**.

### Design
- Job params are an `EngineScanRequest` (the legacy shape); absent params default to a quick scan, malformed params **fail the job** rather than silently running a different scan.
- `engine.Scan` is synchronous with no progress fraction (only `IsScanning`), so the kind **honestly takes no progress callback** — the runner's queued→running→succeeded transitions carry status; a cancelled context unwinds the scan.
- Returns the same `EngineDiscoveryResponse` the legacy endpoint produces (devices + stats + scan result + capabilities) as the opaque job Result.
- Extracted `scanOptsFromRequest`, **shared** by the handler and the kind so both build identical options (DRY).

### Gates
- `go test -race ./internal/api/` (targeted) — 6 white-box kind tests (success / params-applied / cancel / failure / malformed-params / registration) + golden harness, all pass
- `golangci-lint` **0 issues**; `go vet`/`gofmt` clean; binary builds; 1.26.4 base (Security green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)