### PR TITLE
feat(ui): add useEnginePhase hook tracking the current scan phase (P7 S3.2a)

### DIFF
--- a/ui/src/hooks/useEnginePhase.test.ts
+++ b/ui/src/hooks/useEnginePhase.test.ts
@@ -1,0 +1,92 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useEnginePhase } from './useEnginePhase';
+
+// Controllable EventSource fake (same shape as the useJobEvents suite).
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  closed = false;
+  private listeners: Record<string, ((ev: unknown) => void)[]> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, fn: (ev: unknown) => void): void {
+    const existing = this.listeners[type] ?? [];
+    existing.push(fn);
+    this.listeners[type] = existing;
+  }
+
+  removeEventListener(): void {}
+  close(): void {
+    this.closed = true;
+  }
+
+  emit(type: string, ev: unknown): void {
+    for (const fn of this.listeners[type] ?? []) {
+      fn(ev);
+    }
+  }
+}
+
+function progressFrame(phase: string, fraction: number): { data: string } {
+  return { data: JSON.stringify({ type: 'scan.progress', payload: { phase, fraction } }) };
+}
+
+describe('useEnginePhase', () => {
+  let original: typeof EventSource;
+
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    original = global.EventSource;
+    global.EventSource = FakeEventSource as unknown as typeof EventSource;
+  });
+
+  afterEach(() => {
+    global.EventSource = original;
+  });
+
+  it('opens the engine events stream', () => {
+    renderHook(() => useEnginePhase());
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0].url).toContain('/api/v1/discovery/engine/events');
+  });
+
+  it('tracks the latest scan.progress phase', () => {
+    const { result } = renderHook(() => useEnginePhase());
+    expect(result.current.phase).toBe('');
+
+    act(() => FakeEventSource.instances[0].emit('scan.progress', progressFrame('discovery', 0.2)));
+    expect(result.current.phase).toBe('discovery');
+
+    act(() => FakeEventSource.instances[0].emit('scan.progress', progressFrame('enrichment', 0.8)));
+    expect(result.current.phase).toBe('enrichment');
+  });
+
+  it('resets the phase on scan.started', () => {
+    const { result } = renderHook(() => useEnginePhase());
+    act(() => FakeEventSource.instances[0].emit('scan.progress', progressFrame('assessment', 1)));
+    expect(result.current.phase).toBe('assessment');
+
+    act(() => FakeEventSource.instances[0].emit('scan.started', { data: '{}' }));
+    expect(result.current.phase).toBe('');
+  });
+
+  it('ignores a malformed frame without throwing', () => {
+    const { result } = renderHook(() => useEnginePhase());
+    expect(() =>
+      act(() => FakeEventSource.instances[0].emit('scan.progress', { data: 'not json' })),
+    ).not.toThrow();
+    expect(result.current.phase).toBe('');
+  });
+
+  it('closes the stream on unmount', () => {
+    const { unmount } = renderHook(() => useEnginePhase());
+    const source = FakeEventSource.instances[0];
+    unmount();
+    expect(source.closed).toBe(true);
+  });
+});

--- a/ui/src/hooks/useEnginePhase.ts
+++ b/ui/src/hooks/useEnginePhase.ts
@@ -1,0 +1,58 @@
+/**
+ * useEnginePhase — track the discovery engine's current scan phase name.
+ *
+ * The engine-scan job (useEngineScan) carries lifecycle state + a progress
+ * fraction, but not the human phase NAME — that rides the engine event bus.
+ * This hook subscribes to /api/v1/discovery/engine/events and tracks the
+ * latest `scan.progress` phase (S4.2's EventScanProgress), resetting on
+ * `scan.started`. The discovery card pairs it with useEngineScan to show
+ * "bar + % + phase" without the heavier legacy pipeline progress payloads.
+ *
+ * Structurally mirrors useJobEvents (named-event EventSource, callback-free
+ * since it owns its own state, browser-managed reconnect).
+ */
+
+import { useEffect, useState } from 'react';
+import { LogComponents, logger } from '../lib/logger';
+
+/** Path of the engine event stream. */
+const ENGINE_EVENTS_URL = '/api/v1/discovery/engine/events';
+
+/** Shape of a scan.progress event payload (engine NewScanProgressEvent). */
+interface ScanProgressPayload {
+  phase?: string;
+  fraction?: number;
+}
+
+/**
+ * useEnginePhase returns the current scan phase name (empty between scans /
+ * before the first phase completes). Self-resets on scan.started so a new
+ * scan does not briefly show the previous run's last phase.
+ */
+export function useEnginePhase(): { phase: string } {
+  const [phase, setPhase] = useState<string>('');
+
+  useEffect(() => {
+    const fullUrl = `${window.location.protocol}//${window.location.host}${ENGINE_EVENTS_URL}`;
+    const source = new EventSource(fullUrl, { withCredentials: true });
+
+    source.addEventListener('scan.started', () => setPhase(''));
+
+    source.addEventListener('scan.progress', (event: MessageEvent<string>) => {
+      try {
+        const data = JSON.parse(event.data) as { payload?: ScanProgressPayload };
+        if (data.payload?.phase) {
+          setPhase(data.payload.phase);
+        }
+      } catch (error) {
+        logger.error(LogComponents.SSE, 'Failed to parse scan.progress event', error, {
+          data: event.data,
+        });
+      }
+    });
+
+    return () => source.close();
+  }, []);
+
+  return { phase };
+}


### PR DESCRIPTION
The engine-scan job (useEngineScan) carries lifecycle state + a progress
fraction but not the human phase name. Per the S3 UX decision (bar + % +
phase name), this hook subscribes to /api/v1/discovery/engine/events and
tracks the latest scan.progress phase (S4.2's EventScanProgress),
self-resetting on scan.started so a new run doesn't show the previous
run's last phase.

Mirrors useJobEvents (named-event EventSource, browser-managed reconnect).
The discovery card (S3.2b) will pair it with useEngineScan to render a
compact progress display, replacing PipelineProgress.

Additive — no consumer yet. 5 tests cover stream open, phase tracking,
scan.started reset, malformed-frame tolerance, and unmount close.
Token-clean; 185 vitest green.

Refs ADR-0007, SEED_S4_FOLD_PLAN.md
