### PR TITLE
feat(schema): register EngineDiscoveryResponse via the ADR-0008 pure-data exception (P7 S2)

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -63,6 +63,15 @@ type reg struct {
 // GatewayPingResult value object so the published schema stays acyclic.
 // Unexported lowercase DTOs cannot be referenced here.
 //
+// EXCEPTION (ADR-0008): genuinely PURE-DATA domain types whose JSON shape the
+// endpoint already serializes at runtime may be reflected directly, rather than
+// hand-mirrored. EngineDiscoveryResponse uses this for the discovery.* result
+// cluster (DiscoveredDevice/EngineStats/ScanResult and their pure-data closure):
+// internal/discovery is CGO-free, the /discovery/engine endpoint already emits
+// these structs, and the cluster carries no behavior/channels/funcs. The
+// exception is narrow — behavior- or I/O-bearing domain types still get a flat
+// mirror. The round-trip + acyclicity guardrails enforce it either way.
+//
 // Function rather than a package-level var to keep gochecknoglobals happy and
 // so `go run` doesn't pull internal/api into an init side effect.
 func schemaTargets() []schemaTarget {
@@ -234,6 +243,15 @@ func schemaTargets() []schemaTarget {
 		// existed; Phase 7 S1 adds the TS /jobs client that consumes these.
 		{&api.CreateJobRequest{}, "create-job-request.schema.json"},
 		{&api.JobResponse{}, "job-response.schema.json"},
+
+		// Engine discovery result — the ADR-0008 pure-data exception. Reflects
+		// the discovery.* result cluster (DiscoveredDevice/EngineStats/
+		// ScanResult and their pure-data closure) directly rather than
+		// hand-mirroring ~150 fields: internal/discovery is CGO-free, the
+		// /discovery/engine endpoint already serializes these structs, and the
+		// cluster carries no behavior. Unblocks the Phase 7 frontend consuming
+		// typed engine results off the /jobs spine.
+		{&api.EngineDiscoveryResponse{}, "engine-discovery-response.schema.json"},
 	}
 
 	targets := make([]schemaTarget, len(rows))

--- a/docs/architecture/decisions/0008-pure-data-discovery-types-in-schema.md
+++ b/docs/architecture/decisions/0008-pure-data-discovery-types-in-schema.md
@@ -1,0 +1,101 @@
+# ADR-0008: Pure-data discovery types may be reflected into the published schema
+
+**Status:** Accepted — 2026-06-04
+
+## Context
+
+Phase 2 established a policy for the code-first schema registry
+(`cmd/seed-schema`): a DTO is registered only if it is flat or nests only
+local, purpose-built transport sub-structs in `internal/api`. DTOs that put an
+internal **domain** type on the wire (`discovery.*`, `dhcp.*`, `netif.*`,
+`logging.*`, `survey.*`, `config`) were given hand-written flat `internal/api`
+mirrors so the published schema never reaches into a domain package. The
+intent: keep the wire contract decoupled from internal struct layout.
+
+`EngineDiscoveryResponse` (`internal/api/handlers_engine.go`) was the one DTO
+left unregistered under that policy. It embeds the discovery result cluster
+directly:
+
+```go
+type EngineDiscoveryResponse struct {
+    Devices      []*discovery.DiscoveredDevice `json:"devices"`
+    Stats        *discovery.EngineStats        `json:"stats"`
+    ScanResult   *discovery.ScanResult         `json:"scanResult,omitempty"`
+    Capabilities map[string]bool               `json:"capabilities"`
+}
+```
+
+`discovery.DiscoveredDevice` reaches ~20–30 nested structs (LLDP/CDP/EDP/NDP
+info, `DeviceProfile`, `SNMPFullData`, `DeviceVulnerabilities`, `WiFiPresence`,
+`BluetoothPresence`, `EngineStats` → `RegistryStats`/`EventBusStats`,
+`ScanResult` → `ScanStats`) — roughly 150 fields. ADR-0007 deferred registering
+it to Phase 7 and contemplated extracting a CGO-free `internal/discovery/types`
+package to serve as a clean shared contract.
+
+Three facts, established while scoping Phase 7 S2, change the calculus:
+
+1. **`internal/discovery` is already CGO-free.** Phase 6 (ADR-aligned with
+   `CGO_BUILD_STRATEGY.md`) confined libpcap to `internal/capture/pcap`;
+   `CGO_ENABLED=0 go build ./internal/discovery/` now succeeds. The original
+   driver for the types-package extraction — getting these types out of a
+   CGO-coupled package so the schema tool can reflect them — is moot.
+
+2. **The contract is already coupled at runtime.** The live
+   `GET /api/v1/discovery/engine` endpoint already serializes
+   `discovery.DiscoveredDevice` (and the whole cluster) to JSON on the wire.
+   Registering a schema does not *create* coupling between the wire shape and
+   `discovery`'s struct layout — that coupling already ships. A schema only
+   *documents* it and lets us generate the TypeScript types the Phase 7
+   frontend needs.
+
+3. **The cluster is pure data.** Every reachable struct is plain data
+   (strings, ints, bools, `time.Time`, named-string enums, slices, and nested
+   pure-data pointers). The only method in the entire tree is
+   `DiscoveredDevice.ComputeDisplayName()`. The stats types
+   (`RegistryStats`/`EventBusStats`/`ScanStats`) are counter snapshots, not the
+   live registry/event-bus objects — no channels, mutexes, or funcs.
+
+Given (1)–(3), the heavyweight `internal/discovery/types` extraction (a large,
+careful refactor of the hot discovery package) would buy mainly policy purity,
+not CGO-freeness or genuine decoupling — the contract is already what it is.
+Hand-mirroring ~150 fields into `internal/api` would create a perpetual
+sync-burden parallel tree (the explicit anti-goal of the Phase 2 policy).
+
+## Decision
+
+- **Genuinely pure-data discovery types may be reflected directly into the
+  published schema.** `EngineDiscoveryResponse` is registered in
+  `cmd/seed-schema` as-is, reflecting `discovery.DiscoveredDevice`,
+  `discovery.EngineStats`, and `discovery.ScanResult` and their pure-data
+  closure. This carves a narrow exception into the Phase 2 "no domain type in
+  the schema" policy, limited to **pure-data** types whose JSON shape the
+  endpoint already emits at runtime.
+- **The exception does not extend to behavior-bearing or I/O-coupled domain
+  types.** A domain type that carries channels, mutexes, funcs, live handles,
+  or non-trivial behavior still gets a flat `internal/api` mirror (the Phase 2
+  rule). "Pure data the endpoint already serializes" is the test.
+- **The `internal/discovery/types` extraction contemplated by ADR-0007 is
+  withdrawn as unnecessary.** Should a future need arise to decouple the wire
+  contract from `discovery`'s internals (e.g. the struct layout starts churning
+  for reasons unrelated to the API), revisit the extraction then.
+- The round-trip and acyclicity guardrails in `cmd/seed-schema` remain the
+  enforcement: a registered DTO must round-trip against its generated schema
+  and produce an acyclic `$defs` graph. Those tests validate this registration.
+
+## Consequences
+
+- `EngineDiscoveryResponse` gains a generated JSON schema and TypeScript type,
+  unblocking the Phase 7 S3 migration of the discovery UX onto the Engine +
+  jobs spine (the frontend can consume typed device results instead of an
+  opaque `unknown`).
+- The published wire contract for the engine endpoint is now explicit and
+  drift-gated (`check-schema-drift.sh` / `check-types-drift.sh`), where before
+  it was an undocumented runtime serialization. This is a net increase in
+  contract discipline, not a decrease.
+- The wire shape is coupled to `discovery`'s pure-data struct layout. Because
+  the schema is regenerated from the Go structs and drift-gated, a field change
+  surfaces in review as a schema/type diff rather than silently — the coupling
+  is visible and owned.
+- Supersedes the portion of ADR-0007 that deferred the `EngineDiscoveryResponse`
+  schema and contemplated an `internal/discovery/types` extraction as its
+  prerequisite.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -15,3 +15,4 @@ See the [Re-Architecture Blueprint](../RE_ARCHITECTURE_BLUEPRINT.md) for the ful
 | [0005](0005-unified-jobs.md) | Unified async job runner | Accepted |
 | [0006](0006-migrations-sql-goose-strict.md) | Schema as embedded `.sql` files, goose, STRICT tables | Accepted |
 | [0007](0007-discovery-orchestrator-convergence.md) | Discovery orchestrator convergence — engine vs pipeline, deferred to Phase 7 | Accepted |
+| [0008](0008-pure-data-discovery-types-in-schema.md) | Pure-data discovery types may be reflected into the published schema | Accepted |

--- a/docs/schemas/api/engine-discovery-response.schema.json
+++ b/docs/schemas/api/engine-discovery-response.schema.json
@@ -1,0 +1,1142 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/engine-discovery-response.schema.json",
+  "$ref": "#/$defs/EngineDiscoveryResponse",
+  "$defs": {
+    "BluetoothPresence": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "deviceClass": {
+          "type": "string"
+        },
+        "rssi": {
+          "type": "integer"
+        },
+        "txPower": {
+          "type": "integer"
+        },
+        "isPaired": {
+          "type": "boolean"
+        },
+        "isConnected": {
+          "type": "boolean"
+        },
+        "isAuthorized": {
+          "type": "boolean"
+        },
+        "services": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "lastSeen": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "isPaired",
+        "isConnected",
+        "isAuthorized",
+        "lastSeen"
+      ]
+    },
+    "CDPDeviceInfo": {
+      "properties": {
+        "deviceId": {
+          "type": "string"
+        },
+        "portId": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "softwareVersion": {
+          "type": "string"
+        },
+        "capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "managementAddress": {
+          "type": "string"
+        },
+        "nativeVlan": {
+          "type": "integer"
+        },
+        "voiceVlan": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "deviceId",
+        "portId"
+      ]
+    },
+    "DeviceProfile": {
+      "properties": {
+        "profiledAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "openPorts": {
+          "items": {
+            "$ref": "#/$defs/OpenPort"
+          },
+          "type": "array"
+        },
+        "httpInfo": {
+          "$ref": "#/$defs/HTTPInfo"
+        },
+        "snmpInfo": {
+          "$ref": "#/$defs/SNMPInfo"
+        },
+        "mdnsServices": {
+          "items": {
+            "$ref": "#/$defs/MDNSService"
+          },
+          "type": "array"
+        },
+        "deviceType": {
+          "type": "string"
+        },
+        "deviceIcons": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "profiledAt"
+      ]
+    },
+    "DeviceVulnerabilities": {
+      "properties": {
+        "deviceIp": {
+          "type": "string"
+        },
+        "mac": {
+          "type": "string"
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "product": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "vulnerabilities": {
+          "items": {
+            "$ref": "#/$defs/Vulnerability"
+          },
+          "type": "array"
+        },
+        "scanTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "deviceIp",
+        "mac",
+        "hostname",
+        "vendor",
+        "product",
+        "version",
+        "vulnerabilities",
+        "scanTime"
+      ]
+    },
+    "DiscoveredDevice": {
+      "properties": {
+        "ip": {
+          "type": "string"
+        },
+        "ipv6": {
+          "type": "string"
+        },
+        "ipv6Addresses": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mac": {
+          "type": "string"
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "netbiosName": {
+          "type": "string"
+        },
+        "mdnsName": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "osGuess": {
+          "type": "string"
+        },
+        "ttl": {
+          "type": "integer"
+        },
+        "discoveryMethod": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "lastSeen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "isLocal": {
+          "type": "boolean"
+        },
+        "isRouter": {
+          "type": "boolean"
+        },
+        "hasDuplicateIP": {
+          "type": "boolean"
+        },
+        "duplicateMACs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "lldpInfo": {
+          "$ref": "#/$defs/LLDPDeviceInfo"
+        },
+        "cdpInfo": {
+          "$ref": "#/$defs/CDPDeviceInfo"
+        },
+        "edpInfo": {
+          "$ref": "#/$defs/EDPDeviceInfo"
+        },
+        "ndpInfo": {
+          "$ref": "#/$defs/NDPDeviceInfo"
+        },
+        "profile": {
+          "$ref": "#/$defs/DeviceProfile"
+        },
+        "snmpData": {
+          "$ref": "#/$defs/SNMPFullData"
+        },
+        "vulnerabilities": {
+          "$ref": "#/$defs/DeviceVulnerabilities"
+        },
+        "wolCapable": {
+          "type": "boolean"
+        },
+        "wolStatus": {
+          "type": "string"
+        },
+        "connectionTypes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "wifiPresence": {
+          "$ref": "#/$defs/WiFiPresence"
+        },
+        "bluetoothPresence": {
+          "$ref": "#/$defs/BluetoothPresence"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ip",
+        "mac",
+        "discoveryMethod",
+        "lastSeen",
+        "isLocal"
+      ]
+    },
+    "EDPDeviceInfo": {
+      "properties": {
+        "deviceId": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "portId": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "softwareVersion": {
+          "type": "string"
+        },
+        "vlan": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "deviceId",
+        "portId"
+      ]
+    },
+    "EngineDiscoveryResponse": {
+      "properties": {
+        "devices": {
+          "items": {
+            "$ref": "#/$defs/DiscoveredDevice"
+          },
+          "type": "array"
+        },
+        "stats": {
+          "$ref": "#/$defs/EngineStats"
+        },
+        "scanResult": {
+          "$ref": "#/$defs/ScanResult"
+        },
+        "capabilities": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "devices",
+        "stats",
+        "capabilities"
+      ]
+    },
+    "EngineStats": {
+      "properties": {
+        "registry": {
+          "$ref": "#/$defs/RegistryStats"
+        },
+        "events": {
+          "$ref": "#/$defs/EventBusStats"
+        },
+        "scanCount": {
+          "type": "integer"
+        },
+        "running": {
+          "type": "boolean"
+        },
+        "scanning": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "registry",
+        "events",
+        "scanCount",
+        "running",
+        "scanning"
+      ]
+    },
+    "EventBusStats": {
+      "properties": {
+        "eventCount": {
+          "type": "integer"
+        },
+        "subscriberCount": {
+          "type": "integer"
+        },
+        "bufferedEvents": {
+          "type": "integer"
+        },
+        "bufferSize": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "eventCount",
+        "subscriberCount",
+        "bufferedEvents",
+        "bufferSize"
+      ]
+    },
+    "HTTPInfo": {
+      "properties": {
+        "port": {
+          "type": "integer"
+        },
+        "statusCode": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        },
+        "server": {
+          "type": "string"
+        },
+        "isHttps": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "port",
+        "statusCode",
+        "isHttps"
+      ]
+    },
+    "LLDPDeviceInfo": {
+      "properties": {
+        "chassisId": {
+          "type": "string"
+        },
+        "portId": {
+          "type": "string"
+        },
+        "portDescription": {
+          "type": "string"
+        },
+        "systemName": {
+          "type": "string"
+        },
+        "systemDescription": {
+          "type": "string"
+        },
+        "capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "managementAddress": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "chassisId",
+        "portId"
+      ]
+    },
+    "MDNSService": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "txt": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "NDPDeviceInfo": {
+      "properties": {
+        "linkLayerAddress": {
+          "type": "string"
+        },
+        "isRouter": {
+          "type": "boolean"
+        },
+        "reachableTime": {
+          "type": "integer"
+        },
+        "retransTimer": {
+          "type": "integer"
+        },
+        "flags": {
+          "type": "integer"
+        },
+        "lastAdvertisement": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "linkLayerAddress",
+        "isRouter"
+      ]
+    },
+    "OpenPort": {
+      "properties": {
+        "port": {
+          "type": "integer"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "service": {
+          "type": "string"
+        },
+        "banner": {
+          "type": "string"
+        },
+        "isOpen": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "port",
+        "protocol",
+        "isOpen"
+      ]
+    },
+    "RegistryStats": {
+      "properties": {
+        "totalDevices": {
+          "type": "integer"
+        },
+        "wiredDevices": {
+          "type": "integer"
+        },
+        "wifiDevices": {
+          "type": "integer"
+        },
+        "btDevices": {
+          "type": "integer"
+        },
+        "multiConnected": {
+          "type": "integer"
+        },
+        "addCount": {
+          "type": "integer"
+        },
+        "updateCount": {
+          "type": "integer"
+        },
+        "removeCount": {
+          "type": "integer"
+        },
+        "lastUpdate": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "totalDevices",
+        "wiredDevices",
+        "wifiDevices",
+        "btDevices",
+        "multiConnected",
+        "addCount",
+        "updateCount",
+        "removeCount",
+        "lastUpdate"
+      ]
+    },
+    "SNMPEntity": {
+      "properties": {
+        "index": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "vendorType": {
+          "type": "string"
+        },
+        "containedIn": {
+          "type": "integer"
+        },
+        "class": {
+          "type": "string"
+        },
+        "parentRelPos": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "hardwareRev": {
+          "type": "string"
+        },
+        "firmwareRev": {
+          "type": "string"
+        },
+        "softwareRev": {
+          "type": "string"
+        },
+        "serialNum": {
+          "type": "string"
+        },
+        "mfgName": {
+          "type": "string"
+        },
+        "modelName": {
+          "type": "string"
+        },
+        "isFRU": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "index"
+      ]
+    },
+    "SNMPFullData": {
+      "properties": {
+        "collectedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "system": {
+          "$ref": "#/$defs/SystemInfo"
+        },
+        "interfaces": {
+          "items": {
+            "$ref": "#/$defs/SNMPInterface"
+          },
+          "type": "array"
+        },
+        "ipAddresses": {
+          "items": {
+            "$ref": "#/$defs/SNMPIPAddress"
+          },
+          "type": "array"
+        },
+        "macTable": {
+          "items": {
+            "$ref": "#/$defs/SNMPMACEntry"
+          },
+          "type": "array"
+        },
+        "vlans": {
+          "items": {
+            "$ref": "#/$defs/SNMPVLAN"
+          },
+          "type": "array"
+        },
+        "inventory": {
+          "items": {
+            "$ref": "#/$defs/SNMPEntity"
+          },
+          "type": "array"
+        },
+        "lldpNeighbors": {
+          "items": {
+            "$ref": "#/$defs/SNMPLLDPNeighbor"
+          },
+          "type": "array"
+        },
+        "routing": {
+          "items": {
+            "$ref": "#/$defs/SNMPRoute"
+          },
+          "type": "array"
+        },
+        "errors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "collectedAt"
+      ]
+    },
+    "SNMPIPAddress": {
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "integer"
+        },
+        "ifIndex": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "addressIP": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "address",
+        "ifIndex"
+      ]
+    },
+    "SNMPInfo": {
+      "properties": {
+        "sysDescr": {
+          "type": "string"
+        },
+        "sysName": {
+          "type": "string"
+        },
+        "sysContact": {
+          "type": "string"
+        },
+        "sysLocation": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SNMPInterface": {
+      "properties": {
+        "index": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "alias": {
+          "type": "string"
+        },
+        "type": {
+          "type": "integer"
+        },
+        "mtu": {
+          "type": "integer"
+        },
+        "speedMbps": {
+          "type": "integer"
+        },
+        "mac": {
+          "type": "string"
+        },
+        "adminStatus": {
+          "type": "string"
+        },
+        "operStatus": {
+          "type": "string"
+        },
+        "inOctets": {
+          "type": "integer"
+        },
+        "outOctets": {
+          "type": "integer"
+        },
+        "inErrors": {
+          "type": "integer"
+        },
+        "outErrors": {
+          "type": "integer"
+        },
+        "inDiscards": {
+          "type": "integer"
+        },
+        "outDiscards": {
+          "type": "integer"
+        },
+        "lastUpdated": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "index"
+      ]
+    },
+    "SNMPLLDPNeighbor": {
+      "properties": {
+        "localIfIndex": {
+          "type": "integer"
+        },
+        "localPortId": {
+          "type": "string"
+        },
+        "remoteChassisId": {
+          "type": "string"
+        },
+        "remotePortId": {
+          "type": "string"
+        },
+        "remoteSysName": {
+          "type": "string"
+        },
+        "remoteSysDescr": {
+          "type": "string"
+        },
+        "remoteMgmtAddr": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "localIfIndex"
+      ]
+    },
+    "SNMPMACEntry": {
+      "properties": {
+        "mac": {
+          "type": "string"
+        },
+        "vlan": {
+          "type": "integer"
+        },
+        "ifIndex": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "port": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mac",
+        "ifIndex"
+      ]
+    },
+    "SNMPRoute": {
+      "properties": {
+        "destination": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "integer"
+        },
+        "nextHop": {
+          "type": "string"
+        },
+        "ifIndex": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "metric": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "destination"
+      ]
+    },
+    "SNMPVLAN": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "egressPorts": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id"
+      ]
+    },
+    "ScanResult": {
+      "properties": {
+        "devices": {
+          "items": {
+            "$ref": "#/$defs/DiscoveredDevice"
+          },
+          "type": "array"
+        },
+        "stats": {
+          "$ref": "#/$defs/ScanStats"
+        },
+        "phases": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "scanType": {
+          "type": "string"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "duration": {
+          "type": "integer"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "devices",
+        "stats",
+        "phases",
+        "scanType",
+        "startTime",
+        "endTime",
+        "duration"
+      ]
+    },
+    "ScanStats": {
+      "properties": {
+        "totalDevices": {
+          "type": "integer"
+        },
+        "wiredDevices": {
+          "type": "integer"
+        },
+        "wifiDevices": {
+          "type": "integer"
+        },
+        "bluetoothDevices": {
+          "type": "integer"
+        },
+        "multiConnected": {
+          "type": "integer"
+        },
+        "newDevices": {
+          "type": "integer"
+        },
+        "updatedDevices": {
+          "type": "integer"
+        },
+        "enrichedDevices": {
+          "type": "integer"
+        },
+        "vulnerableDevices": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "totalDevices",
+        "wiredDevices",
+        "wifiDevices",
+        "bluetoothDevices",
+        "multiConnected",
+        "newDevices",
+        "updatedDevices",
+        "enrichedDevices",
+        "vulnerableDevices"
+      ]
+    },
+    "SystemInfo": {
+      "properties": {
+        "sysDescr": {
+          "type": "string"
+        },
+        "sysObjectId": {
+          "type": "string"
+        },
+        "sysName": {
+          "type": "string"
+        },
+        "sysContact": {
+          "type": "string"
+        },
+        "sysLocation": {
+          "type": "string"
+        },
+        "sysUpTime": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sysDescr",
+        "sysObjectId",
+        "sysName",
+        "sysContact",
+        "sysLocation",
+        "sysUpTime"
+      ]
+    },
+    "Vulnerability": {
+      "properties": {
+        "cveId": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "string"
+        },
+        "score": {
+          "type": "number"
+        },
+        "published": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "references": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "affectedCpe": {
+          "type": "string"
+        },
+        "activelyExploited": {
+          "type": "boolean"
+        },
+        "ransomwareRelated": {
+          "type": "boolean"
+        },
+        "requiredAction": {
+          "type": "string"
+        },
+        "dueDate": {
+          "type": "string"
+        },
+        "originalSeverity": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "cveId",
+        "description",
+        "severity",
+        "score",
+        "published",
+        "modified",
+        "references",
+        "affectedCpe"
+      ]
+    },
+    "WiFiPresence": {
+      "properties": {
+        "ssid": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "integer"
+        },
+        "channelWidth": {
+          "type": "integer"
+        },
+        "frequencyMHz": {
+          "type": "integer"
+        },
+        "signalDbm": {
+          "type": "integer"
+        },
+        "isAccessPoint": {
+          "type": "boolean"
+        },
+        "isAuthorized": {
+          "type": "boolean"
+        },
+        "securityType": {
+          "type": "string"
+        },
+        "band": {
+          "type": "string"
+        },
+        "lastSeen": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "isAccessPoint",
+        "isAuthorized",
+        "lastSeen"
+      ]
+    }
+  },
+  "title": "EngineDiscoveryResponse",
+  "description": "EngineDiscoveryResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/ui/src/types/generated/engine-discovery-response.ts
+++ b/ui/src/types/generated/engine-discovery-response.ts
@@ -1,0 +1,307 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface EngineDiscoveryResponse {
+  devices: DiscoveredDevice[];
+  stats: EngineStats;
+  scanResult?: ScanResult;
+  capabilities: {
+    [k: string]: boolean;
+  };
+}
+export interface DiscoveredDevice {
+  ip: string;
+  ipv6?: string;
+  ipv6Addresses?: string[];
+  mac: string;
+  hostname?: string;
+  netbiosName?: string;
+  mdnsName?: string;
+  displayName?: string;
+  vendor?: string;
+  osGuess?: string;
+  ttl?: number;
+  discoveryMethod: string[];
+  lastSeen: string;
+  isLocal: boolean;
+  isRouter?: boolean;
+  hasDuplicateIP?: boolean;
+  duplicateMACs?: string[];
+  lldpInfo?: LLDPDeviceInfo;
+  cdpInfo?: CDPDeviceInfo;
+  edpInfo?: EDPDeviceInfo;
+  ndpInfo?: NDPDeviceInfo;
+  profile?: DeviceProfile;
+  snmpData?: SNMPFullData;
+  vulnerabilities?: DeviceVulnerabilities;
+  wolCapable?: boolean;
+  wolStatus?: string;
+  connectionTypes?: string[];
+  wifiPresence?: WiFiPresence;
+  bluetoothPresence?: BluetoothPresence;
+}
+export interface LLDPDeviceInfo {
+  chassisId: string;
+  portId: string;
+  portDescription?: string;
+  systemName?: string;
+  systemDescription?: string;
+  capabilities?: string[];
+  managementAddress?: string;
+}
+export interface CDPDeviceInfo {
+  deviceId: string;
+  portId: string;
+  platform?: string;
+  softwareVersion?: string;
+  capabilities?: string[];
+  managementAddress?: string;
+  nativeVlan?: number;
+  voiceVlan?: number;
+}
+export interface EDPDeviceInfo {
+  deviceId: string;
+  displayName?: string;
+  portId: string;
+  platform?: string;
+  softwareVersion?: string;
+  vlan?: number;
+}
+export interface NDPDeviceInfo {
+  linkLayerAddress: string;
+  isRouter: boolean;
+  reachableTime?: number;
+  retransTimer?: number;
+  flags?: number;
+  lastAdvertisement?: string;
+}
+export interface DeviceProfile {
+  profiledAt: string;
+  openPorts?: OpenPort[];
+  httpInfo?: HTTPInfo;
+  snmpInfo?: SNMPInfo;
+  mdnsServices?: MDNSService[];
+  deviceType?: string;
+  deviceIcons?: string[];
+}
+export interface OpenPort {
+  port: number;
+  protocol: string;
+  service?: string;
+  banner?: string;
+  isOpen: boolean;
+}
+export interface HTTPInfo {
+  port: number;
+  statusCode: number;
+  title?: string;
+  server?: string;
+  isHttps: boolean;
+}
+export interface SNMPInfo {
+  sysDescr?: string;
+  sysName?: string;
+  sysContact?: string;
+  sysLocation?: string;
+}
+export interface MDNSService {
+  name: string;
+  type: string;
+  port?: number;
+  txt?: {
+    [k: string]: string;
+  };
+}
+export interface SNMPFullData {
+  collectedAt: string;
+  system?: SystemInfo;
+  interfaces?: SNMPInterface[];
+  ipAddresses?: SNMPIPAddress[];
+  macTable?: SNMPMACEntry[];
+  vlans?: SNMPVLAN[];
+  inventory?: SNMPEntity[];
+  lldpNeighbors?: SNMPLLDPNeighbor[];
+  routing?: SNMPRoute[];
+  errors?: string[];
+}
+export interface SystemInfo {
+  sysDescr: string;
+  sysObjectId: string;
+  sysName: string;
+  sysContact: string;
+  sysLocation: string;
+  sysUpTime: number;
+}
+export interface SNMPInterface {
+  index: number;
+  name?: string;
+  description?: string;
+  alias?: string;
+  type?: number;
+  mtu?: number;
+  speedMbps?: number;
+  mac?: string;
+  adminStatus?: string;
+  operStatus?: string;
+  inOctets?: number;
+  outOctets?: number;
+  inErrors?: number;
+  outErrors?: number;
+  inDiscards?: number;
+  outDiscards?: number;
+  lastUpdated?: number;
+}
+export interface SNMPIPAddress {
+  address: string;
+  prefix?: number;
+  ifIndex: number;
+  type?: string;
+  addressIP?: string;
+}
+export interface SNMPMACEntry {
+  mac: string;
+  vlan?: number;
+  ifIndex: number;
+  type?: string;
+  port?: string;
+}
+export interface SNMPVLAN {
+  id: number;
+  name?: string;
+  status?: string;
+  egressPorts?: number[];
+  type?: string;
+}
+export interface SNMPEntity {
+  index: number;
+  description?: string;
+  vendorType?: string;
+  containedIn?: number;
+  class?: string;
+  parentRelPos?: number;
+  name?: string;
+  hardwareRev?: string;
+  firmwareRev?: string;
+  softwareRev?: string;
+  serialNum?: string;
+  mfgName?: string;
+  modelName?: string;
+  isFRU?: boolean;
+}
+export interface SNMPLLDPNeighbor {
+  localIfIndex: number;
+  localPortId?: string;
+  remoteChassisId?: string;
+  remotePortId?: string;
+  remoteSysName?: string;
+  remoteSysDescr?: string;
+  remoteMgmtAddr?: string;
+}
+export interface SNMPRoute {
+  destination: string;
+  prefix?: number;
+  nextHop?: string;
+  ifIndex?: number;
+  type?: string;
+  protocol?: string;
+  metric?: number;
+}
+export interface DeviceVulnerabilities {
+  deviceIp: string;
+  mac: string;
+  hostname: string;
+  vendor: string;
+  product: string;
+  version: string;
+  vulnerabilities: Vulnerability[];
+  scanTime: string;
+  error?: string;
+}
+export interface Vulnerability {
+  cveId: string;
+  description: string;
+  severity: string;
+  score: number;
+  published: string;
+  modified: string;
+  references: string[];
+  affectedCpe: string;
+  activelyExploited?: boolean;
+  ransomwareRelated?: boolean;
+  requiredAction?: string;
+  dueDate?: string;
+  originalSeverity?: string;
+}
+export interface WiFiPresence {
+  ssid?: string;
+  channel?: number;
+  channelWidth?: number;
+  frequencyMHz?: number;
+  signalDbm?: number;
+  isAccessPoint: boolean;
+  isAuthorized: boolean;
+  securityType?: string;
+  band?: string;
+  lastSeen: string;
+}
+export interface BluetoothPresence {
+  name?: string;
+  type: string;
+  deviceClass?: string;
+  rssi?: number;
+  txPower?: number;
+  isPaired: boolean;
+  isConnected: boolean;
+  isAuthorized: boolean;
+  services?: string[];
+  lastSeen: string;
+}
+export interface EngineStats {
+  registry: RegistryStats;
+  events: EventBusStats;
+  scanCount: number;
+  running: boolean;
+  scanning: boolean;
+}
+export interface RegistryStats {
+  totalDevices: number;
+  wiredDevices: number;
+  wifiDevices: number;
+  btDevices: number;
+  multiConnected: number;
+  addCount: number;
+  updateCount: number;
+  removeCount: number;
+  lastUpdate: string;
+}
+export interface EventBusStats {
+  eventCount: number;
+  subscriberCount: number;
+  bufferedEvents: number;
+  bufferSize: number;
+}
+export interface ScanResult {
+  devices: DiscoveredDevice[];
+  stats: ScanStats;
+  phases: string[];
+  scanType: string;
+  startTime: string;
+  endTime: string;
+  duration: number;
+  error?: string;
+}
+export interface ScanStats {
+  totalDevices: number;
+  wiredDevices: number;
+  wifiDevices: number;
+  bluetoothDevices: number;
+  multiConnected: number;
+  newDevices: number;
+  updatedDevices: number;
+  enrichedDevices: number;
+  vulnerableDevices: number;
+}


### PR DESCRIPTION
EngineDiscoveryResponse was the last unregistered wire DTO, deferred
because it embeds the discovery.* result cluster (DiscoveredDevice +
~20-30 nested structs, ~150 fields). ADR-0007 contemplated extracting a
CGO-free internal/discovery/types package as a prerequisite.

Three facts make the extraction unnecessary (ADR-0008, accepted):
- internal/discovery is already CGO-free (Phase 6 confined libpcap to
  internal/capture/pcap), so the "types trapped in a CGO package" driver
  is moot.
- The /discovery/engine endpoint ALREADY serializes these structs at
  runtime — the wire contract is already coupled; a schema documents it.
- The cluster is pure data (one method, ComputeDisplayName, in the whole
  tree; stats types are counter snapshots, not live registry/bus objects).

So register EngineDiscoveryResponse as-is under a narrow, documented
exception to the Phase 2 "no domain type in schema" policy, limited to
pure-data types the endpoint already emits. Withdraws ADR-0007's
internal/discovery/types extraction as unnecessary.

Regenerated docs/schemas/api/engine-discovery-response.schema.json + the
ui/src/types/generated/engine-discovery-response.ts twin (full
DiscoveredDevice/EngineStats/ScanResult tree). This unblocks Phase 7 S3
consuming typed engine results off the /jobs spine.

Gates: round-trip + acyclic guardrail (validates the 150-field cluster
reflects + round-trips + stays acyclic), schema-drift, types-drift,
golangci 0, go build ./cmd/seed, ui tsc, golden HTTP harness (no route
change). Generated TS is pure interfaces, token-gate clean.

Refs ADR-0007, ADR-0008
