### PR TITLE
docs(adr): discovery orchestrator convergence — defer fold + schema to P7 (Phase 6 S4)

### DIFF
--- a/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
+++ b/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
@@ -176,6 +176,16 @@ seed/
 
 **Package migration map (current → target):**
 
+> **SUPERSEDED (Phase 3 reconcile, 2026-06).** The `internal/modules/*` +
+> `internal/adapters/*` hexagon rings below were **abandoned**. The backend is
+> **capability-first**: flat `internal/<feature>` packages (e.g. `internal/harvest`,
+> `internal/reporting`, `internal/discovery`), with ports applied as a technique at
+> the I/O seam (e.g. `internal/reporting/store`) and `depguard` enforcing direction.
+> This table is kept only as a record of the original plan. Concretely:
+> `internal/services/discovery` relocated to **`internal/discovery`** (Phase 6 S3,
+> #1489), *not* `internal/modules/shell/*`; `internal/harvest` stayed flat (not
+> `internal/modules/harvest`). Treat the rows below as historical, not the target.
+
 | Current | → Target |
 |---|---|
 | `internal/canopy/{,channel,survey,wifi,data}` | `internal/modules/canopy/…` |

--- a/docs/architecture/decisions/0007-discovery-orchestrator-convergence.md
+++ b/docs/architecture/decisions/0007-discovery-orchestrator-convergence.md
@@ -1,0 +1,69 @@
+# ADR-0007: Discovery orchestrator convergence — engine vs pipeline, deferred to Phase 7
+
+**Status:** Accepted — 2026-06-03
+
+## Context
+
+The discovery subsystem (`internal/discovery`, formerly `internal/services/discovery`)
+carries **four** overlapping orchestrators, discovered while scoping the Phase 6
+split:
+
+| Type | File | Role | Owned by |
+|---|---|---|---|
+| **Engine** | `engine.go` | "primary" unified orchestrator; `DeviceRegistry` is the single source of truth; distributes events | composition root |
+| **Service** | `service.go` | older direct-settings orchestrator; holds the Pipeline via `SetPipeline` | composition root |
+| **Pipeline** | `pipeline.go` + `pipeline_*.go` | sequential phased model (enumeration → resolution → scanning → assessment); own `currentRun` state | Service |
+| **Manager** | `manager.go` | L2 capture coordinator (LLDP/CDP/EDP) | `DeviceDiscovery` |
+
+Engine and Pipeline do the **same job** — discover → enrich (SNMP/portscan/profile)
+→ assess vulnerabilities — two different ways. Engine is the better-architected of
+the two: registry-as-SSoT plus event distribution that dovetails with the new
+events bus (ADR-0004) and jobs spine (ADR-0005). Pipeline is the older phased model
+with a parallel `currentRun` state machine. Service exists mainly to drive Pipeline.
+
+**The decisive finding:** the **frontend discovery UX runs on Pipeline, not Engine.**
+`ui/src/hooks/usePipelineStatus.ts` + `NetworkDiscoveryCard` + `PipelineProgress`
+call seven live `/api/v1/security/pipeline/*` endpoints (status/config/start/cancel/
+port-intensity/timing-profiles); the eight `/api/v1/discovery/engine/*` endpoints
+have **zero** frontend consumers. So the architecturally-preferable orchestrator has
+no users, and the shipping UX rides the one we would otherwise retire.
+
+A related deferral rides on the same fact: registering a code-first schema for
+`EngineDiscoveryResponse` / `discovery.DiscoveredDevice` (the ~150-field cluster across
+~20–30 nested structs) only delivers value once a TypeScript client consumes the
+Engine endpoint — which is the same Phase 7 frontend migration.
+
+## Decision
+
+- **Phase 6 is dedup-only for orchestration.** The capture-port extraction (S1,
+  ADR-aligned with `CGO_BUILD_STRATEGY.md`) and the package relocation (S3) ship; the
+  **orchestrators are not restructured** in Phase 6. No Pipeline/Service behavior
+  changes, no endpoint changes.
+- **Engine is the canonical target;** Pipeline (and the Service-as-Pipeline-driver
+  layer) is the legacy duplicate to retire.
+- **The Pipeline → Engine fold is deferred to Phase 7,** executed together with the
+  frontend migration that moves the discovery UI off `/api/v1/security/pipeline/*`
+  onto Engine + the `/jobs` spine. Folding earlier would mean rewriting Pipeline's
+  phased state machine to delegate to Engine while preserving the exact
+  `/security/pipeline/*` wire shape `PipelineProgress` expects — work that Phase 7
+  then discards when the UI stops calling those endpoints.
+- **The `internal/discovery/types` extraction and the `EngineDiscoveryResponse` /
+  `DiscoveredDevice` schema registration are deferred to Phase 7** (gated on the
+  frontend consuming Engine). Until a consumer exists, the ~150-field cluster stays
+  an opaque `any` job result / unregistered DTO rather than a speculative generated
+  schema maintained against no client.
+
+## Consequences
+
+- Phase 6 closes as **capture port + relocation + this decision** — no speculative
+  restructuring in the hot discovery zone, consistent with the "build it when a
+  consumer exists" stance taken for the transactional outbox (ADR-0004 amendment).
+- The duplication is documented and owned, not silently tolerated: Phase 7 has a
+  named task (Pipeline → Engine fold + endpoint retirement + types/schema) with a
+  clear trigger (the UI migration).
+- Survey stays a stateful interactive session, not an orchestrator (unchanged).
+- Risk: the two orchestrators coexist through Phase 6, so a discovery change may need
+  touching both. Accepted — the alternative (a fold now) is rewritten in Phase 7.
+
+Supersedes the Phase-6 portions of the blueprint that implied an in-phase engine↔
+pipeline consolidation and an in-phase `EngineDiscoveryResponse` schema registration.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -14,3 +14,4 @@ See the [Re-Architecture Blueprint](../RE_ARCHITECTURE_BLUEPRINT.md) for the ful
 | [0004](0004-event-bus.md) | In-process domain event bus | Accepted |
 | [0005](0005-unified-jobs.md) | Unified async job runner | Accepted |
 | [0006](0006-migrations-sql-goose-strict.md) | Schema as embedded `.sql` files, goose, STRICT tables | Accepted |
+| [0007](0007-discovery-orchestrator-convergence.md) | Discovery orchestrator convergence — engine vs pipeline, deferred to Phase 7 | Accepted |


### PR DESCRIPTION
## Phase 6 — Slice 4 (final: docs/decision only)

Closes Phase 6. Scoping showed the originally-planned S4 code work — extracting `internal/discovery/types` and registering the `EngineDiscoveryResponse`/`DiscoveredDevice` schema (~150 fields across ~20–30 of discovery's 176 structs) — **only pays off once the frontend consumes the Engine endpoint**, which has **zero consumers today** (the UI runs on Pipeline) and is Phase 7 work. So per owner decision, S4 ships as docs/decision only — no code change.

### What's here
- **ADR-0007** (`decisions/0007-discovery-orchestrator-convergence.md`, indexed in `decisions/README.md`): records the four-orchestrator finding (Engine / Service / Pipeline / Manager), Engine-is-canonical-but-has-no-consumers vs Pipeline-is-the-shipping-UX (7 live `/api/v1/security/pipeline/*` endpoints), and defers **both** the Pipeline→Engine fold **and** the types-pkg/schema registration to Phase 7 alongside the UI migration. Same "build it when a consumer exists" stance as the outbox deferral (ADR-0004 amendment).
- **`RE_ARCHITECTURE_BLUEPRINT.md`**: SUPERSEDED banner on the stale `internal/modules/*` hexagon "current → target" table (the Phase 3 reconcile went capability-first; discovery relocated to `internal/discovery` in S3 #1489, not `internal/modules/shell`).
- `PHASE3_EXTRACTION_PLAN.md` already carries a top-level SUPERSEDED banner, so its stale path reference is covered — left as-is.

### Phase 6 complete
- **S1** capture port — #1487 (scaffold) + #1488 (migrate 6 seam files, depguard + CGO=0 gate)
- **S3** relocate `services/discovery → internal/discovery` — #1489
- **S4** ADR-0007 + doc reconcile — this PR

Deferred to **Phase 7**: Pipeline→Engine fold + retire `/security/pipeline/*`, `internal/discovery/types` + EngineDiscoveryResponse schema, retire legacy run/status endpoint pairs, profile.ts/settings.ts twins.

Docs-only — no `.go`/UI changes (Backend + Frontend CI jobs skip).