### PR TITLE
feat(api): expose IncludeNameRes + IncludeProfiling on EngineScanRequest (P7 S4.1c)

### DIFF
--- a/docs/schemas/api/engine-scan-request.schema.json
+++ b/docs/schemas/api/engine-scan-request.schema.json
@@ -23,6 +23,12 @@
         "includePortScan": {
           "type": "boolean"
         },
+        "includeProfiling": {
+          "type": "boolean"
+        },
+        "includeNameRes": {
+          "type": "boolean"
+        },
         "includeVulnScan": {
           "type": "boolean"
         },
@@ -60,6 +66,8 @@
         "includeBluetooth",
         "includeSnmp",
         "includePortScan",
+        "includeProfiling",
+        "includeNameRes",
         "includeVulnScan",
         "freshWiredScan",
         "freshWifiScan",

--- a/internal/api/handlers_engine.go
+++ b/internal/api/handlers_engine.go
@@ -36,9 +36,11 @@ type EngineScanRequest struct {
 	IncludeBluetooth bool `json:"includeBluetooth"`
 
 	// Enrichment options (full scan)
-	IncludeSNMP     bool `json:"includeSnmp"`
-	IncludePortScan bool `json:"includePortScan"`
-	IncludeVulnScan bool `json:"includeVulnScan"`
+	IncludeSNMP      bool `json:"includeSnmp"`
+	IncludePortScan  bool `json:"includePortScan"`
+	IncludeProfiling bool `json:"includeProfiling"`
+	IncludeNameRes   bool `json:"includeNameRes"`
+	IncludeVulnScan  bool `json:"includeVulnScan"`
 
 	// Fresh scan triggers
 	FreshWiredScan     bool `json:"freshWiredScan"`
@@ -184,6 +186,8 @@ func scanOptsFromRequest(req EngineScanRequest) *discovery.ScanOptions {
 	opts.IncludeBluetooth = req.IncludeBluetooth
 	opts.IncludeSNMP = req.IncludeSNMP
 	opts.IncludePortScan = req.IncludePortScan
+	opts.IncludeProfiling = req.IncludeProfiling
+	opts.IncludeNameRes = req.IncludeNameRes
 	opts.IncludeVulnScan = req.IncludeVulnScan
 	opts.FreshWiredScan = req.FreshWiredScan
 	opts.FreshWiFiScan = req.FreshWiFiScan

--- a/ui/src/types/generated/engine-scan-request.ts
+++ b/ui/src/types/generated/engine-scan-request.ts
@@ -12,6 +12,8 @@ export interface EngineScanRequest {
   includeBluetooth: boolean;
   includeSnmp: boolean;
   includePortScan: boolean;
+  includeProfiling: boolean;
+  includeNameRes: boolean;
   includeVulnScan: boolean;
   freshWiredScan: boolean;
   freshWifiScan: boolean;


### PR DESCRIPTION
Final engine-side prerequisite for the S3 discovery-UI migration. The
shipping discovery card requests an exact phase set — name resolution +
service discovery (port scan + profiling), no vuln assessment — but
EngineScanRequest only exposed SNMP/PortScan/VulnScan, so a caller could
not request name-res/profiling without inheriting the full-scan defaults'
side effects (fresh L2 scans, vuln scan).

Surface IncludeNameRes + IncludeProfiling as wire fields and map them in
scanOptsFromRequest, consistent with the existing explicit-flag-overrides
-default pattern. ScanOptions already had both; this just lets the request
(and the engine-scan job) drive them.

With this + S4.1 (port-scan intensity), the engine-scan job can express
everything the card's startPipeline override sends — phases, quick
intensity — and bannerGrab(true)/connectTimeout(2s) already match the
profiler defaults (profilerTimeoutS=2). No remaining engine gap for card
parity; the dead pipeline-config surface (SNMP MIBs/timing/persistence)
is intentionally NOT folded (no live UI consumer).

Gates: engine tests, schema round-trip + acyclic, schema/types drift,
golangci 0, golden, CGO=0, ui tsc.

Refs ADR-0007, SEED_S4_FOLD_PLAN.md
