### PR TITLE
feat(ui): add useEngineScan hook driving discovery via the jobs spine (P7 S3.1)

### DIFF
--- a/ui/src/hooks/useEngineScan.test.ts
+++ b/ui/src/hooks/useEngineScan.test.ts
@@ -1,0 +1,121 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JobResponse } from '../types/generated/job-response';
+import { useEngineScan } from './useEngineScan';
+
+// Mock the jobs client (submit/cancel) and capture the useJobEvents callback so
+// the test can drive job lifecycle events.
+vi.mock('../lib/jobsClient', () => ({
+  submitJob: vi.fn(),
+  cancelJob: vi.fn(),
+}));
+
+let jobEventCb: ((job: JobResponse) => void) | null = null;
+vi.mock('./useJobEvents', () => ({
+  useJobEvents: (cb: (job: JobResponse) => void) => {
+    jobEventCb = cb;
+    return { status: 'open' };
+  },
+}));
+
+import { cancelJob, submitJob } from '../lib/jobsClient';
+
+const queuedJob: JobResponse = { id: 'job-1', kind: 'engine-scan', state: 'queued', progress: 0 };
+
+function emit(job: JobResponse): void {
+  act(() => {
+    jobEventCb?.(job);
+  });
+}
+
+describe('useEngineScan', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    jobEventCb = null;
+  });
+
+  it('submits an engine-scan job with the card default params', async () => {
+    vi.mocked(submitJob).mockResolvedValueOnce(queuedJob);
+    const { result } = renderHook(() => useEngineScan());
+
+    await act(async () => {
+      await result.current.startScan();
+    });
+
+    expect(submitJob).toHaveBeenCalledTimes(1);
+    const [req] = vi.mocked(submitJob).mock.calls[0];
+    expect(req.kind).toBe('engine-scan');
+    const params = req.params as Record<string, unknown>;
+    expect(params.includeNameRes).toBe(true);
+    expect(params.includeProfiling).toBe(true);
+    expect(params.includeVulnScan).toBe(false);
+    expect(params.portScanIntensity).toBe('quick');
+    expect(result.current.running).toBe(true);
+    expect(result.current.status.jobId).toBe('job-1');
+  });
+
+  it('updates progress + state from events for its own job', async () => {
+    vi.mocked(submitJob).mockResolvedValueOnce(queuedJob);
+    const { result } = renderHook(() => useEngineScan());
+    await act(async () => {
+      await result.current.startScan();
+    });
+
+    emit({ ...queuedJob, state: 'running', progress: 0.4 });
+    expect(result.current.status.percentComplete).toBe(40);
+    expect(result.current.status.state).toBe('running');
+
+    emit({ ...queuedJob, state: 'succeeded', progress: 1 });
+    expect(result.current.status.state).toBe('complete');
+    expect(result.current.status.percentComplete).toBe(100);
+    expect(result.current.running).toBe(false);
+  });
+
+  it('ignores events for a different job', async () => {
+    vi.mocked(submitJob).mockResolvedValueOnce(queuedJob);
+    const { result } = renderHook(() => useEngineScan());
+    await act(async () => {
+      await result.current.startScan();
+    });
+
+    emit({ id: 'other-job', kind: 'engine-scan', state: 'succeeded', progress: 1 });
+
+    expect(result.current.status.state).toBe('running'); // unchanged
+    expect(result.current.status.jobId).toBe('job-1');
+  });
+
+  it('surfaces a failed submit', async () => {
+    vi.mocked(submitJob).mockRejectedValueOnce(new Error('at capacity'));
+    const { result } = renderHook(() => useEngineScan());
+
+    await expect(result.current.startScan()).rejects.toThrow('at capacity');
+    await waitFor(() => {
+      expect(result.current.status.state).toBe('failed');
+      expect(result.current.status.error).toBe('at capacity');
+    });
+  });
+
+  it('cancels the running job', async () => {
+    vi.mocked(submitJob).mockResolvedValueOnce(queuedJob);
+    vi.mocked(cancelJob).mockResolvedValueOnce({ ...queuedJob, state: 'cancelled' });
+    const { result } = renderHook(() => useEngineScan());
+    await act(async () => {
+      await result.current.startScan();
+    });
+
+    await act(async () => {
+      await result.current.cancelScan();
+    });
+
+    expect(cancelJob).toHaveBeenCalledWith('job-1');
+    expect(result.current.status.state).toBe('canceled');
+  });
+
+  it('cancel is a no-op when no scan is running', async () => {
+    const { result } = renderHook(() => useEngineScan());
+    await act(async () => {
+      await result.current.cancelScan();
+    });
+    expect(cancelJob).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/hooks/useEngineScan.ts
+++ b/ui/src/hooks/useEngineScan.ts
@@ -1,0 +1,158 @@
+/**
+ * useEngineScan — drive a discovery scan through the unified jobs spine.
+ *
+ * This is the Phase 7 S3 replacement for usePipelineStatus: instead of the
+ * legacy /api/v1/security/pipeline/* endpoints, it submits an `engine-scan`
+ * job (ADR-0005/0007), tracks it over the shared /api/v1/jobs/events stream
+ * (useJobEvents), and exposes a small status the discovery card renders.
+ *
+ * Devices are NOT returned here — they continue to load via
+ * useDiscoveredDevices (GET /api/v1/security/devices), unchanged. This hook
+ * owns only the scan lifecycle (start / progress / cancel).
+ *
+ * Progress is the job's cumulative fraction (the engine reports it per phase,
+ * S4.2). The phase *name* rides the engine event bus, not the job stream, so
+ * it is intentionally not surfaced here (see SEED_S4_FOLD_PLAN.md S3 fork).
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { cancelJob, submitJob } from '../lib/jobsClient';
+import type { EngineScanRequest } from '../types/generated/engine-scan-request';
+import type { JobResponse } from '../types/generated/job-response';
+import { useJobEvents } from './useJobEvents';
+
+/** EngineScanState is the discovery-card view of the job lifecycle. */
+export type EngineScanState = 'idle' | 'running' | 'complete' | 'failed' | 'canceled';
+
+/** EngineScanStatus is the scan lifecycle the discovery card renders. */
+export interface EngineScanStatus {
+  state: EngineScanState;
+  jobId: string;
+  /** Cumulative progress, 0..100. */
+  percentComplete: number;
+  error: string | null;
+}
+
+export interface UseEngineScanReturn {
+  status: EngineScanStatus;
+  running: boolean;
+  startScan: (overrides?: Partial<EngineScanRequest>) => Promise<void>;
+  cancelScan: () => Promise<void>;
+}
+
+/**
+ * DEFAULT_SCAN_PARAMS mirrors the discovery card's prior pipeline config:
+ * name resolution + service discovery (port scan + profiling) at quick
+ * intensity, no vuln assessment, fresh discovery across all transports.
+ */
+const DEFAULT_SCAN_PARAMS: EngineScanRequest = {
+  scanType: 'full',
+  includeWired: true,
+  includeWifi: true,
+  includeBluetooth: true,
+  includeSnmp: false,
+  includePortScan: true,
+  includeProfiling: true,
+  includeNameRes: true,
+  includeVulnScan: false,
+  freshWiredScan: true,
+  freshWifiScan: true,
+  freshBluetoothScan: true,
+  portScanIntensity: 'quick',
+};
+
+const IDLE_STATUS: EngineScanStatus = {
+  state: 'idle',
+  jobId: '',
+  percentComplete: 0,
+  error: null,
+};
+
+/** toScanState maps a job lifecycle state to the card's coarser view. */
+function toScanState(jobState: string): EngineScanState {
+  switch (jobState) {
+    case 'queued':
+    case 'running':
+      return 'running';
+    case 'succeeded':
+      return 'complete';
+    case 'failed':
+      return 'failed';
+    case 'cancelled':
+      return 'canceled';
+    default:
+      return 'idle';
+  }
+}
+
+/** pct clamps a job progress fraction (0..1) to an integer percentage. */
+function pct(fraction: number): number {
+  return Math.round(Math.min(Math.max(fraction, 0), 1) * 100);
+}
+
+function statusFromJob(job: JobResponse): EngineScanStatus {
+  return {
+    state: toScanState(job.state),
+    jobId: job.id,
+    percentComplete: pct(job.progress),
+    error: job.error ?? null,
+  };
+}
+
+/**
+ * useEngineScan submits and tracks one discovery engine-scan job at a time.
+ * The job event stream is opened on mount; startScan/cancelScan drive the
+ * lifecycle and the latest snapshot is exposed as `status`.
+ */
+export function useEngineScan(): UseEngineScanReturn {
+  const [status, setStatus] = useState<EngineScanStatus>(IDLE_STATUS);
+  const jobIdRef = useRef<string>('');
+
+  // Apply events for OUR job only; the stream multiplexes every job.
+  useJobEvents(
+    useCallback((job: JobResponse) => {
+      if (job.id !== jobIdRef.current) {
+        return;
+      }
+      setStatus(statusFromJob(job));
+    }, []),
+  );
+
+  const startScan = useCallback(async (overrides?: Partial<EngineScanRequest>): Promise<void> => {
+    const params: EngineScanRequest = { ...DEFAULT_SCAN_PARAMS, ...overrides };
+    setStatus({ state: 'running', jobId: '', percentComplete: 0, error: null });
+    try {
+      const job = await submitJob({ kind: 'engine-scan', params });
+      jobIdRef.current = job.id;
+      setStatus(statusFromJob(job));
+    } catch (err) {
+      jobIdRef.current = '';
+      setStatus({
+        state: 'failed',
+        jobId: '',
+        percentComplete: 0,
+        error: err instanceof Error ? err.message : 'Failed to start scan',
+      });
+      throw err;
+    }
+  }, []);
+
+  const cancelScan = useCallback(async (): Promise<void> => {
+    const id = jobIdRef.current;
+    if (!id) {
+      return;
+    }
+    try {
+      await cancelJob(id);
+      setStatus((prev) => ({ ...prev, state: 'canceled' }));
+    } catch (err) {
+      setStatus((prev) => ({
+        ...prev,
+        error: err instanceof Error ? err.message : 'Failed to cancel scan',
+      }));
+      throw err;
+    }
+  }, []);
+
+  return { status, running: status.state === 'running', startScan, cancelScan };
+}


### PR DESCRIPTION
The Phase 7 S3 replacement for usePipelineStatus: instead of the legacy
/api/v1/security/pipeline/* endpoints, useEngineScan submits an engine-scan
job (jobsClient.submitJob), tracks it over the shared /api/v1/jobs/events
stream (useJobEvents), and exposes a small scan lifecycle (state / percent /
error) plus startScan/cancelScan.

Default scan params mirror the discovery card's prior pipeline config: name
resolution + service discovery (port scan + profiling) at quick intensity,
no vuln assessment, fresh discovery across transports — now expressible on
EngineScanRequest after S4.1/S4.1c.

Progress is the job's cumulative fraction (engine reports per phase, S4.2);
the phase name rides the engine bus, not the job stream, so it is not
surfaced here (S3 fork, deferred to S3.2). Events for other jobs are
ignored (filtered by the submitted job id).

Additive: no consumer yet (S3.2 rewires NetworkDiscoveryCard). 6 tests
cover submit params, own-job progress/terminal mapping, cross-job
filtering, failed submit, and cancel. Token-clean; 180 vitest green.

Refs ADR-0005, ADR-0007, SEED_S4_FOLD_PLAN.md
