### PR TITLE
feat(api): migrate bluetooth/wifi-discovery/device scans to job kinds (ADR-0005)

### DIFF
--- a/internal/api/handlers_bluetooth.go
+++ b/internal/api/handlers_bluetooth.go
@@ -191,16 +191,25 @@ func (s *Server) handleBluetoothScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := BluetoothScanResponse{
+	resp := toBluetoothScanResponse(result, btScanner.GetStats())
+
+	sendJSONResponse(w, logger, http.StatusOK, resp)
+}
+
+// toBluetoothScanResponse maps a scan result + stats to the API wire shape.
+// Shared by the scan handler and the bluetooth-scan job kind so both paths
+// produce an identical response.
+func toBluetoothScanResponse(
+	result *discovery.BluetoothScanResult, stats *discovery.BluetoothDiscoveryStats,
+) BluetoothScanResponse {
+	return BluetoothScanResponse{
 		Devices:      toBluetoothDevices(result.Devices),
 		AdapterName:  result.AdapterName,
 		ScanType:     result.ScanType,
 		ScanTime:     result.ScanTime.Format("2006-01-02T15:04:05Z07:00"),
 		ScanDuration: result.ScanDuration.Milliseconds(),
-		Stats:        toBluetoothStats(btScanner.GetStats()),
+		Stats:        toBluetoothStats(stats),
 	}
-
-	sendJSONResponse(w, logger, http.StatusOK, resp)
 }
 
 // handleBluetoothDevices returns discovered Bluetooth devices.

--- a/internal/api/handlers_wifi.go
+++ b/internal/api/handlers_wifi.go
@@ -912,15 +912,22 @@ func (s *Server) handleWiFiDiscoveryScan(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	resp := WiFiDiscoveryScanResponse{
+	resp := toWiFiDiscoveryScanResponse(result)
+
+	sendJSONResponse(w, logger, http.StatusOK, resp)
+}
+
+// toWiFiDiscoveryScanResponse maps a Wi-Fi scan result to the API wire shape.
+// Shared by the scan handler and the wifi-discovery-scan job kind so both paths
+// produce an identical response.
+func toWiFiDiscoveryScanResponse(result *discovery.WiFiScanResult) WiFiDiscoveryScanResponse {
+	return WiFiDiscoveryScanResponse{
 		Networks:    toWiFiNetworks(result.Networks),
 		APs:         toWiFiAccessPoints(result.APs),
 		Utilization: toChannelUtilizations(result.Utilization),
 		ScanTime:    result.ScanTime.Format("2006-01-02T15:04:05Z07:00"),
 		Interface:   result.Interface,
 	}
-
-	sendJSONResponse(w, logger, http.StatusOK, resp)
 }
 
 // handleWiFiDiscoveryNetworks returns discovered WiFi networks.

--- a/internal/api/jobs_bluetooth.go
+++ b/internal/api/jobs_bluetooth.go
@@ -1,0 +1,47 @@
+package api
+
+// jobs_bluetooth.go registers the Bluetooth scan as a unified job kind
+// (ADR-0005). Thin additive wrapper over the existing ctx-aware scanner behind
+// an interface seam — no discovery-internal refactor. The scan is synchronous
+// and exposes no progress fraction, so the kind takes no progress callback. The
+// legacy /security/bluetooth/scan endpoint is unchanged (retire at Phase-7).
+
+import (
+	"context"
+
+	"github.com/krisarmstrong/seed/internal/logging"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+	"github.com/krisarmstrong/seed/internal/services/discovery"
+)
+
+// bluetoothScanJobKind is the registered kind name for a Bluetooth scan.
+const bluetoothScanJobKind = "bluetooth-scan"
+
+// bluetoothScannerService is the slice of *discovery.BluetoothScanner behaviour
+// the kind needs.
+type bluetoothScannerService interface {
+	Scan(ctx context.Context) (*discovery.BluetoothScanResult, error)
+	GetStats() *discovery.BluetoothDiscoveryStats
+}
+
+// newBluetoothScanHandler returns the job Handler for the "bluetooth-scan" kind.
+// It runs one scan (cancellable via the job context) and returns the same
+// BluetoothScanResponse the legacy endpoint produces.
+func newBluetoothScanHandler(newScanner func() bluetoothScannerService) jobs.Handler {
+	return func(ctx context.Context, _ any, _ func(float64)) (any, error) {
+		scanner := newScanner()
+		result, err := scanner.Scan(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return toBluetoothScanResponse(result, scanner.GetStats()), nil
+	}
+}
+
+// registerBluetoothScanKind registers the bluetooth-scan kind with an injectable
+// scanner factory (the seam that makes the wiring testable without hardware).
+func (s *Server) registerBluetoothScanKind(newScanner func() bluetoothScannerService) {
+	if err := s.jobsRunner().Register(bluetoothScanJobKind, newBluetoothScanHandler(newScanner)); err != nil {
+		logging.GetLogger().Error("failed to register bluetooth-scan job kind", "error", err)
+	}
+}

--- a/internal/api/jobs_bluetooth_internal_test.go
+++ b/internal/api/jobs_bluetooth_internal_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+	"github.com/krisarmstrong/seed/internal/services/discovery"
+)
+
+type fakeBluetoothScanner struct {
+	result  *discovery.BluetoothScanResult
+	err     error
+	release chan struct{}
+}
+
+func (f *fakeBluetoothScanner) Scan(ctx context.Context) (*discovery.BluetoothScanResult, error) {
+	if f.release != nil {
+		select {
+		case <-f.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.result, nil
+}
+
+func (f *fakeBluetoothScanner) GetStats() *discovery.BluetoothDiscoveryStats {
+	return &discovery.BluetoothDiscoveryStats{}
+}
+
+func TestBluetoothScanKindRunsToSuccess(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeBluetoothScanner{result: &discovery.BluetoothScanResult{ScanType: "le", AdapterName: "hci0"}}
+	handler := newBluetoothScanHandler(func() bluetoothScannerService { return fake })
+	if err := runner.Register(bluetoothScanJobKind, handler); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	id, err := runner.Submit(bluetoothScanJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+	j, _ := runner.Get(id)
+	res, ok := j.Result.(BluetoothScanResponse)
+	if !ok || res.ScanType != "le" || res.AdapterName != "hci0" {
+		t.Fatalf("result = %+v (ok=%v), want scanType le / adapter hci0", res, ok)
+	}
+}
+
+func TestBluetoothScanKindCancellation(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeBluetoothScanner{release: make(chan struct{})}
+	handler := newBluetoothScanHandler(func() bluetoothScannerService { return fake })
+	_ = runner.Register(bluetoothScanJobKind, handler)
+
+	id, _ := runner.Submit(bluetoothScanJobKind, nil)
+	waitFor(t, "job running", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateRunning
+	})
+	if err := runner.Cancel(id); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	waitFor(t, "job cancelled", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateCancelled
+	})
+}
+
+func TestBluetoothScanKindFailure(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeBluetoothScanner{err: errors.New("no adapter")}
+	handler := newBluetoothScanHandler(func() bluetoothScannerService { return fake })
+	_ = runner.Register(bluetoothScanJobKind, handler)
+
+	id, _ := runner.Submit(bluetoothScanJobKind, nil)
+	waitFor(t, "job failed", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateFailed
+	})
+	j, _ := runner.Get(id)
+	if j.Err == "" {
+		t.Fatal("failed bluetooth-scan job has empty Err")
+	}
+}
+
+func TestRegisterBluetoothScanKindWiresRunner(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeBluetoothScanner{result: &discovery.BluetoothScanResult{ScanType: "le"}}
+	srv.registerBluetoothScanKind(func() bluetoothScannerService { return fake })
+
+	id, err := runner.Submit(bluetoothScanJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit after registerBluetoothScanKind: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+}

--- a/internal/api/jobs_devices.go
+++ b/internal/api/jobs_devices.go
@@ -1,0 +1,56 @@
+package api
+
+// jobs_devices.go registers the network device scan as a unified job kind
+// (ADR-0005). Thin additive wrapper over the existing ctx-aware
+// DeviceDiscovery.Scan behind an interface seam — no discovery-internal
+// refactor. Unlike the legacy /security/devices/scan endpoint, the kind does NOT
+// auto-trigger a vulnerability scan afterwards: in the jobs model that is a
+// separate vuln-scan submission (one job = one operation). The scan is
+// synchronous with no progress fraction, so the kind takes no progress callback.
+
+import (
+	"context"
+
+	"github.com/krisarmstrong/seed/internal/logging"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+	"github.com/krisarmstrong/seed/internal/services/discovery"
+)
+
+// deviceScanJobKind is the registered kind name for a network device scan.
+const deviceScanJobKind = "device-scan"
+
+// DeviceScanJobResult is the job Result for a device scan: the discovered
+// devices and their count after the scan completes.
+type DeviceScanJobResult struct {
+	Devices []*discovery.DiscoveredDevice `json:"devices"`
+	Count   int                           `json:"count"`
+}
+
+// deviceScanService is the slice of *discovery.DeviceDiscovery behaviour the
+// kind needs.
+type deviceScanService interface {
+	Scan(ctx context.Context) error
+	GetDevices() []*discovery.DiscoveredDevice
+	Count() int
+}
+
+// newDeviceScanHandler returns the job Handler for the "device-scan" kind. It
+// runs one scan (cancellable via the job context) and returns the discovered
+// devices.
+func newDeviceScanHandler(newSvc func() deviceScanService) jobs.Handler {
+	return func(ctx context.Context, _ any, _ func(float64)) (any, error) {
+		svc := newSvc()
+		if err := svc.Scan(ctx); err != nil {
+			return nil, err
+		}
+		return DeviceScanJobResult{Devices: svc.GetDevices(), Count: svc.Count()}, nil
+	}
+}
+
+// registerDeviceScanKind registers the device-scan kind with an injectable
+// service factory (the seam that makes the wiring testable without the network).
+func (s *Server) registerDeviceScanKind(newSvc func() deviceScanService) {
+	if err := s.jobsRunner().Register(deviceScanJobKind, newDeviceScanHandler(newSvc)); err != nil {
+		logging.GetLogger().Error("failed to register device-scan job kind", "error", err)
+	}
+}

--- a/internal/api/jobs_devices_internal_test.go
+++ b/internal/api/jobs_devices_internal_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+	"github.com/krisarmstrong/seed/internal/services/discovery"
+)
+
+type fakeDeviceScanService struct {
+	devices []*discovery.DiscoveredDevice
+	err     error
+	release chan struct{}
+}
+
+func (f *fakeDeviceScanService) Scan(ctx context.Context) error {
+	if f.release != nil {
+		select {
+		case <-f.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return f.err
+}
+
+func (f *fakeDeviceScanService) GetDevices() []*discovery.DiscoveredDevice { return f.devices }
+func (f *fakeDeviceScanService) Count() int                                { return len(f.devices) }
+
+func TestDeviceScanKindRunsToSuccess(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeDeviceScanService{devices: devicesAt("10.0.0.1", "10.0.0.2", "10.0.0.3")}
+	handler := newDeviceScanHandler(func() deviceScanService { return fake })
+	if err := runner.Register(deviceScanJobKind, handler); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	id, err := runner.Submit(deviceScanJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+	j, _ := runner.Get(id)
+	res, ok := j.Result.(DeviceScanJobResult)
+	if !ok || res.Count != 3 || len(res.Devices) != 3 {
+		t.Fatalf("result = %+v (ok=%v), want count 3", res, ok)
+	}
+}
+
+func TestDeviceScanKindCancellation(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeDeviceScanService{release: make(chan struct{})}
+	handler := newDeviceScanHandler(func() deviceScanService { return fake })
+	_ = runner.Register(deviceScanJobKind, handler)
+
+	id, _ := runner.Submit(deviceScanJobKind, nil)
+	waitFor(t, "job running", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateRunning
+	})
+	if err := runner.Cancel(id); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	waitFor(t, "job cancelled", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateCancelled
+	})
+}
+
+func TestDeviceScanKindFailure(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeDeviceScanService{err: errors.New("scan failed")}
+	handler := newDeviceScanHandler(func() deviceScanService { return fake })
+	_ = runner.Register(deviceScanJobKind, handler)
+
+	id, _ := runner.Submit(deviceScanJobKind, nil)
+	waitFor(t, "job failed", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateFailed
+	})
+	j, _ := runner.Get(id)
+	if j.Err == "" {
+		t.Fatal("failed device-scan job has empty Err")
+	}
+}
+
+func TestRegisterDeviceScanKindWiresRunner(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeDeviceScanService{devices: devicesAt("10.0.0.9")}
+	srv.registerDeviceScanKind(func() deviceScanService { return fake })
+
+	id, err := runner.Submit(deviceScanJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit after registerDeviceScanKind: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+}

--- a/internal/api/jobs_speedtest.go
+++ b/internal/api/jobs_speedtest.go
@@ -82,6 +82,9 @@ func (s *Server) registerJobKinds() {
 		return serverVulnScanService{scanner: s.vulnScanner(), devices: s.deviceDiscovery()}
 	})
 	s.registerEngineScanKind(func() engineScanner { return s.services.Discovery.Engine })
+	s.registerBluetoothScanKind(func() bluetoothScannerService { return s.bluetoothScanner() })
+	s.registerWiFiDiscoveryScanKind(func() wifiDiscoveryBridge { return s.wifiBridge() })
+	s.registerDeviceScanKind(func() deviceScanService { return s.deviceDiscovery() })
 }
 
 // registerSpeedtestKind registers the speedtest kind with an injectable tester

--- a/internal/api/jobs_wifi_discovery.go
+++ b/internal/api/jobs_wifi_discovery.go
@@ -1,0 +1,50 @@
+package api
+
+// jobs_wifi_discovery.go registers the Wi-Fi discovery scan as a unified job
+// kind (ADR-0005). Thin additive wrapper over the existing ctx-aware bridge
+// behind an interface seam — no discovery-internal refactor. The scan is
+// synchronous and exposes no progress fraction, so the kind takes no progress
+// callback. The legacy /security/wifi/discovery/scan endpoint is unchanged
+// (retire at Phase-7).
+
+import (
+	"context"
+
+	"github.com/krisarmstrong/seed/internal/logging"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+	"github.com/krisarmstrong/seed/internal/services/discovery"
+)
+
+// wifiDiscoveryScanJobKind is the registered kind name for a Wi-Fi discovery scan.
+const wifiDiscoveryScanJobKind = "wifi-discovery-scan"
+
+// wifiDiscoveryBridge is the slice of *discovery.WiFiBridge behaviour the kind
+// needs.
+type wifiDiscoveryBridge interface {
+	Scan(ctx context.Context) (*discovery.WiFiScanResult, error)
+}
+
+// newWiFiDiscoveryScanHandler returns the job Handler for the
+// "wifi-discovery-scan" kind. It runs one scan (cancellable via the job context)
+// and returns the same WiFiDiscoveryScanResponse the legacy endpoint produces.
+func newWiFiDiscoveryScanHandler(newBridge func() wifiDiscoveryBridge) jobs.Handler {
+	return func(ctx context.Context, _ any, _ func(float64)) (any, error) {
+		bridge := newBridge()
+		result, err := bridge.Scan(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return toWiFiDiscoveryScanResponse(result), nil
+	}
+}
+
+// registerWiFiDiscoveryScanKind registers the wifi-discovery-scan kind with an
+// injectable bridge factory (the seam that makes the wiring testable without
+// hardware).
+func (s *Server) registerWiFiDiscoveryScanKind(newBridge func() wifiDiscoveryBridge) {
+	if err := s.jobsRunner().Register(
+		wifiDiscoveryScanJobKind, newWiFiDiscoveryScanHandler(newBridge),
+	); err != nil {
+		logging.GetLogger().Error("failed to register wifi-discovery-scan job kind", "error", err)
+	}
+}

--- a/internal/api/jobs_wifi_discovery_internal_test.go
+++ b/internal/api/jobs_wifi_discovery_internal_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+	"github.com/krisarmstrong/seed/internal/services/discovery"
+)
+
+type fakeWiFiDiscoveryBridge struct {
+	result  *discovery.WiFiScanResult
+	err     error
+	release chan struct{}
+}
+
+func (f *fakeWiFiDiscoveryBridge) Scan(ctx context.Context) (*discovery.WiFiScanResult, error) {
+	if f.release != nil {
+		select {
+		case <-f.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.result, nil
+}
+
+func TestWiFiDiscoveryScanKindRunsToSuccess(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeWiFiDiscoveryBridge{result: &discovery.WiFiScanResult{Interface: "wlan0"}}
+	handler := newWiFiDiscoveryScanHandler(func() wifiDiscoveryBridge { return fake })
+	if err := runner.Register(wifiDiscoveryScanJobKind, handler); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	id, err := runner.Submit(wifiDiscoveryScanJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+	j, _ := runner.Get(id)
+	res, ok := j.Result.(WiFiDiscoveryScanResponse)
+	if !ok || res.Interface != "wlan0" {
+		t.Fatalf("result = %+v (ok=%v), want interface wlan0", res, ok)
+	}
+}
+
+func TestWiFiDiscoveryScanKindCancellation(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeWiFiDiscoveryBridge{release: make(chan struct{})}
+	handler := newWiFiDiscoveryScanHandler(func() wifiDiscoveryBridge { return fake })
+	_ = runner.Register(wifiDiscoveryScanJobKind, handler)
+
+	id, _ := runner.Submit(wifiDiscoveryScanJobKind, nil)
+	waitFor(t, "job running", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateRunning
+	})
+	if err := runner.Cancel(id); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	waitFor(t, "job cancelled", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateCancelled
+	})
+}
+
+func TestWiFiDiscoveryScanKindFailure(t *testing.T) {
+	t.Parallel()
+
+	_, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeWiFiDiscoveryBridge{err: errors.New("no wifi interface")}
+	handler := newWiFiDiscoveryScanHandler(func() wifiDiscoveryBridge { return fake })
+	_ = runner.Register(wifiDiscoveryScanJobKind, handler)
+
+	id, _ := runner.Submit(wifiDiscoveryScanJobKind, nil)
+	waitFor(t, "job failed", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateFailed
+	})
+	j, _ := runner.Get(id)
+	if j.Err == "" {
+		t.Fatal("failed wifi-discovery-scan job has empty Err")
+	}
+}
+
+func TestRegisterWiFiDiscoveryScanKindWiresRunner(t *testing.T) {
+	t.Parallel()
+
+	srv, runner := newJobsTestServer(t, jobs.Config{})
+	fake := &fakeWiFiDiscoveryBridge{result: &discovery.WiFiScanResult{Interface: "wlan0"}}
+	srv.registerWiFiDiscoveryScanKind(func() wifiDiscoveryBridge { return fake })
+
+	id, err := runner.Submit(wifiDiscoveryScanJobKind, nil)
+	if err != nil {
+		t.Fatalf("Submit after registerWiFiDiscoveryScanKind: %v", err)
+	}
+	waitFor(t, "job succeeded", func() bool {
+		j, ok := runner.Get(id)
+		return ok && j.State == jobs.StateSucceeded
+	})
+}


### PR DESCRIPTION
## Phase 4, Slice 8 — three discovery scans as job kinds (bundled)

Three more discovery long-ops onto the unified runner, bundled into one PR since each is the identical thin-wrapper pattern (all additive, no route/golden churn):

| Kind | Wraps |
|---|---|
| `bluetooth-scan` | `BluetoothScanner.Scan(ctx)` |
| `wifi-discovery-scan` | `WiFiBridge.Scan(ctx)` |
| `device-scan` | `DeviceDiscovery.Scan(ctx)` |

Each is a thin wrapper over the existing ctx-aware scan method behind an interface seam (**no discovery-internal refactor**), registered at startup behind the same factory pattern as the other kinds. All three are synchronous with no progress fraction, so the kinds **honestly take no progress callback** — the runner's queued→running→succeeded transitions carry status; a cancelled context unwinds the scan.

### Results reuse existing wire shapes
- bluetooth & wifi-discovery return the same `BluetoothScanResponse` / `WiFiDiscoveryScanResponse` the legacy endpoints produce — mapping **extracted into shared `toBluetoothScanResponse` / `toWiFiDiscoveryScanResponse` helpers**, now used by both handler and kind (DRY).
- `device-scan` returns a new `DeviceScanJobResult` (devices + count). Unlike the legacy `/security/devices/scan`, it does **not** auto-trigger a vuln scan afterwards — in the jobs model that's a separate `vuln-scan` submission (one job = one operation).

Legacy endpoints unchanged (retire at Phase-7 cutover).

### Gates
- `go test -race ./internal/api/` (targeted) — 12 white-box kind tests (success / cancel / failure / registration × 3) + golden harness, all pass
- `golangci-lint` **0 issues**; `go vet`/`gofmt` clean; binary builds; 1.26.4 base.

This brings the unified runner to **7 real long-op kinds** (speedtest, iperf, vuln-scan, engine-scan, + these three).

🤖 Generated with [Claude Code](https://claude.com/claude-code)