### PR TITLE
docs(adr): network anomaly engine + Wi-Fi monitor capture/decode

### DIFF
--- a/docs/architecture/decisions/0011-network-anomaly-engine.md
+++ b/docs/architecture/decisions/0011-network-anomaly-engine.md
@@ -1,0 +1,66 @@
+# ADR-0011: Network-wide anomaly engine (one typed stream, data-driven catalog)
+
+**Status:** Accepted — 2026-06-05 · implementation pending (Wi-Fi feature W4)
+
+## Context
+
+The owner wants proactive problem/anomaly detection — starting with Wi-Fi (rogue/evil-twin
+APs, vendor mismatch within an SSID, security mismatch, Pineapple/KARMA) but explicitly
+spanning much more: a NetAlly-style catalog that covers Wi-Fi **and** wired/SNMP network
+health (CPU/mem/disk, interface errors/FCS/discards, half-duplex, spanning-tree change,
+duplicate IP, bad mask, SNMPv3-answering-v1/v2) **and** connectivity-test outcomes. The
+detections must be *guided*: each carries a precise description (cite IEEE/802.11 where it
+applies), a concrete fix recommendation, and — where one observation is ambiguous — a way to
+**narrow the diagnosis**, either by auto-running a deeper test or prompting the user.
+
+Two failure modes to avoid:
+1. **Three sibling buckets** ("Network / Wi-Fi / Security Anomalies"). They overlap so heavily
+   (a Pineapple is all three) that users hunt across lists for one problem, and detections get
+   split. The owner agreed this is "a pain in the ass."
+2. **Hard-coding detections per subsystem.** That fragments the catalog, blocks cross-source
+   correlation (e.g. a captured Wi-Fi BSSID whose MAC also appears in the wired ARP/switch
+   table = a rogue AP bridged onto the LAN), and makes the copy/thresholds un-tunable.
+
+## Decision
+
+One **general `internal/anomaly` engine**, network-wide — NOT a Wi-Fi-only or per-subsystem
+detector. "Network Anomalies" is the umbrella; Wi-Fi is its first rule *source*.
+
+- **One typed instance.** `Anomaly{ id, defKey, category, severity, subjectRef (SSID/BSSID/
+  client/device/interface), title, detail, evidence (measured values), firstSeen, lastSeen,
+  count }`. `category` encodes the *domain* (e.g. `security`, `rf`, `roaming`, `capacity`,
+  `nethealth`, `authorization`) — there is exactly one stream, filterable by category + severity.
+- **Data-driven catalog (`AnomalyDef`).** Each anomaly *type* is a catalog entry, separate from
+  its detections: `{ id, category, defaultSeverity, standards []string (cite IEEE/802.11, e.g.
+  "IEEE 802.11w-2009"), title, description, impact, recommendation, followUps []FollowUp }`.
+  Copy is **authored originally** (the competitor's analysis prose is copyrighted and must not be
+  pasted into this source-available repo); the external list is used only as a checklist of what
+  to detect. The catalog lives as data so copy/thresholds are tunable without code changes.
+- **Capability-gated follow-ups (ADR-0002).** A `FollowUp{kind:"auto"|"prompt", label, action}`
+  runs as an automatic deeper test where the platform/adapter registers the capability (Linux
+  active diagnostics — nl80211 station dump, association/auth probe, RTS/CTS hidden-node test,
+  PMF/deauth-response check, throughput retest) and **degrades to a guided user prompt** where it
+  does not. One catalog, two execution modes, chosen per registered capability.
+- **Pluggable rule sources via the event bus (ADR-0004).** Sources (Wi-Fi capture first; wired
+  discovery / SNMP / AutoTest later) evaluate their own domain data and emit detections; the
+  engine dedups, correlates (incl. cross-source, e.g. Wi-Fi↔wired MAC), escalates severity,
+  applies TTL/clear, and persists. The engine has **no dependency on any one source** — it is
+  unit-tested against synthetic detections.
+- **Feeds existing surfaces.** Anomalies map onto the existing severity vocabulary + Alerts model
+  and publish on the event bus for live UI. Wire DTOs are camelCase (ADR-0010), code-first schema
+  (ADR-0008). Where a source is Pro (Wi-Fi management capture / association forensics), its
+  detections are gated by `requireFeature`; the engine itself is tier-neutral.
+
+## Consequences
+
+- One stream scales to a large, growing catalog with no UI sprawl; the "Network Anomalies"
+  umbrella can absorb wired + Wi-Fi + security + test sources over time.
+- Cross-source correlation becomes possible (rogue-AP-on-LAN, IP/MAC conflicts) because all
+  detections land in one engine.
+- Reuses Alerts/severity/events rather than inventing a parallel notification path.
+- The catalog being *data* lets us tune descriptions, IEEE citations, thresholds, and severities
+  without redeploying logic, and makes the catalog reviewable in one place.
+- New responsibilities to design carefully: detection **dedup + TTL + clear**, severity
+  escalation on recurrence, and the follow-up **capability registration** for active diagnostics.
+- The guided-remediation promise depends on the capability registry being wired for the active
+  Linux diagnostics; until then those follow-ups present as prompts everywhere (still useful).

--- a/docs/architecture/decisions/0012-wifi-monitor-capture-decode.md
+++ b/docs/architecture/decisions/0012-wifi-monitor-capture-decode.md
@@ -1,0 +1,70 @@
+# ADR-0012: Wi-Fi monitor-mode capture port + 802.11 decode pipeline
+
+**Status:** Accepted — 2026-06-05 · implementation pending (Wi-Fi feature W1–W6)
+
+## Context
+
+Today's Wi-Fi is OS-level scanning only (`internal/wifi` shells to `airport`/`nmcli`/`iw`): a
+flat neighbor-AP list of SSID/BSSID/signal/channel/security. There is no frame capture, no
+802.11 decode, and no client tracking (`ClientCount` is hardcoded `0`). The owner wants Wi-Fi to
+be **as good as or better than wired discovery + topology**: channel-hop every channel at ~110ms
+dwell, capture **802.11 management frames**, fully decode them, and present a **cross-referenced
+SSID → AP → BSSID → client hierarchy** with capability/IE decode (HT/VHT/HE/EHT, 802.11k RRM
+neighbor reports, 802.11r FT, country/regulatory), client associations down to the BSSID, plus
+co-channel / adjacent-channel interference analysis. This is also the data source for the
+anomaly engine (ADR-0011).
+
+Constraints: raw 802.11 capture needs a **monitor-mode-capable adapter + root/CAP_NET_RAW +
+libpcap (CGO)**. It is reliable on **Linux**; on **Windows/macOS it is best-effort via a
+third-party USB adapter** (the built-in macOS card cannot — Apple blocks raw frames). The
+existing capture port (`internal/capture`, libpcap behind a CGO build tag, null stub under
+CGO=0) already proves the seam used by wired discovery (LLDP/CDP/EDP), DHCP, and VLAN sampling.
+
+## Decision
+
+Extend the existing `internal/capture` port with a **Wi-Fi monitor-mode source**, splitting two
+concerns so the OS-specific surface stays tiny:
+
+- **(a) Capture + decode = OS-agnostic.** Capture runs over any monitor-capable **radiotap**
+  interface via libpcap (CGO). Decode is **CGO-free** — gopacket's `layers.RadioTap` and
+  `layers.Dot11*` are pure Go — so the decoder, the SSID→AP→BSSID→client model, the
+  co-/adjacent-channel interference analysis, and the anomaly rules are all pure-Go and **fully
+  unit-tested off-target** (macOS dev) against captured-frame fixtures. Same code path on
+  Linux/Windows/macOS.
+- **(b) Monitor-mode ENABLEMENT = per-OS best-effort helper, isolated.** Linux nl80211/`iw` is
+  first-class (auto-enable + the active-diagnostic "+1s" — station dump, association probe,
+  RTS/CTS test — registered as capabilities per ADR-0002/0011). Windows (Npcap) and macOS are
+  best-effort. A **"bring-your-own monitor interface"** escape hatch lets a user pre-set the
+  adapter to monitor mode and we capture it by name — so the full feature works wherever a
+  radiotap interface exists, even where auto-enable doesn't.
+- **Channel hopper** — async loop, ~110ms dwell across the regulatory-permitted 2.4/5/6 GHz
+  channels, aggregating decoded frames per channel; feeds the model continuously.
+- **Domain model** — beacons/probe-responses build the SSID→AP→BSSID tree (capabilities/IEs,
+  RRM/FT, country); association/data frames populate clients keyed by MAC, cross-referenced down
+  to the BSSID. Channel occupancy + retry/airtime feed co-channel/adjacent-channel detection.
+- **Runs on the jobs spine (ADR-0005)** as a scan job kind (aligns with the existing
+  `wifi-discovery-scan` kind; the monitor-capture scan extends it or lands as `wifi-capture-scan`),
+  with SSE progress and cancellation.
+- **Graceful degrade.** Under CGO=0, no monitor-capable interface, or an unsupporting platform,
+  the feature falls back to today's OS-level neighbor-AP scan (the existing path becomes the
+  degrade tier) and reports reduced fidelity rather than failing.
+- **Pro-gated** (`wifi_management_capture` / `wifi_association_forensics`, already reserved in the
+  license validator); Free/Starter keep the OS-scan + channel-utilization indicator.
+- **Build-tagged** real vs null capture mirrors the established `wire_capture_real.go` /
+  `wire_capture_null.go` split; new DTOs are camelCase (ADR-0010) via code-first schema (ADR-0008).
+
+## Consequences
+
+- Wi-Fi reaches wired-discovery-grade richness (a real, frame-fed, cross-referenced model) and
+  becomes the first rule source for the anomaly engine (ADR-0011).
+- Keeping decode/model/anomaly CGO-free means the bulk of the subsystem is fast, deterministic,
+  and unit-tested on any dev machine; only the live capture handle needs libpcap.
+- The only OS-specific code is monitor-mode *enablement*, isolated behind a small helper with a
+  BYO-interface fallback — so Windows/macOS third-party adapters use the identical engine, with
+  success gated on the user's driver, not on our code.
+- **Validation needs real monitor-mode hardware** (Linux box / CI), exactly like the wired pcap
+  path — a known-good split, not a new risk class. macOS/Windows third-party monitor mode stays
+  best-effort and is not the validated reference.
+- The legacy OS-scan path is retained (now the graceful-degrade tier), not deleted.
+- A new Pro capability + scan job kind + schema DTOs are added; the channel hopper introduces
+  timing/coverage considerations (beacons ~100ms vs 110ms dwell) to validate on hardware.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -18,3 +18,5 @@ See the [Re-Architecture Blueprint](../RE_ARCHITECTURE_BLUEPRINT.md) for the ful
 | [0008](0008-pure-data-discovery-types-in-schema.md) | Pure-data discovery types may be reflected into the published schema | Accepted |
 | [0009](0009-profile-ui-types-are-a-curated-view.md) | profile.ts/settings.ts are a curated UI view, not a config.Config mirror | Accepted |
 | [0010](0010-identifier-casing-conventions.md) | Identifier casing — camelCase JSON wire, snake_case files/SQL | Accepted |
+| [0011](0011-network-anomaly-engine.md) | Network-wide anomaly engine — one typed stream, data-driven catalog | Accepted |
+| [0012](0012-wifi-monitor-capture-decode.md) | Wi-Fi monitor-mode capture port + 802.11 decode pipeline | Accepted |


### PR DESCRIPTION
Two accepted ADRs that lock the architecture for the Wi-Fi visibility + anomaly feature before implementation.

- **ADR-0011 — Network-wide anomaly engine.** ONE typed `Anomaly` stream (category encodes domain), explicitly NOT separate Network/Wi-Fi/Security buckets. Data-driven `AnomalyDef` catalog: IEEE-cited description + impact + fix recommendation + **capability-gated follow-up tests** (auto active diagnostics on Linux, guided prompt elsewhere). Pluggable rule sources over the event bus (Wi-Fi first, wired/SNMP/test later); feeds the existing severity/Alerts model. Copy authored originally (no competitor prose).
- **ADR-0012 — Wi-Fi monitor-mode capture port + 802.11 decode.** Extends the existing `internal/capture` seam. Capture+decode is OS-agnostic (decode is CGO-free gopacket radiotap/dot11, fully unit-testable off-target); monitor-mode *enablement* is a small per-OS best-effort helper + a BYO-monitor-interface escape hatch. ~110ms channel hopper; SSID→AP→BSSID→client model; jobs-spine scan kind; Pro-gated; graceful degrade to today's OS scan.

Docs-only. Implementation follows as slices W1–W6 on `feat/wifi-visibility`.