### PR TITLE
feat(wifi): 802.11 decoder + airspace model foundation (W1+W2)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -594,6 +594,13 @@ linters:
       - path: 'internal/license/fingerprint\.go'
         text: 'generateFingerprintOnce is a global variable'
         linters: [ gochecknoglobals ]
+      # internal/wifi/dot11/decode.go classify() switches over gopacket's
+      # layers.Dot11Type, a third-party enum with 30+ control/data subtypes. We
+      # map the management subtypes the visibility feature decodes and fold the
+      # rest into KindData/KindOther via default; enumerating every foreign
+      # control-frame subtype would add noise without changing behaviour.
+      - path: 'internal/wifi/dot11/decode\.go'
+        linters: [ exhaustive ]
       - path: '_test\.go'
         linters:
           - bodyclose

--- a/internal/wifi/airspace/airspace.go
+++ b/internal/wifi/airspace/airspace.go
@@ -1,0 +1,198 @@
+// Package airspace aggregates decoded 802.11 frames (internal/wifi/dot11) into
+// a live, cross-referenced SSID → AP → BSSID → client model — the Wi-Fi
+// analogue of the wired discovery device tree (ADR-0012). It is pure data and
+// pure aggregation: CGO-free, no I/O, no hidden clock (callers pass the
+// observation time), so it is fully unit-testable off a monitor-mode host.
+package airspace
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/wifi/dot11"
+)
+
+// apGroupMask groups the BSSIDs of one physical AP. Many APs assign their
+// per-band/per-SSID BSSIDs as a run that differs only in the low bits of the
+// last octet, so masking those bits clusters an AP's radios. It is a heuristic
+// (the only signal available from passive capture) — documented, not exact.
+const apGroupMask = 0xF0
+
+// station is a client observed on a BSS (internal aggregation state).
+type station struct {
+	mac       string
+	signalDBm int8
+	firstSeen time.Time
+	lastSeen  time.Time
+	frames    int
+}
+
+// bss is a single BSSID (one radio advertising one SSID) with its decoded
+// capabilities and the clients seen on it (internal aggregation state).
+type bss struct {
+	bssid       string
+	ssid        string
+	hidden      bool
+	band        dot11.Band
+	channel     int
+	security    dot11.Security
+	standard    dot11.Standard
+	countryCode string
+	pmfRequired bool
+	rrmNeighbor bool
+	btm         bool
+	ft          bool
+	wps         bool
+	signalDBm   int8
+	firstSeen   time.Time
+	lastSeen    time.Time
+	beacons     int
+	stations    map[string]*station
+}
+
+// Airspace is the live aggregate of everything seen on the air. Safe for
+// concurrent Observe/Tree/Prune (the capture loop writes; the API reads).
+type Airspace struct {
+	mu    sync.RWMutex
+	bsses map[string]*bss
+}
+
+// New returns an empty Airspace.
+func New() *Airspace {
+	return &Airspace{bsses: make(map[string]*bss)}
+}
+
+// Observe folds one decoded frame into the model at observation time `at`.
+// Beacons/probe-responses build and refresh BSSes; association and data frames
+// attribute client stations to the right BSSID (via the frame's DS-aware
+// BSSIDOf/StationOf). A nil frame is a no-op.
+func (a *Airspace) Observe(f *dot11.Frame, at time.Time) {
+	if f == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if f.BSS != nil {
+		a.applyBeacon(f, at)
+	}
+	a.applyStation(f, at)
+}
+
+// applyBeacon upserts the BSS advertised by a beacon/probe-response.
+func (a *Airspace) applyBeacon(f *dot11.Frame, at time.Time) {
+	key := macKey(f.BSSID)
+	if key == "" {
+		return
+	}
+	b := a.ensureBSS(key, at)
+	info := f.BSS
+	if info.SSID != "" {
+		b.ssid = info.SSID
+	}
+	b.hidden = info.Hidden && info.SSID == ""
+	b.band = f.Band
+	if f.ChannelNum != 0 {
+		b.channel = f.ChannelNum
+	}
+	b.security = info.Security
+	b.standard = info.Standard
+	b.countryCode = info.CountryCode
+	b.pmfRequired = info.PMFRequired
+	b.rrmNeighbor = info.RRMNeighbor
+	b.btm = info.BTMSupported
+	b.ft = info.FTSupported
+	b.wps = info.WPSEnabled
+	if f.SignalDBm != 0 {
+		b.signalDBm = f.SignalDBm
+	}
+	b.beacons++
+	b.lastSeen = at
+}
+
+// applyStation attributes a client station to its BSS, if the frame identifies
+// one. Frames where the "station" is actually the AP (mgmt from the BSSID
+// itself) are ignored.
+func (a *Airspace) applyStation(f *dot11.Frame, at time.Time) {
+	bssid := macKey(f.BSSIDOf())
+	sta := macKey(f.StationOf())
+	if bssid == "" || sta == "" || sta == bssid {
+		return
+	}
+	b := a.ensureBSS(bssid, at)
+	s, ok := b.stations[sta]
+	if !ok {
+		s = &station{mac: sta, firstSeen: at}
+		b.stations[sta] = s
+	}
+	if f.SignalDBm != 0 {
+		s.signalDBm = f.SignalDBm
+	}
+	s.frames++
+	s.lastSeen = at
+	if at.After(b.lastSeen) {
+		b.lastSeen = at
+	}
+}
+
+// ensureBSS returns the BSS for a key, creating a thin entry (no beacon yet)
+// if a client was seen on a BSSID we have not yet decoded a beacon for.
+func (a *Airspace) ensureBSS(key string, at time.Time) *bss {
+	b, ok := a.bsses[key]
+	if !ok {
+		b = &bss{bssid: key, firstSeen: at, stations: make(map[string]*station)}
+		a.bsses[key] = b
+	}
+	return b
+}
+
+// Prune removes stations not seen since cutoff, and then BSSes that have no
+// beacon and no remaining stations (so transient client-only entries age out).
+func (a *Airspace) Prune(cutoff time.Time) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for key, b := range a.bsses {
+		for mac, s := range b.stations {
+			if s.lastSeen.Before(cutoff) {
+				delete(b.stations, mac)
+			}
+		}
+		if b.beacons == 0 && len(b.stations) == 0 && b.lastSeen.Before(cutoff) {
+			delete(a.bsses, key)
+		}
+	}
+}
+
+// macKey normalizes a hardware address to a lowercase string key, or "" if nil.
+func macKey(mac net.HardwareAddr) string {
+	if len(mac) == 0 {
+		return ""
+	}
+	return mac.String()
+}
+
+// apKey clusters the BSSIDs of one physical AP (see apGroupMask). Falls back to
+// the full BSSID when it cannot be parsed.
+func apKey(bssid string) string {
+	hw, err := net.ParseMAC(bssid)
+	if err != nil || len(hw) == 0 {
+		return bssid
+	}
+	masked := make(net.HardwareAddr, len(hw))
+	copy(masked, hw)
+	masked[len(masked)-1] &= apGroupMask
+	return masked.String()
+}
+
+// vendorOUI returns the 24-bit OUI prefix of a BSSID (e.g. "00:11:22"), the
+// hook the vendor-mismatch anomaly rule (W4) resolves to a vendor name.
+func vendorOUI(bssid string) string {
+	hw, err := net.ParseMAC(bssid)
+	const ouiOctets = 3
+	if err != nil || len(hw) < ouiOctets {
+		return ""
+	}
+	return fmt.Sprintf("%02x:%02x:%02x", hw[0], hw[1], hw[2])
+}

--- a/internal/wifi/airspace/airspace_test.go
+++ b/internal/wifi/airspace/airspace_test.go
@@ -1,0 +1,211 @@
+package airspace_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	"github.com/krisarmstrong/seed/internal/wifi/dot11"
+)
+
+func mac(t *testing.T, s string) net.HardwareAddr {
+	t.Helper()
+	hw, err := net.ParseMAC(s)
+	if err != nil {
+		t.Fatalf("ParseMAC(%q): %v", s, err)
+	}
+	return hw
+}
+
+func beacon(t *testing.T, bssid, ssid string, info dot11.BSS) *dot11.Frame {
+	t.Helper()
+	info.SSID = ssid
+	return &dot11.Frame{
+		Kind:       dot11.KindBeacon,
+		BSSID:      mac(t, bssid),
+		Band:       dot11.Band24GHz,
+		ChannelNum: 6,
+		SignalDBm:  -50,
+		BSS:        &info,
+	}
+}
+
+// dataFromClient builds a client→AP data frame (ToDS): Address1=BSSID,
+// Address2=client.
+func dataFromClient(t *testing.T, bssid, client string) *dot11.Frame {
+	t.Helper()
+	return &dot11.Frame{
+		Kind:        dot11.KindData,
+		ToDS:        true,
+		Receiver:    mac(t, bssid),
+		Transmitter: mac(t, client),
+		SignalDBm:   -60,
+	}
+}
+
+func baseTime() time.Time { return time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC) }
+
+func TestSSIDGroupsTwoRadiosOneAP(t *testing.T) {
+	t.Parallel()
+	a := airspace.New()
+	// Two BSSIDs of the same physical AP (last octet within the group mask)
+	// advertising the same SSID across bands.
+	a.Observe(
+		beacon(
+			t,
+			"00:11:22:33:44:01",
+			"CorpWiFi",
+			dot11.BSS{Security: dot11.SecurityWPA2, Standard: dot11.Standard80211ax, PMFRequired: true},
+		),
+		baseTime(),
+	)
+	a.Observe(
+		beacon(
+			t,
+			"00:11:22:33:44:09",
+			"CorpWiFi",
+			dot11.BSS{Security: dot11.SecurityWPA2, Standard: dot11.Standard80211ax},
+		),
+		baseTime(),
+	)
+	// A client transmitting through the first BSSID.
+	a.Observe(dataFromClient(t, "00:11:22:33:44:01", "aa:bb:cc:dd:ee:ff"), baseTime())
+
+	tree := a.Tree()
+	if len(tree) != 1 {
+		t.Fatalf("got %d SSID groups, want 1", len(tree))
+	}
+	g := tree[0]
+	if g.SSID != "CorpWiFi" {
+		t.Errorf("SSID = %q, want CorpWiFi", g.SSID)
+	}
+	if g.APCount != 1 {
+		t.Errorf("APCount = %d, want 1 (two radios cluster to one AP)", g.APCount)
+	}
+	if g.BSSCount != 2 {
+		t.Errorf("BSSCount = %d, want 2", g.BSSCount)
+	}
+	if g.StationCount != 1 {
+		t.Errorf("StationCount = %d, want 1", g.StationCount)
+	}
+	// The client is under the BSSID it transmitted through.
+	ap := g.APs[0]
+	var found bool
+	for _, b := range ap.BSSes {
+		if b.BSSID == "00:11:22:33:44:01" {
+			if len(b.Stations) != 1 || b.Stations[0].MAC != "aa:bb:cc:dd:ee:ff" {
+				t.Errorf("client not attributed to BSSID 01: %+v", b.Stations)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("BSSID 00:11:22:33:44:01 missing from tree")
+	}
+}
+
+func TestDistinctAPsSameSSID(t *testing.T) {
+	t.Parallel()
+	a := airspace.New()
+	a.Observe(beacon(t, "00:11:22:33:44:01", "Campus", dot11.BSS{Security: dot11.SecurityWPA3}), baseTime())
+	a.Observe(beacon(t, "00:11:22:33:44:21", "Campus", dot11.BSS{Security: dot11.SecurityWPA3}), baseTime())
+
+	tree := a.Tree()
+	if len(tree) != 1 || tree[0].APCount != 2 {
+		t.Fatalf("want 1 SSID with 2 APs, got %d SSIDs / APCount %d", len(tree), groupAPCount(tree))
+	}
+}
+
+func TestBeaconFieldsDecodedIntoView(t *testing.T) {
+	t.Parallel()
+	a := airspace.New()
+	a.Observe(beacon(t, "00:11:22:33:44:01", "Secure", dot11.BSS{
+		Security: dot11.SecurityWPA3, Standard: dot11.Standard80211be,
+		PMFRequired: true, RRMNeighbor: true, BTMSupported: true, FTSupported: true, CountryCode: "US",
+	}), baseTime())
+
+	b := a.Tree()[0].APs[0].BSSes[0]
+	if b.Security != "WPA3" || b.Standard != "802.11be (Wi-Fi 7)" {
+		t.Errorf("security/standard = %q/%q", b.Security, b.Standard)
+	}
+	if !b.PMFRequired || !b.RRMNeighbor || !b.BTMSupported || !b.FTSupported {
+		t.Errorf("capability flags not carried: %+v", b)
+	}
+	if b.CountryCode != "US" || b.Band != "2.4 GHz" || b.Channel != 6 {
+		t.Errorf("country/band/channel = %q/%q/%d", b.CountryCode, b.Band, b.Channel)
+	}
+}
+
+func TestClientOnlyBSSThenBeacon(t *testing.T) {
+	t.Parallel()
+	a := airspace.New()
+	// Client seen before any beacon → a thin BSS is created so the client isn't lost.
+	a.Observe(dataFromClient(t, "00:11:22:33:44:01", "aa:bb:cc:dd:ee:ff"), baseTime())
+	if a.Tree()[0].StationCount != 1 {
+		t.Fatal("client-only BSS should still carry its station")
+	}
+	// Beacon later fills in the SSID.
+	a.Observe(beacon(t, "00:11:22:33:44:01", "Late", dot11.BSS{Security: dot11.SecurityWPA2}), baseTime())
+	tree := a.Tree()
+	if len(tree) != 1 || tree[0].SSID != "Late" || tree[0].StationCount != 1 {
+		t.Errorf("beacon should fill SSID + keep the client: %+v", tree)
+	}
+}
+
+func TestPruneAgesOutStaleStationsAndClientOnlyBSS(t *testing.T) {
+	t.Parallel()
+	a := airspace.New()
+	a.Observe(dataFromClient(t, "00:11:22:33:44:01", "aa:bb:cc:dd:ee:ff"), baseTime())
+	// A beaconed BSS with a stale client.
+	a.Observe(beacon(t, "00:11:22:33:44:02", "Keep", dot11.BSS{Security: dot11.SecurityWPA2}), baseTime())
+	a.Observe(dataFromClient(t, "00:11:22:33:44:02", "11:22:33:44:55:66"), baseTime())
+
+	a.Prune(baseTime().Add(time.Minute)) // cutoff after baseTime → everything stale
+
+	tree := a.Tree()
+	// Client-only BSS (01) is gone; beaconed BSS (02) stays but loses its client.
+	for _, g := range tree {
+		for _, ap := range g.APs {
+			for _, b := range ap.BSSes {
+				if b.BSSID == "00:11:22:33:44:01" {
+					t.Error("client-only stale BSS should be pruned")
+				}
+				if b.BSSID == "00:11:22:33:44:02" && len(b.Stations) != 0 {
+					t.Error("stale station should be pruned from beaconed BSS")
+				}
+			}
+		}
+	}
+}
+
+func TestTreeIsDeterministic(t *testing.T) {
+	t.Parallel()
+	a := airspace.New()
+	a.Observe(beacon(t, "00:11:22:33:44:21", "Zeta", dot11.BSS{Security: dot11.SecurityWPA2}), baseTime())
+	a.Observe(beacon(t, "00:11:22:33:44:01", "Alpha", dot11.BSS{Security: dot11.SecurityWPA2}), baseTime())
+	first := a.Tree()
+	second := a.Tree()
+	if len(first) != 2 || first[0].SSID != "Alpha" || first[1].SSID != "Zeta" {
+		t.Fatalf("SSID groups not sorted: %+v", first)
+	}
+	if first[0].SSID != second[0].SSID || first[1].SSID != second[1].SSID {
+		t.Error("Tree() ordering is not stable across calls")
+	}
+}
+
+func TestNilFrameIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := airspace.New()
+	a.Observe(nil, baseTime())
+	if len(a.Tree()) != 0 {
+		t.Error("nil frame should not create any state")
+	}
+}
+
+func groupAPCount(tree []airspace.SSIDGroup) int {
+	if len(tree) == 0 {
+		return 0
+	}
+	return tree[0].APCount
+}

--- a/internal/wifi/airspace/tree.go
+++ b/internal/wifi/airspace/tree.go
@@ -1,0 +1,134 @@
+package airspace
+
+import (
+	"sort"
+	"time"
+)
+
+// The Tree view is the read model the API + UI consume: the cross-referenced
+// SSID → AP → BSSID → client hierarchy. All slices are sorted deterministically
+// (no map-iteration or time ordering leaks) so equal inputs render identically.
+
+// StationView is one client under a BSS.
+type StationView struct {
+	MAC       string    `json:"mac"`
+	SignalDBm int       `json:"signalDbm"`
+	Frames    int       `json:"frames"`
+	LastSeen  time.Time `json:"lastSeen"`
+}
+
+// BSSView is one BSSID (radio) under an AP.
+type BSSView struct {
+	BSSID        string        `json:"bssid"`
+	SSID         string        `json:"ssid"`
+	Hidden       bool          `json:"hidden"`
+	Band         string        `json:"band"`
+	Channel      int           `json:"channel"`
+	Security     string        `json:"security"`
+	Standard     string        `json:"standard"`
+	CountryCode  string        `json:"countryCode,omitempty"`
+	PMFRequired  bool          `json:"pmfRequired"`
+	RRMNeighbor  bool          `json:"rrmNeighbor"`
+	BTMSupported bool          `json:"btmSupported"`
+	FTSupported  bool          `json:"ftSupported"`
+	WPSEnabled   bool          `json:"wpsEnabled"`
+	SignalDBm    int           `json:"signalDbm"`
+	Beacons      int           `json:"beacons"`
+	LastSeen     time.Time     `json:"lastSeen"`
+	Stations     []StationView `json:"stations"`
+}
+
+// APGroup clusters the BSSIDs believed to belong to one physical AP.
+type APGroup struct {
+	Key    string    `json:"key"`
+	Vendor string    `json:"vendor,omitempty"`
+	BSSes  []BSSView `json:"bsses"`
+}
+
+// SSIDGroup is the top level: one advertised SSID and the APs serving it.
+type SSIDGroup struct {
+	SSID         string    `json:"ssid"`
+	Hidden       bool      `json:"hidden"`
+	APCount      int       `json:"apCount"`
+	BSSCount     int       `json:"bssCount"`
+	StationCount int       `json:"stationCount"`
+	APs          []APGroup `json:"aps"`
+}
+
+// Tree renders the current airspace as the sorted SSID → AP → BSSID → client
+// hierarchy. Hidden/un-named BSSes are grouped under an empty SSID string.
+func (a *Airspace) Tree() []SSIDGroup {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	// Bucket BSSes by SSID, then by AP key.
+	bySSID := make(map[string]map[string][]*bss)
+	for _, b := range a.bsses {
+		apBuckets, ok := bySSID[b.ssid]
+		if !ok {
+			apBuckets = make(map[string][]*bss)
+			bySSID[b.ssid] = apBuckets
+		}
+		k := apKey(b.bssid)
+		apBuckets[k] = append(apBuckets[k], b)
+	}
+
+	groups := make([]SSIDGroup, 0, len(bySSID))
+	for ssid, apBuckets := range bySSID {
+		groups = append(groups, buildSSIDGroup(ssid, apBuckets))
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].SSID < groups[j].SSID })
+	return groups
+}
+
+func buildSSIDGroup(ssid string, apBuckets map[string][]*bss) SSIDGroup {
+	g := SSIDGroup{SSID: ssid}
+	for key, bsses := range apBuckets {
+		ap := APGroup{Key: key, Vendor: vendorOUI(key)}
+		for _, b := range bsses {
+			ap.BSSes = append(ap.BSSes, toBSSView(b))
+			g.BSSCount++
+			g.StationCount += len(b.stations)
+			if b.hidden {
+				g.Hidden = true
+			}
+		}
+		sort.Slice(ap.BSSes, func(i, j int) bool { return ap.BSSes[i].BSSID < ap.BSSes[j].BSSID })
+		g.APs = append(g.APs, ap)
+	}
+	sort.Slice(g.APs, func(i, j int) bool { return g.APs[i].Key < g.APs[j].Key })
+	g.APCount = len(g.APs)
+	return g
+}
+
+func toBSSView(b *bss) BSSView {
+	v := BSSView{
+		BSSID:        b.bssid,
+		SSID:         b.ssid,
+		Hidden:       b.hidden,
+		Band:         b.band.String(),
+		Channel:      b.channel,
+		Security:     b.security.String(),
+		Standard:     b.standard.String(),
+		CountryCode:  b.countryCode,
+		PMFRequired:  b.pmfRequired,
+		RRMNeighbor:  b.rrmNeighbor,
+		BTMSupported: b.btm,
+		FTSupported:  b.ft,
+		WPSEnabled:   b.wps,
+		SignalDBm:    int(b.signalDBm),
+		Beacons:      b.beacons,
+		LastSeen:     b.lastSeen,
+		Stations:     make([]StationView, 0, len(b.stations)),
+	}
+	for _, s := range b.stations {
+		v.Stations = append(v.Stations, StationView{
+			MAC:       s.mac,
+			SignalDBm: int(s.signalDBm),
+			Frames:    s.frames,
+			LastSeen:  s.lastSeen,
+		})
+	}
+	sort.Slice(v.Stations, func(i, j int) bool { return v.Stations[i].MAC < v.Stations[j].MAC })
+	return v
+}

--- a/internal/wifi/dot11/decode.go
+++ b/internal/wifi/dot11/decode.go
@@ -1,0 +1,197 @@
+package dot11
+
+import (
+	"encoding/binary"
+	"errors"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+)
+
+// ErrNotDot11 is returned when the bytes are not a radiotap-framed 802.11 frame
+// (e.g. a different link type, or a frame too short/corrupt to parse a header).
+var ErrNotDot11 = errors.New("dot11: not a radiotap/802.11 frame")
+
+const (
+	// capabilityPrivacyBit is the Privacy bit (bit 4) of the 802.11 Capability
+	// Information field in beacon/probe-response bodies; set => link-layer
+	// encryption is in use (WEP when no RSN/WPA IE is present).
+	capabilityPrivacyBit = 0x0010
+	// beaconFixedParamLen is the beacon/probe-response fixed-parameter block:
+	// timestamp(8) + beacon interval(2) + capability(2).
+	beaconFixedParamLen = 12
+	// capabilityFieldOffset is the byte offset of the Capability Information
+	// word within that fixed-parameter block.
+	capabilityFieldOffset = 10
+
+	// Wi-Fi channel-plan reference frequencies (MHz) for band/channel mapping.
+	freqChannel14         = 2484 // 2.4 GHz channel 14 (Japan), numbered specially
+	channel14             = 14
+	freq24Base            = 2407 // 2.4 GHz: channel = (freq-2407)/5
+	freq5Base             = 5000 // 5 GHz: channel = (freq-5000)/5
+	freq6Base             = 5950 // 6 GHz: channel = (freq-5950)/5
+	freq24Low, freq24High = 2412, 2472
+	freq5Low, freq5High   = 5160, 5895
+	freq6Low, freq6High   = 5955, 7115
+	channelSpacingMHz     = 5
+)
+
+// Decode parses one radiotap-framed 802.11 frame into a Frame. It never panics
+// on malformed input — every field is bounds-checked — and returns ErrNotDot11
+// when the bytes do not contain an 802.11 header.
+func Decode(data []byte) (*Frame, error) {
+	pkt := gopacket.NewPacket(data, layers.LayerTypeRadioTap, gopacket.DecodeOptions{
+		Lazy:   false, // eager: we walk every information-element layer
+		NoCopy: true,
+	})
+
+	d11, ok := pkt.Layer(layers.LayerTypeDot11).(*layers.Dot11)
+	if !ok || d11 == nil {
+		return nil, ErrNotDot11
+	}
+
+	f := &Frame{
+		Kind:        classify(d11.Type),
+		Retry:       d11.Flags.Retry(),
+		Receiver:    d11.Address1,
+		Transmitter: d11.Address2,
+		BSSID:       d11.Address3, // for management frames, Address3 is the BSSID
+	}
+
+	rt, rtOK := pkt.Layer(layers.LayerTypeRadioTap).(*layers.RadioTap)
+	if rtOK && rt != nil && len(rt.RadioTapValues) > 0 {
+		// gopacket v1.6 nests the standard fields in RadioTapValues; the first
+		// segment carries the regular namespace fields. (Present-bit refinement
+		// for multi-segment headers is a later improvement.)
+		v := rt.RadioTapValues[0]
+		f.SignalDBm = v.DBMAntennaSignal
+		f.NoiseDBm = v.DBMAntennaNoise
+		f.ChannelMHz = int(v.ChannelFrequency)
+		f.Band, f.ChannelNum = bandAndChannel(int(v.ChannelFrequency))
+	}
+
+	if f.Kind == KindBeacon || f.Kind == KindProbeResponse {
+		f.BSS = decodeBSS(pkt, f.Band)
+		// The DS Parameter Set IE channel and the radiotap channel can each be
+		// absent; let one fill the other.
+		if f.BSS != nil {
+			if f.BSS.ChannelNum == 0 {
+				f.BSS.ChannelNum = f.ChannelNum
+			} else if f.ChannelNum == 0 {
+				f.ChannelNum = f.BSS.ChannelNum
+			}
+		}
+	}
+
+	return f, nil
+}
+
+// classify maps a gopacket Dot11Type to our coarser Kind.
+func classify(t layers.Dot11Type) Kind {
+	switch t {
+	case layers.Dot11TypeMgmtBeacon:
+		return KindBeacon
+	case layers.Dot11TypeMgmtProbeReq:
+		return KindProbeRequest
+	case layers.Dot11TypeMgmtProbeResp:
+		return KindProbeResponse
+	case layers.Dot11TypeMgmtAssociationReq:
+		return KindAssocRequest
+	case layers.Dot11TypeMgmtAssociationResp:
+		return KindAssocResponse
+	case layers.Dot11TypeMgmtReassociationReq:
+		return KindReassocRequest
+	case layers.Dot11TypeMgmtReassociationResp:
+		return KindReassocResponse
+	case layers.Dot11TypeMgmtAuthentication:
+		return KindAuth
+	case layers.Dot11TypeMgmtDeauthentication:
+		return KindDeauth
+	case layers.Dot11TypeMgmtDisassociation:
+		return KindDisassoc
+	case layers.Dot11TypeMgmtAction, layers.Dot11TypeMgmtActionNoAck:
+		return KindAction
+	default:
+		if t.MainType() == layers.Dot11TypeData {
+			return KindData
+		}
+		return KindOther
+	}
+}
+
+// decodeBSS builds the BSS view from a beacon/probe-response: the Privacy bit
+// from the Capability Information field plus every information element.
+func decodeBSS(pkt gopacket.Packet, band Band) *BSS {
+	bss := &BSS{}
+	privacy := capabilityPrivacy(pkt)
+
+	phy := phyPresence{}
+	for _, l := range pkt.Layers() {
+		ieLayer, ok := l.(*layers.Dot11InformationElement)
+		if !ok {
+			continue
+		}
+		r := toRawIE(ieLayer)
+		applyIE(bss, r)
+		markPHY(&phy, r)
+	}
+	phy.finalize(bss, band)
+
+	// If no RSN/WPA IE classified the suite, the Privacy bit decides WEP vs Open.
+	if bss.Security == SecurityUnknown {
+		if privacy {
+			bss.Security = SecurityWEP
+		} else {
+			bss.Security = SecurityOpen
+		}
+	}
+	return bss
+}
+
+// toRawIE adapts a gopacket information element to our parser shape, splitting
+// out the Element ID Extension sub-ID when ID == 255.
+func toRawIE(ie *layers.Dot11InformationElement) rawIE {
+	r := rawIE{id: uint8(ie.ID), body: ie.Info}
+	if r.id == ieElementExtension && len(ie.Info) >= 1 {
+		r.extID = ie.Info[0]
+		r.body = ie.Info[1:]
+	}
+	return r
+}
+
+// capabilityPrivacy reads the Privacy bit from the Capability Information field
+// in a beacon/probe-response fixed-parameter block (timestamp[8] + beacon
+// interval[2] + capability[2]). Returns false if the block is absent/short.
+func capabilityPrivacy(pkt gopacket.Packet) bool {
+	for _, lt := range []gopacket.LayerType{
+		layers.LayerTypeDot11MgmtBeacon,
+		layers.LayerTypeDot11MgmtProbeResp,
+	} {
+		if l := pkt.Layer(lt); l != nil {
+			body := l.LayerContents()
+			if len(body) >= beaconFixedParamLen {
+				capInfo := binary.LittleEndian.Uint16(body[capabilityFieldOffset : capabilityFieldOffset+2])
+				return capInfo&capabilityPrivacyBit != 0
+			}
+		}
+	}
+	return false
+}
+
+// bandAndChannel derives the band and channel number from a center frequency in
+// MHz (radiotap). Returns BandUnknown/0 for frequencies outside the Wi-Fi bands.
+func bandAndChannel(freqMHz int) (Band, int) {
+	switch {
+	case freqMHz == freqChannel14:
+		return Band24GHz, channel14
+	case freqMHz >= freq24Low && freqMHz <= freq24High:
+		return Band24GHz, (freqMHz - freq24Base) / channelSpacingMHz
+	case freqMHz >= freq5Low && freqMHz <= freq5High:
+		return Band5GHz, (freqMHz - freq5Base) / channelSpacingMHz
+	case freqMHz >= freq6Low && freqMHz <= freq6High:
+		// 6 GHz (Wi-Fi 6E / 7): channels numbered from 5950 MHz.
+		return Band6GHz, (freqMHz - freq6Base) / channelSpacingMHz
+	default:
+		return BandUnknown, 0
+	}
+}

--- a/internal/wifi/dot11/decode.go
+++ b/internal/wifi/dot11/decode.go
@@ -53,6 +53,8 @@ func Decode(data []byte) (*Frame, error) {
 	f := &Frame{
 		Kind:        classify(d11.Type),
 		Retry:       d11.Flags.Retry(),
+		ToDS:        d11.Flags.ToDS(),
+		FromDS:      d11.Flags.FromDS(),
 		Receiver:    d11.Address1,
 		Transmitter: d11.Address2,
 		BSSID:       d11.Address3, // for management frames, Address3 is the BSSID

--- a/internal/wifi/dot11/decode_internal_test.go
+++ b/internal/wifi/dot11/decode_internal_test.go
@@ -1,0 +1,238 @@
+package dot11
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+// radiotapMinimal is an 8-byte radiotap header advertising no present fields
+// (version, pad, len=8, present=0). Radio measurements are then absent and the
+// channel comes from the DS Parameter Set IE — which is what we want to test
+// without hand-assembling radiotap's alignment-sensitive value block.
+func radiotapMinimal() []byte {
+	return []byte{0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00}
+}
+
+// ie assembles one information element: id, length, body.
+func ie(id byte, body ...byte) []byte {
+	return append([]byte{id, byte(len(body))}, body...)
+}
+
+// rsnIE builds a minimal RSN element (CCMP group + pairwise, a single AKM, and
+// the RSN capabilities word) so the security/PMF classifier can be exercised.
+func rsnIE(akmType byte, rsnCaps uint16) []byte {
+	body := []byte{
+		0x01, 0x00, // version 1
+		0x00, 0x0f, 0xac, 0x04, // group cipher: CCMP
+		0x01, 0x00, // pairwise count 1
+		0x00, 0x0f, 0xac, 0x04, // pairwise: CCMP
+		0x01, 0x00, // AKM count 1
+		0x00, 0x0f, 0xac, akmType, // AKM selector
+	}
+	caps := make([]byte, 2)
+	binary.LittleEndian.PutUint16(caps, rsnCaps)
+	body = append(body, caps...)
+	return ie(ieRSN, body...)
+}
+
+// beacon assembles radiotapMinimal + an 802.11 beacon (broadcast DA, the given
+// BSSID, the capability word, the supplied IEs) + a 4-byte dummy FCS (gopacket
+// strips the trailing 4 bytes as the frame checksum).
+func beacon(bssid net.HardwareAddr, capability uint16, ies ...[]byte) []byte {
+	frame := []byte{0x80, 0x00, 0x00, 0x00}                   // FC (mgmt/beacon) + duration
+	frame = append(frame, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff) // Address1 broadcast
+	frame = append(frame, bssid...)                           // Address2
+	frame = append(frame, bssid...)                           // Address3 (BSSID)
+	frame = append(frame, 0x00, 0x00)                         // sequence control
+	frame = append(frame, make([]byte, 8)...)                 // timestamp
+	frame = append(frame, 0x64, 0x00)                         // beacon interval
+	capWord := make([]byte, 2)
+	binary.LittleEndian.PutUint16(capWord, capability)
+	frame = append(frame, capWord...) // capability information
+	for _, e := range ies {
+		frame = append(frame, e...)
+	}
+	frame = append(frame, 0xde, 0xad, 0xbe, 0xef) // dummy FCS
+
+	rt := radiotapMinimal()
+	out := make([]byte, 0, len(rt)+len(frame))
+	out = append(out, rt...)
+	return append(out, frame...)
+}
+
+const (
+	capESS     = 0x0001
+	capPrivacy = 0x0010
+)
+
+// htCapIE's mere presence marks the BSS as 802.11n (HT). The 26-byte body is
+// the HT Capabilities element size; its contents are irrelevant to presence.
+func htCapIE() []byte { return ie(ieHTCapabilities, make([]byte, 26)...) }
+
+// ratesOFDM is a Supported Rates IE that includes OFDM rates (distinguishes g/a).
+func ratesOFDM() []byte { return ie(ieSupportedRates, 0x8c, 0x12, 0x98, 0x24) }
+
+// dsChan6 is a DS Parameter Set IE advertising channel 6.
+func dsChan6() []byte { return ie(ieDSParameterSet, 6) }
+
+func mustDecode(t *testing.T, data []byte) *Frame {
+	t.Helper()
+	f, err := Decode(data)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	return f
+}
+
+func TestDecodeBeaconWPA2N(t *testing.T) {
+	t.Parallel()
+	bssid := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	data := beacon(bssid, capESS|capPrivacy,
+		ie(ieSSID, []byte("TestNet")...),
+		ratesOFDM(), dsChan6(),
+		rsnIE(akmPSK, 0),
+		htCapIE(),
+	)
+
+	f := mustDecode(t, data)
+	if f.Kind != KindBeacon {
+		t.Fatalf("Kind = %v, want beacon", f.Kind)
+	}
+	if f.BSSID.String() != bssid.String() {
+		t.Errorf("BSSID = %v, want %v", f.BSSID, bssid)
+	}
+	if f.BSS == nil {
+		t.Fatal("BSS is nil")
+	}
+	if f.BSS.SSID != "TestNet" {
+		t.Errorf("SSID = %q, want TestNet", f.BSS.SSID)
+	}
+	if f.BSS.ChannelNum != 6 {
+		t.Errorf("ChannelNum = %d, want 6", f.BSS.ChannelNum)
+	}
+	if f.BSS.Security != SecurityWPA2 {
+		t.Errorf("Security = %v, want WPA2", f.BSS.Security)
+	}
+	if f.BSS.Standard != Standard80211n {
+		t.Errorf("Standard = %v, want 802.11n", f.BSS.Standard)
+	}
+}
+
+func TestDecodeBeaconWPA3PMFRequired(t *testing.T) {
+	t.Parallel()
+	const mfpr = 1 << 6 // RSN capabilities: Management Frame Protection Required
+	bssid := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+	data := beacon(bssid, capESS|capPrivacy,
+		ie(ieSSID, []byte("Secure")...),
+		dsChan6(),
+		rsnIE(akmSAE, mfpr),
+	)
+
+	f := mustDecode(t, data)
+	if f.BSS.Security != SecurityWPA3 {
+		t.Errorf("Security = %v, want WPA3", f.BSS.Security)
+	}
+	if !f.BSS.PMFRequired {
+		t.Error("PMFRequired = false, want true")
+	}
+}
+
+func TestDecodeBeaconWPA2WPA3Transition(t *testing.T) {
+	t.Parallel()
+	// Two AKMs — PSK + SAE — in one RSN IE marks WPA3 transition mode.
+	bssid := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01}
+	rsn := []byte{
+		0x01, 0x00,
+		0x00, 0x0f, 0xac, 0x04,
+		0x01, 0x00, 0x00, 0x0f, 0xac, 0x04,
+		0x02, 0x00, // AKM count 2
+		0x00, 0x0f, 0xac, akmPSK,
+		0x00, 0x0f, 0xac, akmSAE,
+		0x00, 0x00,
+	}
+	data := beacon(bssid, capESS|capPrivacy, ie(ieSSID, []byte("Mixed")...), ie(ieRSN, rsn...))
+	f := mustDecode(t, data)
+	if f.BSS.Security != SecurityWPA2WPA3 {
+		t.Errorf("Security = %v, want WPA2/WPA3", f.BSS.Security)
+	}
+}
+
+func TestDecodeBeaconOpenHidden(t *testing.T) {
+	t.Parallel()
+	// No RSN/WPA IE + Privacy clear => Open. Zero-length SSID => hidden.
+	bssid := net.HardwareAddr{0x00, 0x00, 0x00, 0x00, 0x00, 0x02}
+	data := beacon(bssid, capESS, ie(ieSSID), ratesOFDM(), dsChan6())
+	f := mustDecode(t, data)
+	if f.BSS.Security != SecurityOpen {
+		t.Errorf("Security = %v, want Open", f.BSS.Security)
+	}
+	if !f.BSS.Hidden {
+		t.Error("Hidden = false, want true")
+	}
+	if f.BSS.Standard != Standard80211g {
+		t.Errorf("Standard = %v, want 802.11g (OFDM rates, no HT)", f.BSS.Standard)
+	}
+}
+
+func TestDecodeBeaconWEP(t *testing.T) {
+	t.Parallel()
+	// Privacy set, no RSN/WPA IE => WEP.
+	bssid := net.HardwareAddr{0x00, 0x00, 0x00, 0x00, 0x00, 0x03}
+	data := beacon(bssid, capESS|capPrivacy, ie(ieSSID, []byte("OldNet")...), dsChan6())
+	f := mustDecode(t, data)
+	if f.BSS.Security != SecurityWEP {
+		t.Errorf("Security = %v, want WEP", f.BSS.Security)
+	}
+}
+
+func TestDecodeDeauthHasNoBSS(t *testing.T) {
+	t.Parallel()
+	// A deauthentication frame: FC subtype 12 (0xC0), no IE body.
+	frame := []byte{0xc0, 0x00, 0x00, 0x00}
+	frame = append(frame, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55) // Address1
+	frame = append(frame, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff) // Address2
+	frame = append(frame, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff) // Address3 (BSSID)
+	frame = append(frame, 0x00, 0x00)                         // sequence
+	frame = append(frame, 0x07, 0x00)                         // reason code
+	frame = append(frame, 0xde, 0xad, 0xbe, 0xef)             // FCS
+	data := append(radiotapMinimal(), frame...)
+
+	f := mustDecode(t, data)
+	if f.Kind != KindDeauth {
+		t.Errorf("Kind = %v, want deauth", f.Kind)
+	}
+	if f.BSS != nil {
+		t.Error("BSS should be nil for a deauth frame")
+	}
+}
+
+func TestDecodeRejectsNonDot11(t *testing.T) {
+	t.Parallel()
+	if _, err := Decode([]byte{0x01, 0x02, 0x03}); err == nil {
+		t.Error("expected an error decoding garbage, got nil")
+	}
+}
+
+func TestBandAndChannel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		freq    int
+		band    Band
+		channel int
+	}{
+		{2412, Band24GHz, 1},
+		{2437, Band24GHz, 6},
+		{2484, Band24GHz, 14},
+		{5180, Band5GHz, 36},
+		{5955, Band6GHz, 1},
+		{6175, Band6GHz, 45},
+		{9999, BandUnknown, 0},
+	}
+	for _, c := range cases {
+		band, ch := bandAndChannel(c.freq)
+		if band != c.band || ch != c.channel {
+			t.Errorf("bandAndChannel(%d) = %v/%d, want %v/%d", c.freq, band, ch, c.band, c.channel)
+		}
+	}
+}

--- a/internal/wifi/dot11/frame.go
+++ b/internal/wifi/dot11/frame.go
@@ -191,10 +191,18 @@ func (b Band) String() string {
 type Frame struct {
 	Kind Kind
 
-	// 802.11 addresses (nil when not present for the frame type).
-	BSSID       net.HardwareAddr // the BSS the frame belongs to
+	// 802.11 addresses as carried in the header (nil when not present). For
+	// management frames Address3 is the BSSID; for data frames the BSSID and
+	// station addresses depend on ToDS/FromDS — use BSSIDOf/StationOf rather
+	// than reading these directly for data frames.
+	BSSID       net.HardwareAddr // Address3
 	Transmitter net.HardwareAddr // Address2 — who sent it
 	Receiver    net.HardwareAddr // Address1 — intended recipient
+
+	// ToDS/FromDS distinguish the data-frame addressing modes (client→AP,
+	// AP→client, IBSS, WDS) so a station attributes to the right BSSID.
+	ToDS   bool
+	FromDS bool
 
 	// Radio (radiotap) measurements; zero when the header omitted them.
 	SignalDBm  int8
@@ -207,6 +215,51 @@ type Frame struct {
 
 	// BSS advertisement, present for beacon/probe-response frames.
 	BSS *BSS
+}
+
+// BSSIDOf returns the BSSID the frame belongs to, accounting for data-frame
+// ToDS/FromDS addressing. Returns nil when it cannot be determined (e.g. a
+// 4-address WDS frame). For management frames the BSSID is Address3.
+func (f *Frame) BSSIDOf() net.HardwareAddr {
+	if f.Kind != KindData {
+		return f.BSSID // management/control: Address3
+	}
+	switch {
+	case f.ToDS && !f.FromDS: // client → AP: Address1 is the BSSID
+		return f.Receiver
+	case !f.ToDS && f.FromDS: // AP → client: Address2 is the BSSID
+		return f.Transmitter
+	case !f.ToDS && !f.FromDS: // IBSS: Address3 is the BSSID
+		return f.BSSID
+	default: // WDS (4-address): no single BSSID
+		return nil
+	}
+}
+
+// StationOf returns the non-AP station (client) MAC this frame attributes to a
+// BSS, or nil if the frame does not identify a client. It covers the common
+// passive sources: data frames (by DS direction) and (re)association frames.
+func (f *Frame) StationOf() net.HardwareAddr {
+	switch f.Kind {
+	case KindData:
+		switch {
+		case f.ToDS && !f.FromDS: // client → AP: Address2 is the client
+			return f.Transmitter
+		case !f.ToDS && f.FromDS: // AP → client: Address1 is the client
+			return f.Receiver
+		default:
+			return nil
+		}
+	case KindAssocRequest, KindReassocRequest, KindProbeRequest:
+		return f.Transmitter // client transmits to the AP
+	case KindAssocResponse, KindReassocResponse:
+		return f.Receiver // AP responds to the client
+	case KindOther, KindBeacon, KindProbeResponse, KindAuth, KindDeauth,
+		KindDisassoc, KindAction:
+		return nil
+	default:
+		return nil
+	}
 }
 
 // BSS is everything a beacon/probe-response advertises about a basic service

--- a/internal/wifi/dot11/frame.go
+++ b/internal/wifi/dot11/frame.go
@@ -1,0 +1,237 @@
+// Package dot11 decodes IEEE 802.11 radiotap + management frames into
+// structured, pure-data results that the Wi-Fi airspace model and the anomaly
+// engine consume (ADR-0012). It is CGO-free — gopacket's radiotap/dot11 layers
+// are pure Go; only live capture (internal/capture) needs libpcap. The result
+// types carry no behaviour and no I/O, so they are trivially unit-tested off a
+// monitor-mode host against captured-frame fixtures.
+package dot11
+
+import "net"
+
+// Kind classifies an 802.11 frame at the granularity the airspace model needs
+// (build the SSID→AP→BSSID tree from beacons/probe-responses; attribute clients
+// from association/data frames; surface deauth/disassoc for anomaly rules).
+type Kind uint8
+
+const (
+	KindOther Kind = iota
+	KindBeacon
+	KindProbeRequest
+	KindProbeResponse
+	KindAssocRequest
+	KindAssocResponse
+	KindReassocRequest
+	KindReassocResponse
+	KindAuth
+	KindDeauth
+	KindDisassoc
+	KindAction
+	KindData
+)
+
+// String renders the frame kind for logs and JSON.
+func (k Kind) String() string {
+	switch k {
+	case KindBeacon:
+		return "beacon"
+	case KindProbeRequest:
+		return "probe-request"
+	case KindProbeResponse:
+		return "probe-response"
+	case KindAssocRequest:
+		return "assoc-request"
+	case KindAssocResponse:
+		return "assoc-response"
+	case KindReassocRequest:
+		return "reassoc-request"
+	case KindReassocResponse:
+		return "reassoc-response"
+	case KindAuth:
+		return "auth"
+	case KindDeauth:
+		return "deauth"
+	case KindDisassoc:
+		return "disassoc"
+	case KindAction:
+		return "action"
+	case KindData:
+		return "data"
+	case KindOther:
+		return "other"
+	default:
+		return "other"
+	}
+}
+
+// IsManagement reports whether the frame is an 802.11 management frame (the
+// class the visibility feature primarily decodes).
+func (k Kind) IsManagement() bool {
+	switch k {
+	case KindBeacon, KindProbeRequest, KindProbeResponse, KindAssocRequest,
+		KindAssocResponse, KindReassocRequest, KindReassocResponse, KindAuth,
+		KindDeauth, KindDisassoc, KindAction:
+		return true
+	case KindData, KindOther:
+		return false
+	default:
+		return false
+	}
+}
+
+// Security is the access-protection suite a BSS advertises, derived from the
+// RSN/vendor-WPA information elements and the Privacy capability bit.
+type Security uint8
+
+const (
+	SecurityUnknown  Security = iota
+	SecurityOpen              // no encryption
+	SecurityWEP               // Privacy bit set, no RSN/WPA IE — deprecated (802.11-2016)
+	SecurityWPA               // vendor WPA1 / TKIP — deprecated (802.11-2012)
+	SecurityWPA2              // RSN, CCMP, PSK or 802.1X
+	SecurityWPA3              // RSN with SAE / OWE / Suite-B
+	SecurityWPA2WPA3          // WPA3 transition mode (both offered)
+)
+
+// String renders the security suite (protocol nouns kept verbatim).
+func (s Security) String() string {
+	switch s {
+	case SecurityOpen:
+		return "Open"
+	case SecurityWEP:
+		return "WEP"
+	case SecurityWPA:
+		return "WPA"
+	case SecurityWPA2:
+		return "WPA2"
+	case SecurityWPA3:
+		return "WPA3"
+	case SecurityWPA2WPA3:
+		return "WPA2/WPA3"
+	case SecurityUnknown:
+		return "Unknown"
+	default:
+		return "Unknown"
+	}
+}
+
+// Standard is the highest 802.11 generation a BSS advertises, derived from the
+// presence of HT/VHT/HE/EHT information elements. The set runs through Wi-Fi 7
+// and is forward-ready for Wi-Fi 8 (802.11bn / UHR, in draft) — adding a
+// generation is a table addition, not a rewrite.
+type Standard uint8
+
+const (
+	StandardUnknown Standard = iota
+	Standard80211a
+	Standard80211b
+	Standard80211g
+	Standard80211n  // Wi-Fi 4 — HT
+	Standard80211ac // Wi-Fi 5 — VHT
+	Standard80211ax // Wi-Fi 6 / 6E — HE
+	Standard80211be // Wi-Fi 7 — EHT (320 MHz, MLO, 4K-QAM)
+	Standard80211bn // Wi-Fi 8 — UHR (draft); forward-ready
+)
+
+// String renders the marketing + spec label (kept verbatim, DNT).
+func (s Standard) String() string {
+	switch s {
+	case Standard80211a:
+		return "802.11a"
+	case Standard80211b:
+		return "802.11b"
+	case Standard80211g:
+		return "802.11g"
+	case Standard80211n:
+		return "802.11n (Wi-Fi 4)"
+	case Standard80211ac:
+		return "802.11ac (Wi-Fi 5)"
+	case Standard80211ax:
+		return "802.11ax (Wi-Fi 6)"
+	case Standard80211be:
+		return "802.11be (Wi-Fi 7)"
+	case Standard80211bn:
+		return "802.11bn (Wi-Fi 8)"
+	case StandardUnknown:
+		return "Unknown"
+	default:
+		return "Unknown"
+	}
+}
+
+// Band is the frequency band a channel sits in.
+type Band uint8
+
+const (
+	BandUnknown Band = iota
+	Band24GHz
+	Band5GHz
+	Band6GHz
+)
+
+// String renders the band label.
+func (b Band) String() string {
+	switch b {
+	case Band24GHz:
+		return "2.4 GHz"
+	case Band5GHz:
+		return "5 GHz"
+	case Band6GHz:
+		return "6 GHz"
+	case BandUnknown:
+		return "Unknown"
+	default:
+		return "Unknown"
+	}
+}
+
+// Frame is a decoded 802.11 frame. Radio fields come from the radiotap header;
+// the rest from the 802.11 header and (for beacons/probe-responses) the BSS
+// information elements. BSS is non-nil only for frames that carry a full BSS
+// advertisement (beacon, probe-response).
+type Frame struct {
+	Kind Kind
+
+	// 802.11 addresses (nil when not present for the frame type).
+	BSSID       net.HardwareAddr // the BSS the frame belongs to
+	Transmitter net.HardwareAddr // Address2 — who sent it
+	Receiver    net.HardwareAddr // Address1 — intended recipient
+
+	// Radio (radiotap) measurements; zero when the header omitted them.
+	SignalDBm  int8
+	NoiseDBm   int8
+	ChannelMHz int
+	ChannelNum int
+	Band       Band
+
+	Retry bool // the 802.11 Retry bit (feeds the retry-rate anomaly rule)
+
+	// BSS advertisement, present for beacon/probe-response frames.
+	BSS *BSS
+}
+
+// BSS is everything a beacon/probe-response advertises about a basic service
+// set: identity, the protection suite, the generation, and the capability flags
+// the anomaly rules key off (PMF, RRM/BTM/FT roaming support, country).
+type BSS struct {
+	SSID     string // empty + Hidden=true for a cloaked SSID
+	Hidden   bool
+	Security Security
+	Standard Standard
+
+	ChannelNum    int
+	ChannelWidthM int    // operating width in MHz (20/40/80/160/320), 0 if unknown
+	CountryCode   string // 802.11d, "" if absent
+
+	// Capability / roaming-support flags (decoded from IEs).
+	PMFRequired  bool // 802.11w — Management Frame Protection required
+	PMFCapable   bool
+	RRMNeighbor  bool // 802.11k — RM Enabled Capabilities present
+	BTMSupported bool // 802.11v — BSS Transition Management (Ext Cap)
+	FTSupported  bool // 802.11r — Mobility Domain IE present
+	WPSEnabled   bool // vendor WPS IE present
+
+	// BSS Load (802.11e) — station count + channel utilization (0 if absent).
+	StationCount    int
+	ChannelUtilByte int // raw 0..255 channel-utilization figure from the BSS Load IE
+	HasBSSLoad      bool
+}

--- a/internal/wifi/dot11/ie.go
+++ b/internal/wifi/dot11/ie.go
@@ -1,0 +1,311 @@
+package dot11
+
+import "encoding/binary"
+
+// ie.go parses 802.11 information elements (the tagged fields in beacon and
+// probe-response bodies) into the BSS view. Every parser is bounds-checked —
+// real-world IEs are frequently truncated or malformed, and a decoder fed
+// adversarial frames must never panic.
+
+// Information-element IDs (IEEE 802.11-2020 Table 9-92, plus the Element ID
+// Extension space for HE/EHT). Only the ones we decode are named.
+const (
+	ieSSID             = 0
+	ieSupportedRates   = 1
+	ieDSParameterSet   = 3
+	ieCountry          = 7
+	ieBSSLoad          = 11
+	ieHTCapabilities   = 45
+	ieRSN              = 48
+	ieExtSupportRates  = 50
+	ieMobilityDomain   = 54 // 802.11r — Fast BSS Transition
+	ieHTOperation      = 61
+	ieRMEnabledCaps    = 70 // 802.11k — Radio Resource Measurement
+	ieExtendedCaps     = 127
+	ieVHTCapabilities  = 191
+	ieVHTOperation     = 192
+	ieVendorSpecific   = 221
+	ieElementExtension = 255 // Element ID Extension follows in the first Info byte
+)
+
+// Element ID Extension sub-IDs (within IE 255) for the modern PHYs. Wi-Fi 8
+// (802.11bn / UHR) will add new sub-IDs here — extend this list, no rewrite.
+const (
+	extHECapabilities  = 35 // 802.11ax — Wi-Fi 6
+	extHEOperation     = 36
+	extEHTOperation    = 106
+	extEHTCapabilities = 108 // 802.11be — Wi-Fi 7
+)
+
+// RSN AKM suite selectors (suite OUI 00-0F-AC, last byte = type).
+const (
+	akmDot1X     = 1
+	akmPSK       = 2
+	akmFTDot1X   = 3
+	akmFTPSK     = 4
+	akmSAE       = 8 // WPA3-Personal
+	akmFTSAE     = 9
+	akmSuiteB    = 11
+	akmSuiteB192 = 12
+	akmOWE       = 18 // Opportunistic Wireless Encryption (WPA3 "enhanced open")
+)
+
+// Field sizes, offsets, and bit positions used by the IE parsers.
+const (
+	countryCodeLen   = 2 // 802.11d country string prefix
+	bssLoadMinLen    = 3 // station count (2) + channel-util byte (1)
+	rsnVersionLen    = 2
+	cipherSuiteLen   = 4 // a cipher / AKM suite selector is OUI(3) + type(1)
+	countFieldLen    = 2 // the uint16 "count" fields in the RSN IE
+	rsnCapsLen       = 2
+	selectorTypeOff  = 3  // type byte within a 4-byte suite selector
+	vendorMinLen     = 4  // OUI(3) + vendor type(1)
+	mfprBit          = 6  // RSN capabilities: Management Frame Protection Required
+	mfpcBit          = 7  // RSN capabilities: Management Frame Protection Capable
+	btmBit           = 19 // Extended Capabilities: BSS Transition (802.11v)
+	bitsPerByte      = 8
+	rateBasicMask    = 0x7f // strips the "basic rate" high bit
+	maxDSSSRateUnits = 22   // 11 Mbps in 500 kbps units; above this implies OFDM
+	wpaVendorType    = 1    // 00-50-F2 type 1 = WPA1
+	wpsVendorType    = 4    // 00-50-F2 type 4 = WPS
+)
+
+// The Microsoft / Wi-Fi-Alliance OUI (00-50-F2) prefixes the WPA1 and WPS
+// vendor-specific elements.
+const (
+	msftWFAOUI0 = 0x00
+	msftWFAOUI1 = 0x50
+	msftWFAOUI2 = 0xF2
+)
+
+// Operating channel widths in MHz.
+const (
+	width20MHz  = 20
+	width80MHz  = 80
+	width160MHz = 160
+	width320MHz = 320
+)
+
+// rawIE is one parsed tag from the IE list: its ID, the extension sub-ID (only
+// meaningful when ID == 255), and the element body.
+type rawIE struct {
+	id    uint8
+	extID uint8
+	body  []byte
+}
+
+// phyPresence accumulates which PHY generations a BSS advertised so the highest
+// is chosen once every IE has been folded in.
+type phyPresence struct {
+	hasHT, hasVHT, hasHE, hasEHT bool
+	hasOFDMRate                  bool
+}
+
+// applyIE folds an identity/security/capability information element into the
+// BSS. PHY-generation elements are handled separately by markPHY (keeping each
+// function's branch count low).
+func applyIE(bss *BSS, ie rawIE) {
+	switch ie.id {
+	case ieSSID:
+		// A zero-length or all-NUL SSID IE is a cloaked (hidden) network.
+		if len(ie.body) == 0 || allZero(ie.body) {
+			bss.Hidden = true
+		} else {
+			bss.SSID = string(ie.body)
+		}
+	case ieDSParameterSet:
+		if len(ie.body) >= 1 {
+			bss.ChannelNum = int(ie.body[0])
+		}
+	case ieCountry:
+		if len(ie.body) >= countryCodeLen {
+			bss.CountryCode = string(ie.body[:countryCodeLen])
+		}
+	case ieBSSLoad:
+		applyBSSLoad(bss, ie.body)
+	case ieRSN:
+		applyRSN(bss, ie.body)
+	case ieMobilityDomain:
+		bss.FTSupported = true
+	case ieRMEnabledCaps:
+		bss.RRMNeighbor = true
+	case ieExtendedCaps:
+		if btmSupported(ie.body) {
+			bss.BTMSupported = true
+		}
+	case ieVendorSpecific:
+		applyVendor(bss, ie.body)
+	}
+}
+
+// markPHY records the presence of a PHY-generation element (or OFDM rates) so
+// the highest advertised standard can be chosen in finalize.
+func markPHY(phy *phyPresence, ie rawIE) {
+	switch ie.id {
+	case ieSupportedRates, ieExtSupportRates:
+		phy.hasOFDMRate = phy.hasOFDMRate || hasOFDMRate(ie.body)
+	case ieHTCapabilities, ieHTOperation:
+		phy.hasHT = true
+	case ieVHTCapabilities, ieVHTOperation:
+		phy.hasVHT = true
+	case ieElementExtension:
+		switch ie.extID {
+		case extHECapabilities, extHEOperation:
+			phy.hasHE = true
+		case extEHTCapabilities, extEHTOperation:
+			phy.hasEHT = true
+		}
+	}
+}
+
+// finalize sets the BSS standard + a default channel width from the PHY flags,
+// the band, and the rates. Precedence runs newest-first (EHT→HE→VHT→HT→legacy).
+func (p phyPresence) finalize(bss *BSS, band Band) {
+	switch {
+	case p.hasEHT:
+		bss.Standard = Standard80211be
+		bss.ChannelWidthM = maxWidth(bss.ChannelWidthM, width320MHz)
+	case p.hasHE:
+		bss.Standard = Standard80211ax
+		bss.ChannelWidthM = maxWidth(bss.ChannelWidthM, width160MHz)
+	case p.hasVHT:
+		bss.Standard = Standard80211ac
+		bss.ChannelWidthM = maxWidth(bss.ChannelWidthM, width80MHz)
+	case p.hasHT:
+		bss.Standard = Standard80211n
+		bss.ChannelWidthM = maxWidth(bss.ChannelWidthM, width20MHz)
+	case band == Band5GHz:
+		bss.Standard = Standard80211a
+		bss.ChannelWidthM = maxWidth(bss.ChannelWidthM, width20MHz)
+	case p.hasOFDMRate:
+		bss.Standard = Standard80211g
+		bss.ChannelWidthM = maxWidth(bss.ChannelWidthM, width20MHz)
+	default:
+		bss.Standard = Standard80211b
+		bss.ChannelWidthM = maxWidth(bss.ChannelWidthM, width20MHz)
+	}
+}
+
+// applyBSSLoad parses the 802.11e BSS Load IE: station count (uint16 LE) +
+// channel-utilization byte + available admission capacity (uint16, ignored).
+func applyBSSLoad(bss *BSS, body []byte) {
+	if len(body) < bssLoadMinLen {
+		return
+	}
+	bss.StationCount = int(binary.LittleEndian.Uint16(body[0:countFieldLen]))
+	bss.ChannelUtilByte = int(body[countFieldLen])
+	bss.HasBSSLoad = true
+}
+
+// applyRSN parses the RSN IE (802.11i / RSN) to classify WPA2 vs WPA3 (vs the
+// transition mode that offers both) and the PMF (802.11w) capability/required
+// bits. Layout: version(2) | group cipher(4) | pairwise count(2)+suites |
+// AKM count(2)+suites | RSN capabilities(2) | ... (optional fields ignored).
+func applyRSN(bss *BSS, body []byte) {
+	off := rsnVersionLen + cipherSuiteLen // skip version + group cipher suite
+	if len(body) < off+countFieldLen {
+		bss.Security = highestSecurity(bss.Security, SecurityWPA2)
+		return
+	}
+	pairwiseCount := int(binary.LittleEndian.Uint16(body[off : off+countFieldLen]))
+	off += countFieldLen + cipherSuiteLen*pairwiseCount // skip pairwise suites
+	if len(body) < off+countFieldLen {
+		bss.Security = highestSecurity(bss.Security, SecurityWPA2)
+		return
+	}
+	akmCount := int(binary.LittleEndian.Uint16(body[off : off+countFieldLen]))
+	off += countFieldLen
+
+	sae, psk, owe := false, false, false
+	for range akmCount {
+		if len(body) < off+cipherSuiteLen {
+			break
+		}
+		switch body[off+selectorTypeOff] { // suite type (last byte of the selector)
+		case akmSAE, akmFTSAE:
+			sae = true
+		case akmPSK, akmFTPSK, akmDot1X, akmFTDot1X:
+			psk = true
+		case akmOWE, akmSuiteB, akmSuiteB192:
+			owe = true
+		}
+		off += cipherSuiteLen
+	}
+	switch {
+	case sae && psk:
+		bss.Security = highestSecurity(bss.Security, SecurityWPA2WPA3)
+	case sae || owe:
+		bss.Security = highestSecurity(bss.Security, SecurityWPA3)
+	default:
+		bss.Security = highestSecurity(bss.Security, SecurityWPA2)
+	}
+	if len(body) >= off+rsnCapsLen {
+		caps := binary.LittleEndian.Uint16(body[off : off+rsnCapsLen])
+		bss.PMFRequired = caps&(1<<mfprBit) != 0
+		bss.PMFCapable = caps&(1<<mfpcBit) != 0
+	}
+}
+
+// applyVendor handles the vendor-specific IEs we care about: legacy WPA1 (TKIP)
+// and WPS presence. Both use the Microsoft/Wi-Fi-Alliance OUI 00-50-F2.
+func applyVendor(bss *BSS, body []byte) {
+	if len(body) < vendorMinLen {
+		return
+	}
+	isMSOUI := body[0] == msftWFAOUI0 && body[1] == msftWFAOUI1 && body[2] == msftWFAOUI2
+	if !isMSOUI {
+		return
+	}
+	switch body[selectorTypeOff] {
+	case wpaVendorType:
+		bss.Security = highestSecurity(bss.Security, SecurityWPA)
+	case wpsVendorType:
+		bss.WPSEnabled = true
+	}
+}
+
+// btmSupported reads the BSS Transition (802.11v) bit of the Extended
+// Capabilities IE.
+func btmSupported(body []byte) bool {
+	byteIdx := btmBit / bitsPerByte
+	if len(body) <= byteIdx {
+		return false
+	}
+	return body[byteIdx]&(1<<(btmBit%bitsPerByte)) != 0
+}
+
+// hasOFDMRate reports whether a (extended) supported-rates IE lists any OFDM
+// rate (>11 Mbps), which distinguishes 802.11g/a from 802.11b-only.
+func hasOFDMRate(body []byte) bool {
+	for _, r := range body {
+		if r&rateBasicMask > maxDSSSRateUnits {
+			return true
+		}
+	}
+	return false
+}
+
+// highestSecurity keeps the strongest suite seen (an AP may carry both a vendor
+// WPA1 IE and an RSN IE; RSN wins).
+func highestSecurity(a, b Security) Security {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+func maxWidth(a, b int) int {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+func allZero(b []byte) bool {
+	for _, c := range b {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Backend foundation for the Wi-Fi visibility feature (ADR-0012). **Dormant + additive** — no routes, no UI, no consumer yet — so it merges incrementally and de-risks a long-lived branch (the user-facing capture/API/UI ship later). CGO-free and fully unit-tested.

## W1 — 802.11 decoder (`internal/wifi/dot11`)
Pure-Go radiotap + management-frame decoder. Parses SSID/BSSID/channel/signal, RSN security (WPA2/WPA3/transition + 802.11w PMF), 802.11d country, 802.11k/v/r support, BSS Load, and derives the standard through **Wi-Fi 7 (802.11be)**, forward-ready for **Wi-Fi 8 (802.11bn)**. Bounds-checked; never panics on malformed input.

## W2 — airspace model (`internal/wifi/airspace`)
`Observe(frame, at)` folds decoded frames into the deterministic, cross-referenced **SSID → AP → BSSID → client** tree — the Wi-Fi analogue of the wired device tree. DS-aware client attribution (added `ToDS`/`FromDS` + `BSSIDOf`/`StationOf` to the frame), AP clustering by BSSID low-bit mask (documented heuristic), `Prune(cutoff)` TTL aging, vendor OUI exposed for the W4 anomaly rules.

## Tests / gates
16 unit tests across the two packages; `golangci` 0 issues; CGO-free (`go test` runs without libpcap). Two documented per-path lint exclusions (dot11 `exhaustive` over gopacket's enum; reconciled with the license fingerprint exclusion).

Next: W3 capture engine (monitor-mode channel hopper, build-tagged, needs hardware), W4 anomaly engine (CGO-free, runs on this model — not blocked on hardware), W5 API, W6 UI.