### PR TITLE
feat(database): durable jobs table + repository (ADR-0005, Phase 5c-1)

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -75,6 +75,7 @@ type DB struct {
 	clients           *ClientRepository
 	probes            *ProbeRepository
 	pollingTargets    *PollingTargetRepository
+	jobs              *JobRepository
 	snmpObservations  *SNMPObservationsRepository
 	listenerEvents    *ListenerEventsRepository
 	topology          *TopologyRepository

--- a/internal/database/migrations/00002_jobs.sql
+++ b/internal/database/migrations/00002_jobs.sql
@@ -1,0 +1,31 @@
+-- 00002_jobs.sql — durable job store (ADR-0005, Phase 5c).
+-- The platform/jobs Runner shipped (Phase 4) with an in-memory store that loses
+-- jobs on restart — the correct fail-cleanly v1. This table is the durable
+-- backing the Runner writes lifecycle transitions through, so GET /jobs/{id}
+-- survives a restart. The Runner wiring + the transactional outbox land in
+-- follow-up 5c slices; this migration + its repository (repository_jobs.go) are
+-- additive. STRICT + explicit domain CHECKs, consistent with the 0001 baseline
+-- (Phase 5b-3 / 5b-4). Regenerate the gate golden after edits:
+--   UPDATE_SCHEMA_GOLDEN=1 go test ./internal/database/ -run TestSchemaSnapshot
+
+-- +goose Up
+CREATE TABLE jobs (
+	id           TEXT NOT NULL PRIMARY KEY,
+	kind         TEXT NOT NULL,
+	state        TEXT NOT NULL DEFAULT 'queued'
+	             CHECK (state IN ('queued','running','succeeded','failed','cancelled')),
+	progress     REAL NOT NULL DEFAULT 0 CHECK (progress >= 0 AND progress <= 1),
+	result_json  TEXT,
+	error        TEXT,
+	created_at   TEXT NOT NULL,
+	updated_at   TEXT NOT NULL,
+	completed_at TEXT
+) STRICT;
+
+CREATE INDEX idx_jobs_completed ON jobs(completed_at);
+CREATE INDEX idx_jobs_created ON jobs(created_at);
+CREATE INDEX idx_jobs_kind ON jobs(kind);
+CREATE INDEX idx_jobs_state ON jobs(state);
+
+-- +goose Down
+DROP TABLE IF EXISTS jobs;

--- a/internal/database/repository_jobs.go
+++ b/internal/database/repository_jobs.go
@@ -1,0 +1,171 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrJobNotFound is returned when a job lookup misses.
+var ErrJobNotFound = errors.New("job not found")
+
+// JobRecord mirrors a jobs row — the durable projection of a
+// platform/jobs Job (ADR-0005, Phase 5c). The Runner writes the full
+// snapshot through Save on every lifecycle transition; ResultJSON and
+// Error are the serialized success result and failure detail. CompletedAt
+// is the zero time while the job is active (queued or running) and the
+// terminal timestamp once it finishes.
+type JobRecord struct {
+	ID          string    `json:"id"`
+	Kind        string    `json:"kind"`
+	State       string    `json:"state"`
+	Progress    float64   `json:"progress"`
+	ResultJSON  string    `json:"resultJson,omitempty"`
+	Error       string    `json:"error,omitempty"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	CompletedAt time.Time `json:"completedAt,omitzero"`
+}
+
+// JobRepository owns durable read/write access to the jobs table. The
+// Runner persists each transition; GET /jobs reads snapshots; the
+// scheduler-driven retention sweep deletes terminal rows past their
+// window.
+type JobRepository struct {
+	db *DB
+}
+
+// Jobs returns the durable job repository (Phase 5c). The platform/jobs
+// Runner writes lifecycle transitions through it so jobs survive a restart.
+func (db *DB) Jobs() *JobRepository {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.jobs == nil {
+		db.jobs = &JobRepository{db: db}
+	}
+	return db.jobs
+}
+
+// Save upserts a job snapshot. The first write (queued) inserts and fixes
+// created_at + kind; later writes update the mutable lifecycle columns and
+// updated_at only — created_at and kind are immutable after insert. Write the
+// full current snapshot on every transition; this is the Runner's write-through.
+func (r *JobRepository) Save(ctx context.Context, rec *JobRecord) error {
+	if rec.ID == "" {
+		return errors.New("jobs: ID required for Save")
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO jobs
+		  (id, kind, state, progress, result_json, error,
+		   created_at, updated_at, completed_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			state        = excluded.state,
+			progress     = excluded.progress,
+			result_json  = excluded.result_json,
+			error        = excluded.error,
+			updated_at   = excluded.updated_at,
+			completed_at = excluded.completed_at
+	`,
+		rec.ID, rec.Kind, rec.State, rec.Progress,
+		toNullString(rec.ResultJSON), toNullString(rec.Error),
+		rec.CreatedAt.UTC().Format(time.RFC3339Nano),
+		rec.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		toNullTime(rec.CompletedAt),
+	)
+	if err != nil {
+		return fmt.Errorf("save job: %w", err)
+	}
+	return nil
+}
+
+// Get returns the job by id, or ErrJobNotFound when absent.
+func (r *JobRepository) Get(ctx context.Context, id string) (*JobRecord, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, kind, state, progress, result_json, error,
+			created_at, updated_at, completed_at
+		FROM jobs WHERE id = ?
+	`, id)
+	return scanJob(row.Scan)
+}
+
+// List returns all jobs, newest first (by created_at). Intended for the
+// GET /jobs listing and for restart recovery (find jobs left non-terminal).
+func (r *JobRepository) List(ctx context.Context) ([]*JobRecord, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, kind, state, progress, result_json, error,
+			created_at, updated_at, completed_at
+		FROM jobs ORDER BY created_at DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list jobs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*JobRecord
+	for rows.Next() {
+		rec, scanErr := scanJob(rows.Scan)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, rec)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("iterate jobs: %w", rowsErr)
+	}
+	return out, nil
+}
+
+// DeleteCompletedBefore removes terminal jobs whose completed_at is before
+// cutoff and returns the count removed. Active jobs (NULL completed_at) are
+// never touched. This is the durable analogue of the in-memory Runner.Cleanup.
+func (r *JobRepository) DeleteCompletedBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := r.db.Exec(ctx, `
+		DELETE FROM jobs
+		WHERE completed_at IS NOT NULL AND completed_at < ?
+	`, cutoff.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return 0, fmt.Errorf("delete completed jobs: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// scanJob maps one jobs row into a JobRecord, translating [sql.ErrNoRows] into
+// ErrJobNotFound for the single-row Get path.
+func scanJob(scan func(...any) error) (*JobRecord, error) {
+	var (
+		rec          JobRecord
+		resultJSON   sql.NullString
+		errStr       sql.NullString
+		createdAtStr string
+		updatedAtStr string
+		completedAt  sql.NullString
+	)
+	err := scan(
+		&rec.ID, &rec.Kind, &rec.State, &rec.Progress,
+		&resultJSON, &errStr, &createdAtStr, &updatedAtStr, &completedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrJobNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan job: %w", err)
+	}
+
+	if resultJSON.Valid {
+		rec.ResultJSON = resultJSON.String
+	}
+	if errStr.Valid {
+		rec.Error = errStr.String
+	}
+	rec.CreatedAt = parseTime(createdAtStr)
+	rec.UpdatedAt = parseTime(updatedAtStr)
+	if completedAt.Valid {
+		rec.CompletedAt = parseTime(completedAt.String)
+	}
+	return &rec, nil
+}

--- a/internal/database/repository_jobs_test.go
+++ b/internal/database/repository_jobs_test.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package database_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+func setupJobsTest(t *testing.T) (*database.JobRepository, context.Context) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp(t.TempDir(), "seed-jobs-*.db")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	tmpPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() { _ = os.Remove(tmpPath) })
+
+	db, openErr := database.Open(tmpPath)
+	if openErr != nil {
+		t.Fatalf("open db: %v", openErr)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db.Jobs(), context.Background()
+}
+
+func TestJobsSaveInsertThenGet(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupJobsTest(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	rec := &database.JobRecord{
+		ID:        "job-1",
+		Kind:      "speedtest",
+		State:     "queued",
+		Progress:  0,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := repo.Save(ctx, rec); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := repo.Get(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Kind != "speedtest" || got.State != "queued" {
+		t.Errorf("got kind=%q state=%q, want speedtest/queued", got.Kind, got.State)
+	}
+	if !got.CompletedAt.IsZero() {
+		t.Errorf("active job should have zero CompletedAt, got %v", got.CompletedAt)
+	}
+	if !got.CreatedAt.Equal(now) {
+		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, now)
+	}
+}
+
+func TestJobsSaveUpsertPreservesCreatedAtAndKind(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupJobsTest(t)
+
+	created := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	if err := repo.Save(ctx, &database.JobRecord{
+		ID: "job-1", Kind: "iperf", State: "queued",
+		CreatedAt: created, UpdatedAt: created,
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// A later transition writes the full snapshot; created_at and kind must
+	// NOT be overwritten by the upsert, mutable lifecycle columns must be.
+	completed := time.Now().UTC().Truncate(time.Second)
+	if err := repo.Save(ctx, &database.JobRecord{
+		ID: "job-1", Kind: "SHOULD-BE-IGNORED", State: "succeeded",
+		Progress: 1, ResultJSON: `{"ok":true}`,
+		CreatedAt: completed, UpdatedAt: completed, CompletedAt: completed,
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	got, err := repo.Get(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Kind != "iperf" {
+		t.Errorf("kind = %q, want iperf (immutable after insert)", got.Kind)
+	}
+	if !got.CreatedAt.Equal(created) {
+		t.Errorf("CreatedAt = %v, want %v (immutable)", got.CreatedAt, created)
+	}
+	if got.State != "succeeded" || got.Progress != 1 || got.ResultJSON != `{"ok":true}` {
+		t.Errorf("mutable cols not updated: state=%q progress=%v result=%q",
+			got.State, got.Progress, got.ResultJSON)
+	}
+	if got.CompletedAt.IsZero() {
+		t.Error("terminal job should have non-zero CompletedAt")
+	}
+}
+
+func TestJobsGetNotFound(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupJobsTest(t)
+
+	_, err := repo.Get(ctx, "missing")
+	if !errors.Is(err, database.ErrJobNotFound) {
+		t.Errorf("got %v, want ErrJobNotFound", err)
+	}
+}
+
+func TestJobsListNewestFirst(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupJobsTest(t)
+
+	base := time.Now().UTC().Truncate(time.Second)
+	for i, id := range []string{"old", "mid", "new"} {
+		ts := base.Add(time.Duration(i) * time.Minute)
+		if err := repo.Save(ctx, &database.JobRecord{
+			ID: id, Kind: "k", State: "queued", CreatedAt: ts, UpdatedAt: ts,
+		}); err != nil {
+			t.Fatalf("save %s: %v", id, err)
+		}
+	}
+
+	list, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 3 {
+		t.Fatalf("len = %d, want 3", len(list))
+	}
+	if list[0].ID != "new" || list[1].ID != "mid" || list[2].ID != "old" {
+		t.Errorf("order = %s,%s,%s, want new,mid,old",
+			list[0].ID, list[1].ID, list[2].ID)
+	}
+}
+
+func TestJobsDeleteCompletedBefore(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupJobsTest(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	// Terminal, old -> eligible.
+	mustSave(ctx, t, repo, &database.JobRecord{
+		ID: "old-done", Kind: "k", State: "succeeded", Progress: 1,
+		CreatedAt: now.Add(-2 * time.Hour), UpdatedAt: now.Add(-2 * time.Hour),
+		CompletedAt: now.Add(-2 * time.Hour),
+	})
+	// Terminal, recent -> kept.
+	mustSave(ctx, t, repo, &database.JobRecord{
+		ID: "recent-done", Kind: "k", State: "failed", Error: "boom",
+		CreatedAt: now, UpdatedAt: now, CompletedAt: now,
+	})
+	// Active (no completed_at) -> never deleted regardless of age.
+	mustSave(ctx, t, repo, &database.JobRecord{
+		ID: "active", Kind: "k", State: "running",
+		CreatedAt: now.Add(-3 * time.Hour), UpdatedAt: now.Add(-3 * time.Hour),
+	})
+
+	removed, err := repo.DeleteCompletedBefore(ctx, now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("removed = %d, want 1", removed)
+	}
+
+	list, _ := repo.List(ctx)
+	if len(list) != 2 {
+		t.Fatalf("remaining = %d, want 2", len(list))
+	}
+	for _, j := range list {
+		if j.ID == "old-done" {
+			t.Error("old terminal job should have been deleted")
+		}
+	}
+}
+
+// TestJobsStateCheckRejectsInvalid proves the STRICT-table CHECK on state
+// (Phase 5b/5c hardening) rejects an out-of-domain value at the DB, not just in
+// Go. Save surfaces the SQLite constraint failure as an error.
+func TestJobsStateCheckRejectsInvalid(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupJobsTest(t)
+
+	now := time.Now().UTC()
+	err := repo.Save(ctx, &database.JobRecord{
+		ID: "bad", Kind: "k", State: "bogus", CreatedAt: now, UpdatedAt: now,
+	})
+	if err == nil {
+		t.Fatal("expected CHECK violation for invalid state, got nil")
+	}
+}
+
+// TestJobsProgressCheckRejectsOutOfRange proves the CHECK (progress 0..1).
+func TestJobsProgressCheckRejectsOutOfRange(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupJobsTest(t)
+
+	now := time.Now().UTC()
+	err := repo.Save(ctx, &database.JobRecord{
+		ID: "bad", Kind: "k", State: "running", Progress: 1.5,
+		CreatedAt: now, UpdatedAt: now,
+	})
+	if err == nil {
+		t.Fatal("expected CHECK violation for progress > 1, got nil")
+	}
+}
+
+func mustSave(ctx context.Context, t *testing.T, repo *database.JobRepository, rec *database.JobRecord) {
+	t.Helper()
+	if err := repo.Save(ctx, rec); err != nil {
+		t.Fatalf("save %s: %v", rec.ID, err)
+	}
+}

--- a/internal/database/testdata/schema.sql
+++ b/internal/database/testdata/schema.sql
@@ -265,6 +265,18 @@ CREATE INDEX idx_health_hourly_bucket ON health_check_rollups_hourly(hour_bucket
 CREATE UNIQUE INDEX idx_health_hourly_unique
 				ON health_check_rollups_hourly(check_type, endpoint_name, hour_bucket);
 
+-- index: idx_jobs_completed
+CREATE INDEX idx_jobs_completed ON jobs(completed_at);
+
+-- index: idx_jobs_created
+CREATE INDEX idx_jobs_created ON jobs(created_at);
+
+-- index: idx_jobs_kind
+CREATE INDEX idx_jobs_kind ON jobs(kind);
+
+-- index: idx_jobs_state
+CREATE INDEX idx_jobs_state ON jobs(state);
+
 -- index: idx_listener_events_client_kind
 CREATE INDEX idx_listener_events_client_kind ON listener_events(client_id, kind, observed_at);
 
@@ -1018,6 +1030,20 @@ CREATE TABLE health_check_rollups_hourly (
 				max_latency_ms REAL,
 				p95_latency_ms REAL
 			) STRICT;
+
+-- table: jobs
+CREATE TABLE jobs (
+	id           TEXT NOT NULL PRIMARY KEY,
+	kind         TEXT NOT NULL,
+	state        TEXT NOT NULL DEFAULT 'queued'
+	             CHECK (state IN ('queued','running','succeeded','failed','cancelled')),
+	progress     REAL NOT NULL DEFAULT 0 CHECK (progress >= 0 AND progress <= 1),
+	result_json  TEXT,
+	error        TEXT,
+	created_at   TEXT NOT NULL,
+	updated_at   TEXT NOT NULL,
+	completed_at TEXT
+) STRICT;
 
 -- table: listener_events
 CREATE TABLE listener_events (


### PR DESCRIPTION
## Phase 5c-1 — durable jobs table + repository

First slice of **Phase 5c** (durable job store + transactional outbox, ADR-0005). The `platform/jobs` Runner shipped in Phase 4 with an in-memory store that loses jobs on restart — the correct fail-cleanly v1. This adds the durable backing the Runner will write lifecycle transitions through so `GET /jobs/{id}` survives a restart. **Purely additive** — nothing imports `JobRepository` yet (same additive-core cadence as the events bus / jobs core); the Runner wiring + the outbox land in follow-up 5c slices.

### What's here
- **`migrations/00002_jobs.sql`** — `jobs` table, **STRICT**, with explicit domain CHECKs (`state IN` the five lifecycle values; `progress` in `[0,1]`) + 4 indexes (state/kind/created/completed) for listing & retention sweeps. Consistent with the 0001 baseline hardening (5b-3/5b-4).
- **`repository_jobs.go`** — `JobRecord` + `JobRepository`:
  - `Save` — write-through upsert; `created_at`/`kind` immutable after insert, mutable lifecycle columns updated.
  - `Get` — `ErrJobNotFound` on miss.
  - `List` — newest-first (listing + restart recovery).
  - `DeleteCompletedBefore` — durable analogue of `Runner.Cleanup`; never touches active jobs.
  - `db.Jobs()` accessor matches the existing repo pattern; reuses the existing `toNullTime`.

### Gates
- **Full `go test -race ./internal/database/` green** — new repo tests + both schema gates now reproduce the **2-migration** schema, and the dynamic migration-count test self-adjusts to 2.
- Schema golden regenerated; diff is **purely additive** (jobs table + 4 indexes, zero churn to existing objects).
- CHECK constraints proven to reject invalid `state` / out-of-range `progress` at the DB layer.
- `golangci-lint` 0; `go build ./cmd/seed/` ok.

This is the first PR to exercise the new **multi-migration** goose path end-to-end (00001 + 00002), and rides the #1479 backend-filter fix (a migrations+Go PR → Go gate runs). Admin-merge after Backend (Go) + race green.