### PR TITLE
fix(ui): bring AlertsPage onto semantic design tokens (P7 S0)

### DIFF
--- a/ui/src/pages/AlertsPage.tsx
+++ b/ui/src/pages/AlertsPage.tsx
@@ -34,7 +34,7 @@ export function AlertsPage(): JSX.Element {
       <FilterBar filter={filter} onChange={setFilter} count={alerts.length} loading={loading} />
 
       {error ? (
-        <div className="rounded-md border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-200">
+        <div className="rounded-md border border-status-error/40 bg-status-error/10 p-3 text-sm text-status-error">
           {error}
         </div>
       ) : null}
@@ -61,18 +61,18 @@ interface FilterBarProps {
 
 function FilterBar({ filter, onChange, count, loading }: FilterBarProps): JSX.Element {
   return (
-    <div className="flex flex-wrap items-center gap-3 rounded-md border border-zinc-800 bg-zinc-900/30 p-3 text-sm">
-      <span className="text-xs uppercase tracking-wide text-zinc-500">
+    <div className="flex flex-wrap items-center gap-3 rounded-md border border-surface-border bg-surface-raised p-3 text-sm">
+      <span className="text-xs uppercase tracking-wide text-text-muted">
         {loading ? 'Loading…' : `${count} alert${count === 1 ? '' : 's'}`}
       </span>
 
       <div className="ml-auto flex items-center gap-3">
-        <label className="flex items-center gap-2 text-zinc-300">
-          <span className="text-xs uppercase tracking-wide text-zinc-500">Severity</span>
+        <label className="flex items-center gap-2 text-text-secondary">
+          <span className="text-xs uppercase tracking-wide text-text-muted">Severity</span>
           <select
             value={filter.severity}
             onChange={(e): void => onChange({ ...filter, severity: e.target.value })}
-            className="rounded-md border border-zinc-700 bg-zinc-950 px-2 py-1 text-xs text-zinc-100"
+            className="rounded-md border border-surface-border bg-surface-sunken px-2 py-1 text-xs text-text-primary"
           >
             <option value="">all</option>
             <option value="critical">critical</option>
@@ -81,7 +81,7 @@ function FilterBar({ filter, onChange, count, loading }: FilterBarProps): JSX.El
             <option value="info">info</option>
           </select>
         </label>
-        <label className="flex items-center gap-1 text-xs text-zinc-300">
+        <label className="flex items-center gap-1 text-xs text-text-secondary">
           <input
             type="checkbox"
             checked={filter.unacknowledgedOnly}
@@ -89,7 +89,7 @@ function FilterBar({ filter, onChange, count, loading }: FilterBarProps): JSX.El
           />
           unack only
         </label>
-        <label className="flex items-center gap-1 text-xs text-zinc-300">
+        <label className="flex items-center gap-1 text-xs text-text-secondary">
           <input
             type="checkbox"
             checked={filter.unresolvedOnly}
@@ -111,16 +111,16 @@ interface AlertTableProps {
 function AlertTable({ alerts, onAcknowledge, onResolve }: AlertTableProps): JSX.Element {
   if (alerts.length === 0) {
     return (
-      <div className="rounded-md border border-zinc-700 bg-zinc-900/30 p-6 text-center text-sm text-zinc-400">
+      <div className="rounded-md border border-surface-border bg-surface-raised p-6 text-center text-sm text-text-muted">
         No alerts match the current filter. Either nothing's misbehaving or your filter is too
         strict.
       </div>
     );
   }
   return (
-    <div className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/30">
+    <div className="overflow-hidden rounded-lg border border-surface-border bg-surface-raised">
       <table className="w-full text-sm">
-        <thead className="text-left text-xs uppercase tracking-wide text-zinc-500">
+        <thead className="text-left text-xs uppercase tracking-wide text-text-muted">
           <tr>
             <th className="px-4 py-2">When</th>
             <th className="px-4 py-2">Severity</th>
@@ -130,18 +130,18 @@ function AlertTable({ alerts, onAcknowledge, onResolve }: AlertTableProps): JSX.
             <th className="px-4 py-2 text-right">Actions</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-zinc-800">
+        <tbody className="divide-y divide-surface-border">
           {alerts.map((a) => (
             <tr key={a.id} data-testid={`alert-row-${a.id}`}>
-              <td className="px-4 py-2 text-zinc-400">{fmtTime(a.createdAt)}</td>
+              <td className="px-4 py-2 text-text-muted">{fmtTime(a.createdAt)}</td>
               <td className="px-4 py-2">
                 <SeverityBadge severity={a.severity} />
               </td>
               <td className="px-4 py-2">
-                <div className="font-medium text-zinc-100">{a.title}</div>
-                {a.message ? <div className="text-xs text-zinc-500">{a.message}</div> : null}
+                <div className="font-medium text-text-primary">{a.title}</div>
+                {a.message ? <div className="text-xs text-text-muted">{a.message}</div> : null}
               </td>
-              <td className="px-4 py-2 font-mono text-xs text-zinc-300">{a.source || '—'}</td>
+              <td className="px-4 py-2 font-mono text-xs text-text-secondary">{a.source || '—'}</td>
               <td className="px-4 py-2">
                 <StateBadge alert={a} />
               </td>
@@ -150,7 +150,7 @@ function AlertTable({ alerts, onAcknowledge, onResolve }: AlertTableProps): JSX.
                   <button
                     type="button"
                     onClick={(): void => onAcknowledge(a.id)}
-                    className="mr-2 inline-flex items-center gap-1 text-sm text-sky-400 hover:text-sky-300"
+                    className="mr-2 inline-flex items-center gap-1 text-sm text-status-info hover:text-status-info/80"
                   >
                     <Check className="h-3.5 w-3.5" />
                     Ack
@@ -160,7 +160,7 @@ function AlertTable({ alerts, onAcknowledge, onResolve }: AlertTableProps): JSX.
                   <button
                     type="button"
                     onClick={(): void => onResolve(a.id)}
-                    className="inline-flex items-center gap-1 text-sm text-emerald-400 hover:text-emerald-300"
+                    className="inline-flex items-center gap-1 text-sm text-status-success hover:text-status-success/80"
                   >
                     <CheckCircle2 className="h-3.5 w-3.5" />
                     Resolve
@@ -180,12 +180,12 @@ function SeverityBadge({ severity }: { severity: string }): JSX.Element {
   // Anything outside the known set lands in the neutral fallback so
   // server-side rule additions don't break the UI.
   const palette: Record<string, string> = {
-    critical: 'bg-rose-500/20 text-rose-300',
-    error: 'bg-orange-500/20 text-orange-300',
-    warning: 'bg-amber-500/20 text-amber-300',
-    info: 'bg-sky-500/20 text-sky-300',
+    critical: 'bg-severity-high/20 text-severity-high',
+    error: 'bg-status-error/20 text-status-error',
+    warning: 'bg-status-warning/20 text-status-warning',
+    info: 'bg-status-info/20 text-status-info',
   };
-  const cls = palette[severity] ?? 'bg-zinc-700 text-zinc-300';
+  const cls = palette[severity] ?? 'bg-surface-sunken text-text-secondary';
   return (
     <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${cls}`}>
       {severity || 'unknown'}
@@ -196,7 +196,10 @@ function SeverityBadge({ severity }: { severity: string }): JSX.Element {
 function StateBadge({ alert }: { alert: Alert }): JSX.Element {
   if (alert.resolved) {
     return (
-      <span className="text-xs text-emerald-400" title={`Resolved at ${fmtTime(alert.resolvedAt)}`}>
+      <span
+        className="text-xs text-status-success"
+        title={`Resolved at ${fmtTime(alert.resolvedAt)}`}
+      >
         Resolved
       </span>
     );
@@ -204,14 +207,14 @@ function StateBadge({ alert }: { alert: Alert }): JSX.Element {
   if (alert.acknowledged) {
     return (
       <span
-        className="text-xs text-sky-400"
+        className="text-xs text-status-info"
         title={`Acknowledged${alert.acknowledgedBy ? ` by ${alert.acknowledgedBy}` : ''}`}
       >
         Acknowledged
       </span>
     );
   }
-  return <span className="text-xs text-zinc-400">Open</span>;
+  return <span className="text-xs text-text-muted">Open</span>;
 }
 
 function fmtTime(iso?: string): string {


### PR DESCRIPTION
Replace raw zinc/rose/orange/amber/sky palette utilities with semantic
surface/text/status tokens so the page is theme-aware (legible in light
mode) and passes the design-token CI gate (#1437). Severity badges map
to status tokens; critical uses the dedicated severity-high token to
stay visually distinct from error.

Pure token swap — no logic, structure, or behavior change.

Token gate: whole-repo blocking violations 58 -> 32 (AlertsPage now
contributes 0). Second of three NMS-page cleanups.

Refs #1437, SEED_UI_ARCH_PLAN A1
