### PR TITLE
refactor(capture): route discovery/dhcp/vlan capture through the port (Phase 6 S1b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,17 @@ jobs:
       - name: Deterministic build check
         run: go build -trimpath -buildvcs=false ./...
 
+      # Phase 6 capture port: the whole tree must build with CGO disabled, using
+      # the CGO-free null capture adapter. libpcap is confined to the build-tagged
+      # internal/capture/pcap package, which the ./... wildcard skips under
+      # CGO_ENABLED=0. A regression that re-imports gopacket/pcap from a domain
+      # package (depguard also guards this) would fail here.
+      # See docs/architecture/CGO_BUILD_STRATEGY.md.
+      - name: CGO-free build check (null capture adapter)
+        env:
+          CGO_ENABLED: 0
+        run: go build ./...
+
       - name: Check go mod tidy
         run: |
           go mod tidy

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -272,6 +272,19 @@ linters:
               desc: "reporting is persistence-free — define a Repo port, implement it in internal/reporting/store"
             - pkg: github.com/krisarmstrong/seed/internal/reporting/store
               desc: "inward-only — the store adapter imports reporting, never the reverse; wire it in internal/app"
+        # Phase 6 capture port: libpcap (via gopacket/pcap) carries the CGO
+        # taint that re-links libpcap into every dependent test binary. It is
+        # confined to the single adapter package internal/capture/pcap; every
+        # other package (discovery, dhcp, vlan, and everything above them) does
+        # live capture through the CGO-free capture.Opener port, so it builds and
+        # tests with CGO_ENABLED=0. See docs/architecture/CGO_BUILD_STRATEGY.md.
+        "capture-pcap-confinement":
+          files:
+            - "$all"
+            - "!**/internal/capture/pcap/**"
+          deny:
+            - pkg: github.com/gopacket/gopacket/pcap
+              desc: "live capture must go through the capture port (internal/capture); only internal/capture/pcap may import gopacket/pcap"
 
     embeddedstructfieldcheck:
       # Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.

--- a/docs/architecture/CGO_BUILD_STRATEGY.md
+++ b/docs/architecture/CGO_BUILD_STRATEGY.md
@@ -1,6 +1,6 @@
 # CGO build strategy — libpcap blast radius & build speed
 
-**Status:** Findings + plan — 2026-06-01
+**Status:** Implemented — Capture port shipped in Phase 6 S1a/S1b (2026-06-03; findings 2026-06-01)
 **Scope:** Why seed links libpcap (CGO), where that cost lands, and how to keep
 builds fast. Records the four findings from the 2026-06-01 build audit and the
 plan to shrink the CGO blast radius behind a `Capture` port (executes with the
@@ -63,15 +63,30 @@ imports them — `api`, `diagnostics`, `pipeline`, `security`) compile and **tes
   (no feature migration required to establish the precedent), and complete the pcap move as part of the **Phase 6 discovery split**, where
   `dhcp`/`vlan`/`discovery` all migrate together.
 
-### Acceptance criteria (when executed)
+### Acceptance criteria — DONE (Phase 6 S1a #1487 + S1b)
 
-- [ ] Exactly one package imports `gopacket/pcap` (`internal/capture/pcap`).
-- [ ] `go build ./... ` with `CGO_ENABLED=0` succeeds (uses the null adapter);
-      `CGO_ENABLED=1` builds keep live capture.
-- [ ] `go vet`/`go test` for `dhcp`/`discovery`/`vlan` run `CGO_ENABLED=0`.
-- [ ] Golden HTTP suite unchanged; capture features behave identically with the
-      real adapter.
-- [ ] `depguard`: `gopacket/pcap` denied outside `internal/capture/pcap`.
+The `Capture` port shipped in two slices: S1a created `internal/capture`
+(port + `pcap`/`nullcapture` adapters); S1b migrated the six seam files
+(`discovery` cdp/lldp/edp, `dhcp` monitor/rogue, `vlan` traffic) onto the
+injected `capture.Opener` and added the enforcement gates.
+
+- [x] Exactly one package imports `gopacket/pcap` (`internal/capture/pcap`).
+- [x] `go build ./...` with `CGO_ENABLED=0` succeeds (the null adapter is wired;
+      the build-tagged `internal/capture/pcap` is skipped under `CGO_ENABLED=0`
+      on non-Windows). `CGO_ENABLED=1` (and any Windows build) keep live capture.
+- [x] `go build`/`go test` for `dhcp`/`discovery`/`vlan` run `CGO_ENABLED=0` —
+      `dhcp`/`vlan` test binaries no longer link libpcap (≈0.02s vs seconds).
+- [x] Golden HTTP suite unchanged; capture features behave identically with the
+      real adapter (the composition root injects `pcap.New()` via a build-tagged
+      `defaultCaptureOpener`).
+- [x] `depguard`: `gopacket/pcap` denied outside `internal/capture/pcap`.
+- [x] CI gate: a `CGO_ENABLED=0 go build ./...` step in the Backend (Go) job.
+
+**Capture-port wiring:** capture-using constructors take functional options
+(`WithCapture`), defaulting to the CGO-free no-op so existing call sites and
+tests are unchanged; the composition root (`internal/api`) injects the
+build-tagged real adapter via `defaultCaptureOpener` (`wire_capture_real.go`
+`//go:build cgo || windows`; `wire_capture_null.go` `//go:build !cgo && !windows`).
 
 ## 4. CI caching (finding #2 — shipped)
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -178,26 +178,16 @@ func NewServer(
 	primaryInterfaces := append(cfg.Interface.AllEthernet(), cfg.Interface.AllWiFi()...)
 	services.Network.LinkMonitorPool.Reconcile(primaryInterfaces)
 
-	// Initialize discovery services
-	services.Discovery.Device = discovery.NewDeviceDiscoveryWithOUI(
-		cfg.Interface.Default,
-		cfg.NetworkDiscovery.OUIFilePath,
-		cfg.NetworkDiscovery.OUIMaxAge,
-	)
-	// Note: services.Discovery.Service is initialized after profiler is created (see below)
+	// Initialize discovery + capture-using diagnostics services. WithCapture
+	// injects the build-tagged capture adapter (libpcap or CGO-free no-op) so the
+	// domain packages stay CGO-free. See docs/architecture/CGO_BUILD_STRATEGY.md.
+	initCaptureServices(services, cfg)
 
 	// Initialize telemetry services
 	services.Diagnostics.DNS = dns.NewTester("", cfg.DNS.TestHostname, dns.DefaultThresholds())
 	services.Diagnostics.DNSSecurity = dns.NewSecurityScanner(dns.DefaultSecurityScanConfig())
-	services.Diagnostics.DHCP = dhcp.NewMonitor(cfg.Interface.Default)
-	services.Diagnostics.RogueDetector = dhcp.NewRogueDetector(&dhcp.RogueDetectorConfig{
-		Interface:        cfg.Interface.Default,
-		KnownServers:     cfg.DHCP.RogueDetection.KnownServers,
-		AlertOnDetection: cfg.DHCP.RogueDetection.AlertOnDetection,
-	})
 	services.Diagnostics.Gateway = gateway.NewTester(gateway.DefaultThresholds())
 	services.Diagnostics.VLAN = vlan.NewManager(cfg.Interface.Default)
-	services.Diagnostics.VLANTraffic = vlan.NewTrafficMonitor(cfg.Interface.Default)
 	services.Diagnostics.Speedtest = speedtest.NewTesterWithConfig(cfg.Speedtest.ServerID)
 	services.Diagnostics.Iperf = iperf.NewManager()
 	services.Diagnostics.Cable = cable.NewTester(cfg.Interface.Default)
@@ -256,6 +246,32 @@ func NewServer(
 	s.setupRoutes()
 
 	return s
+}
+
+// initCaptureServices constructs the services that perform live packet capture
+// (device discovery via LLDP/CDP/EDP, DHCP monitoring, rogue-DHCP detection, and
+// VLAN traffic) and injects the capture port adapter into each. The adapter is
+// build-tagged (libpcap under CGO/Windows, a CGO-free no-op otherwise) so the
+// domain packages stay CGO-free. See docs/architecture/CGO_BUILD_STRATEGY.md.
+func initCaptureServices(services *ServiceContainer, cfg *config.Config) {
+	captureOpener := defaultCaptureOpener()
+
+	// services.Discovery.Service is initialized later, after the shared profiler.
+	services.Discovery.Device = discovery.NewDeviceDiscoveryWithOUI(
+		cfg.Interface.Default,
+		cfg.NetworkDiscovery.OUIFilePath,
+		cfg.NetworkDiscovery.OUIMaxAge,
+		discovery.WithCapture(captureOpener),
+	)
+	services.Diagnostics.DHCP = dhcp.NewMonitor(cfg.Interface.Default, dhcp.WithCapture(captureOpener))
+	services.Diagnostics.RogueDetector = dhcp.NewRogueDetector(&dhcp.RogueDetectorConfig{
+		Interface:        cfg.Interface.Default,
+		KnownServers:     cfg.DHCP.RogueDetection.KnownServers,
+		AlertOnDetection: cfg.DHCP.RogueDetection.AlertOnDetection,
+	}, dhcp.WithCapture(captureOpener))
+	services.Diagnostics.VLANTraffic = vlan.NewTrafficMonitor(
+		cfg.Interface.Default, vlan.WithCapture(captureOpener),
+	)
 }
 
 // initDatabaseDependentServices wires every service that needs a

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -221,8 +221,12 @@ func (s *Server) initDiscoveryPipeline(cfg *config.Config) {
 		s.services.Discovery.PortScanner = portScanner
 	}
 
-	// Initialize discovery service with the shared profiler
-	s.services.Discovery.Service = discovery.NewService(cfg, cfg.Interface.Default, sharedProfiler)
+	// Initialize discovery service with the shared profiler. WithCapture injects
+	// the build-tagged capture adapter so the Service's internal device discovery
+	// uses real libpcap capture in production (CGO-free no-op under CGO_ENABLED=0).
+	s.services.Discovery.Service = discovery.NewService(
+		cfg, cfg.Interface.Default, sharedProfiler, discovery.WithCapture(defaultCaptureOpener()),
+	)
 	logging.GetLogger().Info("Discovery service initialized with shared profiler")
 
 	// Initialize discovery pipeline with the SAME shared profiler

--- a/internal/api/wire_capture_null.go
+++ b/internal/api/wire_capture_null.go
@@ -1,0 +1,15 @@
+//go:build !cgo && !windows
+
+package api
+
+import (
+	"github.com/krisarmstrong/seed/internal/capture"
+	"github.com/krisarmstrong/seed/internal/capture/nullcapture"
+)
+
+// defaultCaptureOpener returns the CGO-free no-op capture adapter. This file is
+// compiled only for CGO_ENABLED=0 builds on non-Windows platforms, where libpcap
+// cannot be linked — live capture is unavailable and capture calls fail with
+// nullcapture.ErrUnavailable. The libpcap-backed variant lives in
+// wire_capture_real.go. See docs/architecture/CGO_BUILD_STRATEGY.md.
+func defaultCaptureOpener() capture.Opener { return nullcapture.New() }

--- a/internal/api/wire_capture_real.go
+++ b/internal/api/wire_capture_real.go
@@ -1,0 +1,18 @@
+//go:build cgo || windows
+
+package api
+
+import (
+	"github.com/krisarmstrong/seed/internal/capture"
+	"github.com/krisarmstrong/seed/internal/capture/pcap"
+)
+
+// defaultCaptureOpener returns the libpcap-backed capture adapter that powers
+// live packet capture (LLDP/CDP/EDP discovery, DHCP sniffing, VLAN traffic).
+//
+// This file is compiled when CGO is enabled (libpcap is linkable on linux/darwin)
+// or on Windows (where gopacket/pcap is CGO-free via wpcap), preserving live
+// capture on every platform that supported it before the capture-port split. The
+// CGO-free no-op variant for CGO_ENABLED=0 non-Windows builds lives in
+// wire_capture_null.go. See docs/architecture/CGO_BUILD_STRATEGY.md.
+func defaultCaptureOpener() capture.Opener { return pcap.New() }

--- a/internal/capture/pcap/pcap.go
+++ b/internal/capture/pcap/pcap.go
@@ -1,4 +1,12 @@
+//go:build cgo || windows
+
 // Package pcap is the libpcap-backed adapter for the capture port.
+//
+// The build constraint (cgo || windows) keeps this package out of CGO_ENABLED=0
+// builds on non-Windows platforms, where libpcap cannot be linked — there the
+// composition root selects the CGO-free no-op adapter (nullcapture) instead, and
+// a CGO_ENABLED=0 `go build ./...` skips this package cleanly. On Windows
+// gopacket/pcap is CGO-free (wpcap), so live capture is retained there.
 //
 // It is the ONLY package in seed that imports github.com/gopacket/gopacket/pcap,
 // and therefore the only CGO-tainted (libpcap-linked) package. A depguard rule

--- a/internal/capture/pcap/pcap_test.go
+++ b/internal/capture/pcap/pcap_test.go
@@ -1,3 +1,5 @@
+//go:build cgo || windows
+
 package pcap_test
 
 import (

--- a/internal/dhcp/dhcp.go
+++ b/internal/dhcp/dhcp.go
@@ -1,8 +1,9 @@
 package dhcp
 
 //
-// The Monitor uses gopacket/pcap for real-time DHCP packet capture to measure
-// transaction timing (DISCOVER→OFFER→REQUEST→ACK). Requires root/CAP_NET_RAW.
+// The Monitor uses the capture port (internal/capture) for real-time DHCP packet
+// capture to measure transaction timing (DISCOVER→OFFER→REQUEST→ACK). The
+// libpcap-backed adapter requires root/CAP_NET_RAW; wire it via WithCapture.
 
 import (
 	"bufio"
@@ -20,8 +21,8 @@ import (
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
-	"github.com/gopacket/gopacket/pcap"
 
+	"github.com/krisarmstrong/seed/internal/capture"
 	"github.com/krisarmstrong/seed/internal/logging"
 )
 
@@ -147,15 +148,18 @@ type Monitor struct {
 	lastTiming    *Timing
 	transactions  map[uint32]*Transaction
 	stopChan      chan struct{}
-	handle        *pcap.Handle
+	opener        capture.Opener
+	handle        capture.Handle
 	cleanupDone   chan struct{} // Signals cleanup goroutine exit (fixes #841)
 }
 
-// NewMonitor creates a new DHCP monitor.
-func NewMonitor(interfaceName string) *Monitor {
+// NewMonitor creates a new DHCP monitor. opts inject optional dependencies such
+// as the live-capture Opener (WithCapture); the default is the CGO-free no-op.
+func NewMonitor(interfaceName string, opts ...Option) *Monitor {
 	return &Monitor{
 		interfaceName: interfaceName,
 		transactions:  make(map[uint32]*Transaction),
+		opener:        resolveCapture(opts...),
 	}
 }
 
@@ -172,7 +176,7 @@ func (m *Monitor) Start() error {
 	// Open pcap handle on the interface
 	// Snapshot length of pcapSnapshotLen bytes is enough for DHCP packets
 	// Timeout of pcapTimeout for packet batching
-	handle, err := pcap.OpenLive(m.interfaceName, pcapSnapshotLen, true, pcapTimeout)
+	handle, err := m.opener.OpenLive(m.interfaceName, pcapSnapshotLen, true, pcapTimeout)
 	if err != nil {
 		return err
 	}
@@ -202,7 +206,7 @@ func (m *Monitor) Start() error {
 // capturePackets runs the packet capture loop. stopChan is passed as a
 // parameter rather than read from m.stopChan so Stop's nil-assignment doesn't
 // race against this goroutine.
-func (m *Monitor) capturePackets(handle *pcap.Handle, linkType layers.LinkType, stopChan <-chan struct{}) {
+func (m *Monitor) capturePackets(handle capture.Handle, linkType layers.LinkType, stopChan <-chan struct{}) {
 	if handle == nil {
 		return
 	}

--- a/internal/dhcp/options.go
+++ b/internal/dhcp/options.go
@@ -1,0 +1,36 @@
+package dhcp
+
+import (
+	"github.com/krisarmstrong/seed/internal/capture"
+	"github.com/krisarmstrong/seed/internal/capture/nullcapture"
+)
+
+// Option configures optional dependencies of the dhcp constructors
+// (NewMonitor, NewRogueDetector).
+type Option func(*captureConfig)
+
+// captureConfig collects optional construction settings.
+type captureConfig struct {
+	opener capture.Opener
+}
+
+// WithCapture injects the live packet-capture Opener used to sniff DHCP traffic.
+// The composition root passes the libpcap-backed adapter (internal/capture/pcap)
+// under CGO; absent an override the default is the CGO-free no-op (nullcapture),
+// so the dhcp package and its tests never link libpcap. A nil opener is ignored.
+func WithCapture(opener capture.Opener) Option {
+	return func(c *captureConfig) {
+		if opener != nil {
+			c.opener = opener
+		}
+	}
+}
+
+// resolveCapture applies opts over the CGO-free default opener.
+func resolveCapture(opts ...Option) capture.Opener {
+	cfg := captureConfig{opener: nullcapture.New()}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg.opener
+}

--- a/internal/dhcp/rogue.go
+++ b/internal/dhcp/rogue.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
-	"github.com/gopacket/gopacket/pcap"
 
+	"github.com/krisarmstrong/seed/internal/capture"
 	"github.com/krisarmstrong/seed/internal/logging"
 )
 
@@ -53,7 +53,8 @@ type RogueDetector struct {
 	mu              sync.RWMutex
 	config          *RogueDetectorConfig
 	running         bool
-	handle          *pcap.Handle
+	opener          capture.Opener
+	handle          capture.Handle
 	cancel          context.CancelFunc
 	detectedServers map[string]*RogueServer // key is IP address
 	knownServerSet  map[string]bool         // for fast lookup
@@ -61,7 +62,9 @@ type RogueDetector struct {
 
 // NewRogueDetector creates a new rogue DHCP server detector.
 // The Interface field in config must be set - no hardcoded defaults are used (#572).
-func NewRogueDetector(config *RogueDetectorConfig) *RogueDetector {
+// opts inject optional dependencies such as the live-capture Opener (WithCapture);
+// the default is the CGO-free no-op.
+func NewRogueDetector(config *RogueDetectorConfig, opts ...Option) *RogueDetector {
 	if config == nil {
 		config = &RogueDetectorConfig{
 			Interface:        "", // Must be set by caller - no hardcoded defaults
@@ -78,6 +81,7 @@ func NewRogueDetector(config *RogueDetectorConfig) *RogueDetector {
 
 	return &RogueDetector{
 		config:          config,
+		opener:          resolveCapture(opts...),
 		detectedServers: make(map[string]*RogueServer),
 		knownServerSet:  knownSet,
 	}
@@ -101,7 +105,7 @@ func (rd *RogueDetector) startLocked() error {
 	// Use snapshot length of roguePcapSnapshotLen bytes (enough for DHCP packets)
 	// Set promiscuous mode to false (we only need broadcast packets)
 	// Set timeout to roguePcapTimeout for responsive shutdown
-	handle, err := pcap.OpenLive(rd.config.Interface, roguePcapSnapshotLen, false, roguePcapTimeout)
+	handle, err := rd.opener.OpenLive(rd.config.Interface, roguePcapSnapshotLen, false, roguePcapTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to open pcap: %w (requires CAP_NET_RAW or root)", err)
 	}
@@ -169,7 +173,7 @@ func (rd *RogueDetector) IsRunning() bool {
 }
 
 // capturePackets is the main packet capture loop.
-func (rd *RogueDetector) capturePackets(ctx context.Context, handle *pcap.Handle, linkType layers.LinkType) {
+func (rd *RogueDetector) capturePackets(ctx context.Context, handle capture.Handle, linkType layers.LinkType) {
 	// Ensure cleanup happens if capturePackets exits unexpectedly (fixes #831)
 	defer func() {
 		rd.mu.Lock()

--- a/internal/diagnostics/vlan/options.go
+++ b/internal/diagnostics/vlan/options.go
@@ -1,0 +1,36 @@
+package vlan
+
+import (
+	"github.com/krisarmstrong/seed/internal/capture"
+	"github.com/krisarmstrong/seed/internal/capture/nullcapture"
+)
+
+// Option configures optional dependencies of NewTrafficMonitor.
+type Option func(*captureConfig)
+
+// captureConfig collects optional construction settings.
+type captureConfig struct {
+	opener capture.Opener
+}
+
+// WithCapture injects the live packet-capture Opener used to sniff 802.1Q
+// VLAN-tagged traffic. The composition root passes the libpcap-backed adapter
+// (internal/capture/pcap) under CGO; absent an override the default is the
+// CGO-free no-op (nullcapture), so the vlan package and its tests never link
+// libpcap. A nil opener is ignored.
+func WithCapture(opener capture.Opener) Option {
+	return func(c *captureConfig) {
+		if opener != nil {
+			c.opener = opener
+		}
+	}
+}
+
+// resolveCapture applies opts over the CGO-free default opener.
+func resolveCapture(opts ...Option) capture.Opener {
+	cfg := captureConfig{opener: nullcapture.New()}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg.opener
+}

--- a/internal/diagnostics/vlan/traffic.go
+++ b/internal/diagnostics/vlan/traffic.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
-	"github.com/gopacket/gopacket/pcap"
 
+	"github.com/krisarmstrong/seed/internal/capture"
 	"github.com/krisarmstrong/seed/internal/logging"
 )
 
@@ -31,7 +31,8 @@ type Traffic struct {
 // TrafficMonitor captures and tracks 802.1Q VLAN-tagged traffic.
 type TrafficMonitor struct {
 	interfaceName string
-	handle        *pcap.Handle
+	opener        capture.Opener
+	handle        capture.Handle
 	stats         map[int]*Traffic // keyed by VLAN ID
 	mu            sync.RWMutex
 	ctx           context.Context
@@ -39,11 +40,14 @@ type TrafficMonitor struct {
 	started       bool
 }
 
-// NewTrafficMonitor creates a new VLAN traffic monitor.
+// NewTrafficMonitor creates a new VLAN traffic monitor. opts inject optional
+// dependencies such as the live-capture Opener (WithCapture); the default is the
+// CGO-free no-op.
 // Fixes #916: Context is created in Start() to prevent leaks if Start() is never called.
-func NewTrafficMonitor(interfaceName string) *TrafficMonitor {
+func NewTrafficMonitor(interfaceName string, opts ...Option) *TrafficMonitor {
 	return &TrafficMonitor{
 		interfaceName: interfaceName,
+		opener:        resolveCapture(opts...),
 		stats:         make(map[int]*Traffic),
 	}
 }
@@ -57,7 +61,7 @@ func (m *TrafficMonitor) Start() error {
 	}
 
 	// Open capture handle
-	handle, err := pcap.OpenLive(m.interfaceName, pcapSnapshotLen, true, pcap.BlockForever)
+	handle, err := m.opener.OpenLive(m.interfaceName, pcapSnapshotLen, true, capture.BlockForever)
 	if err != nil {
 		m.mu.Unlock()
 		return fmt.Errorf("failed to open capture: %w", err)
@@ -152,7 +156,7 @@ func (m *TrafficMonitor) Reset() {
 }
 
 // captureLoop continuously captures and processes VLAN-tagged frames.
-func (m *TrafficMonitor) captureLoop(ctx context.Context, handle *pcap.Handle, linkType layers.LinkType) {
+func (m *TrafficMonitor) captureLoop(ctx context.Context, handle capture.Handle, linkType layers.LinkType) {
 	if handle == nil {
 		return
 	}

--- a/internal/services/discovery/cdp.go
+++ b/internal/services/discovery/cdp.go
@@ -6,13 +6,13 @@ package discovery
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
-	"github.com/gopacket/gopacket/pcap"
+
+	"github.com/krisarmstrong/seed/internal/capture"
 )
 
 // pcapSnapshotLength is the maximum number of bytes to capture from each packet.
@@ -38,7 +38,8 @@ type CDPNeighbor struct {
 // CDPCapture handles CDP frame capture on an interface.
 type CDPCapture struct {
 	interfaceName string
-	handle        *pcap.Handle
+	opener        capture.Opener
+	handle        capture.Handle
 	neighbors     map[string]*CDPNeighbor // keyed by DeviceID+PortID
 	mu            sync.RWMutex
 	ctx           context.Context
@@ -46,11 +47,13 @@ type CDPCapture struct {
 	started       bool
 }
 
-// NewCDPCapture creates a new CDP capture instance.
+// NewCDPCapture creates a new CDP capture instance bound to the given capture
+// Opener (the libpcap adapter in production, a no-op under CGO_ENABLED=0).
 // Fixes #903: Context is created in Start() to prevent leaks if Start() is never called.
-func NewCDPCapture(interfaceName string) *CDPCapture {
+func NewCDPCapture(opener capture.Opener, interfaceName string) *CDPCapture {
 	return &CDPCapture{
 		interfaceName: interfaceName,
+		opener:        opener,
 		neighbors:     make(map[string]*CDPNeighbor),
 	}
 }
@@ -65,18 +68,13 @@ func (c *CDPCapture) Start() error {
 		return nil
 	}
 
-	// Open capture handle
-	handle, err := pcap.OpenLive(c.interfaceName, pcapSnapshotLength, true, pcap.BlockForever)
+	// CDP frames are sent to the well-known dst MAC 01:00:0c:cc:cc:cc.
+	handle, linkType, err := openProtocolCapture(
+		c.opener, c.interfaceName, pcapSnapshotLength, "ether dst 01:00:0c:cc:cc:cc",
+	)
 	if err != nil {
 		c.mu.Unlock()
-		return fmt.Errorf("failed to open capture: %w", err)
-	}
-
-	// Set BPF filter for CDP (dst MAC 01:00:0c:cc:cc:cc)
-	if filterErr := handle.SetBPFFilter("ether dst 01:00:0c:cc:cc:cc"); filterErr != nil {
-		handle.Close()
-		c.mu.Unlock()
-		return fmt.Errorf("failed to set BPF filter: %w", filterErr)
+		return err
 	}
 
 	c.handle = handle
@@ -85,7 +83,6 @@ func (c *CDPCapture) Start() error {
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 	c.mu.Unlock()
 
-	linkType := handle.LinkType()
 	go c.captureLoop(c.ctx, handle, linkType)
 	return nil
 }
@@ -124,7 +121,7 @@ func (c *CDPCapture) GetNeighbors() []*CDPNeighbor {
 }
 
 // captureLoop continuously captures and processes CDP frames.
-func (c *CDPCapture) captureLoop(ctx context.Context, handle *pcap.Handle, linkType layers.LinkType) {
+func (c *CDPCapture) captureLoop(ctx context.Context, handle capture.Handle, linkType layers.LinkType) {
 	if handle == nil {
 		return
 	}

--- a/internal/services/discovery/devices.go
+++ b/internal/services/discovery/devices.go
@@ -114,16 +114,18 @@ func loadOUIWithAutoUpdate(oui *OUIDatabase, ouiPath string, ouiMaxAge time.Dura
 }
 
 // NewDeviceDiscovery creates a new device discovery aggregator.
-func NewDeviceDiscovery(interfaceName string) *DeviceDiscovery {
-	return NewDeviceDiscoveryWithOUI(interfaceName, "", 0)
+func NewDeviceDiscovery(interfaceName string, opts ...Option) *DeviceDiscovery {
+	return NewDeviceDiscoveryWithOUI(interfaceName, "", 0, opts...)
 }
 
 // NewDeviceDiscoveryWithOUI creates a new device discovery aggregator with OUI configuration.
 // ouiPath specifies the path to store/load the OUI database file.
 // ouiMaxAge specifies how old the file can be before auto-downloading (0 = never auto-update).
+// opts inject optional dependencies such as the live-capture Opener (WithCapture).
 func NewDeviceDiscoveryWithOUI(
 	interfaceName, ouiPath string,
 	ouiMaxAge time.Duration,
+	opts ...Option,
 ) *DeviceDiscovery {
 	oui := NewOUIDatabase()
 	loadOUIDatabase(oui, ouiPath, ouiMaxAge)
@@ -133,7 +135,7 @@ func NewDeviceDiscoveryWithOUI(
 		oui:             oui,
 		arpScanner:      NewARPScanner(interfaceName, oui),
 		ndpScanner:      NewNDPScanner(interfaceName),
-		protoManager:    NewManager(interfaceName),
+		protoManager:    NewManager(interfaceName, opts...),
 		netbiosResolver: NewNetBIOSResolver(),
 		mdnsResolver:    NewMDNSResolver(interfaceName),
 		mdnsListener:    NewMDNSListener(interfaceName),

--- a/internal/services/discovery/edp.go
+++ b/internal/services/discovery/edp.go
@@ -14,7 +14,8 @@ import (
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
-	"github.com/gopacket/gopacket/pcap"
+
+	"github.com/krisarmstrong/seed/internal/capture"
 )
 
 // pcapSnapshotLengthEDP is the maximum number of bytes to capture from each packet.
@@ -62,7 +63,8 @@ type EDPNeighbor struct {
 // EDPCapture handles EDP frame capture on an interface.
 type EDPCapture struct {
 	interfaceName string
-	handle        *pcap.Handle
+	opener        capture.Opener
+	handle        capture.Handle
 	neighbors     map[string]*EDPNeighbor // keyed by DeviceID+PortID
 	mu            sync.RWMutex
 	ctx           context.Context
@@ -70,11 +72,13 @@ type EDPCapture struct {
 	started       bool
 }
 
-// NewEDPCapture creates a new EDP capture instance.
+// NewEDPCapture creates a new EDP capture instance bound to the given capture
+// Opener (the libpcap adapter in production, a no-op under CGO_ENABLED=0).
 // Fixes #903: Context is created in Start() to prevent leaks if Start() is never called.
-func NewEDPCapture(interfaceName string) *EDPCapture {
+func NewEDPCapture(opener capture.Opener, interfaceName string) *EDPCapture {
 	return &EDPCapture{
 		interfaceName: interfaceName,
+		opener:        opener,
 		neighbors:     make(map[string]*EDPNeighbor),
 	}
 }
@@ -89,25 +93,19 @@ func (c *EDPCapture) Start() error {
 		return nil
 	}
 
-	// Open capture handle
-	handle, err := pcap.OpenLive(c.interfaceName, pcapSnapshotLengthEDP, true, pcap.BlockForever)
+	// EDP frames are sent to the well-known dst MAC 00:e0:2b:00:00:00.
+	handle, linkType, err := openProtocolCapture(
+		c.opener, c.interfaceName, pcapSnapshotLengthEDP, "ether dst 00:e0:2b:00:00:00",
+	)
 	if err != nil {
 		c.mu.Unlock()
-		return fmt.Errorf("failed to open capture: %w", err)
-	}
-
-	// Set BPF filter for EDP (dst MAC 00:E0:2B:00:00:00)
-	if filterErr := handle.SetBPFFilter("ether dst 00:e0:2b:00:00:00"); filterErr != nil {
-		handle.Close()
-		c.mu.Unlock()
-		return fmt.Errorf("failed to set BPF filter: %w", filterErr)
+		return err
 	}
 
 	c.handle = handle
 	c.started = true
 	// Fixes #903: Create context here instead of in NewEDPCapture
 	c.ctx, c.cancel = context.WithCancel(context.Background())
-	linkType := handle.LinkType()
 	ctx := c.ctx
 	c.mu.Unlock()
 
@@ -153,7 +151,7 @@ func (c *EDPCapture) GetNeighbors() []*EDPNeighbor {
 }
 
 // captureLoop continuously captures and processes EDP frames.
-func (c *EDPCapture) captureLoop(ctx context.Context, handle *pcap.Handle, linkType layers.LinkType) {
+func (c *EDPCapture) captureLoop(ctx context.Context, handle capture.Handle, linkType layers.LinkType) {
 	if handle == nil {
 		return
 	}

--- a/internal/services/discovery/lldp.go
+++ b/internal/services/discovery/lldp.go
@@ -2,14 +2,14 @@ package discovery
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"sync"
 	"time"
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
-	"github.com/gopacket/gopacket/pcap"
+
+	"github.com/krisarmstrong/seed/internal/capture"
 )
 
 // pcapSnapshotLengthLLDP is the maximum number of bytes to capture from each packet.
@@ -36,7 +36,8 @@ type LLDPNeighbor struct {
 // LLDPCapture handles LLDP frame capture on an interface.
 type LLDPCapture struct {
 	interfaceName string
-	handle        *pcap.Handle
+	opener        capture.Opener
+	handle        capture.Handle
 	neighbors     map[string]*LLDPNeighbor // keyed by ChassisID+PortID
 	mu            sync.RWMutex
 	ctx           context.Context
@@ -44,11 +45,13 @@ type LLDPCapture struct {
 	started       bool
 }
 
-// NewLLDPCapture creates a new LLDP capture instance.
+// NewLLDPCapture creates a new LLDP capture instance bound to the given capture
+// Opener (the libpcap adapter in production, a no-op under CGO_ENABLED=0).
 // Fixes #903: Context is created in Start() to prevent leaks if Start() is never called.
-func NewLLDPCapture(interfaceName string) *LLDPCapture {
+func NewLLDPCapture(opener capture.Opener, interfaceName string) *LLDPCapture {
 	return &LLDPCapture{
 		interfaceName: interfaceName,
+		opener:        opener,
 		neighbors:     make(map[string]*LLDPNeighbor),
 	}
 }
@@ -63,18 +66,13 @@ func (c *LLDPCapture) Start() error {
 		return nil
 	}
 
-	// Open capture handle
-	handle, err := pcap.OpenLive(c.interfaceName, pcapSnapshotLengthLLDP, true, pcap.BlockForever)
+	// LLDP frames carry EtherType 0x88cc.
+	handle, linkType, err := openProtocolCapture(
+		c.opener, c.interfaceName, pcapSnapshotLengthLLDP, "ether proto 0x88cc",
+	)
 	if err != nil {
 		c.mu.Unlock()
-		return fmt.Errorf("failed to open capture: %w", err)
-	}
-
-	// Set BPF filter for LLDP (EtherType 0x88cc)
-	if filterErr := handle.SetBPFFilter("ether proto 0x88cc"); filterErr != nil {
-		handle.Close()
-		c.mu.Unlock()
-		return fmt.Errorf("failed to set BPF filter: %w", filterErr)
+		return err
 	}
 
 	c.handle = handle
@@ -83,7 +81,6 @@ func (c *LLDPCapture) Start() error {
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 	c.mu.Unlock()
 
-	linkType := handle.LinkType()
 	go c.captureLoop(c.ctx, handle, linkType)
 	return nil
 }
@@ -122,7 +119,7 @@ func (c *LLDPCapture) GetNeighbors() []*LLDPNeighbor {
 }
 
 // captureLoop continuously captures and processes LLDP frames.
-func (c *LLDPCapture) captureLoop(ctx context.Context, handle *pcap.Handle, linkType layers.LinkType) {
+func (c *LLDPCapture) captureLoop(ctx context.Context, handle capture.Handle, linkType layers.LinkType) {
 	if handle == nil {
 		return
 	}

--- a/internal/services/discovery/manager.go
+++ b/internal/services/discovery/manager.go
@@ -31,6 +31,8 @@ package discovery
 import (
 	"sync"
 	"time"
+
+	"github.com/krisarmstrong/seed/internal/capture"
 )
 
 // Protocol represents a link-layer discovery protocol type.
@@ -104,12 +106,13 @@ type Neighbor struct {
 //	// Later, get all discovered neighbors
 //	neighbors := mgr.GetNeighbors()
 type Manager struct {
-	interfaceName string       // Network interface to capture on
-	lldp          *LLDPCapture // LLDP protocol capture instance
-	cdp           *CDPCapture  // CDP protocol capture instance
-	edp           *EDPCapture  // EDP protocol capture instance
-	mu            sync.RWMutex // Protects started flag
-	started       bool         // True if captures are running
+	interfaceName string         // Network interface to capture on
+	opener        capture.Opener // Live-capture port (libpcap adapter or no-op)
+	lldp          *LLDPCapture   // LLDP protocol capture instance
+	cdp           *CDPCapture    // CDP protocol capture instance
+	edp           *EDPCapture    // EDP protocol capture instance
+	mu            sync.RWMutex   // Protects started flag
+	started       bool           // True if captures are running
 }
 
 // NewManager creates a new discovery protocol manager for the specified network interface.
@@ -125,12 +128,14 @@ type Manager struct {
 //
 // The returned manager must eventually be stopped via Stop() to release
 // packet capture resources and stop background goroutines.
-func NewManager(interfaceName string) *Manager {
+func NewManager(interfaceName string, opts ...Option) *Manager {
+	opener := resolveCapture(opts...)
 	return &Manager{
 		interfaceName: interfaceName,
-		lldp:          NewLLDPCapture(interfaceName),
-		cdp:           NewCDPCapture(interfaceName),
-		edp:           NewEDPCapture(interfaceName),
+		opener:        opener,
+		lldp:          NewLLDPCapture(opener, interfaceName),
+		cdp:           NewCDPCapture(opener, interfaceName),
+		edp:           NewEDPCapture(opener, interfaceName),
 	}
 }
 
@@ -348,9 +353,9 @@ func (m *Manager) SetInterface(interfaceName string) error {
 
 	// Recreate captures for new interface
 	m.interfaceName = interfaceName
-	m.lldp = NewLLDPCapture(interfaceName)
-	m.cdp = NewCDPCapture(interfaceName)
-	m.edp = NewEDPCapture(interfaceName)
+	m.lldp = NewLLDPCapture(m.opener, interfaceName)
+	m.cdp = NewCDPCapture(m.opener, interfaceName)
+	m.edp = NewEDPCapture(m.opener, interfaceName)
 
 	// Restart if was running
 	if wasRunning {

--- a/internal/services/discovery/options.go
+++ b/internal/services/discovery/options.go
@@ -1,0 +1,37 @@
+package discovery
+
+import (
+	"github.com/krisarmstrong/seed/internal/capture"
+	"github.com/krisarmstrong/seed/internal/capture/nullcapture"
+)
+
+// Option configures optional dependencies of the discovery constructors
+// (NewDeviceDiscovery, NewDeviceDiscoveryWithOUI, NewManager, NewService).
+type Option func(*captureConfig)
+
+// captureConfig collects optional construction settings.
+type captureConfig struct {
+	opener capture.Opener
+}
+
+// WithCapture injects the live packet-capture Opener used for LLDP/CDP/EDP
+// neighbor discovery. The composition root passes the libpcap-backed adapter
+// (internal/capture/pcap) under CGO; absent an override the default is the
+// CGO-free no-op (nullcapture), so the discovery package and its tests never
+// link libpcap. A nil opener is ignored (keeps the default).
+func WithCapture(opener capture.Opener) Option {
+	return func(c *captureConfig) {
+		if opener != nil {
+			c.opener = opener
+		}
+	}
+}
+
+// resolveCapture applies opts over the CGO-free default opener.
+func resolveCapture(opts ...Option) capture.Opener {
+	cfg := captureConfig{opener: nullcapture.New()}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg.opener
+}

--- a/internal/services/discovery/protocol_capture.go
+++ b/internal/services/discovery/protocol_capture.go
@@ -1,0 +1,32 @@
+package discovery
+
+import (
+	"fmt"
+
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/krisarmstrong/seed/internal/capture"
+)
+
+// openProtocolCapture opens a live capture handle on iface in promiscuous mode,
+// installs the given BPF filter, and returns the handle with its link type.
+//
+// It is shared by the LLDP, CDP, and EDP captures, whose open sequences are
+// identical apart from the snapshot length and BPF expression. Centralizing it
+// keeps the three Start methods small and free of duplicated open/filter logic.
+func openProtocolCapture(
+	opener capture.Opener,
+	iface string,
+	snaplen int32,
+	bpfFilter string,
+) (capture.Handle, layers.LinkType, error) {
+	handle, err := opener.OpenLive(iface, snaplen, true, capture.BlockForever)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to open capture: %w", err)
+	}
+	if filterErr := handle.SetBPFFilter(bpfFilter); filterErr != nil {
+		handle.Close()
+		return nil, 0, fmt.Errorf("failed to set BPF filter: %w", filterErr)
+	}
+	return handle, handle.LinkType(), nil
+}

--- a/internal/services/discovery/service.go
+++ b/internal/services/discovery/service.go
@@ -63,7 +63,12 @@ type ServiceStatus struct {
 // NewService creates a new unified discovery service.
 // If profiler is nil, a new DeviceProfiler is created internally.
 // If profiler is provided, it will be shared (e.g., with Pipeline).
-func NewService(cfg *config.Config, interfaceName string, profiler *DeviceProfiler) *Service {
+func NewService(
+	cfg *config.Config,
+	interfaceName string,
+	profiler *DeviceProfiler,
+	opts ...Option,
+) *Service {
 	if profiler == nil {
 		profiler = NewDeviceProfiler(DefaultProfilerConfig(), &cfg.SNMP)
 	}
@@ -74,6 +79,7 @@ func NewService(cfg *config.Config, interfaceName string, profiler *DeviceProfil
 			interfaceName,
 			cfg.NetworkDiscovery.OUIFilePath,
 			cfg.NetworkDiscovery.OUIMaxAge,
+			opts...,
 		),
 		profiler: profiler,
 		metrics:  NewMetrics(),


### PR DESCRIPTION
## Phase 6 — Slice 1b (capture-port migration + enforcement)

Migrates the **six libpcap seam files** onto the `capture.Opener` port from S1a (#1487), confining the CGO/libpcap taint to `internal/capture/pcap` so the domain packages build and test with `CGO_ENABLED=0`. This is the slice that delivers the build/test-speed win.

### Seam files migrated
`handle *pcap.Handle → capture.Handle`; `pcap.OpenLive → opener.OpenLive`; `pcap.BlockForever → capture.BlockForever`; drop the `gopacket/pcap` import, keep the CGO-free `gopacket` + `gopacket/layers`:
- **discovery**: `cdp.go`, `lldp.go`, `edp.go` — shared open+BPF logic extracted to `protocol_capture.go` so the three `Start` methods stay small and duplication-free.
- **dhcp**: `dhcp.go` (Monitor), `rogue.go` (RogueDetector).
- **vlan**: `traffic.go` (TrafficMonitor).

### Injection (zero test churn)
Capture-using constructors gain functional options (`WithCapture`) that **default to the CGO-free no-op** (nullcapture), so all existing call sites and ~300 tests compile and run unchanged. New `options.go` in each of discovery/dhcp/vlan. `Manager` threads the opener to its LLDP/CDP/EDP captures (including `SetInterface` recreation); `DeviceDiscovery`/`Service` forward opts.

### Composition root
`defaultCaptureOpener` selects the adapter by build tag:
- `wire_capture_real.go` (`//go:build cgo || windows`) → `pcap.New()`
- `wire_capture_null.go` (`//go:build !cgo && !windows`) → `nullcapture.New()`

NewServer's capture-using services moved into `initCaptureServices` (mirrors the existing `initDatabaseDependentServices` pattern). `internal/capture/pcap` is now build-tagged (`cgo || windows`) so `CGO_ENABLED=0 go build ./...` skips it. **Behavior preserved on every platform that captured before** — linux/darwin with CGO, and Windows (where `gopacket/pcap` is CGO-free via wpcap). Only new behavior: linux/darwin `CGO_ENABLED=0` (which never built before) gets the documented no-op adapter.

### Enforcement
- **depguard**: `gopacket/pcap` denied outside `internal/capture/pcap`.
- **CI**: new `CGO-free build check` step (`CGO_ENABLED=0 go build ./...`) in Backend (Go).

### Verification
- `CGO_ENABLED=0 go build ./...` ✅ (was failing before) · `go build ./...` (CGO) ✅
- `dhcp`/`vlan` test binaries no longer link libpcap (~0.02s vs seconds) ✅
- `go test -race` for capture/discovery/dhcp/vlan ✅ · golden HTTP harness ✅
- `golangci-lint run ./...` → **0 issues** (full repo, incl. new depguard rule) ✅

Closes the `docs/architecture/CGO_BUILD_STRATEGY.md` §3 acceptance criteria (updated to DONE). Part of the Phase 6 discovery split.