### PR TITLE
ci+test: fix two E2E flakes (artifact digest-mismatch + stale gateway mock)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # download-artifact v8 enforces a stricter digest check that is
+      # incompatible with artifacts produced by upload-artifact v7 (which
+      # has no v8 release yet), so a v7-uploaded artifact intermittently
+      # fails the v8 download with `digest-mismatch: error` under the
+      # concurrent restores of the 8-way E2E shard matrix. Pin both to v7
+      # until upload-artifact ships a matching v8 and bump them together.
+      - dependency-name: "actions/download-artifact"
+        update-types: ["version-update:semver-major"]
 
   # Keep Go dependencies up to date
   - package-ecosystem: "gomod"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,7 +695,7 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Download frontend build
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: frontend-dist
           path: internal/api/ui/
@@ -856,7 +856,7 @@ jobs:
         uses: ./.github/actions/setup-libpcap
 
       - name: Download frontend build
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: frontend-dist
           path: internal/api/ui/
@@ -959,7 +959,7 @@ jobs:
         uses: ./.github/actions/setup-libpcap
 
       - name: Download frontend build
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: frontend-dist
           path: internal/api/ui/
@@ -1053,7 +1053,7 @@ jobs:
         uses: ./.github/actions/setup-libpcap
 
       - name: Download frontend build
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: frontend-dist
           path: internal/api/ui/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
           apt-get install -y libpcap-dev libpcap-dev:arm64
 
       - name: Download iperf3 artifacts (amd64 + arm64)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: iperf3-linux-*
           path: bin/
@@ -216,7 +216,7 @@ jobs:
         run: chmod +x bin/iperf3-linux-*
 
       - name: Download UI dist
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ui-dist
           path: internal/api/ui/

--- a/ui/e2e/gateway.spec.ts
+++ b/ui/e2e/gateway.spec.ts
@@ -66,7 +66,7 @@ const MOCK_GATEWAY = {
 };
 
 async function mockGatewayEndpoint(page: import('@playwright/test').Page): Promise<void> {
-  await page.route(/\/api\/v1\/sap\/gateway(\?.*)?$/, (route) => {
+  await page.route(/\/api\/v1\/telemetry\/gateway(\?.*)?$/, (route) => {
     route.fulfill({
       status: 200,
       contentType: 'application/json',


### PR DESCRIPTION
Two independent E2E flakes surfaced while clearing the #1437 token gate in P7 S0. Both are fixed here; both are pre-existing and unrelated to the token-cleanup PRs (#1491/#1492/#1493).

## 1. `frontend-dist` artifact `digest-mismatch` (infra)
The 8-way E2E shard matrix + build-container jobs intermittently failed restoring `frontend-dist` with `digest-mismatch: error`, leaving `internal/api/ui` empty so the backend never started and every test in the shard failed.

**Root cause:** version skew — artifacts are produced with `upload-artifact@v7.0.1` (its latest; there is no v8) but restored with `download-artifact@v8.0.1`, whose stricter digest check is incompatible with v7-produced artifacts.

**Fix:** pin all 6 `download-artifact` sites (4 `ci.yml` + 2 `release.yml`) to v7.0.0 (matched pairing) + a dependabot `ignore` on `download-artifact` semver-major so v8 isn't auto-reintroduced. Lift it and bump both together once `upload-artifact` ships a v8.

## 2. `gateway.spec.ts` stale mock (test)
The spec mocks the gateway endpoint to render the populated `GatewayCard` branch deterministically, but its `page.route` regex still matched the pre-#1451 botanical path `/api/v1/sap/gateway` while the app now calls `/api/v1/telemetry/gateway`. The mock never intercepted, so the spec fell through to the real endpoint and only passed when live CI gateway detection happened to succeed.

**Fix:** point the mock at `/api/v1/telemetry/gateway`. Swept the rest of `ui/e2e` — this was the only stale botanical route mock.

## Out of scope (flagged, not fixed here)
`auth-complete.spec.ts` shows a **webkit-only** session-persist/re-login timing flake. That belongs to the `internal/auth`/`oauth` workstream (CLAUDE.md: coordinate, don't cross in) and is a different failure class. Tracked separately.