### PR TITLE
feat(ui): add jobs client + job event stream hook (P7 S1b)

### DIFF
--- a/ui/src/hooks/useJobEvents.test.ts
+++ b/ui/src/hooks/useJobEvents.test.ts
@@ -1,0 +1,122 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JobResponse } from '../types/generated/job-response';
+import { useJobEvents } from './useJobEvents';
+
+/**
+ * Controllable EventSource fake: records listeners by event name and lets
+ * the test emit frames and drive readyState. Replaces the coarse global
+ * mock from test/setup.ts for this suite (per its "mock further per-suite"
+ * note).
+ */
+class FakeEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+  static instances: FakeEventSource[] = [];
+
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSED = 2;
+
+  url: string;
+  readyState = 0;
+  closed = false;
+  private listeners: Record<string, ((ev: unknown) => void)[]> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, fn: (ev: unknown) => void): void {
+    const existing = this.listeners[type] ?? [];
+    existing.push(fn);
+    this.listeners[type] = existing;
+  }
+
+  removeEventListener(): void {}
+
+  close(): void {
+    this.closed = true;
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  emit(type: string, ev: unknown): void {
+    for (const fn of this.listeners[type] ?? []) {
+      fn(ev);
+    }
+  }
+}
+
+const runningJob: JobResponse = {
+  id: 'job-1',
+  kind: 'engine-scan',
+  state: 'running',
+  progress: 0.5,
+};
+
+describe('useJobEvents', () => {
+  let originalEventSource: typeof EventSource;
+
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    originalEventSource = global.EventSource;
+    global.EventSource = FakeEventSource as unknown as typeof EventSource;
+  });
+
+  afterEach(() => {
+    global.EventSource = originalEventSource;
+  });
+
+  it('opens one stream at the jobs events path', () => {
+    renderHook(() => useJobEvents(vi.fn()));
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0].url).toContain('/api/v1/jobs/events');
+  });
+
+  it('invokes onJob with the parsed job for each `job` frame', () => {
+    const onJob = vi.fn();
+    renderHook(() => useJobEvents(onJob));
+
+    FakeEventSource.instances[0].emit('job', { data: JSON.stringify(runningJob) });
+
+    expect(onJob).toHaveBeenCalledWith(runningJob);
+  });
+
+  it('reports open status once the stream opens', () => {
+    const { result } = renderHook(() => useJobEvents(vi.fn()));
+
+    expect(result.current.status).toBe('connecting');
+    act(() => FakeEventSource.instances[0].emit('open', {}));
+    expect(result.current.status).toBe('open');
+  });
+
+  it('ignores a malformed frame without throwing or calling onJob', () => {
+    const onJob = vi.fn();
+    renderHook(() => useJobEvents(onJob));
+
+    expect(() => FakeEventSource.instances[0].emit('job', { data: 'not json' })).not.toThrow();
+    expect(onJob).not.toHaveBeenCalled();
+  });
+
+  it('closes the stream on unmount', () => {
+    const { unmount } = renderHook(() => useJobEvents(vi.fn()));
+    const source = FakeEventSource.instances[0];
+
+    unmount();
+
+    expect(source.closed).toBe(true);
+  });
+
+  it('does not re-open the stream when only the callback identity changes', () => {
+    const { rerender } = renderHook(({ cb }) => useJobEvents(cb), {
+      initialProps: { cb: vi.fn() },
+    });
+
+    rerender({ cb: vi.fn() });
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+});

--- a/ui/src/hooks/useJobEvents.ts
+++ b/ui/src/hooks/useJobEvents.ts
@@ -1,0 +1,71 @@
+/**
+ * useJobEvents — subscribe to the unified job event stream.
+ *
+ * The backend multiplexes every job lifecycle transition (queued →
+ * running → succeeded/failed/cancelled) onto one SSE stream at
+ * /api/v1/jobs/events as named `job` frames whose data is a JobResponse
+ * (handlers_jobs.go). This hook opens that stream once and invokes
+ * `onJob` for each frame; the browser's EventSource handles reconnection.
+ *
+ * It is the read side of the jobs spine: callers submit work with
+ * jobsClient.submitJob and observe progress/completion here, rather than
+ * polling per-job. A single stream serves all in-flight jobs, so mount
+ * one subscription and route by job id at the callback.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { LogComponents, logger } from '../lib/logger';
+import type { JobResponse } from '../types/generated/job-response';
+
+/** Path of the multiplexed job event stream. */
+const JOBS_EVENTS_URL = '/api/v1/jobs/events';
+
+/** Connection status of the job event stream. */
+export type JobEventsStatus = 'connecting' | 'open' | 'closed';
+
+/**
+ * useJobEvents opens the job SSE stream and calls `onJob` for every
+ * state-change frame. Returns the live connection status. The callback
+ * is held in a ref so changing it does not tear down the stream.
+ */
+export function useJobEvents(onJob: (job: JobResponse) => void): { status: JobEventsStatus } {
+  const [status, setStatus] = useState<JobEventsStatus>('connecting');
+
+  // Hold the callback in a ref so a new function identity each render
+  // does not re-open the EventSource (the effect deliberately has no deps).
+  const onJobRef = useRef(onJob);
+  useEffect(() => {
+    onJobRef.current = onJob;
+  }, [onJob]);
+
+  useEffect(() => {
+    // EventSource does not accept relative URLs in all browsers; build an
+    // absolute one the same way useSse does.
+    const fullUrl = `${window.location.protocol}//${window.location.host}${JOBS_EVENTS_URL}`;
+    const source = new EventSource(fullUrl, { withCredentials: true });
+    setStatus('connecting');
+
+    source.addEventListener('open', () => setStatus('open'));
+
+    source.addEventListener('job', (event: MessageEvent<string>) => {
+      try {
+        const job = JSON.parse(event.data) as JobResponse;
+        onJobRef.current(job);
+      } catch (error) {
+        logger.error(LogComponents.SSE, 'Failed to parse job event', error, {
+          data: event.data,
+        });
+      }
+    });
+
+    source.addEventListener('error', () => {
+      // EventSource auto-reconnects unless it has hard-closed. Reflect the
+      // state so callers can surface a connection indicator.
+      setStatus(source.readyState === EventSource.CLOSED ? 'closed' : 'connecting');
+    });
+
+    return () => source.close();
+  }, []);
+
+  return { status };
+}

--- a/ui/src/lib/jobsClient.test.ts
+++ b/ui/src/lib/jobsClient.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CreateJobRequest } from '../types/generated/create-job-request';
+import type { JobResponse } from '../types/generated/job-response';
+import { cancelJob, getJob, isTerminalJobState, submitJob } from './jobsClient';
+
+// Mock the shared API client so we assert the exact endpoint/method/headers
+// the jobs client uses, without exercising fetch/CSRF plumbing here.
+vi.mock('../api/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { api } from '../api/client';
+
+const sampleJob: JobResponse = {
+  id: 'job-123',
+  kind: 'engine-scan',
+  state: 'queued',
+  progress: 0,
+};
+
+describe('jobsClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('submitJob', () => {
+    it('POSTs to /api/v1/jobs with the request body', async () => {
+      vi.mocked(api.post).mockResolvedValueOnce(sampleJob);
+      const req: CreateJobRequest = { kind: 'engine-scan' };
+
+      const result = await submitJob(req);
+
+      expect(api.post).toHaveBeenCalledWith('/api/v1/jobs', req, undefined);
+      expect(result).toEqual(sampleJob);
+    });
+
+    it('passes an Idempotency-Key header when given', async () => {
+      vi.mocked(api.post).mockResolvedValueOnce(sampleJob);
+      const req: CreateJobRequest = { kind: 'speedtest' };
+
+      await submitJob(req, 'key-abc');
+
+      expect(api.post).toHaveBeenCalledWith('/api/v1/jobs', req, {
+        headers: { 'Idempotency-Key': 'key-abc' },
+      });
+    });
+  });
+
+  describe('getJob', () => {
+    it('GETs the id-scoped endpoint, url-encoding the id', async () => {
+      vi.mocked(api.get).mockResolvedValueOnce(sampleJob);
+
+      await getJob('a/b id');
+
+      expect(api.get).toHaveBeenCalledWith('/api/v1/jobs/a%2Fb%20id');
+    });
+  });
+
+  describe('cancelJob', () => {
+    it('DELETEs the id-scoped endpoint', async () => {
+      vi.mocked(api.delete).mockResolvedValueOnce({ ...sampleJob, state: 'cancelled' });
+
+      const result = await cancelJob('job-123');
+
+      expect(api.delete).toHaveBeenCalledWith('/api/v1/jobs/job-123');
+      expect(result.state).toBe('cancelled');
+    });
+  });
+
+  describe('isTerminalJobState', () => {
+    it('is true for terminal states', () => {
+      expect(isTerminalJobState('succeeded')).toBe(true);
+      expect(isTerminalJobState('failed')).toBe(true);
+      expect(isTerminalJobState('cancelled')).toBe(true);
+    });
+
+    it('is false for in-flight states', () => {
+      expect(isTerminalJobState('queued')).toBe(false);
+      expect(isTerminalJobState('running')).toBe(false);
+      expect(isTerminalJobState('')).toBe(false);
+    });
+  });
+});

--- a/ui/src/lib/jobsClient.ts
+++ b/ui/src/lib/jobsClient.ts
@@ -1,0 +1,62 @@
+/**
+ * jobsClient — typed client for the unified job runner spine (ADR-0005).
+ *
+ * The backend exposes long-running operations through one /api/v1/jobs
+ * surface: POST submits a job of a given kind, GET snapshots it, DELETE
+ * cancels it, and GET /jobs/events streams every state change (see
+ * useJobEvents). These thin wrappers ride the shared CSRF-aware `api`
+ * client so credentials, CSRF tokens, and 401-refresh are handled the
+ * same way as every other call.
+ *
+ * The request params and job result are intentionally opaque (`unknown`
+ * in the generated types): each kind owns its own params/result shape.
+ * Callers narrow them at the use site.
+ */
+
+import { api } from '../api/client';
+import type { CreateJobRequest } from '../types/generated/create-job-request';
+import type { JobResponse } from '../types/generated/job-response';
+
+/** JobState mirrors the platform/jobs runner lifecycle (ADR-0005). */
+export type JobState = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+
+/** Base path for the jobs surface. */
+const JOBS_BASE = '/api/v1/jobs';
+
+/**
+ * submitJob POSTs a new job of the given kind and returns the created
+ * snapshot (state is usually `queued` or `running`). Pass an idempotency
+ * key to make retries safe: the backend replays the original job for the
+ * same key + body, and rejects a reused key with a different body (409).
+ */
+export async function submitJob(
+  req: CreateJobRequest,
+  idempotencyKey?: string,
+): Promise<JobResponse> {
+  const init: RequestInit | undefined = idempotencyKey
+    ? { headers: { 'Idempotency-Key': idempotencyKey } }
+    : undefined;
+  return api.post<JobResponse>(JOBS_BASE, req, init);
+}
+
+/** getJob returns the current snapshot of a job by id. */
+export async function getJob(id: string): Promise<JobResponse> {
+  return api.get<JobResponse>(`${JOBS_BASE}/${encodeURIComponent(id)}`);
+}
+
+/**
+ * cancelJob requests cancellation of a job. The backend acknowledges
+ * asynchronously (202) and returns the snapshot at cancel time; the
+ * terminal `cancelled` state arrives over the event stream.
+ */
+export async function cancelJob(id: string): Promise<JobResponse> {
+  return api.delete<JobResponse>(`${JOBS_BASE}/${encodeURIComponent(id)}`);
+}
+
+/**
+ * isTerminalJobState reports whether a job state is final — i.e. no
+ * further events will arrive for it. Useful for stopping a watch.
+ */
+export function isTerminalJobState(state: string): boolean {
+  return state === 'succeeded' || state === 'failed' || state === 'cancelled';
+}


### PR DESCRIPTION
The read/write foundation for the unified job spine (ADR-0005), consuming
the JobResponse/CreateJobRequest types registered in S1a (#1497):

- lib/jobsClient.ts — submitJob/getJob/cancelJob over the shared
  CSRF-aware `api` client (so credentials, CSRF, 401-refresh are handled
  uniformly), plus isTerminalJobState. submitJob accepts an
  Idempotency-Key for safe retries.
- hooks/useJobEvents.ts — subscribes to the multiplexed /api/v1/jobs/events
  SSE stream and invokes onJob per `job` frame; one stream serves all
  in-flight jobs, callback held in a ref so it never tears down the
  connection, EventSource handles reconnect.

Tests (12, all green): client endpoint/method/header assertions incl.
id url-encoding and idempotency header; event hook parses frames, tracks
open/connecting/closed status, ignores malformed frames, closes on
unmount, and does not re-open on callback identity change.

Purely additive — no consumer yet; Phase 7 S3 migrates the discovery UX
onto this (engine-scan kind + this stream) off the pipeline endpoints.

Refs ADR-0005, ADR-0007
