### PR TITLE
docs(adr): record outbox deferral with a trigger; mark jobs durability done

### DIFF
--- a/docs/architecture/decisions/0004-event-bus.md
+++ b/docs/architecture/decisions/0004-event-bus.md
@@ -1,6 +1,7 @@
 # ADR-0004: In-process domain event bus
 
-**Status:** Accepted — 2026-05-31
+**Status:** Accepted — 2026-05-31 · Core implemented (Phase 4) — 2026-06-02 ·
+Outbox deferred (Phase 5c) — 2026-06-03
 
 ## Context
 
@@ -32,3 +33,51 @@ Semantics:
 - Needs the outbox to stay consistent with persistence.
 - Rejected pure app-layer orchestration: verbose for publish-many, grows the app layer.
   (Hybrid still allowed for trivial 1:1 calls, but the bus is the default.)
+
+## Implementation status (Phase 4 — 2026-06-02)
+
+- **Bus core** `internal/platform/events` (#1466): typed `Event` facts, `Subscribe`/
+  `Publish`/`Close`; async, ordered per-subscriber, at-least-once on `Close` drain,
+  panic-isolated. The unified jobs runner (ADR-0005) publishes `job.*` state-change
+  facts onto it; the `GET /api/v1/jobs/events` SSE stream is the first subscriber.
+
+## Amendment (2026-06-03): transactional outbox **deferred**, with a trigger
+
+The Decision above mandates a **transactional outbox** (events emit only after the
+DB commit). After Phase 5c made the jobs store durable (#1481–#1485 — write-through
+persistence, boot recovery, durable idempotency, retention), we deliberately
+**defer** the outbox rather than build it now. This is a recorded decision, not an
+omission.
+
+**Why defer.** The transactional outbox exists to prevent a *dual-write
+inconsistency* between the database and an **external or durable** consumer (a
+message broker, another process, a persistent worker): "state committed but the
+event to an outside party was lost." seed has no such consumer today:
+
+- the bus is **in-process, single binary** (this ADR) — no broker;
+- its only subscriber is the **ephemeral SSE bridge** (and a future in-process
+  lifecycle supervisor), which is gone on restart anyway;
+- on reconnect, clients **re-fetch state** from the now-durable `GET /jobs/{id}`
+  (Phase 5c), so a state change that committed without its in-process event being
+  observed is **self-healing** — there is no observable victim of the gap.
+
+Building the outbox now would rewrite the live publish path (the runner would stop
+publishing directly; `Save` would write job + outbox rows in one transaction; a
+relay would poll/signal, publish post-commit, and mark rows published) — adding a
+relay goroutine, poll cadence, and ordering concerns **for no present benefit**.
+That is premature infrastructure; fitting the pattern to the actual problem is the
+best-practice call.
+
+**Trigger to build it.** Implement the transactional outbox when **any** of these
+becomes true — at which point the dual-write gap gains an observable victim:
+
+1. a **cross-process** or out-of-band event consumer is introduced (a broker, a
+   sidecar, a separate worker, webhooks/push to an external system);
+2. a **durable subscriber** that must not miss an event across a restart exists
+   (e.g. a persisted audit/notification pipeline that does not re-derive from
+   queryable state);
+3. an event carries information **not reconstructable** from durable state via a
+   re-fetch (so "re-sync on reconnect" no longer heals a lost event).
+
+Until then the in-process bus + durable, queryable job state is the correct design.
+ADR-0005's "events emit post-commit via outbox" line is governed by this amendment.

--- a/docs/architecture/decisions/0005-unified-jobs.md
+++ b/docs/architecture/decisions/0005-unified-jobs.md
@@ -49,8 +49,14 @@ Shipped:
 
 Deviations / deferred from the original decision:
 
-- **Persistence is in-memory v1** (fail-cleanly-on-restart), not durable. The transactional
-  outbox + durable job store land in **Phase 5**; the runner already exposes the seam.
+- **Persistence is in-memory v1** (fail-cleanly-on-restart), not durable. — *Updated
+  (Phase 5c, 2026-06-03):* the **durable job store landed** (#1481–#1485): write-through
+  persistence + Get fallback (`jobs.Store` / `dbJobStore` over the `jobs` table),
+  boot recovery (`Recover` → in-flight jobs reconciled to failed), durable
+  Idempotency-Key dedup, and a retention sweep on the maintenance loop. The
+  **transactional outbox is deferred** with a documented trigger — see the ADR-0004
+  amendment (in-process bus + re-fetch-on-reconnect makes the dual-write gap
+  unobservable today).
 - **Legacy endpoints retained.** Each migrated op keeps its old `/telemetry/*` or
   `/security/*` run/status endpoint (additive strangler); the "~15 endpoints collapse"
   completes when the frontend consumes `/jobs` in **Phase 7**, at which point the legacy


### PR DESCRIPTION
## ADR-0004/0005 — outbox deferral, on the record

Phase 5c made the jobs store durable (#1481–#1485: write-through persistence, boot recovery, durable idempotency, retention sweep). ADR-0004 mandates a **transactional outbox**; rather than leave that mandate dangling, this records a **deliberate deferral with a trigger** — keeping the architecture decision honest.

- **ADR-0004** — adds an implementation-status note (bus core #1466) and an amendment: *why* the outbox is deferred (in-process bus, ephemeral SSE subscriber, clients re-fetch durable state on reconnect → the dual-write gap has no observable victim today), and an explicit **trigger** to build it (a cross-process/durable consumer appears, or an event carries info not reconstructable from durable state).
- **ADR-0005** — marks the durable job store as landed and points the outbox line at the ADR-0004 amendment.

Docs-only; no code change. CI Complete should pass with all code gates skipped.