### PR TITLE
feat(database): add proven goose schema baseline (ADR-0006, Phase 5b-1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/mdlayher/genetlink v1.4.0 // indirect
 	github.com/mdlayher/netlink v1.11.2 // indirect
 	github.com/mdlayher/socket v0.6.0 // indirect
+	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
@@ -63,6 +64,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/shoenig/go-m1cpu v0.2.1 // indirect
 	github.com/shoenig/test v1.12.2 // indirect
 	github.com/test-go/testify v1.1.4 // indirect
@@ -72,6 +74,7 @@ require (
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
@@ -91,4 +94,5 @@ require (
 	github.com/go-webauthn/webauthn v0.17.4
 	github.com/invopop/jsonschema v0.14.0
 	github.com/pquerna/otp v1.5.0
+	github.com/pressly/goose/v3 v3.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/mdlayher/socket v0.6.0 h1:ScZPaAGyO1icQnbFrhPM8mnXyMu9qukC1K4ZoM2IQKU
 github.com/mdlayher/socket v0.6.0/go.mod h1:q7vozUAnxSqnjHc12Fik5yUKIzfZ8ITCfMkhOtE9z18=
 github.com/mdlayher/wifi v0.7.2 h1:5yBq4nTm2HIYarKpJHrHU8q2BuxlX/BEfPa8kVKeOYU=
 github.com/mdlayher/wifi v0.7.2/go.mod h1:zJM6S0QpUxpUgf915rgAQHE4/e1YzRRkhK3M26NPakI=
+github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=
+github.com/mfridman/interpolate v0.0.2/go.mod h1:p+7uk6oE07mpE/Ik1b8EckO0O4ZXiGAfshKBWLUM9Xg=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nicksnyder/go-i18n/v2 v2.6.1 h1:JDEJraFsQE17Dut9HFDHzCoAWGEQJom5s0TRd17NIEQ=
@@ -101,6 +103,8 @@ github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
+github.com/pressly/goose/v3 v3.27.1 h1:6uEvcprBybDmW4hcz3gYujhARhye+GoWKhEWyzD5sh4=
+github.com/pressly/goose/v3 v3.27.1/go.mod h1:maruOxsPnIG2yHHyo8UqKWXYKFcH7Q76csUV7+7KYoM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
@@ -111,6 +115,8 @@ github.com/safchain/ethtool v0.7.0 h1:rlJzfDetsVvT61uz8x1YIcFn12akMfuPulHtZjtb7I
 github.com/safchain/ethtool v0.7.0/go.mod h1:MenQKEjXdfkjD3mp2QdCk8B/hwvkrlOTm/FD4gTpFxQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
+github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/iZ9pI=
 github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
 github.com/shoenig/go-m1cpu v0.2.1 h1:yqRB4fvOge2+FyRXFkXqsyMoqPazv14Yyy+iyccT2E4=
@@ -148,6 +154,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=

--- a/internal/database/goose_baseline_test.go
+++ b/internal/database/goose_baseline_test.go
@@ -1,0 +1,134 @@
+package database_test
+
+// goose_baseline_test.go bootstraps and proves the Phase-5 goose baseline
+// (ADR-0006). TestGenerateGooseBaseline (run once, guarded) writes
+// migrations/00001_init.sql faithfully from the legacy runner's schema;
+// TestGooseBaselineReproducesSchema then applies that baseline via goose to a
+// fresh empty DB and asserts the resulting schema matches the snapshot golden —
+// i.e. goose + the baseline produce byte-identical schema to the homegrown
+// runner. That proof gates the runner swap.
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// schemaDDLByType returns the (name, ddl) pairs of the given sqlite_master type
+// (e.g. "table", "index"), sorted by name, excluding bookkeeping + internals.
+func schemaDDLByType(t *testing.T, conn *sql.DB, objType string) [][2]string {
+	t.Helper()
+	rows, err := conn.Query(
+		`SELECT name, sql FROM sqlite_master WHERE type=? AND sql IS NOT NULL AND name NOT LIKE 'sqlite_%'`,
+		objType,
+	)
+	if err != nil {
+		t.Fatalf("query %s: %v", objType, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	bookkeeping := schemaBookkeepingTables()
+	var out [][2]string
+	for rows.Next() {
+		var name, ddl string
+		if scanErr := rows.Scan(&name, &ddl); scanErr != nil {
+			t.Fatalf("scan: %v", scanErr)
+		}
+		if bookkeeping[name] {
+			continue
+		}
+		out = append(out, [2]string{name, strings.TrimSpace(ddl)})
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		t.Fatalf("rows: %v", rowsErr)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i][0] < out[j][0] })
+	return out
+}
+
+func TestGenerateGooseBaseline(t *testing.T) {
+	if os.Getenv("GEN_BASELINE") != "1" {
+		t.Skip("set GEN_BASELINE=1 to (re)generate migrations/00001_init.sql")
+	}
+
+	dir := t.TempDir()
+	db, err := database.Open(filepath.Join(dir, "gen.db"))
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	tables := schemaDDLByType(t, db.Conn(), "table")
+	indexes := schemaDDLByType(t, db.Conn(), "index")
+
+	var b strings.Builder
+	b.WriteString("-- 00001_init.sql — Phase-5 schema baseline (ADR-0006).\n")
+	b.WriteString("-- Faithful collapse of the legacy migration history; generated from the\n")
+	b.WriteString("-- schema the old runner produced. NOT yet STRICT (that is a follow-up).\n")
+	b.WriteString("-- Regenerate: GEN_BASELINE=1 go test ./internal/database/ -run TestGenerateGooseBaseline\n\n")
+	b.WriteString("-- +goose Up\n")
+	for _, tb := range tables {
+		b.WriteString(tb[1])
+		b.WriteString(";\n")
+	}
+	b.WriteString("\n")
+	for _, ix := range indexes {
+		b.WriteString(ix[1])
+		b.WriteString(";\n")
+	}
+	b.WriteString("\n-- +goose Down\n")
+	for _, tb := range slices.Backward(tables) {
+		b.WriteString("DROP TABLE IF EXISTS ")
+		b.WriteString(tb[0])
+		b.WriteString(";\n")
+	}
+
+	if mkErr := os.MkdirAll("migrations", 0o750); mkErr != nil {
+		t.Fatalf("mkdir migrations: %v", mkErr)
+	}
+	if wErr := os.WriteFile(filepath.Join("migrations", "00001_init.sql"), []byte(b.String()), 0o600); wErr != nil {
+		t.Fatalf("write baseline: %v", wErr)
+	}
+	t.Logf("wrote migrations/00001_init.sql (%d tables, %d indexes)", len(tables), len(indexes))
+}
+
+func TestGooseBaselineReproducesSchema(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	rawDB, err := sql.Open("sqlite", "file:"+filepath.Join(dir, "goose.db")+"?_txlock=immediate")
+	if err != nil {
+		t.Fatalf("open raw sqlite: %v", err)
+	}
+	defer func() { _ = rawDB.Close() }()
+	if _, pragmaErr := rawDB.Exec("PRAGMA foreign_keys = ON"); pragmaErr != nil {
+		t.Fatalf("pragma: %v", pragmaErr)
+	}
+
+	provider, err := goose.NewProvider(goose.DialectSQLite3, rawDB, os.DirFS("migrations"))
+	if err != nil {
+		t.Fatalf("goose provider: %v", err)
+	}
+	if _, upErr := provider.Up(context.Background()); upErr != nil {
+		t.Fatalf("goose up: %v", upErr)
+	}
+
+	got := dumpSchema(t, rawDB)
+	want, err := os.ReadFile(filepath.Join("testdata", "schema.sql"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got != string(want) {
+		t.Errorf("goose baseline schema != snapshot golden: the baseline does not faithfully\n" +
+			"reproduce the legacy schema. Regenerate with GEN_BASELINE=1 and review.")
+	}
+}

--- a/internal/database/migrations/00001_init.sql
+++ b/internal/database/migrations/00001_init.sql
@@ -1,0 +1,1104 @@
+-- 00001_init.sql — Phase-5 schema baseline (ADR-0006).
+-- Faithful collapse of the legacy migration history; generated from the
+-- schema the old runner produced. NOT yet STRICT (that is a follow-up).
+-- Regenerate: GEN_BASELINE=1 go test ./internal/database/ -run TestGenerateGooseBaseline
+
+-- +goose Up
+CREATE TABLE alert_rules (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				name TEXT NOT NULL UNIQUE,
+				enabled INTEGER NOT NULL DEFAULT 1,
+				match_kind TEXT,
+				match_severity TEXT,
+				match_payload_contains TEXT,
+				alert_type TEXT NOT NULL,
+				alert_severity TEXT NOT NULL,
+				alert_title TEXT NOT NULL,
+				alert_message TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			, window_seconds INTEGER NOT NULL DEFAULT 0, threshold_count INTEGER NOT NULL DEFAULT 1);
+CREATE TABLE alert_suppressions (
+					fingerprint TEXT PRIMARY KEY,
+					rule_id TEXT NOT NULL,
+					entity_key TEXT NOT NULL,
+					suppress_until TEXT NOT NULL,
+					created_at TEXT NOT NULL
+				);
+CREATE TABLE alerts (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				type TEXT NOT NULL,
+				severity TEXT NOT NULL,
+				title TEXT NOT NULL,
+				message TEXT NOT NULL,
+				source TEXT,
+				device_id TEXT,
+				acknowledged INTEGER DEFAULT 0,
+				acknowledged_by TEXT,
+				acknowledged_at TEXT,
+				resolved INTEGER DEFAULT 0,
+				resolved_at TEXT,
+				created_at TEXT NOT NULL,
+				metadata_json TEXT, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE SET NULL
+			);
+CREATE TABLE "api_tokens" (
+				id              TEXT PRIMARY KEY,
+				owner_username  TEXT NOT NULL,
+				name            TEXT NOT NULL,
+				token_hash      TEXT NOT NULL UNIQUE,
+				prefix          TEXT NOT NULL,
+				created_at      TEXT NOT NULL,
+				last_used_at    TEXT,
+				revoked_at      TEXT, scope TEXT
+			    CHECK (scope IS NULL OR scope IN ('admin','operator','viewer')),
+				FOREIGN KEY (owner_username) REFERENCES users(username) ON DELETE CASCADE ON UPDATE CASCADE
+			);
+CREATE TABLE audit_log (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				action TEXT NOT NULL,
+				user TEXT,
+				resource_type TEXT,
+				resource_id TEXT,
+				old_value_json TEXT,
+				new_value_json TEXT,
+				ip_address TEXT,
+				user_agent TEXT,
+				timestamp TEXT NOT NULL
+			);
+CREATE TABLE bgp_sessions (
+				id TEXT PRIMARY KEY,
+				device_id TEXT,
+				peer_address TEXT NOT NULL,
+				peer_as INTEGER,
+				local_as INTEGER,
+				state TEXT NOT NULL,
+				established_at TEXT,
+				last_state_change TEXT NOT NULL,
+				prefixes_received INTEGER DEFAULT 0,
+				prefixes_sent INTEGER DEFAULT 0,
+				last_error TEXT,
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				FOREIGN KEY (device_id) REFERENCES discovered_devices(id) ON DELETE SET NULL
+			);
+CREATE TABLE bluetooth_devices (
+				id TEXT PRIMARY KEY,
+				device_id TEXT,
+				address TEXT NOT NULL UNIQUE,
+				name TEXT,
+				alias TEXT,
+				vendor TEXT,
+				bluetooth_type TEXT NOT NULL,
+				device_class TEXT,
+				appearance INTEGER DEFAULT 0,
+				class_of_device INTEGER DEFAULT 0,
+				rssi INTEGER,
+				tx_power INTEGER,
+				is_connected INTEGER DEFAULT 0,
+				is_connectable INTEGER DEFAULT 0,
+				is_authorized INTEGER DEFAULT 0,
+				is_trusted INTEGER DEFAULT 0,
+				is_paired INTEGER DEFAULT 0,
+				is_blocked INTEGER DEFAULT 0,
+				service_uuids_json TEXT,
+				manufacturer_id INTEGER,
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				metadata_json TEXT, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+
+				FOREIGN KEY (device_id) REFERENCES discovered_devices(id) ON DELETE SET NULL
+			);
+CREATE TABLE bluetooth_scan_history (
+				id TEXT PRIMARY KEY,
+				adapter_name TEXT,
+				scan_type TEXT NOT NULL,
+				devices_found INTEGER NOT NULL,
+				classic_count INTEGER DEFAULT 0,
+				ble_count INTEGER DEFAULT 0,
+				scan_duration_ms INTEGER,
+				scan_time TEXT NOT NULL
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE channel_utilization (
+				id TEXT PRIMARY KEY,
+				channel INTEGER NOT NULL,
+				band TEXT NOT NULL,
+				frequency_mhz INTEGER NOT NULL,
+
+				-- Utilization metrics
+				utilization_percent REAL,
+				non_wifi_percent REAL,
+				retry_percent REAL,
+				ap_count INTEGER,
+				client_count INTEGER,
+
+				recorded_at TEXT NOT NULL, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+
+				UNIQUE(channel, band, recorded_at)
+			);
+CREATE TABLE clients (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				slug TEXT NOT NULL UNIQUE,
+				branding_json TEXT,
+				default_retention_overrides_json TEXT,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+CREATE TABLE device_credentials (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				snmp_community_enc BLOB,
+				snmp_v3_user TEXT,
+				snmp_v3_auth_enc BLOB,
+				snmp_v3_priv_enc BLOB,
+				snmp_v3_auth_proto TEXT,
+				snmp_v3_priv_proto TEXT,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE device_interfaces (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				device_id TEXT NOT NULL,
+				if_index INTEGER NOT NULL,
+				name TEXT,
+				description TEXT,
+				alias TEXT,
+				type INTEGER,
+				mtu INTEGER,
+				speed_mbps INTEGER,
+				mac_address TEXT,
+				admin_status TEXT,
+				oper_status TEXT,
+				collected_at TEXT NOT NULL,
+				FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
+			);
+CREATE TABLE device_ports (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				device_id TEXT NOT NULL,
+				port INTEGER NOT NULL,
+				protocol TEXT NOT NULL DEFAULT 'tcp',
+				state TEXT NOT NULL DEFAULT 'open',
+				service_name TEXT,
+				banner TEXT,
+				version TEXT,
+				scanned_at TEXT NOT NULL,
+				FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
+			);
+CREATE TABLE device_vulnerabilities (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				device_id TEXT NOT NULL,
+				cve_id TEXT NOT NULL,
+				severity TEXT,
+				cvss_score REAL,
+				cvss_vector TEXT,
+				affected_component TEXT,
+				affected_version TEXT,
+				fix_available INTEGER DEFAULT 0,
+				status TEXT DEFAULT 'new',
+				detected_at TEXT NOT NULL,
+				resolved_at TEXT,
+				notes TEXT,
+				FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
+			);
+CREATE TABLE devices (
+				id TEXT PRIMARY KEY,
+				ip_address TEXT NOT NULL,
+				mac_address TEXT,
+				hostname TEXT,
+				vendor TEXT,
+				device_type TEXT,
+				os_family TEXT,
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				is_active INTEGER DEFAULT 1,
+				ports_json TEXT,
+				metadata_json TEXT
+			);
+CREATE TABLE discovered_devices (
+				id TEXT PRIMARY KEY,
+				primary_mac TEXT NOT NULL UNIQUE,
+				hostname TEXT,
+				vendor TEXT,
+				device_type TEXT DEFAULT 'unknown',
+				device_model TEXT,
+				authorization_status TEXT DEFAULT 'unknown',
+				criticality INTEGER DEFAULT 5,
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				is_online INTEGER DEFAULT 1,
+				notes TEXT,
+				tags TEXT,
+				metadata_json TEXT,
+				created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+				updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE discovery_history (
+				id TEXT PRIMARY KEY,
+				device_id TEXT NOT NULL,
+				event_type TEXT NOT NULL,
+				event_data TEXT,
+				recorded_at TEXT NOT NULL, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+
+				FOREIGN KEY (device_id) REFERENCES discovered_devices(id) ON DELETE CASCADE
+			);
+CREATE TABLE discovery_interfaces (
+				id TEXT PRIMARY KEY,
+				device_id TEXT NOT NULL,
+				interface_type TEXT NOT NULL,
+				mac_address TEXT NOT NULL,
+				ip_addresses TEXT,
+				interface_name TEXT,
+				is_primary INTEGER DEFAULT 0,
+
+				-- Wired-specific
+				switch_port TEXT,
+				switch_name TEXT,
+				vlan_id INTEGER,
+				duplex TEXT,
+				speed_mbps INTEGER,
+				poe_status TEXT,
+
+				-- WiFi-specific
+				ssid TEXT,
+				bssid TEXT,
+				signal_dbm INTEGER,
+				noise_dbm INTEGER,
+				channel INTEGER,
+				channel_width INTEGER,
+				frequency_mhz INTEGER,
+				wifi_standards TEXT,
+				security_type TEXT,
+
+				-- Bluetooth-specific
+				bt_class TEXT,
+				bt_version TEXT,
+				bt_signal INTEGER,
+
+				last_seen TEXT NOT NULL,
+				created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+				updated_at TEXT DEFAULT CURRENT_TIMESTAMP, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+
+				FOREIGN KEY (device_id) REFERENCES discovered_devices(id) ON DELETE CASCADE,
+				UNIQUE(device_id, mac_address)
+			);
+CREATE TABLE dns_results (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				interface_name TEXT NOT NULL,
+				server TEXT NOT NULL,
+				hostname TEXT NOT NULL,
+				response_time_ms REAL,
+				resolved_ip TEXT,
+				status TEXT NOT NULL,
+				error_message TEXT,
+				timestamp TEXT NOT NULL
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE gateway_results (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				interface_name TEXT NOT NULL,
+				gateway TEXT NOT NULL,
+				latency_ms REAL,
+				packet_loss REAL,
+				reachable INTEGER,
+				timestamp TEXT NOT NULL
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE health_check_results (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				check_type TEXT NOT NULL,
+				endpoint_name TEXT NOT NULL,
+				endpoint_target TEXT NOT NULL,
+				success INTEGER NOT NULL,
+				latency_ms REAL,
+				status_code INTEGER,
+				error_message TEXT,
+				metadata_json TEXT,
+				recorded_at TEXT NOT NULL
+			);
+CREATE TABLE health_check_rollups_daily (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				check_type TEXT NOT NULL,
+				endpoint_name TEXT NOT NULL,
+				day_bucket TEXT NOT NULL,
+				total_checks INTEGER NOT NULL,
+				successful_checks INTEGER NOT NULL,
+				avg_latency_ms REAL,
+				min_latency_ms REAL,
+				max_latency_ms REAL,
+				p95_latency_ms REAL,
+				availability_percent REAL
+			);
+CREATE TABLE health_check_rollups_hourly (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				check_type TEXT NOT NULL,
+				endpoint_name TEXT NOT NULL,
+				hour_bucket TEXT NOT NULL,
+				total_checks INTEGER NOT NULL,
+				successful_checks INTEGER NOT NULL,
+				avg_latency_ms REAL,
+				min_latency_ms REAL,
+				max_latency_ms REAL,
+				p95_latency_ms REAL
+			);
+CREATE TABLE listener_events (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				kind TEXT NOT NULL,
+				source_addr TEXT NOT NULL,
+				target_kind TEXT,
+				target_id TEXT,
+				severity TEXT,
+				observed_at TEXT NOT NULL,
+				payload_json TEXT NOT NULL,
+				ingested_at TEXT NOT NULL
+			);
+CREATE TABLE logs (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				timestamp TEXT NOT NULL,
+				level TEXT NOT NULL,
+				layer TEXT NOT NULL,
+				message TEXT NOT NULL,
+				component TEXT,
+				request_id TEXT,
+				session_id TEXT,
+				duration_ms INTEGER,
+				metadata_json TEXT,
+				stack TEXT
+			);
+CREATE TABLE metrics (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				interface_name TEXT NOT NULL,
+				metric_type TEXT NOT NULL,
+				value REAL NOT NULL,
+				unit TEXT,
+				timestamp TEXT NOT NULL,
+				metadata_json TEXT
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id), target_kind TEXT NOT NULL DEFAULT 'interface', target_id TEXT NOT NULL DEFAULT '');
+CREATE TABLE metrics_daily (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				metric_type TEXT NOT NULL,
+				interface_name TEXT NOT NULL,
+				day_bucket TEXT NOT NULL,
+				sample_count INTEGER NOT NULL,
+				avg_value REAL,
+				min_value REAL,
+				max_value REAL,
+				p95_value REAL, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id), target_kind TEXT NOT NULL DEFAULT 'interface', target_id TEXT NOT NULL DEFAULT '',
+				UNIQUE(metric_type, interface_name, day_bucket)
+			);
+CREATE TABLE metrics_hourly (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				metric_type TEXT NOT NULL,
+				interface_name TEXT NOT NULL,
+				hour_bucket TEXT NOT NULL,
+				sample_count INTEGER NOT NULL,
+				avg_value REAL,
+				min_value REAL,
+				max_value REAL,
+				p95_value REAL, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id), target_kind TEXT NOT NULL DEFAULT 'interface', target_id TEXT NOT NULL DEFAULT '',
+				UNIQUE(metric_type, interface_name, hour_bucket)
+			);
+CREATE TABLE mib_oid_names (
+				name TEXT PRIMARY KEY,           -- Human-readable name (e.g., "sysDescr")
+				oid TEXT NOT NULL,               -- Numeric OID (e.g., "1.3.6.1.2.1.1.1")
+				full_path TEXT,                  -- Full descriptive path (optional)
+				mib_name TEXT,                   -- Source MIB name (e.g., "SNMPv2-MIB")
+				created_at TEXT DEFAULT (datetime('now'))
+			);
+CREATE TABLE mib_sources (
+				mib_name TEXT PRIMARY KEY,
+				description TEXT,
+				vendor TEXT,
+				rfc_reference TEXT,
+				loaded_at TEXT DEFAULT (datetime('now'))
+			);
+CREATE TABLE microburst_events (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				timestamp TEXT NOT NULL,
+				device_id TEXT,
+				interface_name TEXT NOT NULL,
+				direction TEXT NOT NULL,
+				peak_utilization_pct REAL NOT NULL,
+				duration_ms INTEGER NOT NULL,
+				sampling_mode TEXT NOT NULL,
+				link_speed_mbps INTEGER, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				FOREIGN KEY (device_id) REFERENCES discovered_devices(id) ON DELETE SET NULL
+			);
+CREATE TABLE network_problems (
+				id TEXT PRIMARY KEY,
+				problem_type TEXT NOT NULL,
+				severity TEXT NOT NULL,
+				device_id TEXT,
+				interface_id TEXT,
+				description TEXT NOT NULL,
+				details_json TEXT,
+				is_resolved INTEGER DEFAULT 0,
+				detected_at TEXT NOT NULL,
+				resolved_at TEXT,
+				acknowledged_at TEXT,
+				acknowledged_by TEXT, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+
+				FOREIGN KEY (device_id) REFERENCES discovered_devices(id) ON DELETE CASCADE,
+				FOREIGN KEY (interface_id) REFERENCES discovery_interfaces(id) ON DELETE CASCADE
+			);
+CREATE TABLE oui_vendors (
+				oui TEXT PRIMARY KEY,
+				vendor_name TEXT NOT NULL,
+				vendor_short TEXT,
+				is_private INTEGER DEFAULT 0,
+				device_category TEXT,
+				updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+			);
+CREATE TABLE pipeline_runs (
+				id TEXT PRIMARY KEY,
+				started_at TEXT NOT NULL,
+				completed_at TEXT,
+				status TEXT NOT NULL,
+				triggered_by TEXT,
+				phases_enabled TEXT NOT NULL,
+				config_json TEXT,
+				summary_json TEXT,
+				error_message TEXT
+			);
+CREATE TABLE polling_targets (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				ip_address TEXT NOT NULL,
+				snmp_version TEXT NOT NULL DEFAULT 'v2c',
+				credentials_id TEXT,
+				poll_interval_seconds INTEGER NOT NULL DEFAULT 300,
+				enabled INTEGER NOT NULL DEFAULT 1,
+				last_polled_at TEXT,
+				last_status TEXT,
+				last_error TEXT,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id), collector_chain TEXT NOT NULL DEFAULT '["sys_info","if_table","lldp","arp","fdb"]');
+CREATE TABLE probe_results (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				probe_id TEXT NOT NULL,
+				client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				kind TEXT NOT NULL,
+				timestamp TEXT NOT NULL,
+				success INTEGER NOT NULL,
+				latency_ms REAL,
+				error TEXT,
+				metadata_json TEXT,
+				FOREIGN KEY (probe_id) REFERENCES probes(id) ON DELETE CASCADE
+			);
+CREATE TABLE probe_rollups_daily (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				kind TEXT NOT NULL,
+				probe_id TEXT NOT NULL,
+				day_bucket TEXT NOT NULL,
+				sample_count INTEGER NOT NULL,
+				success_count INTEGER NOT NULL,
+				avg_latency_ms REAL,
+				min_latency_ms REAL,
+				max_latency_ms REAL,
+				p95_latency_ms REAL,
+				UNIQUE(client_id, kind, probe_id, day_bucket)
+			);
+CREATE TABLE probe_rollups_hourly (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				kind TEXT NOT NULL,
+				probe_id TEXT NOT NULL,
+				hour_bucket TEXT NOT NULL,
+				sample_count INTEGER NOT NULL,
+				success_count INTEGER NOT NULL,
+				avg_latency_ms REAL,
+				min_latency_ms REAL,
+				max_latency_ms REAL,
+				p95_latency_ms REAL,
+				UNIQUE(client_id, kind, probe_id, hour_bucket)
+			);
+CREATE TABLE probes (
+				id TEXT PRIMARY KEY,
+				client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				kind TEXT NOT NULL,
+				display_name TEXT NOT NULL,
+				target TEXT NOT NULL,
+				params_json TEXT,
+				interval_seconds INTEGER NOT NULL DEFAULT 60,
+				enabled INTEGER NOT NULL DEFAULT 1,
+				warning_json TEXT,
+				critical_json TEXT,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+CREATE TABLE profiles (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL UNIQUE,
+				description TEXT,
+				config_json TEXT NOT NULL,
+				is_default INTEGER DEFAULT 0,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE reports (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				type TEXT NOT NULL,
+				format TEXT NOT NULL,
+				template TEXT,
+				status TEXT NOT NULL DEFAULT 'pending',
+				file_path TEXT,
+				file_size INTEGER DEFAULT 0,
+				parameters_json TEXT,
+				error TEXT,
+				created_at TEXT NOT NULL,
+				completed_at TEXT,
+				expires_at TEXT
+			);
+CREATE TABLE scheduled_reports (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				template TEXT NOT NULL,
+				format TEXT NOT NULL,
+				schedule_json TEXT NOT NULL,
+				parameters_json TEXT,
+				recipients_json TEXT,
+				enabled INTEGER DEFAULT 1,
+				last_run TEXT,
+				next_run TEXT,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+CREATE TABLE settings (
+				key TEXT PRIMARY KEY,
+				value TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+CREATE TABLE snmp_observations (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				target_id TEXT NOT NULL,
+				kind TEXT NOT NULL,
+				observed_at TEXT NOT NULL,
+				payload_json TEXT NOT NULL,
+				ingested_at TEXT NOT NULL
+			);
+CREATE TABLE speedtest_results (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				interface_name TEXT NOT NULL,
+				server_name TEXT,
+				server_location TEXT,
+				download_mbps REAL,
+				upload_mbps REAL,
+				latency_ms REAL,
+				jitter_ms REAL,
+				packet_loss REAL,
+				timestamp TEXT NOT NULL,
+				metadata_json TEXT
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE survey_samples (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				survey_id TEXT NOT NULL,
+				x REAL NOT NULL,
+				y REAL NOT NULL,
+				signal_dbm INTEGER,
+				noise_dbm INTEGER,
+				snr_db INTEGER,
+				channel INTEGER,
+				frequency_mhz INTEGER,
+				bssid TEXT,
+				ssid TEXT,
+				timestamp TEXT NOT NULL,
+				networks_json TEXT,
+				metadata_json TEXT
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE topology_arp_bindings (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				source_node_id TEXT NOT NULL REFERENCES topology_nodes(id) ON DELETE CASCADE,
+				if_index INTEGER NOT NULL,
+				ip_address TEXT NOT NULL,
+				mac_address TEXT NOT NULL,
+				media_type INTEGER,
+				last_seen TEXT NOT NULL,
+				UNIQUE(source_node_id, if_index, ip_address)
+			);
+CREATE TABLE topology_interfaces (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				node_id TEXT NOT NULL REFERENCES topology_nodes(id) ON DELETE CASCADE,
+				if_index INTEGER NOT NULL,
+				if_name TEXT,
+				if_descr TEXT,
+				if_alias TEXT,
+				if_type INTEGER,
+				if_admin_status INTEGER,
+				if_oper_status INTEGER,
+				if_phys_addr TEXT,
+				speed_bps INTEGER,
+				last_seen TEXT NOT NULL,
+				UNIQUE(node_id, if_index)
+			);
+CREATE TABLE topology_links (
+				id TEXT PRIMARY KEY,
+				source_node_id TEXT NOT NULL,
+				target_node_id TEXT NOT NULL,
+				source_interface TEXT,
+				target_interface TEXT,
+				link_type TEXT NOT NULL DEFAULT 'unknown',
+				status TEXT NOT NULL DEFAULT 'up',
+				speed_mbps INTEGER,
+				utilization_pct REAL,
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				evidence_json TEXT, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				FOREIGN KEY (source_node_id) REFERENCES topology_nodes(id) ON DELETE CASCADE,
+				FOREIGN KEY (target_node_id) REFERENCES topology_nodes(id) ON DELETE CASCADE
+			);
+CREATE TABLE topology_nodes (
+				id TEXT PRIMARY KEY,
+				identity_hash TEXT NOT NULL UNIQUE,
+				display_name TEXT NOT NULL,
+				device_type TEXT,
+				chassis_id TEXT,
+				sys_name TEXT,
+				primary_mac TEXT,
+				primary_ip TEXT,
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				expires_at TEXT,
+				metadata_json TEXT
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE topology_target_nodes (
+				client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				target_id TEXT NOT NULL,
+				node_id TEXT NOT NULL REFERENCES topology_nodes(id) ON DELETE CASCADE,
+				last_seen TEXT NOT NULL,
+				PRIMARY KEY (client_id, target_id)
+			);
+CREATE TABLE "users" (
+				id              INTEGER PRIMARY KEY AUTOINCREMENT,
+				username        TEXT    NOT NULL UNIQUE CHECK (LENGTH(username) >= 3 AND LENGTH(username) <= 64),
+				password_hash   TEXT    NOT NULL,
+				role            TEXT    NOT NULL DEFAULT 'viewer' CHECK (role IN ('admin','operator','viewer')),
+				is_active       INTEGER NOT NULL DEFAULT 1,
+				last_login      TEXT,
+				failed_attempts INTEGER NOT NULL DEFAULT 0,
+				locked_until    TEXT,
+				token_version   INTEGER NOT NULL DEFAULT 1,
+				totp_secret     TEXT,
+				totp_enabled    INTEGER NOT NULL DEFAULT 0,
+				auth_provider   TEXT    NOT NULL DEFAULT 'local' CHECK (auth_provider IN ('local','google','microsoft','github')),
+				external_id     TEXT,
+				email           TEXT,
+				display_name    TEXT,
+				created_at      TEXT    NOT NULL,
+				updated_at      TEXT    NOT NULL,
+				UNIQUE (auth_provider, external_id)
+			);
+CREATE TABLE voip_calls (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				call_id TEXT NOT NULL,
+				src_ip TEXT NOT NULL,
+				dst_ip TEXT NOT NULL,
+				src_port INTEGER,
+				dst_port INTEGER,
+				codec TEXT,
+				started_at TEXT NOT NULL,
+				ended_at TEXT,
+				duration_seconds INTEGER,
+				mos_score REAL,
+				avg_jitter_ms REAL,
+				packet_loss_pct REAL,
+				avg_latency_ms REAL,
+				direction TEXT
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE webauthn_credentials (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				user_id INTEGER NOT NULL,
+				credential_id BLOB NOT NULL UNIQUE,
+				public_key BLOB NOT NULL,
+				sign_count INTEGER NOT NULL DEFAULT 0,
+				attestation_type TEXT,
+				transports TEXT,
+				aaguid BLOB,
+				created_at TEXT NOT NULL,
+				last_used_at TEXT,
+				FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+			);
+CREATE TABLE wifi_access_points (
+				id TEXT PRIMARY KEY,
+				device_id TEXT,
+				bssid TEXT NOT NULL UNIQUE,
+				ssid_id TEXT,
+				ap_name TEXT,
+				vendor TEXT,
+
+				-- Radio info
+				channel INTEGER,
+				channel_width INTEGER,
+				frequency_mhz INTEGER,
+				band TEXT,
+				wifi_standards TEXT,
+
+				-- Signal
+				signal_dbm INTEGER,
+				noise_dbm INTEGER,
+
+				-- Status
+				client_count INTEGER DEFAULT 0,
+				max_clients INTEGER,
+				is_authorized INTEGER DEFAULT 1,
+
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				metadata_json TEXT, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id), beacon_interval_tu INTEGER, rsn_cipher TEXT, rsn_akm TEXT, phy_capabilities TEXT, supports_11k INTEGER DEFAULT 0, supports_11v INTEGER DEFAULT 0, supports_11r INTEGER DEFAULT 0, bss_load_json TEXT, vendor_ies_json TEXT,
+
+				FOREIGN KEY (device_id) REFERENCES discovered_devices(id) ON DELETE SET NULL,
+				FOREIGN KEY (ssid_id) REFERENCES wifi_networks(id) ON DELETE SET NULL
+			);
+CREATE TABLE wifi_associations (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				timestamp TEXT NOT NULL,
+				client_mac TEXT NOT NULL,
+				ap_bssid TEXT NOT NULL,
+				ssid TEXT,
+				attempt_type TEXT NOT NULL,
+				status_code INTEGER,
+				status_text TEXT,
+				failure_stage TEXT,
+				duration_ms INTEGER,
+				rsn_negotiation_json TEXT
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE wifi_clients (
+				id TEXT PRIMARY KEY,
+				mac_full TEXT NOT NULL UNIQUE,
+				vendor_oui TEXT,
+				vendor_name TEXT,
+				capabilities_json TEXT,
+				pnl_json TEXT,
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				anonymized INTEGER NOT NULL DEFAULT 0
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE wifi_deauths (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				timestamp TEXT NOT NULL,
+				ap_bssid TEXT NOT NULL,
+				client_mac TEXT NOT NULL,
+				frame_type TEXT NOT NULL,
+				reason_code INTEGER NOT NULL,
+				reason_text TEXT,
+				originator TEXT NOT NULL
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE wifi_networks (
+				id TEXT PRIMARY KEY,
+				ssid TEXT NOT NULL,
+				is_hidden INTEGER DEFAULT 0,
+				security_type TEXT,
+				authorization_status TEXT DEFAULT 'unknown',
+				first_seen TEXT NOT NULL,
+				last_seen TEXT NOT NULL,
+				metadata_json TEXT, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
+				UNIQUE(ssid, security_type)
+			);
+CREATE TABLE wifi_roams (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				client_mac TEXT NOT NULL,
+				from_bssid TEXT NOT NULL,
+				to_bssid TEXT NOT NULL,
+				ssid TEXT,
+				started_at TEXT NOT NULL,
+				completed_at TEXT,
+				duration_ms INTEGER,
+				roam_type TEXT,
+				rssi_before INTEGER,
+				rssi_after INTEGER
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+CREATE TABLE wifi_rogues (
+				id TEXT PRIMARY KEY,
+				detected_at TEXT NOT NULL,
+				ap_bssid TEXT NOT NULL,
+				ssid TEXT,
+				rogue_type TEXT NOT NULL,
+				severity TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'active',
+				evidence_json TEXT,
+				acknowledged_at TEXT,
+				resolved_at TEXT
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id));
+
+CREATE INDEX idx_alert_rules_enabled ON alert_rules(enabled);
+CREATE INDEX idx_alert_suppressions_until
+				  ON alert_suppressions(suppress_until);
+CREATE INDEX idx_alerts_acknowledged ON alerts(acknowledged);
+CREATE INDEX idx_alerts_client ON alerts(client_id);
+CREATE INDEX idx_alerts_created ON alerts(created_at);
+CREATE INDEX idx_alerts_device ON alerts(device_id);
+CREATE INDEX idx_alerts_resolved ON alerts(resolved);
+CREATE INDEX idx_alerts_severity ON alerts(severity);
+CREATE INDEX idx_alerts_type ON alerts(type);
+CREATE INDEX idx_api_tokens_active ON api_tokens(revoked_at);
+CREATE INDEX idx_api_tokens_hash   ON api_tokens(token_hash);
+CREATE INDEX idx_api_tokens_owner  ON api_tokens(owner_username);
+CREATE INDEX idx_arp_bindings_ip ON topology_arp_bindings(ip_address);
+CREATE INDEX idx_arp_bindings_last_seen ON topology_arp_bindings(last_seen);
+CREATE INDEX idx_arp_bindings_mac ON topology_arp_bindings(mac_address);
+CREATE INDEX idx_audit_action ON audit_log(action);
+CREATE INDEX idx_audit_resource ON audit_log(resource_type, resource_id);
+CREATE INDEX idx_audit_timestamp ON audit_log(timestamp);
+CREATE INDEX idx_audit_user ON audit_log(user);
+CREATE INDEX idx_bgp_sessions_client ON bgp_sessions(client_id);
+CREATE INDEX idx_bgp_sessions_device ON bgp_sessions(device_id);
+CREATE INDEX idx_bgp_sessions_peer ON bgp_sessions(peer_address);
+CREATE INDEX idx_bgp_sessions_state ON bgp_sessions(state);
+CREATE INDEX idx_bluetooth_devices_client ON bluetooth_devices(client_id);
+CREATE INDEX idx_bluetooth_scan_history_client ON bluetooth_scan_history(client_id);
+CREATE INDEX idx_bt_devices_address ON bluetooth_devices(address);
+CREATE INDEX idx_bt_devices_authorized ON bluetooth_devices(is_authorized);
+CREATE INDEX idx_bt_devices_class ON bluetooth_devices(device_class);
+CREATE INDEX idx_bt_devices_connected ON bluetooth_devices(is_connected);
+CREATE INDEX idx_bt_devices_last_seen ON bluetooth_devices(last_seen);
+CREATE INDEX idx_bt_devices_name ON bluetooth_devices(name);
+CREATE INDEX idx_bt_devices_type ON bluetooth_devices(bluetooth_type);
+CREATE INDEX idx_bt_devices_vendor ON bluetooth_devices(vendor);
+CREATE INDEX idx_bt_scan_time ON bluetooth_scan_history(scan_time);
+CREATE INDEX idx_bt_scan_type ON bluetooth_scan_history(scan_type);
+CREATE INDEX idx_channel_util_channel ON channel_utilization(channel, band);
+CREATE INDEX idx_channel_util_time ON channel_utilization(recorded_at);
+CREATE INDEX idx_channel_utilization_client ON channel_utilization(client_id);
+CREATE INDEX idx_clients_slug ON clients(slug);
+CREATE INDEX idx_device_credentials_client ON device_credentials(client_id);
+CREATE INDEX idx_device_credentials_name ON device_credentials(name);
+CREATE INDEX idx_device_interfaces_device ON device_interfaces(device_id);
+CREATE INDEX idx_device_interfaces_mac ON device_interfaces(mac_address);
+CREATE UNIQUE INDEX idx_device_interfaces_unique ON device_interfaces(device_id, if_index);
+CREATE INDEX idx_device_ports_device ON device_ports(device_id);
+CREATE INDEX idx_device_ports_port ON device_ports(port);
+CREATE UNIQUE INDEX idx_device_ports_unique ON device_ports(device_id, port, protocol);
+CREATE INDEX idx_device_vulns_cve ON device_vulnerabilities(cve_id);
+CREATE INDEX idx_device_vulns_device ON device_vulnerabilities(device_id);
+CREATE INDEX idx_device_vulns_severity ON device_vulnerabilities(severity);
+CREATE INDEX idx_device_vulns_status ON device_vulnerabilities(status);
+CREATE UNIQUE INDEX idx_device_vulns_unique ON device_vulnerabilities(device_id, cve_id);
+CREATE INDEX idx_devices_active ON devices(is_active);
+CREATE INDEX idx_devices_hostname ON devices(hostname);
+CREATE INDEX idx_devices_ip ON devices(ip_address);
+CREATE INDEX idx_devices_last_seen ON devices(last_seen);
+CREATE INDEX idx_devices_mac ON devices(mac_address);
+CREATE INDEX idx_disc_devices_auth ON discovered_devices(authorization_status);
+CREATE INDEX idx_disc_devices_last_seen ON discovered_devices(last_seen);
+CREATE INDEX idx_disc_devices_mac ON discovered_devices(primary_mac);
+CREATE INDEX idx_disc_devices_online ON discovered_devices(is_online);
+CREATE INDEX idx_disc_devices_type ON discovered_devices(device_type);
+CREATE INDEX idx_disc_devices_vendor ON discovered_devices(vendor);
+CREATE INDEX idx_disc_history_device ON discovery_history(device_id);
+CREATE INDEX idx_disc_history_time ON discovery_history(recorded_at);
+CREATE INDEX idx_disc_history_type ON discovery_history(event_type);
+CREATE INDEX idx_disc_iface_bssid ON discovery_interfaces(bssid);
+CREATE INDEX idx_disc_iface_device ON discovery_interfaces(device_id);
+CREATE INDEX idx_disc_iface_mac ON discovery_interfaces(mac_address);
+CREATE INDEX idx_disc_iface_ssid ON discovery_interfaces(ssid);
+CREATE INDEX idx_disc_iface_type ON discovery_interfaces(interface_type);
+CREATE INDEX idx_discovered_devices_client ON discovered_devices(client_id);
+CREATE INDEX idx_discovery_history_client ON discovery_history(client_id);
+CREATE INDEX idx_discovery_interfaces_client ON discovery_interfaces(client_id);
+CREATE INDEX idx_dns_interface ON dns_results(interface_name);
+CREATE INDEX idx_dns_results_client ON dns_results(client_id);
+CREATE INDEX idx_dns_server ON dns_results(server);
+CREATE INDEX idx_dns_timestamp ON dns_results(timestamp);
+CREATE INDEX idx_gateway_interface ON gateway_results(interface_name);
+CREATE INDEX idx_gateway_results_client ON gateway_results(client_id);
+CREATE INDEX idx_gateway_timestamp ON gateway_results(timestamp);
+CREATE INDEX idx_health_check_endpoint_time ON health_check_results(endpoint_name, recorded_at);
+CREATE INDEX idx_health_check_recorded ON health_check_results(recorded_at);
+CREATE INDEX idx_health_check_type_time ON health_check_results(check_type, recorded_at);
+CREATE INDEX idx_health_daily_bucket ON health_check_rollups_daily(day_bucket);
+CREATE UNIQUE INDEX idx_health_daily_unique
+				ON health_check_rollups_daily(check_type, endpoint_name, day_bucket);
+CREATE INDEX idx_health_hourly_bucket ON health_check_rollups_hourly(hour_bucket);
+CREATE UNIQUE INDEX idx_health_hourly_unique
+				ON health_check_rollups_hourly(check_type, endpoint_name, hour_bucket);
+CREATE INDEX idx_listener_events_client_kind ON listener_events(client_id, kind, observed_at);
+CREATE INDEX idx_listener_events_observed_at ON listener_events(observed_at);
+CREATE INDEX idx_listener_events_source ON listener_events(source_addr, observed_at);
+CREATE INDEX idx_logs_component ON logs(component);
+CREATE INDEX idx_logs_layer ON logs(layer);
+CREATE INDEX idx_logs_level ON logs(level);
+CREATE INDEX idx_logs_request_id ON logs(request_id);
+CREATE INDEX idx_logs_timestamp ON logs(timestamp);
+CREATE INDEX idx_metrics_client ON metrics(client_id);
+CREATE INDEX idx_metrics_daily_bucket ON metrics_daily(day_bucket);
+CREATE INDEX idx_metrics_daily_client ON metrics_daily(client_id);
+CREATE INDEX idx_metrics_daily_target ON metrics_daily(target_kind, target_id, day_bucket);
+CREATE INDEX idx_metrics_daily_type ON metrics_daily(metric_type, day_bucket);
+CREATE INDEX idx_metrics_hourly_bucket ON metrics_hourly(hour_bucket);
+CREATE INDEX idx_metrics_hourly_client ON metrics_hourly(client_id);
+CREATE INDEX idx_metrics_hourly_target ON metrics_hourly(target_kind, target_id, hour_bucket);
+CREATE INDEX idx_metrics_hourly_type ON metrics_hourly(metric_type, hour_bucket);
+CREATE INDEX idx_metrics_interface ON metrics(interface_name);
+CREATE INDEX idx_metrics_interface_type_time ON metrics(interface_name, metric_type, timestamp);
+CREATE INDEX idx_metrics_target ON metrics(target_kind, target_id);
+CREATE INDEX idx_metrics_timestamp ON metrics(timestamp);
+CREATE INDEX idx_metrics_type ON metrics(metric_type);
+CREATE INDEX idx_mib_oid_names_mib ON mib_oid_names(mib_name);
+CREATE INDEX idx_mib_oid_names_oid ON mib_oid_names(oid);
+CREATE INDEX idx_microburst_device ON microburst_events(device_id);
+CREATE INDEX idx_microburst_events_client ON microburst_events(client_id);
+CREATE INDEX idx_microburst_interface ON microburst_events(interface_name);
+CREATE INDEX idx_microburst_timestamp ON microburst_events(timestamp);
+CREATE INDEX idx_net_problems_detected ON network_problems(detected_at);
+CREATE INDEX idx_net_problems_device ON network_problems(device_id);
+CREATE INDEX idx_net_problems_resolved ON network_problems(is_resolved);
+CREATE INDEX idx_net_problems_severity ON network_problems(severity);
+CREATE INDEX idx_net_problems_type ON network_problems(problem_type);
+CREATE INDEX idx_network_problems_client ON network_problems(client_id);
+CREATE INDEX idx_oui_category ON oui_vendors(device_category);
+CREATE INDEX idx_oui_vendor_name ON oui_vendors(vendor_name);
+CREATE INDEX idx_pipeline_runs_started ON pipeline_runs(started_at);
+CREATE INDEX idx_pipeline_runs_status ON pipeline_runs(status);
+CREATE INDEX idx_polling_targets_client ON polling_targets(client_id);
+CREATE INDEX idx_polling_targets_enabled ON polling_targets(enabled);
+CREATE INDEX idx_polling_targets_ip ON polling_targets(ip_address);
+CREATE INDEX idx_probe_results_client ON probe_results(client_id);
+CREATE INDEX idx_probe_results_client_kind_ts ON probe_results(client_id, kind, timestamp);
+CREATE INDEX idx_probe_results_kind ON probe_results(kind);
+CREATE INDEX idx_probe_results_probe ON probe_results(probe_id);
+CREATE INDEX idx_probe_results_timestamp ON probe_results(timestamp);
+CREATE INDEX idx_probe_rollups_daily_bucket ON probe_rollups_daily(day_bucket);
+CREATE INDEX idx_probe_rollups_daily_probe ON probe_rollups_daily(probe_id, day_bucket);
+CREATE INDEX idx_probe_rollups_hourly_bucket ON probe_rollups_hourly(hour_bucket);
+CREATE INDEX idx_probe_rollups_hourly_probe ON probe_rollups_hourly(probe_id, hour_bucket);
+CREATE INDEX idx_probes_client ON probes(client_id);
+CREATE INDEX idx_probes_client_kind ON probes(client_id, kind);
+CREATE INDEX idx_probes_enabled ON probes(enabled);
+CREATE INDEX idx_probes_kind ON probes(kind);
+CREATE INDEX idx_profiles_client ON profiles(client_id);
+CREATE INDEX idx_profiles_is_default ON profiles(is_default);
+CREATE INDEX idx_profiles_name ON profiles(name);
+CREATE INDEX idx_reports_created_at ON reports(created_at);
+CREATE INDEX idx_reports_status ON reports(status);
+CREATE INDEX idx_reports_type ON reports(type);
+CREATE INDEX idx_scheduled_reports_enabled ON scheduled_reports(enabled);
+CREATE INDEX idx_scheduled_reports_next_run ON scheduled_reports(next_run);
+CREATE INDEX idx_snmp_observations_client_kind ON snmp_observations(client_id, kind, observed_at);
+CREATE INDEX idx_snmp_observations_observed_at ON snmp_observations(observed_at);
+CREATE INDEX idx_snmp_observations_target ON snmp_observations(target_id, observed_at);
+CREATE INDEX idx_speedtest_interface ON speedtest_results(interface_name);
+CREATE INDEX idx_speedtest_results_client ON speedtest_results(client_id);
+CREATE INDEX idx_speedtest_timestamp ON speedtest_results(timestamp);
+CREATE INDEX idx_survey_samples_client ON survey_samples(client_id);
+CREATE INDEX idx_survey_samples_coords ON survey_samples(x, y);
+CREATE INDEX idx_survey_samples_survey ON survey_samples(survey_id);
+CREATE INDEX idx_topology_interfaces_last_seen ON topology_interfaces(last_seen);
+CREATE INDEX idx_topology_interfaces_node ON topology_interfaces(node_id);
+CREATE INDEX idx_topology_interfaces_oper ON topology_interfaces(if_oper_status);
+CREATE INDEX idx_topology_links_client ON topology_links(client_id);
+CREATE INDEX idx_topology_links_last_seen ON topology_links(last_seen);
+CREATE INDEX idx_topology_links_source ON topology_links(source_node_id);
+CREATE INDEX idx_topology_links_target ON topology_links(target_node_id);
+CREATE INDEX idx_topology_nodes_client ON topology_nodes(client_id);
+CREATE INDEX idx_topology_nodes_identity ON topology_nodes(identity_hash);
+CREATE INDEX idx_topology_nodes_last_seen ON topology_nodes(last_seen);
+CREATE INDEX idx_topology_nodes_type ON topology_nodes(device_type);
+CREATE INDEX idx_topology_target_nodes_node ON topology_target_nodes(node_id);
+CREATE INDEX idx_users_active               ON users(is_active);
+CREATE INDEX idx_users_email                ON users(email);
+CREATE INDEX idx_users_provider_external_id ON users(auth_provider, external_id);
+CREATE INDEX idx_users_username             ON users(username);
+CREATE INDEX idx_voip_calls_call_id ON voip_calls(call_id);
+CREATE INDEX idx_voip_calls_client ON voip_calls(client_id);
+CREATE INDEX idx_voip_calls_mos ON voip_calls(mos_score);
+CREATE INDEX idx_voip_calls_started ON voip_calls(started_at);
+CREATE UNIQUE INDEX idx_webauthn_credential_id
+				ON webauthn_credentials(credential_id);
+CREATE INDEX idx_webauthn_user ON webauthn_credentials(user_id);
+CREATE INDEX idx_wifi_access_points_client ON wifi_access_points(client_id);
+CREATE INDEX idx_wifi_aps_band ON wifi_access_points(band);
+CREATE INDEX idx_wifi_aps_bssid ON wifi_access_points(bssid);
+CREATE INDEX idx_wifi_aps_channel ON wifi_access_points(channel);
+CREATE INDEX idx_wifi_aps_device ON wifi_access_points(device_id);
+CREATE INDEX idx_wifi_aps_ssid ON wifi_access_points(ssid_id);
+CREATE INDEX idx_wifi_assoc_ap ON wifi_associations(ap_bssid);
+CREATE INDEX idx_wifi_assoc_client ON wifi_associations(client_mac);
+CREATE INDEX idx_wifi_assoc_status ON wifi_associations(status_code);
+CREATE INDEX idx_wifi_assoc_timestamp ON wifi_associations(timestamp);
+CREATE INDEX idx_wifi_associations_client ON wifi_associations(client_id);
+CREATE INDEX idx_wifi_clients_client ON wifi_clients(client_id);
+CREATE INDEX idx_wifi_clients_last_seen ON wifi_clients(last_seen);
+CREATE INDEX idx_wifi_clients_mac ON wifi_clients(mac_full);
+CREATE INDEX idx_wifi_clients_oui ON wifi_clients(vendor_oui);
+CREATE INDEX idx_wifi_deauths_ap ON wifi_deauths(ap_bssid);
+CREATE INDEX idx_wifi_deauths_client ON wifi_deauths(client_mac);
+CREATE INDEX idx_wifi_deauths_reason ON wifi_deauths(reason_code);
+CREATE INDEX idx_wifi_deauths_timestamp ON wifi_deauths(timestamp);
+CREATE INDEX idx_wifi_networks_auth ON wifi_networks(authorization_status);
+CREATE INDEX idx_wifi_networks_client ON wifi_networks(client_id);
+CREATE INDEX idx_wifi_networks_ssid ON wifi_networks(ssid);
+CREATE INDEX idx_wifi_roams_client ON wifi_roams(client_mac);
+CREATE INDEX idx_wifi_roams_from ON wifi_roams(from_bssid);
+CREATE INDEX idx_wifi_roams_started ON wifi_roams(started_at);
+CREATE INDEX idx_wifi_roams_to ON wifi_roams(to_bssid);
+CREATE INDEX idx_wifi_rogues_bssid ON wifi_rogues(ap_bssid);
+CREATE INDEX idx_wifi_rogues_client ON wifi_rogues(client_id);
+CREATE INDEX idx_wifi_rogues_detected ON wifi_rogues(detected_at);
+CREATE INDEX idx_wifi_rogues_severity ON wifi_rogues(severity);
+CREATE INDEX idx_wifi_rogues_status ON wifi_rogues(status);
+
+-- +goose Down
+DROP TABLE IF EXISTS wifi_rogues;
+DROP TABLE IF EXISTS wifi_roams;
+DROP TABLE IF EXISTS wifi_networks;
+DROP TABLE IF EXISTS wifi_deauths;
+DROP TABLE IF EXISTS wifi_clients;
+DROP TABLE IF EXISTS wifi_associations;
+DROP TABLE IF EXISTS wifi_access_points;
+DROP TABLE IF EXISTS webauthn_credentials;
+DROP TABLE IF EXISTS voip_calls;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS topology_target_nodes;
+DROP TABLE IF EXISTS topology_nodes;
+DROP TABLE IF EXISTS topology_links;
+DROP TABLE IF EXISTS topology_interfaces;
+DROP TABLE IF EXISTS topology_arp_bindings;
+DROP TABLE IF EXISTS survey_samples;
+DROP TABLE IF EXISTS speedtest_results;
+DROP TABLE IF EXISTS snmp_observations;
+DROP TABLE IF EXISTS settings;
+DROP TABLE IF EXISTS scheduled_reports;
+DROP TABLE IF EXISTS reports;
+DROP TABLE IF EXISTS profiles;
+DROP TABLE IF EXISTS probes;
+DROP TABLE IF EXISTS probe_rollups_hourly;
+DROP TABLE IF EXISTS probe_rollups_daily;
+DROP TABLE IF EXISTS probe_results;
+DROP TABLE IF EXISTS polling_targets;
+DROP TABLE IF EXISTS pipeline_runs;
+DROP TABLE IF EXISTS oui_vendors;
+DROP TABLE IF EXISTS network_problems;
+DROP TABLE IF EXISTS microburst_events;
+DROP TABLE IF EXISTS mib_sources;
+DROP TABLE IF EXISTS mib_oid_names;
+DROP TABLE IF EXISTS metrics_hourly;
+DROP TABLE IF EXISTS metrics_daily;
+DROP TABLE IF EXISTS metrics;
+DROP TABLE IF EXISTS logs;
+DROP TABLE IF EXISTS listener_events;
+DROP TABLE IF EXISTS health_check_rollups_hourly;
+DROP TABLE IF EXISTS health_check_rollups_daily;
+DROP TABLE IF EXISTS health_check_results;
+DROP TABLE IF EXISTS gateway_results;
+DROP TABLE IF EXISTS dns_results;
+DROP TABLE IF EXISTS discovery_interfaces;
+DROP TABLE IF EXISTS discovery_history;
+DROP TABLE IF EXISTS discovered_devices;
+DROP TABLE IF EXISTS devices;
+DROP TABLE IF EXISTS device_vulnerabilities;
+DROP TABLE IF EXISTS device_ports;
+DROP TABLE IF EXISTS device_interfaces;
+DROP TABLE IF EXISTS device_credentials;
+DROP TABLE IF EXISTS clients;
+DROP TABLE IF EXISTS channel_utilization;
+DROP TABLE IF EXISTS bluetooth_scan_history;
+DROP TABLE IF EXISTS bluetooth_devices;
+DROP TABLE IF EXISTS bgp_sessions;
+DROP TABLE IF EXISTS audit_log;
+DROP TABLE IF EXISTS api_tokens;
+DROP TABLE IF EXISTS alerts;
+DROP TABLE IF EXISTS alert_suppressions;
+DROP TABLE IF EXISTS alert_rules;


### PR DESCRIPTION
## Phase 5b-1 — goose baseline, proven faithful (no runner change yet)

Introduces **goose** (pinned `v3.27.1`) and a faithful `0001_init.sql` baseline that collapses the legacy migration history into one file — the first half of the runner swap, kept **additive and provably correct**.

### The proof (the whole point of this PR)
`internal/database/migrations/00001_init.sql` is generated from the schema the legacy runner produces (**61 tables + 212 indexes**, no triggers/views). `TestGooseBaselineReproducesSchema` applies it via goose to a fresh empty DB and asserts the result is **byte-identical to the schema-snapshot golden** (#1476) — i.e. goose + this baseline reproduce the legacy schema *exactly*. That answers the riskiest question of the whole persistence phase — *is the collapse faithful?* — **before any production code changes.**

### What this PR deliberately does NOT do
The production runner is **unchanged**: `db.migrate()` still runs the homegrown definitions. The actual swap (point `db.migrate()` at goose, rewire the test-only `MigrationStatus`/`SchemaVersion`, delete the 2.2k-line homegrown migration internals) is the focused follow-up **5b-2** — now de-risked because the baseline is already trusted and gated. STRICT-table conversion is **5b-3**.

This staging means each step is independently verifiable instead of one irreversible core-DB rewrite.

The baseline regenerates idempotently: `GEN_BASELINE=1 go test ./internal/database/ -run TestGenerateGooseBaseline`.

### Gates
- `go test -race ./internal/database/ -run 'TestSchemaSnapshot|TestGooseBaselineReproducesSchema'` — both pass
- `golangci-lint` **0 issues**; build clean; `go mod tidy` clean (goose now a direct dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)