### PR TITLE
feat(jobs): durable Idempotency-Key store for POST /jobs (ADR-0005, Phase 5c-4)

### DIFF
--- a/internal/api/handlers_jobs.go
+++ b/internal/api/handlers_jobs.go
@@ -101,7 +101,7 @@ func (s *Server) handleJobs(w http.ResponseWriter, r *http.Request) {
 	// than creating a duplicate; the same key with a different body conflicts.
 	key := r.Header.Get("Idempotency-Key")
 	if key != "" {
-		switch res := s.jobIdempotency().check(key, req); res.kind {
+		switch res := s.jobIdempotency().check(r.Context(), key, req); res.kind {
 		case idemConflict:
 			sendErrorResponseWithDetails(w, logger, http.StatusConflict, ErrCodeConflict,
 				"Idempotency-Key already used with different parameters", "")
@@ -122,7 +122,7 @@ func (s *Server) handleJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if key != "" {
-		s.jobIdempotency().store(key, req, id)
+		s.jobIdempotency().store(r.Context(), key, req, id)
 	}
 
 	j, _ := s.jobsRunner().Get(id)
@@ -359,8 +359,18 @@ func requestHash(req CreateJobRequest) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+// jobIdempotencyStore dedups POST /jobs by Idempotency-Key. The in-memory
+// jobIdempotencyCache (no database) and the durable dbJobIdempotency both
+// satisfy it; ctx is honored by the durable implementation and ignored by the
+// cache. Both are best-effort: a backend error degrades to idemMiss (create)
+// rather than failing the request.
+type jobIdempotencyStore interface {
+	check(ctx context.Context, key string, req CreateJobRequest) idemResult
+	store(ctx context.Context, key string, req CreateJobRequest, jobID string)
+}
+
 // check classifies a key against a request without recording anything.
-func (c *jobIdempotencyCache) check(key string, req CreateJobRequest) idemResult {
+func (c *jobIdempotencyCache) check(_ context.Context, key string, req CreateJobRequest) idemResult {
 	h := requestHash(req)
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -375,7 +385,7 @@ func (c *jobIdempotencyCache) check(key string, req CreateJobRequest) idemResult
 }
 
 // store records the job a key created, evicting the oldest key past capacity.
-func (c *jobIdempotencyCache) store(key string, req CreateJobRequest, jobID string) {
+func (c *jobIdempotencyCache) store(_ context.Context, key string, req CreateJobRequest, jobID string) {
 	h := requestHash(req)
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/api/jobs_store.go
+++ b/internal/api/jobs_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/database"
@@ -81,6 +82,40 @@ func (s *dbJobStore) Load(ctx context.Context, id string) (jobs.Job, bool, error
 // MarkInterrupted reconciles persisted in-flight jobs at startup.
 func (s *dbJobStore) MarkInterrupted(ctx context.Context) (int, error) {
 	return s.repo.MarkInterrupted(ctx)
+}
+
+// dbJobIdempotency is the durable Idempotency-Key store backing POST /jobs
+// (Phase 5c-4), satisfying jobIdempotencyStore over database.JobRepository.
+// Best-effort, matching the in-memory cache: a backend error degrades a check to
+// idemMiss (create afresh) and a store failure is logged, never surfaced.
+type dbJobIdempotency struct {
+	repo   *database.JobRepository
+	logger *slog.Logger
+}
+
+func newDBJobIdempotency(db *database.DB, logger *slog.Logger) *dbJobIdempotency {
+	return &dbJobIdempotency{repo: db.Jobs(), logger: logger}
+}
+
+func (d *dbJobIdempotency) check(ctx context.Context, key string, req CreateJobRequest) idemResult {
+	jobID, storedHash, found, err := d.repo.LookupIdempotency(ctx, key)
+	if err != nil {
+		d.logger.ErrorContext(ctx, "idempotency lookup failed; treating as miss", "err", err)
+		return idemResult{kind: idemMiss}
+	}
+	if !found {
+		return idemResult{kind: idemMiss}
+	}
+	if storedHash != requestHash(req) {
+		return idemResult{kind: idemConflict}
+	}
+	return idemResult{id: jobID, kind: idemHit}
+}
+
+func (d *dbJobIdempotency) store(ctx context.Context, key string, req CreateJobRequest, jobID string) {
+	if err := d.repo.RecordIdempotency(ctx, key, requestHash(req), jobID); err != nil {
+		d.logger.ErrorContext(ctx, "idempotency record failed", "err", err)
+	}
 }
 
 // jobStateTerminal reports whether a job state is final. It mirrors the runner's

--- a/internal/api/jobs_store_internal_test.go
+++ b/internal/api/jobs_store_internal_test.go
@@ -12,6 +12,37 @@ import (
 	"github.com/krisarmstrong/seed/internal/platform/jobs"
 )
 
+// TestDBJobIdempotency exercises the durable Idempotency-Key store through its
+// interface: miss -> store -> hit (same body) -> conflict (changed body).
+func TestDBJobIdempotency(t *testing.T) {
+	t.Parallel()
+	db := newJobStoreTestDB(t)
+	ctx := context.Background()
+
+	// The key's FK requires the job row to exist first (the runner persists on
+	// Submit before the handler records the key).
+	if err := newDBJobStore(db).Save(ctx, jobs.Job{ID: "j1", Kind: "speedtest", State: jobs.StateQueued}); err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+
+	var idem jobIdempotencyStore = newDBJobIdempotency(db, slog.New(slog.DiscardHandler))
+	req := CreateJobRequest{Kind: "speedtest", Params: json.RawMessage(`{"server":"a"}`)}
+
+	if res := idem.check(ctx, "key-1", req); res.kind != idemMiss {
+		t.Fatalf("first check = %v, want idemMiss", res.kind)
+	}
+	idem.store(ctx, "key-1", req, "j1")
+
+	if res := idem.check(ctx, "key-1", req); res.kind != idemHit || res.id != "j1" {
+		t.Errorf("replay check = (%v,%q), want (idemHit,j1)", res.kind, res.id)
+	}
+
+	other := CreateJobRequest{Kind: "speedtest", Params: json.RawMessage(`{"server":"DIFFERENT"}`)}
+	if res := idem.check(ctx, "key-1", other); res.kind != idemConflict {
+		t.Errorf("changed-body check = %v, want idemConflict", res.kind)
+	}
+}
+
 func newJobStoreTestDB(t *testing.T) *database.DB {
 	t.Helper()
 	db, err := database.Open(filepath.Join(t.TempDir(), "jobs-store.db"))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -702,7 +702,7 @@ func (s *Server) sseHub() *SSEHub                          { return s.services.R
 func (s *Server) logBroadcaster() *logging.LogBroadcaster  { return s.services.RealTime.LogBroadcaster }
 func (s *Server) eventBus() *events.Bus                    { return s.services.RealTime.EventBus }
 func (s *Server) jobsRunner() *jobs.Runner                 { return s.services.RealTime.Jobs }
-func (s *Server) jobIdempotency() *jobIdempotencyCache     { return s.services.RealTime.JobIdempotency }
+func (s *Server) jobIdempotency() jobIdempotencyStore      { return s.services.RealTime.JobIdempotency }
 func (s *Server) db() *database.DB                         { return s.services.Database.DB }
 
 // webAuthnConfigFromServer derives the relying-party config for the

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -165,7 +165,13 @@ func (s *Server) initSSEAndLogging(db *database.DB) {
 	s.services.RealTime.Jobs = jobs.New(
 		s.services.RealTime.EventBus, logging.GetLogger(), jobsCfg,
 	)
-	s.services.RealTime.JobIdempotency = newJobIdempotencyCache(jobIdempotencyCapacity)
+	if db != nil {
+		// Durable Idempotency-Key dedup (Phase 5c-4): survives restart, so a
+		// client retry across a restart still replays rather than duplicating.
+		s.services.RealTime.JobIdempotency = newDBJobIdempotency(db, logging.GetLogger())
+	} else {
+		s.services.RealTime.JobIdempotency = newJobIdempotencyCache(jobIdempotencyCapacity)
+	}
 	s.registerJobKinds()
 
 	// Reconcile jobs left in-flight by a previous process: their handler

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -176,7 +176,7 @@ type RealTimeServices struct {
 	LogBroadcaster *logging.LogBroadcaster // Log streaming
 	EventBus       *events.Bus             // in-process domain event bus (ADR-0004)
 	Jobs           *jobs.Runner            // unified async job runner (ADR-0005)
-	JobIdempotency *jobIdempotencyCache    // Idempotency-Key dedup for POST /jobs
+	JobIdempotency jobIdempotencyStore     // Idempotency-Key dedup for POST /jobs
 }
 
 // DatabaseServices groups database-related services.

--- a/internal/database/migrations/00003_job_idempotency.sql
+++ b/internal/database/migrations/00003_job_idempotency.sql
@@ -1,0 +1,23 @@
+-- 00003_job_idempotency.sql — durable Idempotency-Key store (ADR-0005, Phase 5c-4).
+-- The POST /jobs Idempotency-Key dedup shipped (Phase 4) as a bounded in-memory
+-- FIFO cache — lost on restart, so a client retry across a restart could create
+-- a duplicate job. This table makes it durable: a key maps to the job it
+-- created plus a hash of the request, so a replay is detected and a reused key
+-- with a different body conflicts. ON DELETE CASCADE ties a key's lifetime to
+-- its job — when retention deletes the job, its key goes too (a later replay
+-- then misses and creates afresh, which the handler already tolerates).
+-- STRICT, consistent with the 0001/0002 baselines. Regenerate the gate golden:
+--   UPDATE_SCHEMA_GOLDEN=1 go test ./internal/database/ -run TestSchemaSnapshot
+
+-- +goose Up
+CREATE TABLE job_idempotency (
+	key          TEXT NOT NULL PRIMARY KEY,
+	request_hash TEXT NOT NULL,
+	job_id       TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+	created_at   TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX idx_job_idempotency_job ON job_idempotency(job_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS job_idempotency;

--- a/internal/database/repository_jobs.go
+++ b/internal/database/repository_jobs.go
@@ -153,6 +153,40 @@ func (r *JobRepository) MarkInterrupted(ctx context.Context) (int, error) {
 	return int(n), nil
 }
 
+// LookupIdempotency returns the job an Idempotency-Key created and the request
+// hash recorded with it. found is false (with nil error) when the key is unseen
+// — the caller should create a new job.
+func (r *JobRepository) LookupIdempotency(
+	ctx context.Context, key string,
+) (string, string, bool, error) {
+	var jobID, requestHash string
+	row := r.db.QueryRow(ctx,
+		`SELECT job_id, request_hash FROM job_idempotency WHERE key = ?`, key)
+	if scanErr := row.Scan(&jobID, &requestHash); scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return "", "", false, nil
+		}
+		return "", "", false, fmt.Errorf("lookup idempotency key: %w", scanErr)
+	}
+	return jobID, requestHash, true, nil
+}
+
+// RecordIdempotency binds an Idempotency-Key to the job it created plus the
+// request hash. A repeat of the same key is a no-op (the first write wins), so
+// concurrent retries converge. The job_id FK requires the job row to exist —
+// the runner persists it on Submit before the handler records the key.
+func (r *JobRepository) RecordIdempotency(ctx context.Context, key, requestHash, jobID string) error {
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO job_idempotency (key, request_hash, job_id, created_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(key) DO NOTHING
+	`, key, requestHash, jobID, time.Now().UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("record idempotency key: %w", err)
+	}
+	return nil
+}
+
 // scanJob maps one jobs row into a JobRecord, translating [sql.ErrNoRows] into
 // ErrJobNotFound for the single-row Get path.
 func scanJob(scan func(...any) error) (*JobRecord, error) {

--- a/internal/database/repository_jobs_test.go
+++ b/internal/database/repository_jobs_test.go
@@ -252,6 +252,68 @@ func TestJobsMarkInterrupted(t *testing.T) {
 	}
 }
 
+func TestJobsIdempotency(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupJobsTest(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	mustSave(ctx, t, repo, &database.JobRecord{ID: "j1", Kind: "k", State: "queued", CreatedAt: now, UpdatedAt: now})
+
+	// Unseen key.
+	if _, _, found, err := repo.LookupIdempotency(ctx, "k1"); err != nil || found {
+		t.Fatalf("unseen key: found=%v err=%v, want false/nil", found, err)
+	}
+
+	// Record then look up.
+	if err := repo.RecordIdempotency(ctx, "k1", "hashA", "j1"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	jobID, hash, found, err := repo.LookupIdempotency(ctx, "k1")
+	if err != nil || !found || jobID != "j1" || hash != "hashA" {
+		t.Fatalf("lookup = (%q,%q,%v,%v), want (j1,hashA,true,nil)", jobID, hash, found, err)
+	}
+
+	// First write wins: a repeat is a no-op (ON CONFLICT DO NOTHING).
+	if recErr := repo.RecordIdempotency(ctx, "k1", "hashB", "j1"); recErr != nil {
+		t.Fatalf("re-record: %v", recErr)
+	}
+	if _, gotHash, _, _ := repo.LookupIdempotency(ctx, "k1"); gotHash != "hashA" {
+		t.Errorf("hash = %q after repeat, want hashA (first write wins)", gotHash)
+	}
+}
+
+func TestJobsIdempotencyFKRequiresJob(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupJobsTest(t)
+
+	// No job row exists for "ghost" -> the FK rejects the key.
+	if err := repo.RecordIdempotency(ctx, "k", "h", "ghost"); err == nil {
+		t.Fatal("expected FK violation recording a key for a nonexistent job")
+	}
+}
+
+func TestJobsIdempotencyCascadeOnJobDelete(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupJobsTest(t)
+
+	old := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+	mustSave(ctx, t, repo, &database.JobRecord{
+		ID: "j1", Kind: "k", State: "succeeded", Progress: 1,
+		CreatedAt: old, UpdatedAt: old, CompletedAt: old,
+	})
+	if err := repo.RecordIdempotency(ctx, "k1", "h", "j1"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	// Retention deletes the job; ON DELETE CASCADE removes its key too.
+	if _, err := repo.DeleteCompletedBefore(ctx, time.Now().UTC().Add(-time.Hour)); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, _, found, _ := repo.LookupIdempotency(ctx, "k1"); found {
+		t.Error("idempotency key survived its job's deletion; expected CASCADE")
+	}
+}
+
 func mustSave(ctx context.Context, t *testing.T, repo *database.JobRepository, rec *database.JobRecord) {
 	t.Helper()
 	if err := repo.Save(ctx, rec); err != nil {

--- a/internal/database/testdata/schema.sql
+++ b/internal/database/testdata/schema.sql
@@ -265,6 +265,9 @@ CREATE INDEX idx_health_hourly_bucket ON health_check_rollups_hourly(hour_bucket
 CREATE UNIQUE INDEX idx_health_hourly_unique
 				ON health_check_rollups_hourly(check_type, endpoint_name, hour_bucket);
 
+-- index: idx_job_idempotency_job
+CREATE INDEX idx_job_idempotency_job ON job_idempotency(job_id);
+
 -- index: idx_jobs_completed
 CREATE INDEX idx_jobs_completed ON jobs(completed_at);
 
@@ -1030,6 +1033,14 @@ CREATE TABLE health_check_rollups_hourly (
 				max_latency_ms REAL,
 				p95_latency_ms REAL
 			) STRICT;
+
+-- table: job_idempotency
+CREATE TABLE job_idempotency (
+	key          TEXT NOT NULL PRIMARY KEY,
+	request_hash TEXT NOT NULL,
+	job_id       TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+	created_at   TEXT NOT NULL
+) STRICT;
 
 -- table: jobs
 CREATE TABLE jobs (


### PR DESCRIPTION
## Phase 5c-4 — durable Idempotency-Key store

Fourth slice of **Phase 5c**. The Phase-4 `Idempotency-Key` dedup was a bounded in-memory FIFO cache — lost on restart, so a client retry *across* a restart could create a duplicate job. This makes it durable, keeping the in-memory cache as the no-database fallback.

### What's here
- **`migrations/00003_job_idempotency.sql`** — `job_idempotency` (STRICT) mapping `key → (request_hash, job_id)` with an FK to `jobs(id) ON DELETE CASCADE` (a key's lifetime is tied to its job; retention deletes both, and a later replay then misses → creates afresh, which the handler already tolerates) + an index on `job_id` for the cascade.
- **`repository_jobs.go`** — `LookupIdempotency` + `RecordIdempotency` (`INSERT … ON CONFLICT(key) DO NOTHING` — first write wins, so concurrent retries converge).
- **`handlers_jobs.go`** — extracted a `jobIdempotencyStore` interface (`check`/`store` now take `ctx`); both the in-memory cache and the durable store satisfy it.
- **`jobs_store.go`** — `dbJobIdempotency` over `JobRepository`, best-effort like the cache (a lookup error degrades to `idemMiss`/create; a store error is logged).
- **`server_init.go`** — durable store when a database is present, else the in-memory cache. Field/accessor widened to the interface.

### Gates
- **Full `go test -race ./internal/database/` green** — repo idempotency tests (lookup/record, first-write-wins, FK-requires-job, CASCADE-on-job-delete) + the 3-migration schema gates.
- **`internal/api` green** — `dbJobIdempotency` miss/hit/conflict through the interface; the existing handler `409`/replay tests still pass on the in-memory cache; golden HTTP harness unchanged.
- `golangci-lint` 0; `go build ./cmd/seed/` ok. Schema golden additive (table + index only).

Remaining 5c: the transactional **outbox** (deferred by design decision — revisit given the in-process bus) and the durable **retention sweep** (wire `Cleanup`/`DeleteCompletedBefore` to a scheduler tick — none exists yet). Admin-merge after Go gates green.