### PR TITLE
feat(ui): migrate discovery card onto the engine-scan job (P7 S3.2b)

### DIFF
--- a/ui/src/components/cards/NetworkDiscoveryCard.tsx
+++ b/ui/src/components/cards/NetworkDiscoveryCard.tsx
@@ -2,8 +2,9 @@
 import type React from 'react';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useEnginePhase } from '../../hooks/useEnginePhase';
+import { useEngineScan } from '../../hooks/useEngineScan';
 import { useNetworkDiscoveryAutoScan } from '../../hooks/useNetworkDiscoveryAutoScan';
-import { usePipelineStatus } from '../../hooks/usePipelineStatus';
 import { button, cn, icon as iconTokens, radius, spacing } from '../../styles/theme';
 import { Card, CardValue, type Status } from '../ui/card';
 import { Maximize2, RefreshCw, ScanSearch } from '../ui/icons';
@@ -52,15 +53,11 @@ export const NetworkDiscoveryCard: React.NamedExoticComponent<NetworkDiscoveryCa
     // Search and sort state lived here when the card embedded a sortable
     // device table; those rows now live entirely inside DiscoveryModal.
 
-    // Pipeline status hook for multi-phase progress display
-    const { status: pipelineStatus, startPipeline, cancelPipeline } = usePipelineStatus();
-
-    // Check if pipeline is actively running
-    const isPipelineRunning =
-      pipelineStatus.state !== 'idle' &&
-      pipelineStatus.state !== 'complete' &&
-      pipelineStatus.state !== 'failed' &&
-      pipelineStatus.state !== 'canceled';
+    // Discovery scan via the unified jobs spine: an engine-scan job
+    // (useEngineScan) drives lifecycle + progress %, and the engine event bus
+    // (useEnginePhase) supplies the current phase name.
+    const { running, status: scanStatus, startScan, cancelScan } = useEngineScan();
+    const { phase: scanPhase } = useEnginePhase();
 
     // Auto-scan + vuln-scan orchestration lives in its own hook
     const { handleDeepScan } = useNetworkDiscoveryAutoScan(data);
@@ -135,7 +132,7 @@ export const NetworkDiscoveryCard: React.NamedExoticComponent<NetworkDiscoveryCa
     const categories = categorizeDevices(devices);
 
     const getOverallStatus = (): Status => {
-      if (status.scanning || isPipelineRunning) {
+      if (status.scanning || running) {
         return 'loading';
       }
       if (deviceCount === 0) {
@@ -173,56 +170,41 @@ export const NetworkDiscoveryCard: React.NamedExoticComponent<NetworkDiscoveryCa
             </button>
 
             {/* Scan button */}
-            {onScan || startPipeline ? (
-              <button
-                type="button"
-                onClick={(): void => {
-                  // Use pipeline start with port scanning enabled
-                  // This enables the serviceDiscovery phase with quick port scan
-                  startPipeline({
-                    phases: {
-                      enumeration: true,
-                      nameResolution: true,
-                      serviceDiscovery: true,
-                      vulnAssessment: false,
-                    },
-                    portScan: {
-                      intensity: 'quick',
-                      bannerGrab: true,
-                      connectTimeout: 2000,
-                    },
-                  }).catch(() => {
-                    // Errors handled in usePipelineStatus
-                  });
-                  // Also call onScan for backwards compatibility
-                  onScan?.();
-                }}
-                disabled={status.scanning || isPipelineRunning}
-                className={cn(
-                  spacing.chip.sm,
-                  'bg-brand-primary text-on-brand',
-                  radius.md,
-                  'hover:bg-brand-primary/90 transition-colors font-medium caption disabled:opacity-50 disabled:cursor-not-allowed flex items-center',
-                  spacing.inline.sm,
-                )}
-                aria-label={
-                  status.scanning || isPipelineRunning ? 'Scanning network' : 'Start network scan'
-                }
-                data-testid="discovery-scan-button"
-              >
-                {status.scanning || isPipelineRunning ? (
-                  <>
-                    <RefreshCw
-                      className={cn(iconTokens.size.xs, 'animate-spin')}
-                      aria-hidden="true"
-                    />
-                    {t('discovery.scan')}
-                  </>
-                ) : (
-                  t('discovery.scan')
-                )}
-              </button>
-            ) : null}
+            <button
+              type="button"
+              onClick={(): void => {
+                // Submit an engine-scan job (name resolution + service
+                // discovery at quick intensity) via the unified jobs spine.
+                // The hook's default params encode the prior pipeline config.
+                startScan().catch(() => {
+                  // Errors surfaced via useEngineScan status.
+                });
+                // Also call onScan for backwards compatibility.
+                onScan?.();
+              }}
+              disabled={status.scanning || running}
+              className={cn(
+                spacing.chip.sm,
+                'bg-brand-primary text-on-brand',
+                radius.md,
+                'hover:bg-brand-primary/90 transition-colors font-medium caption disabled:opacity-50 disabled:cursor-not-allowed flex items-center',
+                spacing.inline.sm,
+              )}
+              aria-label={status.scanning || running ? 'Scanning network' : 'Start network scan'}
+              data-testid="discovery-scan-button"
+            >
+              {status.scanning || running ? (
+                <>
+                  <RefreshCw
+                    className={cn(iconTokens.size.xs, 'animate-spin')}
+                    aria-hidden="true"
+                  />
+                  {t('discovery.scan')}
+                </>
+              ) : (
+                t('discovery.scan')
+              )}
+            </button>
           </div>
         }
       >
@@ -231,11 +213,13 @@ export const NetworkDiscoveryCard: React.NamedExoticComponent<NetworkDiscoveryCa
           status={status}
           deviceCount={deviceCount}
           categories={categories}
-          pipelineStatus={pipelineStatus}
-          onCancelPipeline={cancelPipeline}
+          scanRunning={running}
+          scanPercent={scanStatus.percentComplete}
+          scanPhase={scanPhase}
+          onCancelScan={cancelScan}
           t={t}
         />
-        {deviceCount === 0 && !status.scanning && !isPipelineRunning ? (
+        {deviceCount === 0 && !status.scanning && !running ? (
           <p className={cn('body-small text-text-muted text-center', spacing.pad.default)}>
             {t('discovery.noDevices')}
           </p>

--- a/ui/src/components/cards/NetworkDiscoveryCardHelpers.tsx
+++ b/ui/src/components/cards/NetworkDiscoveryCardHelpers.tsx
@@ -12,7 +12,6 @@
 import type React from 'react';
 import { useMemo, useState } from 'react';
 import type { useTranslation } from 'react-i18next';
-import type { usePipelineStatus } from '../../hooks/usePipelineStatus';
 import {
   category as categoryTheme,
   cn,
@@ -34,7 +33,7 @@ import {
   Wifi,
 } from '../ui/icons';
 import type { DiscoveredDevice, DiscoveryStatus } from './networkDiscoveryCardTypes';
-import { PipelineProgress } from './PipelineProgress';
+import { ScanProgress } from './ScanProgress';
 
 type CardsT = ReturnType<typeof useTranslation<'cards'>>['t'];
 
@@ -260,30 +259,26 @@ export function DiscoverySummary({
   status,
   deviceCount,
   categories,
-  pipelineStatus,
-  onCancelPipeline,
+  scanRunning,
+  scanPercent,
+  scanPhase,
+  onCancelScan,
   t,
 }: {
   status: DiscoveryStatus;
   deviceCount: number;
   categories: CategoryCounts;
-  pipelineStatus?: ReturnType<typeof usePipelineStatus>['status'];
-  onCancelPipeline?: () => void;
+  scanRunning?: boolean;
+  scanPercent?: number;
+  scanPhase?: string;
+  onCancelScan?: () => void;
   t: CardsT;
 }): React.ReactElement {
-  // Check if pipeline is actively running
-  const isPipelineRunning =
-    pipelineStatus &&
-    pipelineStatus.state !== 'idle' &&
-    pipelineStatus.state !== 'complete' &&
-    pipelineStatus.state !== 'failed' &&
-    pipelineStatus.state !== 'canceled';
-
-  // Show pipeline progress when running
-  if (isPipelineRunning && pipelineStatus) {
+  // Show scan progress while the engine-scan job is running (S3).
+  if (scanRunning) {
     return (
       <div className="stack-sm">
-        <PipelineProgress status={pipelineStatus} onCancel={onCancelPipeline} />
+        <ScanProgress percent={scanPercent ?? 0} phase={scanPhase ?? ''} onCancel={onCancelScan} />
       </div>
     );
   }

--- a/ui/src/components/cards/ScanProgress.tsx
+++ b/ui/src/components/cards/ScanProgress.tsx
@@ -1,0 +1,89 @@
+/**
+ * ScanProgress — compact discovery scan progress.
+ *
+ * The Phase 7 S3 replacement for PipelineProgress: where the legacy pipeline
+ * emitted rich per-phase payloads (device counts, current target, per-phase
+ * durations), the unified jobs spine surfaces a cumulative progress fraction
+ * (useEngineScan) plus the current phase name (useEnginePhase, from the engine
+ * event bus). This renders bar + percent + phase + cancel — the agreed S3
+ * progress UX.
+ */
+
+import { Loader2, X } from 'lucide-react';
+import type React from 'react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { button, cn, icon as iconTokens, radius } from '../../styles/theme';
+
+interface ScanProgressProps {
+  /** Cumulative scan progress, 0..100. */
+  percent: number;
+  /** Engine phase name (e.g. discovery / enrichment); empty if not yet known. */
+  phase: string;
+  onCancel?: () => void;
+}
+
+// Engine scan phase → human label. Engine phases differ from the legacy
+// pipeline's (discovery/correlation/name_resolution/enrichment/assessment).
+const PHASE_LABELS: Record<string, string> = {
+  discovery: 'Discovery',
+  correlation: 'Correlating',
+  name_resolution: 'Name resolution',
+  enrichment: 'Enrichment',
+  assessment: 'Assessment',
+};
+
+export const ScanProgress: React.NamedExoticComponent<ScanProgressProps> = memo(
+  function scanProgress({ percent, phase, onCancel }: ScanProgressProps): React.ReactElement {
+    const { t } = useTranslation('cards');
+    const clamped = Math.min(Math.max(percent, 0), 100);
+    const phaseLabel = phase ? PHASE_LABELS[phase] || phase : '';
+
+    return (
+      <div className="stack-xs" data-testid="scan-progress">
+        <div className="flex-between">
+          <div className="flex items-center gap-compact">
+            <Loader2 className={cn(iconTokens.size.sm, 'text-brand-primary animate-spin')} />
+            <span className="body-small font-medium text-text-primary">
+              {phaseLabel
+                ? t('discovery.scanningPhase', {
+                    phase: phaseLabel,
+                    defaultValue: `Scanning — ${phaseLabel}`,
+                  })
+                : t('discovery.scanning', { defaultValue: 'Scanning…' })}
+            </span>
+          </div>
+          {onCancel ? (
+            <button
+              type="button"
+              onClick={onCancel}
+              data-testid="scan-cancel-button"
+              className={cn(
+                button.base,
+                button.size.sm,
+                button.variant.secondary,
+                'flex items-center gap-tight',
+              )}
+              aria-label={t('pipeline.cancel', { defaultValue: 'Cancel' })}
+            >
+              <X className={iconTokens.size.xs} />
+              <span className="hidden sm:inline">
+                {t('pipeline.cancel', { defaultValue: 'Cancel' })}
+              </span>
+            </button>
+          ) : null}
+        </div>
+        <div className={cn('h-2 bg-surface-sunken overflow-hidden', radius.default)}>
+          <div
+            className={cn('h-full bg-brand-primary transition-all duration-300', radius.default)}
+            style={{ width: `${clamped}%` }}
+            data-testid="scan-progress-bar"
+          />
+        </div>
+        <div className="flex justify-end caption text-text-muted">
+          <span>{Math.round(clamped)}%</span>
+        </div>
+      </div>
+    );
+  },
+);


### PR DESCRIPTION
Rewire NetworkDiscoveryCard off the legacy pipeline onto the unified jobs
spine: the scan button submits an engine-scan job (useEngineScan) instead
of POST /api/v1/security/pipeline/start, and progress is shown by a new
compact ScanProgress component (bar + percent + phase name) fed by
useEngineScan (% from job progress) + useEnginePhase (phase from the
engine event bus), replacing PipelineProgress.

- DiscoverySummary now takes scanRunning/scanPercent/scanPhase/onCancelScan
  instead of the pipeline status object; renders ScanProgress while running.
- isPipelineRunning -> running (from useEngineScan); the card's own
  data?.status.scanning is unchanged.
- Devices still load via useDiscoveredDevices (GET /api/v1/security/devices),
  unaffected.

Per the S3 UX decision, the rich pipeline progress (device counts, current
target, per-phase durations) is intentionally not reproduced — the jobs
spine surfaces percent + phase. usePipelineStatus/PipelineProgress are now
unused by the card and are removed in S3.3 (still imported for types by
useCardState until then).

Token-clean; tsc + biome clean; 185 vitest green. Live browser flow
verified via CI full E2E (discovery-scan-button specs).

Refs ADR-0007, SEED_S4_FOLD_PLAN.md
