### PR TITLE
refactor(capture): Capture port + pcap/nullcapture adapters (Phase 6 S1a)

### DIFF
--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -1,0 +1,59 @@
+// Package capture defines the live packet-capture port used by the discovery,
+// dhcp, and vlan features.
+//
+// The port exists to confine CGO. Live capture is backed by libpcap, pulled in
+// transitively by github.com/gopacket/gopacket/pcap (its pcap_unix.go /
+// pcap_darwin.go carry "#cgo LDFLAGS: -lpcap"). Importing that package taints a
+// build with CGO and re-links libpcap into every dependent test binary. By
+// routing capture through this interface, exactly one package imports
+// gopacket/pcap — the libpcap-backed adapter in internal/capture/pcap — so it is
+// the only CGO-tainted package. internal/capture/nullcapture is the CGO-free
+// stub used for CGO_ENABLED=0 builds (e.g. Windows) and pure-Go test runs.
+//
+// Only github.com/gopacket/gopacket/pcap carries the CGO directive; the gopacket
+// core and gopacket/layers are pure Go, so this port may name their types
+// (PacketDataSource, CaptureInfo, layers.LinkType) without taking on the taint.
+// See docs/architecture/CGO_BUILD_STRATEGY.md.
+package capture
+
+import (
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+)
+
+// BlockForever is the OpenLive timeout that makes packet reads block until a
+// packet arrives instead of returning on a timeout. It mirrors the value of
+// pcap.BlockForever so the libpcap adapter can pass it straight through; the
+// pcap adapter's test asserts the two stay equal so a gopacket upgrade that
+// changed the sentinel cannot silently break block-forever semantics here.
+const BlockForever = -10 * time.Millisecond
+
+// Handle is an open live-capture handle. It embeds gopacket.PacketDataSource so a
+// handle can be passed straight to
+// gopacket.NewPacketSource(handle, handle.LinkType()).
+type Handle interface {
+	gopacket.PacketDataSource
+
+	// SetBPFFilter installs a Berkeley Packet Filter expression, restricting the
+	// frames delivered by the handle.
+	SetBPFFilter(filter string) error
+
+	// LinkType reports the link-layer type of the handle, used as the gopacket
+	// decoder when building a packet source.
+	LinkType() layers.LinkType
+
+	// Close releases the handle and any associated OS resources.
+	Close()
+}
+
+// Opener opens live-capture handles on a named network interface. Implementations
+// are the libpcap adapter (internal/capture/pcap) and the no-op stub
+// (internal/capture/nullcapture).
+type Opener interface {
+	// OpenLive opens iface for live capture. snaplen is the per-packet capture
+	// length in bytes; promiscuous toggles promiscuous mode; timeout is the read
+	// timeout — pass BlockForever to block until a packet arrives.
+	OpenLive(iface string, snaplen int32, promiscuous bool, timeout time.Duration) (Handle, error)
+}

--- a/internal/capture/nullcapture/nullcapture.go
+++ b/internal/capture/nullcapture/nullcapture.go
@@ -1,0 +1,35 @@
+// Package nullcapture is the CGO-free capture.Opener used when live packet
+// capture is not compiled in: CGO_ENABLED=0 builds (e.g. Windows, where capture
+// is a no-op) and pure-Go test runs that must not link libpcap.
+//
+// OpenLive always fails with ErrUnavailable so callers degrade gracefully
+// ("capture unavailable") instead of panicking or linking libpcap.
+// See docs/architecture/CGO_BUILD_STRATEGY.md.
+package nullcapture
+
+import (
+	"errors"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/capture"
+)
+
+// ErrUnavailable is returned by OpenLive when the binary was built without live
+// capture support (CGO/libpcap).
+var ErrUnavailable = errors.New(
+	"capture: live packet capture unavailable (built without CGO/libpcap)",
+)
+
+// Compile-time guarantee: this stub implements the port.
+var _ capture.Opener = Opener{}
+
+// Opener is the no-op capture.Opener.
+type Opener struct{}
+
+// New returns a no-op capture.Opener.
+func New() Opener { return Opener{} }
+
+// OpenLive always returns ErrUnavailable.
+func (Opener) OpenLive(_ string, _ int32, _ bool, _ time.Duration) (capture.Handle, error) {
+	return nil, ErrUnavailable
+}

--- a/internal/capture/nullcapture/nullcapture_test.go
+++ b/internal/capture/nullcapture/nullcapture_test.go
@@ -1,0 +1,25 @@
+package nullcapture_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/capture"
+	"github.com/krisarmstrong/seed/internal/capture/nullcapture"
+)
+
+// TestOpenLiveReturnsUnavailable verifies the stub never opens a handle and
+// reports ErrUnavailable so callers degrade gracefully on CGO_ENABLED=0 builds.
+func TestOpenLiveReturnsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	var opener capture.Opener = nullcapture.New()
+
+	handle, err := opener.OpenLive("eth0", 65535, true, capture.BlockForever)
+	if handle != nil {
+		t.Errorf("OpenLive returned a non-nil handle: %v", handle)
+	}
+	if !errors.Is(err, nullcapture.ErrUnavailable) {
+		t.Errorf("OpenLive error = %v, want ErrUnavailable", err)
+	}
+}

--- a/internal/capture/pcap/pcap.go
+++ b/internal/capture/pcap/pcap.go
@@ -1,0 +1,49 @@
+// Package pcap is the libpcap-backed adapter for the capture port.
+//
+// It is the ONLY package in seed that imports github.com/gopacket/gopacket/pcap,
+// and therefore the only CGO-tainted (libpcap-linked) package. A depguard rule
+// confines gopacket/pcap to this package so the taint cannot leak back into the
+// domain. See docs/architecture/CGO_BUILD_STRATEGY.md.
+package pcap
+
+import (
+	"time"
+
+	"github.com/gopacket/gopacket/pcap"
+
+	"github.com/krisarmstrong/seed/internal/capture"
+)
+
+// Compile-time guarantees: this adapter implements the port, and *pcap.Handle
+// satisfies capture.Handle directly (ReadPacketData/SetBPFFilter/LinkType/Close),
+// so OpenLive returns it without a wrapper type.
+var (
+	_ capture.Opener = Opener{}
+	_ capture.Handle = (*pcap.Handle)(nil)
+)
+
+// Opener is the libpcap-backed capture.Opener.
+type Opener struct{}
+
+// New returns a libpcap-backed capture.Opener.
+func New() Opener { return Opener{} }
+
+// OpenLive opens a live libpcap capture handle.
+//
+// *pcap.Handle already satisfies capture.Handle — it has ReadPacketData,
+// SetBPFFilter, LinkType, and Close with matching signatures — so the returned
+// handle needs no wrapping.
+func (Opener) OpenLive(
+	iface string,
+	snaplen int32,
+	promiscuous bool,
+	timeout time.Duration,
+) (capture.Handle, error) {
+	handle, err := pcap.OpenLive(iface, snaplen, promiscuous, timeout)
+	if err != nil {
+		// Return an explicit nil interface (not a typed-nil *pcap.Handle) so
+		// callers' `handle == nil` checks behave. Callers add feature context.
+		return nil, err
+	}
+	return handle, nil
+}

--- a/internal/capture/pcap/pcap_test.go
+++ b/internal/capture/pcap/pcap_test.go
@@ -1,0 +1,26 @@
+package pcap_test
+
+import (
+	"testing"
+
+	gpcap "github.com/gopacket/gopacket/pcap"
+
+	"github.com/krisarmstrong/seed/internal/capture"
+)
+
+// TestBlockForeverMatchesPcap guards against drift: capture.BlockForever is
+// defined CGO-free (the port may not import gopacket/pcap) by mirroring
+// pcap.BlockForever's value. The adapter passes the timeout straight through, so
+// if a gopacket upgrade changed the sentinel, callers using capture.BlockForever
+// would silently lose block-forever semantics. This test is the only place that
+// can compare the two values.
+func TestBlockForeverMatchesPcap(t *testing.T) {
+	t.Parallel()
+
+	if capture.BlockForever != gpcap.BlockForever {
+		t.Fatalf(
+			"capture.BlockForever (%v) != pcap.BlockForever (%v): update the constant in internal/capture",
+			capture.BlockForever, gpcap.BlockForever,
+		)
+	}
+}


### PR DESCRIPTION
## Phase 6 — Slice 1a (capture port scaffold)

First slice of the discovery split. Introduces `internal/capture` as the live packet-capture **port** that confines CGO (libpcap) to a single adapter. **Purely additive — nothing consumes it yet.** The 6 seam files (`discovery` cdp/lldp/edp, `dhcp` ×2, `vlan` ×1) migrate onto the port in **S1b**, where the depguard confinement rule and the `CGO_ENABLED=0` build gate land.

### What's here
- **`internal/capture`** — the CGO-free port. `Handle` embeds `gopacket.PacketDataSource` so a handle feeds straight into `gopacket.NewPacketSource(handle, handle.LinkType())`; `Opener.OpenLive` mirrors `pcap.OpenLive`. It names only `gopacket` + `gopacket/layers` types, which are pure Go (only `gopacket/pcap` carries the `#cgo` directive), so the port stays CGO-free. `BlockForever` mirrors `pcap.BlockForever`.
- **`internal/capture/pcap`** — the libpcap-backed adapter; the **only** package that imports `gopacket/pcap`. `*pcap.Handle` already satisfies `capture.Handle` (matching `ReadPacketData`/`SetBPFFilter`/`LinkType`/`Close`), so `OpenLive` needs no wrapper type. A test asserts `capture.BlockForever == pcap.BlockForever` to guard against gopacket-upgrade drift.
- **`internal/capture/nullcapture`** — CGO-free stub for `CGO_ENABLED=0` builds (Windows, pure-Go test runs); `OpenLive` returns `ErrUnavailable`.

### Verification
- `go build ./...` ✅ · `go test -race ./internal/capture/...` ✅
- **`CGO_ENABLED=0`**: `internal/capture` + `internal/capture/nullcapture` build & test with **no libpcap link** (nullcapture test 0.006s vs 1.0s); `internal/capture/pcap` correctly fails to build (requires CGO) ✅
- `golangci-lint run ./internal/capture/...` → 0 issues ✅ · gofumpt clean ✅
- Golden HTTP harness ✅ (no api changes → no route/golden churn)

Refs: `docs/architecture/CGO_BUILD_STRATEGY.md` §3. Part of the Phase 6 discovery split (RE_ARCHITECTURE_BLUEPRINT).