### PR TITLE
docs(architecture): reconcile ADR-0005 + blueprint §8 to implemented jobs state

### DIFF
--- a/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
+++ b/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
@@ -538,6 +538,18 @@ Uniform surface: `POST /jobs` (kind + params), `GET /jobs/{id}`, `DELETE /jobs/{
 (cancel), one SSE stream. Collapses ~15 endpoints into one model with consistent
 cancellation, progress, and timeouts.
 
+**Status — implemented in Phase 4 (2026-06-02).** Runner core (`internal/platform/jobs`),
+the HTTP surface (`/api/v1/jobs` + `/api/v1/jobs/events` SSE), and **7 long-op kinds**
+(speedtest, iperf, vuln-scan, engine-scan, bluetooth-scan, wifi-discovery-scan,
+device-scan) are on `main`. Each kind is an additive thin wrapper over the existing
+ctx-aware service behind an interface seam; the legacy run/status endpoints are retained
+until the frontend consumes `/jobs` (Phase 7), at which point they retire. Carve-outs:
+**persistence is in-memory v1** (durable store + transactional outbox → Phase 5);
+**survey stays a session** (not a one-shot job); **pipeline is deferred to Phase 6** —
+it duplicates the discovery `engine` (the canonical DeviceRegistry-as-SSoT orchestrator,
+already the `engine-scan` kind), so engine↔pipeline consolidation folds into the Phase-6
+discovery split rather than being enshrined as a kind. See ADR-0005 for detail.
+
 ---
 
 ## 9. Observability (local-only)

--- a/docs/architecture/decisions/0005-unified-jobs.md
+++ b/docs/architecture/decisions/0005-unified-jobs.md
@@ -1,6 +1,6 @@
 # ADR-0005: Unified async job runner
 
-**Status:** Accepted — 2026-05-31
+**Status:** Accepted — 2026-05-31 · Core implemented (Phase 4) — 2026-06-02
 
 ## Context
 
@@ -30,3 +30,36 @@ Semantics:
 - The frontend's "one SSE manager → React Query cache" becomes concrete (one stream).
 - Requires upfront design of the job abstraction and persistence.
 - Each long-op must be refactored into a job kind (Phase 4).
+
+## Implementation status (Phase 4 — 2026-06-02)
+
+Shipped:
+
+- **Runner core** `internal/platform/jobs` (#1467): `Job{ID,Kind,State,Progress,Result,Err}`,
+  `Runner.Register/Submit/Get/Cancel/Cleanup/Close`. Bounded concurrency with a hard
+  cap (`ErrAtCapacity` → 503); cancel via context; clamped progress; panic-isolated
+  handlers; state-change facts published on the `platform/events` bus (`job.*` topics);
+  in-memory store with retention.
+- **HTTP surface** (#1468): `POST /api/v1/jobs`, `GET /api/v1/jobs/{id}`,
+  `DELETE /api/v1/jobs/{id}`, and one SSE stream `GET /api/v1/jobs/events`. Wired through
+  the capability registry (POST/DELETE operator-gated); Idempotency-Key on create.
+- **7 long-op kinds**: speedtest (#1470), iperf (#1471), vuln-scan (#1472),
+  engine-scan (#1473), bluetooth-scan / wifi-discovery-scan / device-scan (#1474). Each is
+  an additive thin wrapper over the existing ctx-aware service behind an interface seam.
+
+Deviations / deferred from the original decision:
+
+- **Persistence is in-memory v1** (fail-cleanly-on-restart), not durable. The transactional
+  outbox + durable job store land in **Phase 5**; the runner already exposes the seam.
+- **Legacy endpoints retained.** Each migrated op keeps its old `/telemetry/*` or
+  `/security/*` run/status endpoint (additive strangler); the "~15 endpoints collapse"
+  completes when the frontend consumes `/jobs` in **Phase 7**, at which point the legacy
+  pairs retire.
+- **survey is NOT a job kind.** `create → add-floors → add-samples → generate-report` is a
+  stateful interactive *session*, not a one-shot long-op; it stays a session. (Its
+  `generate-report` step may later become a job.)
+- **pipeline deferred to Phase 6.** The discovery `pipeline` duplicates the discovery
+  `engine` (both orchestrate discover→enrich→assess). Rather than enshrine the redundancy
+  as a job kind, engine↔pipeline consolidation is folded into the **Phase-6** discovery
+  split; the engine (DeviceRegistry-as-SSoT + event distribution) is the canonical
+  orchestrator and is already exposed as the `engine-scan` kind.


### PR DESCRIPTION
## Phase-4 docs gate — reconcile the jobs ADR + blueprint to reality

The unified job runner (ADR-0005) is now **implemented** on `main`. This updates the ADR status + blueprint §8 from the original forward-looking plan to the as-built state (the blueprint treats docs alignment as a per-phase gate).

### What it records
- **Shipped:** runner core (#1467), HTTP surface + SSE (#1468), and **7 long-op kinds** (speedtest/iperf/vuln-scan/engine-scan/bluetooth/wifi-discovery/device, #1470–1474).
- **Carve-outs from the original decision:**
  - persistence is **in-memory v1** (durable store + transactional outbox → Phase 5; runner exposes the seam);
  - legacy run/status endpoints **retained** (additive strangler) until the frontend consumes `/jobs` in Phase 7, then they retire;
  - **survey stays a session**, not a job kind;
  - **pipeline deferred to Phase 6** — it duplicates the discovery **engine** (DeviceRegistry-as-SSoT, the canonical orchestrator, already the `engine-scan` kind), so engine↔pipeline consolidation folds into the Phase-6 discovery split rather than being enshrined as a kind.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)