### PR TITLE
feat(discovery): fold port-scan intensity + timing into the engine (P7 S4.1)

### DIFF
--- a/docs/schemas/api/engine-scan-request.schema.json
+++ b/docs/schemas/api/engine-scan-request.schema.json
@@ -34,6 +34,18 @@
         },
         "freshBluetoothScan": {
           "type": "boolean"
+        },
+        "portScanIntensity": {
+          "type": "string"
+        },
+        "portScanCustomPorts": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "timingProfile": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/docs/schemas/api/engine-scan-request.schema.json
+++ b/docs/schemas/api/engine-scan-request.schema.json
@@ -46,6 +46,9 @@
         },
         "timingProfile": {
           "type": "string"
+        },
+        "acknowledgeIdsRisk": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/internal/api/handlers_engine.go
+++ b/internal/api/handlers_engine.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -50,6 +53,13 @@ type EngineScanRequest struct {
 	PortScanIntensity   string `json:"portScanIntensity,omitempty"`
 	PortScanCustomPorts []int  `json:"portScanCustomPorts,omitempty"`
 	TimingProfile       string `json:"timingProfile,omitempty"`
+
+	// AcknowledgeIDsRisk is the job-params equivalent of the
+	// X-Acknowledge-Ids-Risk header the pipeline endpoint requires for
+	// comprehensive scans (which may trip IDS/IPS). The direct
+	// /discovery/engine/scan handler reads the header; the engine-scan job
+	// reads this field, since a job carries no request headers to its run.
+	AcknowledgeIDsRisk bool `json:"acknowledgeIdsRisk,omitempty"`
 }
 
 // handleEngineDiscovery returns all devices from the discovery engine registry.
@@ -101,6 +111,64 @@ func (s *Server) handleEngineDiscovery(w http.ResponseWriter, r *http.Request) {
 	sendJSONResponse(w, logger, http.StatusOK, resp)
 }
 
+// maxEngineCustomPorts bounds an engine-scan custom port list so a single
+// request can't queue an unbounded scan.
+const maxEngineCustomPorts = 1024
+
+// errIDsRiskUnacknowledged signals that a comprehensive scan was requested
+// without the IDS-risk acknowledgment. Callers map it to 428 (the direct
+// endpoint) or surface it as a job error; ordinary validation failures map to
+// 400.
+var errIDsRiskUnacknowledged = errors.New(
+	"comprehensive port scanning may trigger IDS/IPS alerts; acknowledge the risk to proceed",
+)
+
+// validateEngineScanConfig enforces, for the engine scan paths, the same guards
+// the pipeline applies to risky scan configuration (ADR-0007 fold, S4):
+//   - comprehensive intensity requires an explicit IDS-risk acknowledgment
+//     (acknowledged = X-Acknowledge-Ids-Risk header on the direct endpoint, or
+//     the acknowledgeIdsRisk param on the engine-scan job);
+//   - custom ports are only valid with custom intensity, must each be in
+//     1..65535, and are bounded in number.
+func validateEngineScanConfig(req EngineScanRequest, acknowledged bool) error {
+	if req.PortScanIntensity == string(discovery.PortScanComprehensive) && !acknowledged {
+		return errIDsRiskUnacknowledged
+	}
+	if len(req.PortScanCustomPorts) == 0 {
+		return nil
+	}
+	if req.PortScanIntensity != string(discovery.PortScanCustom) {
+		return fmt.Errorf("custom ports require portScanIntensity=%q", discovery.PortScanCustom)
+	}
+	if len(req.PortScanCustomPorts) > maxEngineCustomPorts {
+		return fmt.Errorf("too many custom ports: %d (max %d)",
+			len(req.PortScanCustomPorts), maxEngineCustomPorts)
+	}
+	for _, p := range req.PortScanCustomPorts {
+		if p < 1 || p > 65535 {
+			return fmt.Errorf("custom port out of range: %d (must be 1..65535)", p)
+		}
+	}
+	return nil
+}
+
+// dedupePorts returns the input with duplicates removed, order preserved.
+func dedupePorts(ports []int) []int {
+	if len(ports) == 0 {
+		return ports
+	}
+	seen := make(map[int]struct{}, len(ports))
+	out := make([]int, 0, len(ports))
+	for _, p := range ports {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
 // scanOptsFromRequest builds discovery scan options from a request: the
 // quick/full default plus the per-feature overrides. Shared by the engine-scan
 // handler and the engine-scan job kind so both produce identical options.
@@ -121,9 +189,40 @@ func scanOptsFromRequest(req EngineScanRequest) *discovery.ScanOptions {
 	opts.FreshWiFiScan = req.FreshWiFiScan
 	opts.FreshBluetoothScan = req.FreshBluetoothScan
 	opts.PortScanIntensity = discovery.PortScanIntensity(req.PortScanIntensity)
-	opts.PortScanCustomPorts = req.PortScanCustomPorts
+	opts.PortScanCustomPorts = dedupePorts(req.PortScanCustomPorts)
 	opts.TimingProfile = discovery.ScanTimingProfile(req.TimingProfile)
 	return opts
+}
+
+// parseEngineScanOpts decodes and validates the optional scan body, applying
+// the same IDS-risk + custom-port guards as the engine-scan job. On a bad or
+// unacknowledged request it writes the error response (428 for the IDS gate,
+// 400 otherwise) and returns ok=false. An empty body yields a quick scan.
+func parseEngineScanOpts(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+) (*discovery.ScanOptions, bool) {
+	if r.ContentLength <= 0 {
+		return discovery.DefaultQuickScanOpts(), true
+	}
+	// Note: previously this handler leaked the json parser error into the
+	// `details` field; the strict helper drops that (the structured WARN log
+	// retains the diagnostic).
+	var req EngineScanRequest
+	if !decodeJSONStrict(w, r, &req, MaxBodySizeJSON) {
+		return nil, false
+	}
+	acknowledged := r.Header.Get("X-Acknowledge-Ids-Risk") == "true"
+	if err := validateEngineScanConfig(req, acknowledged); err != nil {
+		status, code := http.StatusBadRequest, ErrCodeValidation
+		if errors.Is(err, errIDsRiskUnacknowledged) {
+			status, code = http.StatusPreconditionRequired, ErrCodePreconditionFail
+		}
+		sendErrorResponseWithDetails(w, logger, status, code, err.Error(), "")
+		return nil, false
+	}
+	return scanOptsFromRequest(req), true
 }
 
 // handleEngineScan triggers a discovery engine scan.
@@ -191,19 +290,10 @@ func (s *Server) handleEngineScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse options from body, default to quick scan
-	var opts *discovery.ScanOptions
-	if r.ContentLength > 0 {
-		// Note: previously this handler leaked the json parser error into
-		// the `details` field; the strict helper drops that (the
-		// structured WARN log retains the diagnostic).
-		var req EngineScanRequest
-		if !decodeJSONStrict(w, r, &req, MaxBodySizeJSON) {
-			return
-		}
-		opts = scanOptsFromRequest(req)
-	} else {
-		opts = discovery.DefaultQuickScanOpts()
+	// Parse + validate options from body, default to quick scan.
+	opts, ok := parseEngineScanOpts(w, r, logger)
+	if !ok {
+		return
 	}
 
 	// Run scan

--- a/internal/api/handlers_engine.go
+++ b/internal/api/handlers_engine.go
@@ -41,6 +41,15 @@ type EngineScanRequest struct {
 	FreshWiredScan     bool `json:"freshWiredScan"`
 	FreshWiFiScan      bool `json:"freshWifiScan"`
 	FreshBluetoothScan bool `json:"freshBluetoothScan"`
+
+	// Port-scan + timing config, folded from the pipeline orchestrator
+	// (ADR-0007, Phase 7 S4). Empty PortScanIntensity = engine default
+	// (profiler config left unchanged). Intensity is one of
+	// off/quick/standard/comprehensive/custom; TimingProfile is one of
+	// polite/normal/aggressive.
+	PortScanIntensity   string `json:"portScanIntensity,omitempty"`
+	PortScanCustomPorts []int  `json:"portScanCustomPorts,omitempty"`
+	TimingProfile       string `json:"timingProfile,omitempty"`
 }
 
 // handleEngineDiscovery returns all devices from the discovery engine registry.
@@ -111,6 +120,9 @@ func scanOptsFromRequest(req EngineScanRequest) *discovery.ScanOptions {
 	opts.FreshWiredScan = req.FreshWiredScan
 	opts.FreshWiFiScan = req.FreshWiFiScan
 	opts.FreshBluetoothScan = req.FreshBluetoothScan
+	opts.PortScanIntensity = discovery.PortScanIntensity(req.PortScanIntensity)
+	opts.PortScanCustomPorts = req.PortScanCustomPorts
+	opts.TimingProfile = discovery.ScanTimingProfile(req.TimingProfile)
 	return opts
 }
 

--- a/internal/api/handlers_engine_validate_internal_test.go
+++ b/internal/api/handlers_engine_validate_internal_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateEngineScanConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		req          EngineScanRequest
+		acknowledged bool
+		wantErr      bool
+		wantIDSGate  bool // err is errIDsRiskUnacknowledged
+	}{
+		{
+			name: "quick scan needs no acknowledgment",
+			req:  EngineScanRequest{PortScanIntensity: "quick"},
+		},
+		{
+			name: "comprehensive without acknowledgment is gated",
+			req:  EngineScanRequest{PortScanIntensity: "comprehensive"},
+			// acknowledged: false
+			wantErr:     true,
+			wantIDSGate: true,
+		},
+		{
+			name:         "comprehensive with acknowledgment proceeds",
+			req:          EngineScanRequest{PortScanIntensity: "comprehensive"},
+			acknowledged: true,
+		},
+		{
+			name:    "custom ports require custom intensity",
+			req:     EngineScanRequest{PortScanIntensity: "quick", PortScanCustomPorts: []int{80, 443}},
+			wantErr: true,
+		},
+		{
+			name: "valid custom ports pass",
+			req:  EngineScanRequest{PortScanIntensity: "custom", PortScanCustomPorts: []int{22, 80, 443}},
+		},
+		{
+			name:    "out-of-range port rejected (zero)",
+			req:     EngineScanRequest{PortScanIntensity: "custom", PortScanCustomPorts: []int{0}},
+			wantErr: true,
+		},
+		{
+			name:    "out-of-range port rejected (too high)",
+			req:     EngineScanRequest{PortScanIntensity: "custom", PortScanCustomPorts: []int{70000}},
+			wantErr: true,
+		},
+		{
+			name: "too many custom ports rejected",
+			req: EngineScanRequest{
+				PortScanIntensity:   "custom",
+				PortScanCustomPorts: makePorts(maxEngineCustomPorts + 1),
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty config is valid",
+			req:  EngineScanRequest{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateEngineScanConfig(tt.req, tt.acknowledged)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("validateEngineScanConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantIDSGate && !errors.Is(err, errIDsRiskUnacknowledged) {
+				t.Fatalf("expected errIDsRiskUnacknowledged, got %v", err)
+			}
+			if !tt.wantIDSGate && errors.Is(err, errIDsRiskUnacknowledged) {
+				t.Fatalf("unexpected IDS-risk gate error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDedupePorts(t *testing.T) {
+	t.Parallel()
+
+	got := dedupePorts([]int{80, 443, 80, 22, 443})
+	want := []int{80, 443, 22}
+	if len(got) != len(want) {
+		t.Fatalf("dedupePorts length = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dedupePorts[%d] = %d, want %d (order must be preserved)", i, got[i], want[i])
+		}
+	}
+	if dedupePorts(nil) != nil {
+		t.Fatalf("dedupePorts(nil) should return nil")
+	}
+}
+
+func makePorts(n int) []int {
+	ports := make([]int, n)
+	for i := range ports {
+		ports[i] = (i % 65535) + 1
+	}
+	return ports
+}

--- a/internal/api/handlers_types.go
+++ b/internal/api/handlers_types.go
@@ -30,6 +30,7 @@ const (
 	ErrCodeForbidden        = "FORBIDDEN"
 	ErrCodeNotFound         = "NOT_FOUND"
 	ErrCodeConflict         = "CONFLICT"
+	ErrCodePreconditionFail = "PRECONDITION_FAILED"
 	ErrCodeMethodNotAllowed = "METHOD_NOT_ALLOWED"
 	ErrCodeInternal         = "INTERNAL_ERROR"
 	ErrCodeServiceUnavail   = "SERVICE_UNAVAILABLE"

--- a/internal/api/jobs_engine.go
+++ b/internal/api/jobs_engine.go
@@ -68,6 +68,11 @@ func engineScanOptsFromParams(params any) (*discovery.ScanOptions, error) {
 	if err := json.Unmarshal(raw, &req); err != nil {
 		return nil, fmt.Errorf("invalid engine-scan params: %w", err)
 	}
+	// Same guards as the direct endpoint; a job carries no request headers, so
+	// the IDS-risk acknowledgment travels in the acknowledgeIdsRisk param.
+	if err := validateEngineScanConfig(req, req.AcknowledgeIDsRisk); err != nil {
+		return nil, err
+	}
 	return scanOptsFromRequest(req), nil
 }
 

--- a/internal/discovery/engine.go
+++ b/internal/discovery/engine.go
@@ -389,11 +389,16 @@ func (e *Engine) Scan(ctx context.Context, opts *ScanOptions) (*ScanResult, erro
 	}
 	defer e.endScan()
 
-	// Apply folded pipeline port-scan/timing config to the profiler (S4). Gated
-	// on a set intensity so the default (unset) path leaves the profiler's
-	// existing configuration — and thus prior behavior — untouched.
+	// Apply folded pipeline port-scan/timing config to the profiler (S4) for the
+	// duration of THIS scan only. Gated on a set intensity so the default (unset)
+	// path leaves the profiler's configuration untouched. The prior config is
+	// captured and restored on return so a one-off override does not silently
+	// become the engine's persistent scan policy (scans are serialized by
+	// tryStartScan, so the snapshot/restore pair is not racing another scan).
 	if e.profiler != nil && opts.PortScanIntensity != "" {
+		prevIntensity, prevPorts, prevTiming := e.profiler.ScanConfigSnapshot()
 		e.profiler.UpdateScanConfig(opts.PortScanIntensity, opts.PortScanCustomPorts, opts.TimingProfile)
+		defer e.profiler.UpdateScanConfig(prevIntensity, prevPorts, prevTiming)
 	}
 
 	timeout := opts.Timeout

--- a/internal/discovery/engine.go
+++ b/internal/discovery/engine.go
@@ -142,6 +142,15 @@ type ScanOptions struct {
 
 	// Scan timeout (0 = use engine default)
 	Timeout time.Duration
+
+	// Port-scan + timing configuration, folded from the pipeline orchestrator
+	// (ADR-0007, Phase 7 S4). These tune the profiler's port scan the same way
+	// Pipeline does via DeviceProfiler.UpdateScanConfig. Zero values are inert:
+	// an empty PortScanIntensity leaves the profiler's existing config
+	// untouched, so the engine's prior behavior is unchanged when unset.
+	PortScanIntensity   PortScanIntensity
+	PortScanCustomPorts []int
+	TimingProfile       ScanTimingProfile
 }
 
 // DefaultQuickScanOpts returns options for a quick correlation-only scan.
@@ -379,6 +388,13 @@ func (e *Engine) Scan(ctx context.Context, opts *ScanOptions) (*ScanResult, erro
 		return nil, errors.New("scan already in progress")
 	}
 	defer e.endScan()
+
+	// Apply folded pipeline port-scan/timing config to the profiler (S4). Gated
+	// on a set intensity so the default (unset) path leaves the profiler's
+	// existing configuration — and thus prior behavior — untouched.
+	if e.profiler != nil && opts.PortScanIntensity != "" {
+		e.profiler.UpdateScanConfig(opts.PortScanIntensity, opts.PortScanCustomPorts, opts.TimingProfile)
+	}
 
 	timeout := opts.Timeout
 	if timeout == 0 {

--- a/internal/discovery/profiler_config.go
+++ b/internal/discovery/profiler_config.go
@@ -136,6 +136,16 @@ func (c *ProfilerConfig) GetPortsForIntensity() []int {
 	}
 }
 
+// ScanConfigSnapshot returns the current port-scan configuration (intensity,
+// custom ports, timing) so a caller can restore it after a one-off per-scan
+// override. Thread-safe; the returned slice is a copy.
+func (p *DeviceProfiler) ScanConfigSnapshot() (PortScanIntensity, []int, ScanTimingProfile) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	ports := append([]int(nil), p.config.CustomPorts...)
+	return p.config.PortScanIntensity, ports, p.config.TimingProfile
+}
+
 // UpdateScanConfig updates the port scanning configuration.
 // This allows Pipeline to set the scan intensity without recreating the profiler.
 // Thread-safe: can be called while profiler is running.

--- a/ui/src/types/generated/engine-scan-request.ts
+++ b/ui/src/types/generated/engine-scan-request.ts
@@ -19,4 +19,5 @@ export interface EngineScanRequest {
   portScanIntensity?: string;
   portScanCustomPorts?: number[];
   timingProfile?: string;
+  acknowledgeIdsRisk?: boolean;
 }

--- a/ui/src/types/generated/engine-scan-request.ts
+++ b/ui/src/types/generated/engine-scan-request.ts
@@ -16,4 +16,7 @@ export interface EngineScanRequest {
   freshWiredScan: boolean;
   freshWifiScan: boolean;
   freshBluetoothScan: boolean;
+  portScanIntensity?: string;
+  portScanCustomPorts?: number[];
+  timingProfile?: string;
 }


### PR DESCRIPTION
First parity step of the Pipeline → Engine fold (ADR-0007, Phase 7 S4): give the engine the port-scan/timing config the pipeline UX exposes, so the UI can later migrate off the pipeline without losing those knobs.

## What
- `ScanOptions` + `EngineScanRequest` gain PortScanIntensity / PortScanCustomPorts / TimingProfile.
- `engine.Scan` applies them via the existing `DeviceProfiler.UpdateScanConfig` (the capability already existed on the shared profiler — pipeline used it, the engine didn't). Both the direct `/discovery/engine/scan` handler and the engine-scan job (what S3's UI will drive) pick them up via the shared `scanOptsFromRequest`.
- Additive + behavior-preserving: an unset intensity leaves the profiler config untouched.

## Security hardening (from the push review)
1. **State drift (HIGH):** the per-scan override is now snapshotted and restored via `defer`, so a one-off scan can't permanently change the shared profiler's policy.
2. **Gate parity (HIGH):** comprehensive scans require the IDS-risk acknowledgment the pipeline enforces — `X-Acknowledge-Ids-Risk: true` on the direct handler (428 on miss), or an `acknowledgeIdsRisk` param on the job.
3. **Custom-port validation (MEDIUM):** ports validated (1..65535, deduped, capped 1024, custom-intensity-only) → 400 on violation.

## Gates
`go test -race` on discovery (incl. pipeline regression tests) + api (incl. 9 new validator/dedup tests), schema round-trip + acyclic guardrail, schema/types drift, golangci 0, `CGO_ENABLED=0` build, golden HTTP harness, ui tsc.

Refs ADR-0007, SEED_S4_FOLD_PLAN.md