### PR TITLE
feat(discovery): emit phase-grained scan progress from the engine (P7 S4.2)

### DIFF
--- a/internal/api/jobs_engine.go
+++ b/internal/api/jobs_engine.go
@@ -33,13 +33,16 @@ type engineScanner interface {
 // newEngineScanHandler returns the job Handler for the "engine-scan" kind. It
 // runs one scan (cancellable via the job context) and returns the same
 // EngineDiscoveryResponse the legacy endpoint produces. The report callback is
-// unused: the engine surfaces no progress fraction, only running/idle.
+// driven by the engine's per-phase progress (S4.2).
 func newEngineScanHandler(newEngine func() engineScanner) jobs.Handler {
-	return func(ctx context.Context, params any, _ func(float64)) (any, error) {
+	return func(ctx context.Context, params any, report func(float64)) (any, error) {
 		opts, err := engineScanOptsFromParams(params)
 		if err != nil {
 			return nil, err
 		}
+		// Surface engine phase boundaries as job progress; the phase name is
+		// observable on the engine event bus, the job tracks the fraction.
+		opts.Progress = func(fraction float64, _ string) { report(fraction) }
 
 		engine := newEngine()
 		result, scanErr := engine.Scan(ctx, opts)

--- a/internal/discovery/engine.go
+++ b/internal/discovery/engine.go
@@ -151,7 +151,16 @@ type ScanOptions struct {
 	PortScanIntensity   PortScanIntensity
 	PortScanCustomPorts []int
 	TimingProfile       ScanTimingProfile
+
+	// Progress, if non-nil, is invoked once per completed scan phase with the
+	// cumulative fraction in [0,1] and the phase name. It lets a caller (e.g.
+	// the engine-scan job) surface phase-grained progress; nil disables it.
+	// Not serialized — it is a server-side observability hook, not wire config.
+	Progress ProgressFunc
 }
+
+// ProgressFunc reports cumulative scan progress at a phase boundary.
+type ProgressFunc func(fraction float64, phase string)
 
 // DefaultQuickScanOpts returns options for a quick correlation-only scan.
 func DefaultQuickScanOpts() *ScanOptions {
@@ -429,8 +438,16 @@ func (e *Engine) Scan(ctx context.Context, opts *ScanOptions) (*ScanResult, erro
 	return result, nil
 }
 
-// runScanPhases executes all scan phases in order.
+// runScanPhases executes all scan phases in order, reporting cumulative
+// progress at each phase boundary (S4.2).
 func (e *Engine) runScanPhases(ctx context.Context, logger *slog.Logger, opts *ScanOptions, result *ScanResult) {
+	total := e.countScanPhases(opts)
+	done := 0
+	complete := func(phase string) {
+		done++
+		e.reportScanProgress(opts, phase, float64(done)/float64(total))
+	}
+
 	// Phase 1: Discovery
 	logger.InfoContext(ctx, "Starting discovery phase")
 	result.Phases = append(result.Phases, "discovery")
@@ -438,11 +455,13 @@ func (e *Engine) runScanPhases(ctx context.Context, logger *slog.Logger, opts *S
 		result.Error = err.Error()
 		logger.ErrorContext(ctx, "Discovery phase failed", "error", err)
 	}
+	complete("discovery")
 
 	// Phase 2: Correlation
 	logger.InfoContext(ctx, "Starting correlation phase")
 	result.Phases = append(result.Phases, "correlation")
 	e.correlateDevices(ctx)
+	complete("correlation")
 
 	// Phase 3: Name Resolution
 	if opts.IncludeNameRes && e.wiredCollector != nil {
@@ -450,6 +469,7 @@ func (e *Engine) runScanPhases(ctx context.Context, logger *slog.Logger, opts *S
 		result.Phases = append(result.Phases, "name_resolution")
 		e.wiredCollector.ResolveNetBIOSNames(ctx)
 		e.wiredCollector.ResolveMDNSNames(ctx)
+		complete("name_resolution")
 	}
 
 	// Phase 4: Enrichment
@@ -457,6 +477,7 @@ func (e *Engine) runScanPhases(ctx context.Context, logger *slog.Logger, opts *S
 		logger.InfoContext(ctx, "Starting enrichment phase")
 		result.Phases = append(result.Phases, "enrichment")
 		e.runEnrichmentPhase(ctx, opts, result.Stats)
+		complete("enrichment")
 	}
 
 	// Phase 5: Assessment
@@ -464,7 +485,37 @@ func (e *Engine) runScanPhases(ctx context.Context, logger *slog.Logger, opts *S
 		logger.InfoContext(ctx, "Starting assessment phase")
 		result.Phases = append(result.Phases, "assessment")
 		e.runAssessmentPhase(ctx, result.Stats)
+		complete("assessment")
 	}
+}
+
+// countScanPhases returns how many phases this scan will run, so progress
+// fractions are denominated against the actual (opts-gated) phase set.
+// Discovery + correlation always run; the rest are conditional.
+func (e *Engine) countScanPhases(opts *ScanOptions) int {
+	total := 2 // discovery + correlation always run
+	if opts.IncludeNameRes && e.wiredCollector != nil {
+		total++
+	}
+	if opts.IncludeSNMP || opts.IncludePortScan || opts.IncludeProfiling {
+		total++
+	}
+	if opts.IncludeVulnScan && e.vulnScanner != nil {
+		total++
+	}
+	return total
+}
+
+// reportScanProgress surfaces a completed-phase progress update on both the
+// per-scan callback (opts.Progress, e.g. the engine-scan job) and the engine
+// event bus (EventScanProgress, for /discovery/engine/events subscribers).
+// Both are nil-safe / always-on respectively; behavior is unchanged when no
+// caller supplies a Progress hook and nothing subscribes to the bus.
+func (e *Engine) reportScanProgress(opts *ScanOptions, phase string, fraction float64) {
+	if opts.Progress != nil {
+		opts.Progress(fraction, phase)
+	}
+	e.eventBus.Publish(NewScanProgressEvent(phase, fraction))
 }
 
 // QuickScan performs a quick correlation-only scan.

--- a/internal/discovery/engine_test.go
+++ b/internal/discovery/engine_test.go
@@ -131,6 +131,44 @@ func TestEngineScanWithoutCollectors(t *testing.T) {
 	}
 }
 
+func TestEngineScanReportsPhaseProgress(t *testing.T) {
+	engine := discovery.NewEngine(nil)
+	defer engine.Stop()
+
+	var fractions []float64
+	var phases []string
+	opts := discovery.DefaultQuickScanOpts()
+	opts.Progress = func(fraction float64, phase string) {
+		fractions = append(fractions, fraction)
+		phases = append(phases, phase)
+	}
+
+	if _, err := engine.Scan(context.Background(), opts); err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+
+	// No collectors + quick opts => discovery + correlation always run.
+	if len(fractions) < 2 {
+		t.Fatalf("expected >=2 progress reports, got %d (%v)", len(fractions), phases)
+	}
+	prev := 0.0
+	for i, f := range fractions {
+		if f < prev {
+			t.Errorf("progress went backwards at %d: %v", i, fractions)
+		}
+		if f < 0 || f > 1 {
+			t.Errorf("progress fraction out of [0,1] at %d: %v", i, f)
+		}
+		prev = f
+	}
+	if last := fractions[len(fractions)-1]; last != 1.0 {
+		t.Errorf("final progress = %v, want 1.0 (%v)", last, fractions)
+	}
+	if phases[0] != "discovery" {
+		t.Errorf("first phase = %q, want discovery", phases[0])
+	}
+}
+
 func TestEngineScanAlreadyInProgress(_ *testing.T) {
 	engine := discovery.NewEngine(&discovery.EngineConfig{
 		ScanTimeout: 5 * time.Second,

--- a/internal/discovery/events.go
+++ b/internal/discovery/events.go
@@ -160,6 +160,15 @@ func NewScanStartedEvent(scanType string) *Event {
 	})
 }
 
+// NewScanProgressEvent creates a scan progress event marking the completion of
+// a named phase. fraction is the cumulative scan progress in [0,1].
+func NewScanProgressEvent(phase string, fraction float64) *Event {
+	return NewEvent(EventScanProgress, SourceEngine).WithPayload(map[string]any{
+		"phase":    phase,
+		"fraction": fraction,
+	})
+}
+
 // NewScanCompletedEvent creates a scan completed event.
 func NewScanCompletedEvent(scanType string, deviceCount int, duration time.Duration) *Event {
 	return NewEvent(EventScanCompleted, SourceEngine).WithPayload(map[string]any{


### PR DESCRIPTION
Second parity step of the Pipeline -> Engine fold (ADR-0007). The pipeline
UX shows per-phase progress; the engine ran its five phases (discovery,
correlation, name_resolution, enrichment, assessment) silently and the
engine-scan job's report callback was unused.

engine.Scan now reports cumulative progress at each phase boundary,
denominated against the actual opts-gated phase set (countScanPhases), via
two nil-safe channels:
- ScanOptions.Progress — a server-side callback (not serialized); the
  engine-scan job wires it to the job's report() so /jobs/events streams a
  progress fraction (what Phase 7 S3's UI will consume);
- the engine event bus — publishes the previously-defined-but-unused
  EventScanProgress (NewScanProgressEvent) for /discovery/engine/events
  subscribers.

Behavior-preserving: no Progress hook + no bus subscriber => no observable
change. No wire/DTO change.

Gates: go test -race ./internal/discovery/ (incl. the new progress test +
pipeline regression) + ./internal/api/ (engine job), golangci 0, CGO=0
build, golden HTTP harness, schema/types drift clean.

Refs ADR-0007, SEED_S4_FOLD_PLAN.md
