### PR TITLE
fix(license): memoize device fingerprint to stop spurious invalidation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -584,6 +584,16 @@ linters:
       # the dupl clones it would otherwise produce.
       - path: 'cmd/seed-schema/main\.go'
         linters: [ funlen ]
+      # internal/license/fingerprint.go memoizes the device fingerprint for the
+      # process lifetime via sync.OnceValues (a package-level var). This is a
+      # required process-singleton: the fingerprint is a stable machine property,
+      # and recomputing it per call shells out to OS tools that transiently fail
+      # under load, yielding a non-deterministic Hash() that spuriously
+      # invalidates a valid license on reload. The memo must outlive any single
+      # Manager, so it cannot hang off an instance.
+      - path: 'internal/license/fingerprint\.go'
+        text: 'generateFingerprintOnce is a global variable'
+        linters: [ gochecknoglobals ]
       - path: '_test\.go'
         linters:
           - bodyclose

--- a/internal/license/fingerprint.go
+++ b/internal/license/fingerprint.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -40,9 +41,27 @@ type DeviceFingerprint struct {
 	Platform   string `json:"platform"`
 }
 
-// GenerateFingerprint creates a unique device fingerprint.
-// The result is cached after the first call since hardware IDs don't change.
+// generateFingerprintOnce memoizes the device fingerprint for the process
+// lifetime. The fingerprint is a stable machine property, but computing it
+// shells out to OS tools (getCPUSerial/getDiskSerial, 5s timeout) and reads
+// the host interfaces, all of which can transiently fail, time out, or reorder
+// under load. Recomputing per call therefore yielded a NON-DETERMINISTIC
+// Hash() within a single process — which spuriously invalidated a valid
+// license on reload (state.DeviceHash != fingerprint.Hash()) on a busy host,
+// and flaked TestActivationLifecycle under parallel test load. Computing it
+// once and reusing it is both correct (the device does not change while the
+// process runs) and what the original doc comment always promised.
+var generateFingerprintOnce = sync.OnceValues(computeFingerprint)
+
+// GenerateFingerprint returns the process-wide device fingerprint, computing
+// it on first call and caching it thereafter (hardware IDs don't change).
 func GenerateFingerprint() (*DeviceFingerprint, error) {
+	return generateFingerprintOnce()
+}
+
+// computeFingerprint gathers the raw device identifiers. Called at most once
+// per process via generateFingerprintOnce.
+func computeFingerprint() (*DeviceFingerprint, error) {
 	fp := &DeviceFingerprint{
 		MACAddress: "",
 		CPUSerial:  "",


### PR DESCRIPTION
## Bug

`GenerateFingerprint` recomputed the device fingerprint on **every** call, despite its doc comment claiming the result was cached. Each `Manager` built its own fingerprint from `net.Interfaces()` (ordering/transient) + `getCPUSerial`/`getDiskSerial` (shell out, 5s timeout). Under load those can time out / return empty / reorder, so two managers in one process compute **different** fingerprints → `Hash()` is non-deterministic.

On reload, activation validation compares `state.DeviceHash` to the live fingerprint `Hash()`. A mismatch reads a valid Pro license as **not-activated**:
- **Production:** a valid license is spuriously invalidated on a busy host.
- **CI:** flaked `TestActivationLifecycle` under the parallel `go test ./...` run ("expected reloaded state to be activated" + a downstream nil deref) — passed in isolation, failed under load.

## Fix

Memoize the fingerprint for the process lifetime via `sync.OnceValues` — it's a stable machine property that doesn't change while the process runs (exactly what the original comment promised). Both managers now receive the identical cached fingerprint, so `DeviceHash == Hash()` on reload always holds. A justified `gochecknoglobals` exclusion covers the required process-singleton var.

## Verification

License package green under `-race`; `TestActivationLifecycle` stable across repeated runs; golangci 0 issues.