### PR TITLE
feat(jobs): wire jobs retention into the maintenance loop (ADR-0005, Phase 5c)

### DIFF
--- a/internal/api/jobs_retention.go
+++ b/internal/api/jobs_retention.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+// sweepJobs evicts terminal jobs past the retention window (ADR-0005, Phase 5c).
+// It runs both halves of jobs retention: the in-memory runner's Cleanup (frees
+// the snapshot map) and the durable store's DeleteCompletedBefore (frees disk).
+// repo may be nil (no database) — then only the in-memory sweep runs. It is the
+// periodic jobs-retention task, driven by the maintenance loop; the two
+// primitives it calls are independently safe for terminal-only, age-bounded
+// eviction.
+func sweepJobs(
+	ctx context.Context,
+	runner *jobs.Runner,
+	repo *database.JobRepository,
+	cutoff time.Time,
+	logger *slog.Logger,
+) {
+	if runner != nil {
+		if n := runner.Cleanup(); n > 0 {
+			logger.DebugContext(ctx, "evicted terminal jobs from memory", "count", n)
+		}
+	}
+	if repo != nil {
+		if n, err := repo.DeleteCompletedBefore(ctx, cutoff); err != nil {
+			logger.ErrorContext(ctx, "jobs retention cleanup failed", "error", err)
+		} else if n > 0 {
+			logger.InfoContext(ctx, "jobs retention cleanup completed", "jobs_deleted", n)
+		}
+	}
+}

--- a/internal/api/jobs_retention_internal_test.go
+++ b/internal/api/jobs_retention_internal_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/database"
+	"github.com/krisarmstrong/seed/internal/platform/events"
+	"github.com/krisarmstrong/seed/internal/platform/jobs"
+)
+
+// TestSweepJobsDurable: only terminal jobs older than the cutoff are deleted
+// from the durable store; recent terminal jobs survive.
+func TestSweepJobsDurable(t *testing.T) {
+	t.Parallel()
+	repo := newJobStoreTestDB(t).Jobs()
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	if err := repo.Save(ctx, &database.JobRecord{
+		ID: "old", Kind: "k", State: "succeeded", Progress: 1,
+		CreatedAt: now.Add(-2 * time.Hour), UpdatedAt: now.Add(-2 * time.Hour),
+		CompletedAt: now.Add(-2 * time.Hour),
+	}); err != nil {
+		t.Fatalf("save old: %v", err)
+	}
+	if err := repo.Save(ctx, &database.JobRecord{
+		ID: "recent", Kind: "k", State: "failed", Error: "x",
+		CreatedAt: now, UpdatedAt: now, CompletedAt: now,
+	}); err != nil {
+		t.Fatalf("save recent: %v", err)
+	}
+
+	sweepJobs(ctx, nil, repo, now.Add(-time.Hour), slog.New(slog.DiscardHandler))
+
+	if _, err := repo.Get(ctx, "old"); !errors.Is(err, database.ErrJobNotFound) {
+		t.Errorf("old terminal job not evicted (err=%v)", err)
+	}
+	if _, err := repo.Get(ctx, "recent"); err != nil {
+		t.Errorf("recent terminal job wrongly evicted: %v", err)
+	}
+}
+
+// TestSweepJobsInMemory: a terminal job past the (zero) retention window is
+// evicted from the runner's in-memory map.
+func TestSweepJobsInMemory(t *testing.T) {
+	t.Parallel()
+	bus := events.New(slog.New(slog.DiscardHandler))
+	runner := jobs.New(bus, slog.New(slog.DiscardHandler), jobs.Config{Retention: 0})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = runner.Close(ctx)
+		_ = bus.Close(ctx)
+	})
+	if err := runner.Register("noop", func(context.Context, any, func(float64)) (any, error) {
+		return "ok", nil
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	id, err := runner.Submit("noop", nil)
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	// Wait for the job to reach a terminal state before sweeping.
+	deadline := time.After(5 * time.Second)
+	for {
+		j, ok := runner.Get(id)
+		if ok && (j.State == jobs.StateSucceeded || j.State == jobs.StateFailed) {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("job never reached terminal state")
+		case <-time.After(2 * time.Millisecond):
+		}
+	}
+
+	sweepJobs(context.Background(), runner, nil, time.Now().UTC(), slog.New(slog.DiscardHandler))
+
+	if _, ok := runner.Get(id); ok {
+		t.Error("terminal job not evicted from the in-memory runner")
+	}
+}
+
+// TestSweepJobsNilSafe: nil runner and nil repo are tolerated (no-op, no panic).
+func TestSweepJobsNilSafe(t *testing.T) {
+	t.Parallel()
+	sweepJobs(context.Background(), nil, nil, time.Now(), slog.New(slog.DiscardHandler))
+}

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -109,11 +109,12 @@ func (s *Server) initDatabaseServices(cfg *config.Config, db *database.DB) {
 	// Initialize MIB database for SNMP OID resolution
 	s.initMibDatabase(db)
 
-	// Start data retention cleanup in background (fixes #848)
-	if cfg.Database.RetentionDays > 0 {
-		s.services.Database.RetentionStopCh = make(chan struct{})
-		go s.startDataRetention(cfg.Database.RetentionDays)
-	}
+	// Start the background maintenance loop (fixes #848). db is non-nil here
+	// (the function returns early otherwise), so it always runs: it sweeps jobs
+	// retention every tick (the runner map + jobs table always grow) and applies
+	// the data-retention policy when a positive window is configured.
+	s.services.Database.RetentionStopCh = make(chan struct{})
+	go s.startMaintenance(cfg.Database.RetentionDays)
 }
 
 // initMibDatabase initializes the MIB database and loads built-in OID definitions.

--- a/internal/api/server_shutdown.go
+++ b/internal/api/server_shutdown.go
@@ -151,9 +151,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// startDataRetention runs periodic data cleanup based on retention policy (#755).
-// The goroutine respects shutdown signals to avoid leaks (fixes #848).
-func (s *Server) startDataRetention(retentionDays int) {
+// startMaintenance runs the periodic background maintenance loop: jobs retention
+// every tick (ADR-0005, Phase 5c) plus the data-retention policy (#755) when a
+// positive window is configured. The goroutine respects shutdown signals to
+// avoid leaks (fixes #848).
+func (s *Server) startMaintenance(retentionDays int) {
 	// Run cleanup every hour
 	ticker := time.NewTicker(time.Hour)
 	defer ticker.Stop()
@@ -174,8 +176,20 @@ func (s *Server) startDataRetention(retentionDays int) {
 			logging.GetLogger().Debug("Data retention goroutine shutting down")
 			return
 		case <-ticker.C:
-			if s.db() == nil {
-				return
+			// Jobs retention runs every tick, independent of the data-retention
+			// policy: the in-memory runner map and the durable jobs table both
+			// grow with every completed job (Phase 5c).
+			var jobsRepo *database.JobRepository
+			if s.db() != nil {
+				jobsRepo = s.db().Jobs()
+			}
+			sweepJobs(context.Background(), s.jobsRunner(), jobsRepo,
+				time.Now().UTC().Add(-jobsRetention), logging.GetLogger())
+
+			// Data-retention policy (metrics/alerts/etc.) is only applied when
+			// enabled; a zero window must never be interpreted as "delete all".
+			if retentionDays <= 0 || s.db() == nil {
+				continue
 			}
 			result, err := s.db().RunCleanup(context.Background(), policy)
 			if err != nil {


### PR DESCRIPTION
## Phase 5c — jobs retention sweep

Closes the real gap left by Phase 4: `Runner.Cleanup` and (5c-1) `JobRepository.DeleteCompletedBefore` both existed but **nothing called them**, so terminal jobs accumulated forever — in the in-memory runner map and in the `jobs` table. The existing hourly data-retention goroutine is generalized into a **maintenance loop** that sweeps jobs retention every tick, independent of the data-retention-days policy.

### What's here
- **`jobs_retention.go`** — `sweepJobs(ctx, runner, repo, cutoff, logger)`: evicts terminal jobs past the window from memory (`Runner.Cleanup`) and the durable store (`DeleteCompletedBefore`). nil repo (no database) runs the in-memory sweep only; nil runner tolerated.
- **`server_shutdown.go`** — `startDataRetention` → `startMaintenance`. Every tick sweeps jobs first (`cutoff = now - jobsRetention`), then applies the data-retention policy **only when `retentionDays > 0`** (a zero window must never mean "delete everything"). `db == nil` mid-loop now `continue`s (keeps sweeping memory) instead of killing the goroutine.
- **`server_init.go`** — the loop starts unconditionally in `initDatabaseServices` (which already returns early when `db` is nil), so jobs cleanup always runs in a database-backed deployment.

### Gates
- **`internal/api` tests green** — `sweepJobs` durable eviction (old terminal deleted, recent kept), in-memory eviction, nil-safety; golden HTTP harness unchanged.
- `platform/jobs` `-race` green; `golangci-lint` 0; `go build ./cmd/seed/` ok.

With this, Phase 5c's persistence is complete bar the outbox (deferred by decision — see ADR-0004 amendment coming next). Admin-merge after Go gates green.