### PR TITLE
feat(jobs): wire durable SQLite store into the runner + boot recovery (ADR-0005, Phase 5c-3)

### DIFF
--- a/internal/api/jobs_store.go
+++ b/internal/api/jobs_store.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+// dbJobStore adapts the durable database.JobRepository to the jobs.Store seam
+// the runner write-throughs (ADR-0005, Phase 5c). It is the composition-root
+// bridge between platform/jobs (which must not know about persistence) and the
+// jobs table: it marshals the job's result to JSON and derives the
+// created/updated/completed timestamps the in-memory Job snapshot does not carry.
+type dbJobStore struct {
+	repo *database.JobRepository
+	now  func() time.Time
+}
+
+// newDBJobStore builds the adapter over db's jobs repository.
+func newDBJobStore(db *database.DB) *dbJobStore {
+	return &dbJobStore{
+		repo: db.Jobs(),
+		now:  func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Save write-throughs a snapshot. created_at is set on every call but kept by
+// the repository's upsert only on first insert; completed_at is stamped once the
+// job reaches a terminal state and left NULL while active.
+func (s *dbJobStore) Save(ctx context.Context, j jobs.Job) error {
+	now := s.now()
+	rec := &database.JobRecord{
+		ID:        j.ID,
+		Kind:      j.Kind,
+		State:     string(j.State),
+		Progress:  j.Progress,
+		Error:     j.Err,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if j.Result != nil {
+		if b, err := json.Marshal(j.Result); err == nil {
+			rec.ResultJSON = string(b)
+		}
+	}
+	if jobStateTerminal(j.State) {
+		rec.CompletedAt = now
+	}
+	return s.repo.Save(ctx, rec)
+}
+
+// Load returns the persisted job. A missing row is (zero, false, nil), not an
+// error, so the runner's Get fallback treats it as a plain miss. The stored
+// result comes back as [json.RawMessage] — the HTTP layer re-marshals it
+// transparently, so a store-served job is wire-identical to a memory-served one.
+func (s *dbJobStore) Load(ctx context.Context, id string) (jobs.Job, bool, error) {
+	rec, err := s.repo.Get(ctx, id)
+	if errors.Is(err, database.ErrJobNotFound) {
+		return jobs.Job{}, false, nil
+	}
+	if err != nil {
+		return jobs.Job{}, false, err
+	}
+	j := jobs.Job{
+		ID:       rec.ID,
+		Kind:     rec.Kind,
+		State:    jobs.State(rec.State),
+		Progress: rec.Progress,
+		Err:      rec.Error,
+	}
+	if rec.ResultJSON != "" {
+		j.Result = json.RawMessage(rec.ResultJSON)
+	}
+	return j, true, nil
+}
+
+// MarkInterrupted reconciles persisted in-flight jobs at startup.
+func (s *dbJobStore) MarkInterrupted(ctx context.Context) (int, error) {
+	return s.repo.MarkInterrupted(ctx)
+}
+
+// jobStateTerminal reports whether a job state is final. It mirrors the runner's
+// own (unexported) notion so the adapter can decide when to stamp completed_at.
+func jobStateTerminal(state jobs.State) bool {
+	switch state {
+	case jobs.StateSucceeded, jobs.StateFailed, jobs.StateCancelled:
+		return true
+	case jobs.StateQueued, jobs.StateRunning:
+		return false
+	default:
+		return false
+	}
+}

--- a/internal/api/jobs_store_internal_test.go
+++ b/internal/api/jobs_store_internal_test.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/platform/events"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+func newJobStoreTestDB(t *testing.T) *database.DB {
+	t.Helper()
+	db, err := database.Open(filepath.Join(t.TempDir(), "jobs-store.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestDBJobStoreSaveLoadRoundTrip proves a terminal job round-trips through the
+// adapter: the result is stored as JSON and returned as [json.RawMessage].
+func TestDBJobStoreSaveLoadRoundTrip(t *testing.T) {
+	t.Parallel()
+	store := newDBJobStore(newJobStoreTestDB(t))
+	ctx := context.Background()
+
+	want := jobs.Job{
+		ID: "j1", Kind: "speedtest", State: jobs.StateSucceeded, Progress: 1,
+		Result: map[string]any{"downloadMbps": 100},
+	}
+	if err := store.Save(ctx, want); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, ok, err := store.Load(ctx, "j1")
+	if err != nil || !ok {
+		t.Fatalf("load: ok=%v err=%v", ok, err)
+	}
+	if got.Kind != "speedtest" || got.State != jobs.StateSucceeded || got.Progress != 1 {
+		t.Errorf("got %+v, want speedtest/succeeded/1", got)
+	}
+	raw, isRaw := got.Result.(json.RawMessage)
+	if !isRaw {
+		t.Fatalf("Result type = %T, want json.RawMessage", got.Result)
+	}
+	var decoded map[string]any
+	if uErr := json.Unmarshal(raw, &decoded); uErr != nil {
+		t.Fatalf("unmarshal result: %v", uErr)
+	}
+	if decoded["downloadMbps"] != float64(100) {
+		t.Errorf("result = %v, want downloadMbps=100", decoded)
+	}
+}
+
+// TestDBJobStoreLoadMiss: an unknown id is a clean miss, not an error.
+func TestDBJobStoreLoadMiss(t *testing.T) {
+	t.Parallel()
+	store := newDBJobStore(newJobStoreTestDB(t))
+
+	_, ok, err := store.Load(context.Background(), "absent")
+	if err != nil {
+		t.Fatalf("load miss returned error: %v", err)
+	}
+	if ok {
+		t.Error("load miss returned ok=true")
+	}
+}
+
+// TestDBJobStoreMarkInterrupted: only non-terminal jobs are reconciled to failed.
+func TestDBJobStoreMarkInterrupted(t *testing.T) {
+	t.Parallel()
+	store := newDBJobStore(newJobStoreTestDB(t))
+	ctx := context.Background()
+
+	for _, j := range []jobs.Job{
+		{ID: "run", Kind: "k", State: jobs.StateRunning, Progress: 0.5},
+		{ID: "queue", Kind: "k", State: jobs.StateQueued},
+		{ID: "done", Kind: "k", State: jobs.StateSucceeded, Progress: 1},
+	} {
+		if err := store.Save(ctx, j); err != nil {
+			t.Fatalf("save %s: %v", j.ID, err)
+		}
+	}
+
+	n, err := store.MarkInterrupted(ctx)
+	if err != nil {
+		t.Fatalf("mark interrupted: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("interrupted = %d, want 2", n)
+	}
+	for _, id := range []string{"run", "queue"} {
+		j, _, _ := store.Load(ctx, id)
+		if j.State != jobs.StateFailed {
+			t.Errorf("%s state = %q, want failed", id, j.State)
+		}
+	}
+	done, _, _ := store.Load(ctx, "done")
+	if done.State != jobs.StateSucceeded {
+		t.Errorf("terminal job mutated to %q", done.State)
+	}
+}
+
+// TestRunnerRecoversAcrossRestart wires the adapter into a runner and proves the
+// full restart story: a job persisted as running by a prior process is
+// reconciled to failed on Recover and is then retrievable via the runner's
+// store fallback even though it was never in this runner's memory.
+func TestRunnerRecoversAcrossRestart(t *testing.T) {
+	t.Parallel()
+	db := newJobStoreTestDB(t)
+	store := newDBJobStore(db)
+	ctx := context.Background()
+
+	// Prior process left a job mid-flight.
+	if err := store.Save(ctx, jobs.Job{ID: "stale", Kind: "engine-scan", State: jobs.StateRunning}); err != nil {
+		t.Fatalf("seed running job: %v", err)
+	}
+
+	// New process: fresh runner over the same durable store.
+	bus := events.New(slog.New(slog.DiscardHandler))
+	runner := jobs.New(bus, slog.New(slog.DiscardHandler), jobs.Config{Store: store})
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = runner.Close(closeCtx)
+		_ = bus.Close(closeCtx)
+	})
+
+	n, err := runner.Recover(ctx)
+	if err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("recovered = %d, want 1", n)
+	}
+
+	// The job is not in this runner's memory; Get must fall back to the store
+	// and report the reconciled terminal state.
+	got, ok := runner.Get("stale")
+	if !ok {
+		t.Fatal("Get(stale) !ok; expected store fallback")
+	}
+	if got.State != jobs.StateFailed {
+		t.Errorf("recovered job state = %q, want failed", got.State)
+	}
+}

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -155,11 +155,29 @@ func (s *Server) initSSEAndLogging(db *database.DB) {
 	// adapts it. No job kinds are registered yet — they arrive as the real
 	// long-ops are migrated in a later slice; both Close() on shutdown.
 	s.services.RealTime.EventBus = events.New(logging.GetLogger())
+	jobsCfg := jobs.Config{Retention: jobsRetention}
+	if db != nil {
+		// Durable backing (Phase 5c): the runner write-throughs lifecycle
+		// transitions so a job survives a restart. Without a database the runner
+		// stays in-memory only (the fail-cleanly v1).
+		jobsCfg.Store = newDBJobStore(db)
+	}
 	s.services.RealTime.Jobs = jobs.New(
-		s.services.RealTime.EventBus, logging.GetLogger(), jobs.Config{Retention: jobsRetention},
+		s.services.RealTime.EventBus, logging.GetLogger(), jobsCfg,
 	)
 	s.services.RealTime.JobIdempotency = newJobIdempotencyCache(jobIdempotencyCapacity)
 	s.registerJobKinds()
+
+	// Reconcile jobs left in-flight by a previous process: their handler
+	// goroutines died with that process, so they can never complete and are
+	// transitioned to failed. No-op when the runner has no durable store.
+	if db != nil {
+		if n, recErr := s.jobsRunner().Recover(context.Background()); recErr != nil {
+			logging.GetLogger().Warn("job recovery failed", "error", recErr)
+		} else if n > 0 {
+			logging.GetLogger().Info("recovered interrupted jobs from a prior run", "count", n)
+		}
+	}
 
 	// Wire up database persistence for logs if database is available
 	if db != nil {

--- a/internal/database/repository_jobs.go
+++ b/internal/database/repository_jobs.go
@@ -134,6 +134,25 @@ func (r *JobRepository) DeleteCompletedBefore(ctx context.Context, cutoff time.T
 	return n, nil
 }
 
+// MarkInterrupted transitions every non-terminal job (queued or running) to
+// failed, stamping an interruption error and the completion time. It is the
+// startup-recovery primitive (Phase 5c): after a restart the handler goroutines
+// of any in-flight job are gone, so those rows can never reach a terminal state
+// on their own and are reconciled here. Returns the number of rows transitioned.
+func (r *JobRepository) MarkInterrupted(ctx context.Context) (int, error) {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	res, err := r.db.Exec(ctx, `
+		UPDATE jobs
+		SET state = 'failed', error = ?, updated_at = ?, completed_at = ?
+		WHERE state IN ('queued', 'running')
+	`, "interrupted by restart", now, now)
+	if err != nil {
+		return 0, fmt.Errorf("mark interrupted jobs: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
 // scanJob maps one jobs row into a JobRecord, translating [sql.ErrNoRows] into
 // ErrJobNotFound for the single-row Get path.
 func scanJob(scan func(...any) error) (*JobRecord, error) {

--- a/internal/database/repository_jobs_test.go
+++ b/internal/database/repository_jobs_test.go
@@ -213,6 +213,45 @@ func TestJobsProgressCheckRejectsOutOfRange(t *testing.T) {
 	}
 }
 
+func TestJobsMarkInterrupted(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupJobsTest(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	mustSave(ctx, t, repo, &database.JobRecord{ID: "q", Kind: "k", State: "queued", CreatedAt: now, UpdatedAt: now})
+	mustSave(
+		ctx,
+		t,
+		repo,
+		&database.JobRecord{ID: "r", Kind: "k", State: "running", Progress: 0.5, CreatedAt: now, UpdatedAt: now},
+	)
+	mustSave(ctx, t, repo, &database.JobRecord{
+		ID: "ok", Kind: "k", State: "succeeded", Progress: 1,
+		CreatedAt: now, UpdatedAt: now, CompletedAt: now,
+	})
+
+	n, err := repo.MarkInterrupted(ctx)
+	if err != nil {
+		t.Fatalf("mark interrupted: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("interrupted = %d, want 2 (queued + running)", n)
+	}
+	for _, id := range []string{"q", "r"} {
+		got, gErr := repo.Get(ctx, id)
+		if gErr != nil {
+			t.Fatalf("get %s: %v", id, gErr)
+		}
+		if got.State != "failed" || got.Error == "" || got.CompletedAt.IsZero() {
+			t.Errorf("%s: state=%q error=%q completedAt=%v, want failed/non-empty/non-zero",
+				id, got.State, got.Error, got.CompletedAt)
+		}
+	}
+	if got, _ := repo.Get(ctx, "ok"); got.State != "succeeded" {
+		t.Errorf("terminal job mutated to %q", got.State)
+	}
+}
+
 func mustSave(ctx context.Context, t *testing.T, repo *database.JobRepository, rec *database.JobRecord) {
 	t.Helper()
 	if err := repo.Save(ctx, rec); err != nil {


### PR DESCRIPTION
## Phase 5c-3 — durable store wired into the live runner

Third slice of **Phase 5c**: the durability seam (5c-2) meets the durable jobs table (5c-1). The live runner now **persists across restarts**; with no database it still degrades to the in-memory fail-cleanly v1.

### What's here
- **`internal/api/jobs_store.go`** — `dbJobStore` adapts `database.JobRepository` to the `jobs.Store` interface: the composition-root bridge that keeps `platform/jobs` free of persistence. Marshals the job result to JSON, derives the created/updated/completed timestamps the in-memory snapshot lacks, maps `ErrJobNotFound` to a clean `(false)` miss, and returns a stored result as `json.RawMessage` (wire-identical to a memory-served job).
- **`repository_jobs.go`** — `JobRepository.MarkInterrupted`: one `UPDATE` transitioning `queued`/`running` rows to `failed` (the startup-recovery primitive).
- **`server_init.go`** — when a database is present the runner is built with `Config.Store = newDBJobStore(db)` and, after kinds are registered, `runner.Recover()` reconciles jobs left in-flight by the prior process.

### Gates
- **Full `go test -race ./internal/database/` green** (+ direct `TestJobsMarkInterrupted`).
- **`internal/api` jobs-store integration tests green**: Save/Load round-trip with result, clean miss, MarkInterrupted, and a **full restart simulation** — a persisted `running` job → `Recover` → `failed` → retrievable via the runner's store fallback.
- **Golden HTTP harness green** — no route/response churn; jobs simply persist now.
- `golangci-lint` 0; `go build ./cmd/seed/` ok.

After this, durable jobs survive restart end-to-end. Remaining 5c: the transactional **outbox** (events emit post-commit) and **durable idempotency** (swap the Phase-4 in-memory `Idempotency-Key` cache). Admin-merge after Go gates green.