### PR TITLE
feat(jobs): durable Store seam in the runner (ADR-0005, Phase 5c-2)

### DIFF
--- a/internal/platform/jobs/jobs.go
+++ b/internal/platform/jobs/jobs.go
@@ -31,8 +31,10 @@
 //   - Retention: terminal jobs are kept in memory until Cleanup removes those
 //     older than the configured retention window (driven by the scheduler).
 //
-// Durability across restarts is the persistence phase's concern; an in-memory
-// store that loses jobs on restart is the correct fail-cleanly v1 (ADR-0005).
+// Durability is optional via Config.Store (Phase 5c): when set, the runner
+// write-throughs each state transition and reads through on a Get miss, and
+// Recover reconciles jobs left in-flight by a previous process at startup. With
+// no store the runner is in-memory only — the correct fail-cleanly v1 (ADR-0005).
 package jobs
 
 import (
@@ -108,6 +110,24 @@ type JobEvent struct {
 // Topic routes the event by the job's new state, e.g. "job.succeeded".
 func (e JobEvent) Topic() string { return Topic(e.Job.State) }
 
+// Store is the durable backing for jobs (ADR-0005, Phase 5c). The Runner
+// write-throughs a snapshot on every state transition and falls back to it on a
+// Get miss, so a job survives a restart. nil disables persistence — the
+// in-memory map stays the source of truth for active jobs (the fail-cleanly v1).
+// Progress ticks are deliberately not persisted (too frequent); only state
+// changes are. Implementations must be safe for concurrent use.
+type Store interface {
+	// Save persists the current snapshot of j (upsert by ID). Best-effort from
+	// the Runner's perspective: a Save error is logged, never fails the job.
+	Save(ctx context.Context, j Job) error
+	// Load returns the persisted job and whether it exists.
+	Load(ctx context.Context, id string) (Job, bool, error)
+	// MarkInterrupted transitions every persisted non-terminal job (queued or
+	// running) to failed — called once at startup via Recover, since a restart's
+	// lost handler goroutines can't resume them. Returns the count transitioned.
+	MarkInterrupted(ctx context.Context) (int, error)
+}
+
 // Handler executes one job of a kind. It receives a context cancelled when the
 // job is cancelled or the runner shuts down, the submit-time params, and a
 // report callback for progress in [0,1]. Its return value becomes Job.Result; a
@@ -115,13 +135,18 @@ func (e JobEvent) Topic() string { return Topic(e.Job.State) }
 // is done.
 type Handler func(ctx context.Context, params any, report func(float64)) (any, error)
 
-// Config tunes a Runner. The zero value is valid: an 8-job cap and zero
-// retention (terminal jobs are eligible for Cleanup immediately).
+// Config tunes a Runner. The zero value is valid: an 8-job cap, zero
+// retention (terminal jobs are eligible for Cleanup immediately), and no
+// persistence.
 type Config struct {
 	// MaxConcurrent caps active (queued or running) jobs. <= 0 uses the default.
 	MaxConcurrent int
 	// Retention is how long a terminal job is kept before Cleanup may remove it.
 	Retention time.Duration
+	// Store, when non-nil, durably backs the runner: snapshots are written
+	// through on each state transition and read on a Get miss. nil keeps the
+	// in-memory-only fail-cleanly behavior.
+	Store Store
 }
 
 // Runner schedules and tracks jobs. The zero value is not usable; call New. A
@@ -129,6 +154,7 @@ type Config struct {
 type Runner struct {
 	bus       *events.Bus
 	logger    *slog.Logger
+	store     Store // nil when persistence is disabled
 	cap       int
 	retention time.Duration
 
@@ -159,6 +185,7 @@ func New(bus *events.Bus, logger *slog.Logger, cfg Config) *Runner {
 	return &Runner{
 		bus:       bus,
 		logger:    logger,
+		store:     cfg.Store,
 		cap:       cfg.MaxConcurrent,
 		retention: cfg.Retention,
 		handlers:  make(map[string]Handler),
@@ -220,19 +247,34 @@ func (r *Runner) Submit(kind string, params any) (string, error) {
 	r.mu.Unlock()
 
 	r.bus.Publish(JobEvent{Job: snap})
+	r.persist(snap)
 	go r.execute(ctx, e, h, params)
 	return id, nil
 }
 
-// Get returns a snapshot of the job and whether it exists.
+// Get returns a snapshot of the job and whether it exists. Active and recently
+// terminal jobs are served from memory; on a miss it falls back to the durable
+// store (if configured), so a job that completed before the last restart, or
+// was evicted by Cleanup but not yet by retention, is still retrievable.
 func (r *Runner) Get(id string) (Job, bool) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	e, ok := r.jobs[id]
-	if !ok {
+	if ok {
+		snap := e.job
+		r.mu.Unlock()
+		return snap, true
+	}
+	r.mu.Unlock()
+
+	if r.store == nil {
 		return Job{}, false
 	}
-	return e.job, true
+	j, found, err := r.store.Load(context.Background(), id)
+	if err != nil {
+		r.logger.ErrorContext(context.Background(), "load job from store", "job", id, "err", err)
+		return Job{}, false
+	}
+	return j, found
 }
 
 // Cancel requests cancellation of a job, cancelling its context so a
@@ -349,6 +391,7 @@ func (r *Runner) finish(e *entry, result any, err error) {
 	r.mu.Unlock()
 
 	r.bus.Publish(JobEvent{Job: snap})
+	r.persist(snap)
 }
 
 // transition mutates a job's state under the lock and publishes the new fact.
@@ -359,6 +402,34 @@ func (r *Runner) transition(e *entry, mutate func(*Job)) {
 	r.mu.Unlock()
 
 	r.bus.Publish(JobEvent{Job: snap})
+	r.persist(snap)
+}
+
+// persist write-throughs a snapshot to the durable store, if one is configured.
+// It is best-effort: a store error is logged, never propagated — the in-memory
+// runner stays authoritative for the live job, so a transient persistence
+// failure never stalls or fails execution. Called outside the lock (after the
+// bus publish) so it never extends the critical section.
+func (r *Runner) persist(snap Job) {
+	if r.store == nil {
+		return
+	}
+	if err := r.store.Save(context.Background(), snap); err != nil {
+		r.logger.ErrorContext(context.Background(), "persist job snapshot",
+			"job", snap.ID, "state", snap.State, "err", err)
+	}
+}
+
+// Recover reconciles the durable store with reality at startup: any persisted
+// job still marked queued or running is from a previous process whose handler
+// goroutine is gone, so it can never complete — MarkInterrupted transitions it
+// to failed. It returns the number of jobs reconciled. A no-op (0, nil) when no
+// store is configured. Call once after Register, before serving.
+func (r *Runner) Recover(ctx context.Context) (int, error) {
+	if r.store == nil {
+		return 0, nil
+	}
+	return r.store.MarkInterrupted(ctx)
 }
 
 // safeRun invokes a handler with panic recovery, converting a panic into a

--- a/internal/platform/jobs/jobs_store_test.go
+++ b/internal/platform/jobs/jobs_store_test.go
@@ -1,0 +1,200 @@
+package jobs_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+// fakeStore is a concurrency-safe in-memory jobs.Store for exercising the
+// runner's durability seam without a database.
+type fakeStore struct {
+	mu       sync.Mutex
+	jobs     map[string]jobs.Job
+	saves    int
+	loadErr  error
+	failSave bool
+}
+
+func newFakeStore() *fakeStore { return &fakeStore{jobs: make(map[string]jobs.Job)} }
+
+func (s *fakeStore) Save(_ context.Context, j jobs.Job) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failSave {
+		return errors.New("fakeStore: save failed")
+	}
+	s.jobs[j.ID] = j
+	s.saves++
+	return nil
+}
+
+func (s *fakeStore) Load(_ context.Context, id string) (jobs.Job, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.loadErr != nil {
+		return jobs.Job{}, false, s.loadErr
+	}
+	j, ok := s.jobs[id]
+	return j, ok, nil
+}
+
+func (s *fakeStore) MarkInterrupted(_ context.Context) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for id, j := range s.jobs {
+		if j.State == jobs.StateQueued || j.State == jobs.StateRunning {
+			j.State = jobs.StateFailed
+			j.Err = "interrupted by restart"
+			s.jobs[id] = j
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (s *fakeStore) snapshot(id string) (jobs.Job, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[id]
+	return j, ok
+}
+
+// waitForStoreState polls the store until id reaches state, failing on timeout.
+// The runner persists after publishing, so a test that awaits the bus event
+// must still wait for the (best-effort, slightly later) write-through.
+func waitForStoreState(t *testing.T, s *fakeStore, id string, state jobs.State) jobs.Job {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		if j, ok := s.snapshot(id); ok && j.State == state {
+			return j
+		}
+		select {
+		case <-deadline:
+			j, _ := s.snapshot(id)
+			t.Fatalf("store never saw job %s in state %q (last %q)", id, state, j.State)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+// TestRunnerWritesThroughToStore verifies a successful job's terminal snapshot
+// is persisted, with the success result captured.
+func TestRunnerWritesThroughToStore(t *testing.T) {
+	t.Parallel()
+
+	fs := newFakeStore()
+	f := newFixture(t, jobs.Config{Store: fs})
+	if err := f.runner.Register("noop", okHandler("payload")); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	succeeded := f.watch(t, jobs.StateSucceeded)
+
+	id, err := f.runner.Submit("noop", nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	awaitJob(t, succeeded, id)
+
+	persisted := waitForStoreState(t, fs, id, jobs.StateSucceeded)
+	if persisted.Kind != "noop" {
+		t.Errorf("persisted kind = %q, want noop", persisted.Kind)
+	}
+	if persisted.Result != "payload" {
+		t.Errorf("persisted result = %v, want payload", persisted.Result)
+	}
+}
+
+// TestRunnerGetFallsBackToStore proves a Get miss in memory is served from the
+// store — the post-restart / post-eviction retrieval path.
+func TestRunnerGetFallsBackToStore(t *testing.T) {
+	t.Parallel()
+
+	fs := newFakeStore()
+	fs.jobs["ghost"] = jobs.Job{
+		ID: "ghost", Kind: "speedtest", State: jobs.StateSucceeded,
+		Progress: 1, Result: "from-store",
+	}
+	f := newFixture(t, jobs.Config{Store: fs})
+
+	got, ok := f.runner.Get("ghost")
+	if !ok {
+		t.Fatal("Get returned !ok; expected fallback to store")
+	}
+	if got.State != jobs.StateSucceeded || got.Result != "from-store" {
+		t.Errorf("got %+v, want succeeded/from-store", got)
+	}
+}
+
+// TestRunnerGetStoreMissReturnsFalse: unknown id, store also misses.
+func TestRunnerGetStoreMissReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{Store: newFakeStore()})
+	if _, ok := f.runner.Get("nope"); ok {
+		t.Error("Get returned ok for an id absent from memory and store")
+	}
+}
+
+// TestRunnerRecoverMarksInterrupted: jobs left non-terminal by a prior process
+// are transitioned to failed at startup.
+func TestRunnerRecoverMarksInterrupted(t *testing.T) {
+	t.Parallel()
+
+	fs := newFakeStore()
+	fs.jobs["a"] = jobs.Job{ID: "a", Kind: "k", State: jobs.StateRunning}
+	fs.jobs["b"] = jobs.Job{ID: "b", Kind: "k", State: jobs.StateQueued}
+	fs.jobs["c"] = jobs.Job{ID: "c", Kind: "k", State: jobs.StateSucceeded}
+	f := newFixture(t, jobs.Config{Store: fs})
+
+	n, err := f.runner.Recover(context.Background())
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("recovered = %d, want 2 (the running + queued)", n)
+	}
+	if j, _ := fs.snapshot("c"); j.State != jobs.StateSucceeded {
+		t.Errorf("terminal job c mutated to %q", j.State)
+	}
+}
+
+// TestRunnerStoreSaveErrorDoesNotFailJob proves persistence is best-effort: a
+// store that always errors must not stop a job from running to success.
+func TestRunnerStoreSaveErrorDoesNotFailJob(t *testing.T) {
+	t.Parallel()
+
+	fs := newFakeStore()
+	fs.failSave = true
+	f := newFixture(t, jobs.Config{Store: fs})
+	if err := f.runner.Register("noop", okHandler("ok")); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	succeeded := f.watch(t, jobs.StateSucceeded)
+
+	id, err := f.runner.Submit("noop", nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	done := awaitJob(t, succeeded, id)
+	if done.State != jobs.StateSucceeded {
+		t.Errorf("state = %q, want succeeded despite store errors", done.State)
+	}
+}
+
+// TestRunnerNilStoreRecoverNoOp: Recover is a no-op without a store.
+func TestRunnerNilStoreRecoverNoOp(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t, jobs.Config{})
+	n, err := f.runner.Recover(context.Background())
+	if err != nil || n != 0 {
+		t.Errorf("Recover with nil store = (%d, %v), want (0, nil)", n, err)
+	}
+}


### PR DESCRIPTION
## Phase 5c-2 — durable Store seam

Second slice of **Phase 5c**. The `platform/jobs` Runner gains an optional durable backing via a new **`jobs.Store`** interface (`Save` / `Load` / `MarkInterrupted`), wired as `Config.Store`. **Purely additive** — a nil Store keeps the in-memory-only fail-cleanly v1, so the live server (which doesn't set it yet) is unchanged. The SQLite adapter over the 5c-1 `JobRepository` + composition-root wiring + boot recovery land in the next slice.

### What's here
- **Write-through** on the three state transitions — Submit (`queued`), the `running` transition, and finish (terminal). Progress ticks are deliberately **not** persisted (too frequent; a restart marks an in-flight job interrupted anyway). Persistence is **best-effort**: a Save error is logged, never fails the job — the in-memory map stays authoritative for the live job. Done outside the lock (after the bus publish), so it never extends the critical section.
- **Get read-fallback** — a memory miss falls back to `Store.Load`, so a job that completed before a restart (or was evicted by `Cleanup`) is still retrievable.
- **`Recover(ctx)`** — at startup, transitions persisted `queued`/`running` jobs (whose handler goroutines died with the old process) to `failed` via `MarkInterrupted`. No-op without a store.

### Gates
- **Full `go test -race ./internal/platform/jobs/` green** — existing tests unchanged (nil store = no behavior change) + **6 new store-seam tests** against a fake store: write-through with result capture, Get fallback, store miss, Recover (only non-terminal transitioned), best-effort save-error doesn't fail the job, nil-store no-op.
- `golangci-lint` 0; `go build ./cmd/seed/` ok.

No migration/golden/UI churn — Go-only PR; Backend (Go) + race run, Frontend skips. Admin-merge after the Go gates are green.