### PR TITLE
fix(deploy): do not auto-open the firewall on install; require opt-in

### DIFF
--- a/deploy/deb/postinst
+++ b/deploy/deb/postinst
@@ -73,12 +73,20 @@ else
     echo "  sudo apt install libcap2-bin"
 fi
 
-# Configure firewall (ufw) if available and active
-if command -v ufw >/dev/null 2>&1; then
-    if ufw status 2>/dev/null | grep -q "Status: active"; then
-        ufw allow 8443/tcp comment 'Seed WebUI HTTPS' >/dev/null 2>&1 || true
-        echo "Firewall configured for Seed service (port 8443)"
-    fi
+# Network exposure is the operator's choice. We do NOT open the firewall by
+# default; set SEED_OPEN_FIREWALL=1 to opt in (e.g. automated provisioning).
+if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "Status: active"; then
+    case "${SEED_OPEN_FIREWALL:-0}" in
+        1|true|yes|TRUE|YES)
+            ufw allow 8443/tcp comment 'Seed WebUI HTTPS' >/dev/null 2>&1 || true
+            echo "Opened TCP 8443 in ufw (SEED_OPEN_FIREWALL set)"
+            ;;
+        *)
+            echo "An active firewall was detected; TCP 8443 is NOT open to the network."
+            echo "To allow remote access to the web interface, run:"
+            echo "  sudo ufw allow 8443/tcp"
+            ;;
+    esac
 fi
 
 # Reload systemd daemon

--- a/deploy/nfpm/postinstall.sh
+++ b/deploy/nfpm/postinstall.sh
@@ -10,14 +10,38 @@ else
     echo "warning: setcap not found; install libcap/libcap2-bin for non-root diagnostics"
 fi
 
-if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "Status: active"; then
-    ufw allow 8443/tcp comment 'Seed WebUI HTTPS' >/dev/null 2>&1 || true
-fi
+PORT=8443
 
-if command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
-    firewall-cmd --permanent --add-port=8443/tcp >/dev/null 2>&1 || true
-    firewall-cmd --reload >/dev/null 2>&1 || true
-fi
+open_firewall() {
+    opened=""
+    if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "Status: active"; then
+        if ufw allow ${PORT}/tcp comment 'Seed WebUI HTTPS' >/dev/null 2>&1; then
+            opened="ufw"
+        fi
+    fi
+    if command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+        firewall-cmd --permanent --add-port=${PORT}/tcp >/dev/null 2>&1 || true
+        firewall-cmd --reload >/dev/null 2>&1 || true
+        opened="${opened:+$opened, }firewalld"
+    fi
+    if [ -n "$opened" ]; then
+        echo "Opened TCP ${PORT} on: $opened (SEED_OPEN_FIREWALL set)"
+    fi
+}
+
+firewall_hint() {
+    if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "Status: active"; then
+        echo "  sudo ufw allow ${PORT}/tcp"
+    elif command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+        echo "  sudo firewall-cmd --permanent --add-port=${PORT}/tcp && sudo firewall-cmd --reload"
+    fi
+}
+
+# Network exposure is the operator's choice. We do NOT open the firewall by
+# default; set SEED_OPEN_FIREWALL=1 to opt in (e.g. automated provisioning).
+case "${SEED_OPEN_FIREWALL:-0}" in
+    1 | true | yes | TRUE | YES) open_firewall ;;
+esac
 
 if command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload || true
@@ -44,5 +68,20 @@ Commands:
   Stop:       sudo systemctl stop seed
 
 EOF
+
+# When we did not open the firewall, tell the operator how (only if one is active).
+case "${SEED_OPEN_FIREWALL:-0}" in
+    1 | true | yes | TRUE | YES) : ;;
+    *)
+        hint=$(firewall_hint)
+        if [ -n "$hint" ]; then
+            echo "An active firewall was detected; TCP ${PORT} is NOT open to the network."
+            echo "To allow remote access to the web interface, run:"
+            echo "$hint"
+            echo "(or re-install with SEED_OPEN_FIREWALL=1 to open it automatically)"
+            echo ""
+        fi
+        ;;
+esac
 
 exit 0

--- a/deploy/rpm/seed.spec
+++ b/deploy/rpm/seed.spec
@@ -64,11 +64,21 @@ chown -R seed:seed /etc/seed /var/lib/seed /var/log/seed
 # - CAP_NET_ADMIN: Required for ethtool link configuration, interface control
 /usr/sbin/setcap 'cap_net_raw,cap_net_admin=+ep' /usr/bin/seed || true
 
-# Configure firewall if firewalld is running
+# Network exposure is the operator's choice. We do NOT open the firewall by
+# default; set SEED_OPEN_FIREWALL=1 to opt in (e.g. automated provisioning).
 if systemctl is-active --quiet firewalld 2>/dev/null; then
-    firewall-cmd --permanent --add-port=8443/tcp 2>/dev/null || true
-    firewall-cmd --reload 2>/dev/null || true
-    echo "Firewall configured for Seed service (port 8443)"
+    case "${SEED_OPEN_FIREWALL:-0}" in
+        1|true|yes|TRUE|YES)
+            firewall-cmd --permanent --add-port=8443/tcp 2>/dev/null || true
+            firewall-cmd --reload 2>/dev/null || true
+            echo "Opened TCP 8443 in firewalld (SEED_OPEN_FIREWALL set)"
+            ;;
+        *)
+            echo "An active firewall was detected; TCP 8443 is NOT open to the network."
+            echo "To allow remote access to the web interface, run:"
+            echo "  sudo firewall-cmd --permanent --add-port=8443/tcp && sudo firewall-cmd --reload"
+            ;;
+    esac
 fi
 
 %systemd_post seed.service


### PR DESCRIPTION
## What

Actions arch-review finding **#5**. Package install no longer silently opens TCP 8443 in the host firewall.

## Why

For a diagnostic appliance, exposing the web UI to the network is a security-relevant decision that belongs to the operator — not a silent side effect of `apt install` / `dnf install`. The operator may want localhost-only access, or manage the firewall via config management.

## Change

All **three** packaging paths opened 8443 unconditionally:
- `deploy/nfpm/postinstall.sh` (canonical, goreleaser+nfpm) — ufw + firewalld
- `deploy/deb/postinst` — ufw
- `deploy/rpm/seed.spec` — firewalld

Now they open it **only** when `SEED_OPEN_FIREWALL` is set (`1`/`true`/`yes`) — for automated provisioning. Otherwise, when an active firewall is detected, they **print the exact command** to open it manually (and mention the opt-in env var). No active firewall → silent, as before.

## Verification

Ran `postinstall.sh` against faked active `ufw`+`firewalld`:
- **default**: 0 mutating firewall calls; prints `sudo ufw allow 8443/tcp` + opt-in note.
- **`SEED_OPEN_FIREWALL=1`**: makes `ufw allow` + `firewall-cmd --add-port=8443/tcp` + `--reload`; prints `Opened TCP 8443 ...`.

`shellcheck` clean on `postinstall.sh` + `postinst`. The rpm postremove still removes the port on full uninstall (harmless idempotent cleanup).