### PR TITLE
feat(schema): register JobResponse + CreateJobRequest DTOs (P7 S1a)

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -225,6 +225,15 @@ func schemaTargets() []schemaTarget {
 		{&api.ProfileListResponse{}, "profile-list-response.schema.json"},
 		{&api.ProfileImportRequest{}, "profile-import-request.schema.json"},
 		{&api.ProfileExportResponse{}, "profile-export-response.schema.json"},
+
+		// Jobs spine — unified job runner transport (ADR-0005, §8). The job
+		// request params and the job result are deliberately opaque: params is
+		// json.RawMessage (each kind validates its own shape) and result is a
+		// bare interface (kind-specific payload), so both document as arbitrary
+		// JSON. Registration was deferred in #1468 until a frontend consumer
+		// existed; Phase 7 S1 adds the TS /jobs client that consumes these.
+		{&api.CreateJobRequest{}, "create-job-request.schema.json"},
+		{&api.JobResponse{}, "job-response.schema.json"},
 	}
 
 	targets := make([]schemaTarget, len(rows))

--- a/docs/schemas/api/create-job-request.schema.json
+++ b/docs/schemas/api/create-job-request.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/create-job-request.schema.json",
+  "$ref": "#/$defs/CreateJobRequest",
+  "$defs": {
+    "CreateJobRequest": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "params": true
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind"
+      ]
+    }
+  },
+  "title": "CreateJobRequest",
+  "description": "CreateJobRequest — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/job-response.schema.json
+++ b/docs/schemas/api/job-response.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/job-response.schema.json",
+  "$ref": "#/$defs/JobResponse",
+  "$defs": {
+    "JobResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "progress": {
+          "type": "number"
+        },
+        "result": true,
+        "error": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "kind",
+        "state",
+        "progress"
+      ]
+    }
+  },
+  "title": "JobResponse",
+  "description": "JobResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/src/types/generated/create-job-request.ts
+++ b/ui/src/types/generated/create-job-request.ts
@@ -1,0 +1,11 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface CreateJobRequest {
+  kind: string;
+  params?: unknown;
+}

--- a/ui/src/types/generated/job-response.ts
+++ b/ui/src/types/generated/job-response.ts
@@ -1,0 +1,15 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface JobResponse {
+  id: string;
+  kind: string;
+  state: string;
+  progress: number;
+  result?: unknown;
+  error?: string;
+}


### PR DESCRIPTION
#1468 left the /jobs transport DTOs unregistered in the code-first schema
("add when frontend consumes"). Phase 7 S1 builds that consumer (the TS
/jobs client), so register them now: one declarative row each in
cmd/seed-schema, regenerated docs/schemas/api/*.json and the
ui/src/types/generated/*.ts twins.

Both opaque fields document as arbitrary JSON → TS `unknown`:
CreateJobRequest.params (json.RawMessage; each kind validates its own
shape) and JobResponse.result (bare interface; kind-specific payload).
This is intentional and correct until a specific kind's result needs a
typed schema.

Gates: round-trip + acyclic guardrail, schema-drift, types-drift,
golangci 0, go build ./cmd/seed, ui tsc, golden HTTP harness (no route
change — additive schema only). Generated TS files are pure interfaces,
token-gate clean.

Refs #1468, ADR-0005
