### PR TITLE
feat(api): make HTTP method + body-limit authoritative in the route registry

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -584,6 +584,14 @@ linters:
       # the dupl clones it would otherwise produce.
       - path: 'cmd/seed-schema/main\.go'
         linters: [ funlen ]
+      # internal/api/server_routes.go's setup* helpers are declarative route
+      # tables (ADR-0002 capability registry): one row per route carrying its
+      # path/handler/methods/body-limit/role/feature/rate policy. Their length is
+      # data, not logic complexity, and grows by one (golines-wrapped) row per
+      # route. Same spirit as the seed-schema table above — keeping each as one
+      # cohesive table beats near-identical split functions (which dupl flags).
+      - path: 'internal/api/server_routes\.go'
+        linters: [ funlen ]
       # internal/license/fingerprint.go memoizes the device fingerprint for the
       # process lifetime via sync.OnceValues (a package-level var). This is a
       # required process-singleton: the fingerprint is a stable machine property,

--- a/docs/architecture/decisions/0002-capability-registry.md
+++ b/docs/architecture/decisions/0002-capability-registry.md
@@ -32,3 +32,34 @@ every route and appends to an audit manifest.
 - One machine-readable policy manifest for fleet security audits.
 - Auth + CSRF stay global and untouched; only the per-route trio moves into the registry.
 - Pure routing refactor — no business logic changes; guarded by golden tests.
+
+## Amendment (2026-06-05) — method + body-limit are authoritative in the registry
+
+The initial implementation captured only role/feature/rate-limit in `route{}`;
+HTTP **method** validation and **request-body-size** limits still lived in
+handlers (each handler's own `switch r.Method`/`MaxBytesReader`) and in a
+separate path-switching `bodyLimitMiddleware` — a second, drift-prone source of
+truth (arch-review finding #6; it had already drifted: `/wifi/survey/floor/floorplan`
+wanted 10 MB but the path-switch capped it at 256 KB first).
+
+`route{}` now also carries `methods []string` and `maxBodyBytes int64`, both
+enforced by `register()`:
+
+- **Method**: `register()` installs a `methodGate` that returns `405` + an
+  `Allow` header for any method outside the declared set (using the project's
+  JSON error envelope), composed *before* feature/role checks. Routes that use a
+  Go 1.22 method-prefixed path (`"GET /api/v1/..."`) are enforced natively by
+  ServeMux and leave `methods` empty.
+- **Body limit**: `register()` wraps every route in a `MaxBytesReader` at
+  `maxBodyBytes` (default `MaxBodySizeJSON`; explicit for tighter auth/config
+  limits and the 10 MB/50 MB upload routes). The global `bodyLimitMiddleware` is
+  reduced to a backstop for **non-API** paths only — `/api/v1` body limits are
+  the registry's, eliminating the duplication and its drift.
+
+Canonical composition order is now
+`rateLimit → methodGate → requireFeature → requireRole → bodyLimit → handler`.
+
+Enforced by `TestEveryAPIRouteDeclaresMethodAndBodyLimit`, which fails if any
+`/api/v1` route is registered without a declared method or body limit (the
+"no route bypasses the policy" guard), and `TestMethodGateRejectsUndeclaredMethod`.
+The `/__capabilities` manifest exposes `methods`/`maxBodyBytes` for fleet audit.

--- a/internal/api/handlers_jobs.go
+++ b/internal/api/handlers_jobs.go
@@ -303,9 +303,24 @@ func writeJobError(w http.ResponseWriter, logger *slog.Logger, err error) {
 func (s *Server) jobsRoutes() []route {
 	op := database.RoleOperator
 	return []route{
-		{path: APIVersionPrefix + "/jobs", handler: s.handleJobs, minRole: op, rateLimited: true},
-		{path: APIVersionPrefix + "/jobs/events", handler: s.handleJobsEvents},
-		{path: APIVersionPrefix + "/jobs/", handler: s.handleJobByID, minRole: op},
+		{
+			path:        APIVersionPrefix + "/jobs",
+			handler:     s.handleJobs,
+			methods:     []string{http.MethodPost},
+			minRole:     op,
+			rateLimited: true,
+		},
+		{
+			path:    APIVersionPrefix + "/jobs/events",
+			handler: s.handleJobsEvents,
+			methods: []string{http.MethodGet},
+		},
+		{
+			path:    APIVersionPrefix + "/jobs/",
+			handler: s.handleJobByID,
+			methods: []string{http.MethodGet, http.MethodDelete},
+			minRole: op,
+		},
 	}
 }
 
@@ -370,7 +385,11 @@ type jobIdempotencyStore interface {
 }
 
 // check classifies a key against a request without recording anything.
-func (c *jobIdempotencyCache) check(_ context.Context, key string, req CreateJobRequest) idemResult {
+func (c *jobIdempotencyCache) check(
+	_ context.Context,
+	key string,
+	req CreateJobRequest,
+) idemResult {
 	h := requestHash(req)
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -385,7 +404,12 @@ func (c *jobIdempotencyCache) check(_ context.Context, key string, req CreateJob
 }
 
 // store records the job a key created, evicting the oldest key past capacity.
-func (c *jobIdempotencyCache) store(_ context.Context, key string, req CreateJobRequest, jobID string) {
+func (c *jobIdempotencyCache) store(
+	_ context.Context,
+	key string,
+	req CreateJobRequest,
+	jobID string,
+) {
 	h := requestHash(req)
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/api/handlers_path_gate_internal_test.go
+++ b/internal/api/handlers_path_gate_internal_test.go
@@ -24,7 +24,7 @@ func TestRootsPathRequiresPro(t *testing.T) {
 	s.setupRoutes()
 
 	// 1. No license → 402.
-	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/path/path", http.NoBody)
+	req := httptest.NewRequest(http.MethodPost, APIVersionPrefix+"/path/path", http.NoBody)
 	req.Header.Set("X-Username", "alice")
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
@@ -48,7 +48,7 @@ func TestRootsPathRequiresPro(t *testing.T) {
 	if res := mgr.StartTrial(); !res.Success {
 		t.Fatalf("StartTrial: %s", res.Message)
 	}
-	req2 := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/path/path", http.NoBody)
+	req2 := httptest.NewRequest(http.MethodPost, APIVersionPrefix+"/path/path", http.NoBody)
 	req2.Header.Set("X-Username", "alice")
 	w2 := httptest.NewRecorder()
 	s.mux.ServeHTTP(w2, req2)

--- a/internal/api/handlers_profiles_authz_internal_test.go
+++ b/internal/api/handlers_profiles_authz_internal_test.go
@@ -127,20 +127,21 @@ func TestCallerRole_NoDBIsImplicitAdmin(t *testing.T) {
 }
 
 // TestWriteGate_WiredOnSettingsRoute proves the wrapper is actually
-// attached at route registration: a viewer hitting POST /api/v1/settings
-// is rejected with 403 by the gate, never reaching handleSettings. If
-// somebody removes the s.writeGated(...) wrap at registration time, this
-// test fails — guarding against a silent regression of the policy.
+// attached at route registration: a viewer hitting PUT /api/v1/settings
+// (a mutating method the route accepts) is rejected with 403 by the gate,
+// never reaching handleSettings. If somebody removes the s.writeGated(...)
+// wrap at registration time, this test fails — guarding against a silent
+// regression of the policy.
 func TestWriteGate_WiredOnSettingsRoute(t *testing.T) {
 	t.Parallel()
 	s, _ := usersTestSetup(t)
 	seedRoledUser(t, s, "viewer1", database.RoleViewer)
 	s.setupRoutes()
 
-	req := newAuthedRequest(http.MethodPost, APIVersionPrefix+"/settings", []byte(`{}`), "viewer1")
+	req := newAuthedRequest(http.MethodPut, APIVersionPrefix+"/settings", []byte(`{}`), "viewer1")
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusForbidden {
-		t.Errorf("viewer POST /settings via mux: status = %d, want 403 (gate must be wired at registration)", w.Code)
+		t.Errorf("viewer PUT /settings via mux: status = %d, want 403 (gate must be wired at registration)", w.Code)
 	}
 }

--- a/internal/api/route.go
+++ b/internal/api/route.go
@@ -9,20 +9,32 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"slices"
+	"strings"
 
 	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/logging"
 )
 
 // route declares an HTTP route and its per-route policy. Authentication and CSRF
-// are enforced globally (server_lifecycle.go) and are NOT part of this policy —
-// the trio captured here is exactly what was previously hand-wrapped at
-// registration: a role gate, a license-feature gate, and rate limiting.
+// are enforced globally (server_lifecycle.go) and are NOT part of this policy.
+// Everything a route's request handling is gated on lives here so the registry
+// is the single authoritative source (ADR-0002): allowed methods, body-size
+// limit, a role gate, a license-feature gate, and rate limiting.
 type route struct {
-	// path is the full request path (callers pass APIVersionPrefix+"/...").
+	// path is the full request path (callers pass APIVersionPrefix+"/..."). It
+	// MAY carry a Go 1.22 method prefix ("GET /api/v1/..."), in which case the
+	// method is enforced natively by ServeMux and `methods` is left empty.
 	path string
 	// handler is the terminal handler for the route.
 	handler http.HandlerFunc
+	// methods is the set of HTTP methods the route accepts. register() rejects
+	// any other method with 405 + an Allow header (before feature/role checks).
+	// Leave empty ONLY when path carries a method prefix (ServeMux enforces it).
+	methods []string
+	// maxBodyBytes caps the request body (DoS guard). 0 means the default
+	// (MaxBodySizeJSON); set explicitly for larger uploads or tighter limits.
+	maxBodyBytes int64
 	// minRole gates state-changing methods. The supported value today is
 	// database.RoleOperator, applied via writeGated (safe GET/HEAD/OPTIONS pass;
 	// mutating methods require operator+). Empty = no role gate.
@@ -33,24 +45,83 @@ type route struct {
 	rateLimited bool
 }
 
+// methodFromPath extracts a Go 1.22 method prefix ("GET /path") if present.
+func methodFromPath(path string) (string, bool) {
+	i := strings.IndexByte(path, ' ')
+	if i <= 0 {
+		return "", false
+	}
+	switch m := path[:i]; m {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodOptions:
+		return m, true
+	default:
+		return "", false
+	}
+}
+
+// effectiveMethods is the route's declared method set: a method prefix on the
+// path (ServeMux-enforced) takes precedence, otherwise the methods field.
+func effectiveMethods(rt route) []string {
+	if m, ok := methodFromPath(rt.path); ok {
+		return []string{m}
+	}
+	return rt.methods
+}
+
+// methodGate rejects any method outside allowed with a 405 + Allow header,
+// preserving the project's JSON error envelope.
+func (s *Server) methodGate(allowed []string, next http.HandlerFunc) http.HandlerFunc {
+	allowHeader := strings.Join(allowed, ", ")
+	return func(w http.ResponseWriter, r *http.Request) {
+		if slices.Contains(allowed, r.Method) {
+			next(w, r)
+			return
+		}
+		w.Header().Set("Allow", allowHeader)
+		sendErrorResponseWithDetails(w, logging.FromContext(r.Context()),
+			http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed, "Method not allowed", "")
+	}
+}
+
+// bodyLimited caps the request body before the handler reads it.
+func bodyLimited(limit int64, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, limit)
+		next(w, r)
+	}
+}
+
 // register installs rt on the mux, composing middleware in ONE canonical order
 // for every route: rateLimit → requireFeature → requireRole → handler (rate
 // limit outermost, role gate closest to the handler). Composing here — rather
 // than at each call site — makes the policy declarative and the ordering
 // uniform, and is the single choke point a future audit/CI gate can enforce.
 func (s *Server) register(rt route) {
-	// Record the route for the /__capabilities manifest before composing.
+	// Resolve the effective policy, then record it for the /__capabilities
+	// manifest (and the route-policy test) before composing middleware.
+	rt.methods = effectiveMethods(rt)
+	if rt.maxBodyBytes == 0 {
+		rt.maxBodyBytes = MaxBodySizeJSON
+	}
 	s.manifest = append(s.manifest, rt)
 
 	h := rt.handler
 
-	// requireRole closest to the handler.
+	// bodyLimit closest to the handler so r.Body is capped before any read.
+	h = bodyLimited(rt.maxBodyBytes, h)
+	// requireRole next.
 	if rt.minRole == database.RoleOperator {
 		h = s.writeGated(h)
 	}
 	// requireFeature next.
 	if rt.feature != "" {
 		h = s.requireFeature(rt.feature, h)
+	}
+	// methodGate before feature/role so a wrong method 405s early. Skipped when
+	// the path carries a method prefix — ServeMux enforces the method itself.
+	if len(rt.methods) > 0 && !hasMethodPrefix(rt.path) {
+		h = s.methodGate(rt.methods, h)
 	}
 	// rateLimit outermost. RateLimitMiddleware takes and returns http.Handler;
 	// an http.HandlerFunc satisfies http.Handler.
@@ -59,6 +130,12 @@ func (s *Server) register(rt route) {
 		return
 	}
 	s.mux.HandleFunc(rt.path, h)
+}
+
+// hasMethodPrefix reports whether path carries a Go 1.22 method prefix.
+func hasMethodPrefix(path string) bool {
+	_, ok := methodFromPath(path)
+	return ok
 }
 
 // registerAll installs a slice of routes.
@@ -71,10 +148,12 @@ func (s *Server) registerAll(routes []route) {
 // capabilityView is the JSON-serializable projection of a route's policy for
 // the /__capabilities manifest (the handler func itself is not exposed).
 type capabilityView struct {
-	Path        string `json:"path"`
-	MinRole     string `json:"minRole,omitempty"`
-	Feature     string `json:"feature,omitempty"`
-	RateLimited bool   `json:"rateLimited,omitempty"`
+	Path         string   `json:"path"`
+	Methods      []string `json:"methods,omitempty"`
+	MaxBodyBytes int64    `json:"maxBodyBytes,omitempty"`
+	MinRole      string   `json:"minRole,omitempty"`
+	Feature      string   `json:"feature,omitempty"`
+	RateLimited  bool     `json:"rateLimited,omitempty"`
 }
 
 // handleCapabilities serves the route-policy manifest: every route registered
@@ -85,10 +164,12 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	views := make([]capabilityView, 0, len(s.manifest))
 	for _, rt := range s.manifest {
 		views = append(views, capabilityView{
-			Path:        rt.path,
-			MinRole:     rt.minRole,
-			Feature:     rt.feature,
-			RateLimited: rt.rateLimited,
+			Path:         rt.path,
+			Methods:      rt.methods,
+			MaxBodyBytes: rt.maxBodyBytes,
+			MinRole:      rt.minRole,
+			Feature:      rt.feature,
+			RateLimited:  rt.rateLimited,
 		})
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/route_policy_internal_test.go
+++ b/internal/api/route_policy_internal_test.go
@@ -1,0 +1,74 @@
+package api
+
+// route_policy_test.go enforces that method + body-limit are declared in the
+// capability registry for every /api/v1 route (ADR-0002), and that the method
+// gate actually rejects undeclared methods. This is the "no route bypasses the
+// method/body-limit policy" guard for finding #6.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// apiPath strips a Go 1.22 method prefix ("GET /api/v1/x" -> "/api/v1/x").
+func apiPath(path string) string {
+	if _, ok := methodFromPath(path); ok {
+		if i := strings.IndexByte(path, ' '); i > 0 {
+			return path[i+1:]
+		}
+	}
+	return path
+}
+
+// TestEveryAPIRouteDeclaresMethodAndBodyLimit fails if any /api/v1 route is
+// registered without a declared method or body limit — i.e. bypasses the
+// per-route policy the registry is meant to make authoritative.
+func TestEveryAPIRouteDeclaresMethodAndBodyLimit(t *testing.T) {
+	s := NewTestServer()
+	defer s.Close()
+
+	if len(s.manifest) == 0 {
+		t.Fatal("route manifest is empty; setupRoutes did not run")
+	}
+
+	for _, rt := range s.manifest {
+		if !strings.HasPrefix(apiPath(rt.path), APIVersionPrefix) {
+			continue // infra introspection / static — not an API surface
+		}
+		if len(rt.methods) == 0 {
+			t.Errorf("route %q bypasses the method policy: no method declared "+
+				"(set route.methods, or use a Go 1.22 method-prefixed path)", rt.path)
+		}
+		if rt.maxBodyBytes <= 0 {
+			t.Errorf("route %q has no body limit (register() should default it)", rt.path)
+		}
+	}
+}
+
+// TestMethodGateRejectsUndeclaredMethod proves the registry's method gate
+// enforces the declared set: an undeclared method gets 405 + Allow, and the
+// declared method reaches the handler.
+func TestMethodGateRejectsUndeclaredMethod(t *testing.T) {
+	s := NewTestServer()
+	defer s.Close()
+
+	// /api/v1/status is public and GET-only.
+	const path = APIVersionPrefix + "/status"
+
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, path, nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST %s: got status %d, want 405", path, rec.Code)
+	}
+	if allow := rec.Header().Get("Allow"); allow != http.MethodGet {
+		t.Errorf("405 Allow header: got %q, want %q", allow, http.MethodGet)
+	}
+
+	rec = httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET %s: got status %d, want 200", path, rec.Code)
+	}
+}

--- a/internal/api/server_middleware.go
+++ b/internal/api/server_middleware.go
@@ -91,32 +91,16 @@ func corsMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// bodyLimitMiddleware enforces request body size limits to prevent DoS attacks.
-// Different endpoints have different limits based on expected payload size.
+// bodyLimitMiddleware caps request bodies on NON-API paths (a DoS backstop for
+// the SPA/static + infra routes). Per-route body limits for /api/v1 are
+// authoritative in the capability registry (route.maxBodyBytes, applied by
+// register()), so a path-switch here would be a second, drift-prone source of
+// truth — the registry is the single source (ADR-0002).
 func bodyLimitMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Determine limit based on endpoint
-		var limit int64
-		path := r.URL.Path
-
-		switch {
-		case strings.HasPrefix(path, APIVersionPrefix+"/auth/"):
-			limit = MaxBodySizeAuth
-		case strings.HasPrefix(path, APIVersionPrefix+"/config/"):
-			limit = MaxBodySizeConfig
-		case path == APIVersionPrefix+"/wifi/survey/floorplan":
-			limit = MaxBodySizeFloorPlan
-		case path == APIVersionPrefix+"/wifi/survey/import/airmapper":
-			limit = MaxBodySizeAirMapper
-		case strings.HasPrefix(path, APIVersionPrefix):
-			limit = MaxBodySizeJSON
-		default:
-			limit = MaxBodySizeDefault
+		if !strings.HasPrefix(r.URL.Path, APIVersionPrefix) {
+			r.Body = http.MaxBytesReader(w, r.Body, MaxBodySizeDefault)
 		}
-
-		// Wrap the body with a limit reader
-		r.Body = http.MaxBytesReader(w, r.Body, limit)
-
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/api/server_middleware_test.go
+++ b/internal/api/server_middleware_test.go
@@ -10,13 +10,14 @@ import (
 	api "github.com/krisarmstrong/seed/internal/api"
 )
 
-// Verifies BodyLimitMiddleware applies to GET requests (regression for #766).
+// Verifies bodyLimitMiddleware caps GET requests on NON-API paths (regression
+// for #766) and, per ADR-0002, leaves /api/v1 bodies to the capability registry
+// (route.maxBodyBytes) rather than capping them itself.
 func TestBodyLimitMiddleware_GETEnforced(t *testing.T) {
-	// Handler that reads the entire body and surfaces the read error
+	// Handler that reads the entire body and surfaces the read error.
 	handler := api.ExportBodyLimitMiddleware(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, err := io.ReadAll(r.Body)
-			if err != nil {
+			if _, err := io.ReadAll(r.Body); err != nil {
 				http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
 				return
 			}
@@ -24,14 +25,23 @@ func TestBodyLimitMiddleware_GETEnforced(t *testing.T) {
 		}),
 	)
 
-	// Build a GET request with a body larger than the default 1MB limit
-	largeBody := bytes.Repeat([]byte("a"), 2*1024*1024) // 2MB
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", bytes.NewReader(largeBody))
+	largeBody := bytes.Repeat([]byte("a"), 2*1024*1024) // 2MB > MaxBodySizeDefault (1MB)
+
+	// Non-API path: the middleware backstop caps it -> 413.
+	req := httptest.NewRequest(http.MethodGet, "/static/asset", bytes.NewReader(largeBody))
 	rr := httptest.NewRecorder()
-
 	handler.ServeHTTP(rr, req)
-
 	if rr.Code != http.StatusRequestEntityTooLarge {
-		t.Fatalf("expected status %d, got %d", http.StatusRequestEntityTooLarge, rr.Code)
+		t.Fatalf("non-API path: expected status %d, got %d", http.StatusRequestEntityTooLarge, rr.Code)
+	}
+
+	// API path: the middleware does NOT cap it (the registry does), so a read of
+	// the full body succeeds here -> 200.
+	apiReq := httptest.NewRequest(http.MethodGet, "/api/v1/test", bytes.NewReader(largeBody))
+	apiRR := httptest.NewRecorder()
+	handler.ServeHTTP(apiRR, apiReq)
+	if apiRR.Code != http.StatusOK {
+		t.Fatalf("API path (registry owns the limit): expected status %d, got %d",
+			http.StatusOK, apiRR.Code)
 	}
 }

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -37,24 +37,57 @@ func (s *Server) setupRoutes() {
 // middleware as the rest of /api/v1.
 func (s *Server) setupTopologyRoutes() {
 	op := database.RoleOperator
+	get := []string{http.MethodGet}
+	post := []string{http.MethodPost}
+	getPost := []string{http.MethodGet, http.MethodPost}
+	getPutDelete := []string{http.MethodGet, http.MethodPut, http.MethodDelete}
 	s.registerAll([]route{
 		// /nodes must register BEFORE /nodes/ so the router doesn't treat the
 		// list endpoint as a /nodes/{id} request.
-		{path: APIVersionPrefix + "/topology/nodes", handler: s.handleTopologyNodes},
-		{path: APIVersionPrefix + "/topology/nodes/", handler: s.handleTopologyNodeByID},
-		{path: APIVersionPrefix + "/topology/links", handler: s.handleTopologyLinks},
-		{path: APIVersionPrefix + "/topology/arp", handler: s.handleTopologyARP},
+		{path: APIVersionPrefix + "/topology/nodes", handler: s.handleTopologyNodes, methods: get},
+		{
+			path:    APIVersionPrefix + "/topology/nodes/",
+			handler: s.handleTopologyNodeByID,
+			methods: get,
+		},
+		{path: APIVersionPrefix + "/topology/links", handler: s.handleTopologyLinks, methods: get},
+		{path: APIVersionPrefix + "/topology/arp", handler: s.handleTopologyARP, methods: get},
 		// A5.2 alerts: GET read-only; the action endpoint is operator-gated.
-		{path: APIVersionPrefix + "/alerts", handler: s.handleAlerts},
-		{path: APIVersionPrefix + "/alerts/", handler: s.handleAlertAction, minRole: op},
+		{path: APIVersionPrefix + "/alerts", handler: s.handleAlerts, methods: get},
+		{
+			path:    APIVersionPrefix + "/alerts/",
+			handler: s.handleAlertAction,
+			methods: post,
+			minRole: op,
+		},
 		// A5.3 polling targets CRUD: both writeGated (collection accepts POST).
-		{path: APIVersionPrefix + "/polling-targets", handler: s.handlePollingTargets, minRole: op},
-		{path: APIVersionPrefix + "/polling-targets/", handler: s.handlePollingTargetByID, minRole: op},
+		{
+			path:    APIVersionPrefix + "/polling-targets",
+			handler: s.handlePollingTargets,
+			methods: getPost,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/polling-targets/",
+			handler: s.handlePollingTargetByID,
+			methods: getPutDelete,
+			minRole: op,
+		},
 		// A5.8 read-only engine registry surface.
-		{path: APIVersionPrefix + "/engines", handler: s.handleEngines},
+		{path: APIVersionPrefix + "/engines", handler: s.handleEngines, methods: get},
 		// A5.10 operator-defined alert rules: both writeGated.
-		{path: APIVersionPrefix + "/alert-rules", handler: s.handleAlertRules, minRole: op},
-		{path: APIVersionPrefix + "/alert-rules/", handler: s.handleAlertRuleByID, minRole: op},
+		{
+			path:    APIVersionPrefix + "/alert-rules",
+			handler: s.handleAlertRules,
+			methods: getPost,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/alert-rules/",
+			handler: s.handleAlertRuleByID,
+			methods: getPutDelete,
+			minRole: op,
+		},
 	})
 }
 
@@ -63,192 +96,641 @@ func (s *Server) setupTopologyRoutes() {
 // know whether the mint button should be enabled.
 func (s *Server) setupAPITokenRoutes() {
 	op := database.RoleOperator
+	get := []string{http.MethodGet}
+	getPost := []string{http.MethodGet, http.MethodPost}
+	del := []string{http.MethodDelete}
+	getPatchDelete := []string{http.MethodGet, http.MethodPatch, http.MethodDelete}
 	s.registerAll([]route{
-		{path: APIVersionPrefix + "/tokens", handler: s.handleAPITokens, minRole: op},
-		{path: APIVersionPrefix + "/tokens/", handler: s.handleAPITokenByID, minRole: op},
-		{path: APIVersionPrefix + "/license", handler: s.handleLicenseStatus},
+		{
+			path:    APIVersionPrefix + "/tokens",
+			handler: s.handleAPITokens,
+			methods: getPost,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/tokens/",
+			handler: s.handleAPITokenByID,
+			methods: del,
+			minRole: op,
+		},
+		{path: APIVersionPrefix + "/license", handler: s.handleLicenseStatus, methods: get},
 		// Users CRUD (#1191): /users/me registers before /users/ for path routing.
 		// POST /users is admin-only AND Pro-gated, enforced inside the handler so the
 		// response carries the right 403/402 FeatureGateResponse.
-		{path: APIVersionPrefix + "/users/me", handler: s.handleCurrentUser},
-		{path: APIVersionPrefix + "/users", handler: s.handleUsers},
-		{path: APIVersionPrefix + "/users/", handler: s.handleUserByName},
+		{path: APIVersionPrefix + "/users/me", handler: s.handleCurrentUser, methods: get},
+		{path: APIVersionPrefix + "/users", handler: s.handleUsers, methods: getPost},
+		{path: APIVersionPrefix + "/users/", handler: s.handleUserByName, methods: getPatchDelete},
 	})
 }
 
 // setupCoreRoutes registers auth, settings, config, and setup routes.
 func (s *Server) setupCoreRoutes() {
 	op := database.RoleOperator
+	get := []string{http.MethodGet}
+	post := []string{http.MethodPost}
+	put := []string{http.MethodPut}
+	del := []string{http.MethodDelete}
+	getPut := []string{http.MethodGet, http.MethodPut}
+	getPostPut := []string{http.MethodGet, http.MethodPost, http.MethodPut}
+	crud := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete}
+	authBody := MaxBodySizeAuth  // 1 KB — auth payloads are tiny.
+	cfgBody := MaxBodySizeConfig // 64 KB — settings/config JSON.
 	s.registerAll([]route{
-		{path: APIVersionPrefix + "/auth/login", handler: s.handleLogin},
-		{path: APIVersionPrefix + "/auth/logout", handler: s.handleLogout},
-		{path: APIVersionPrefix + "/auth/refresh", handler: s.handleRefreshToken},
-		{path: APIVersionPrefix + "/auth/csrf", handler: s.handleCSRFToken},
+		{
+			path:         APIVersionPrefix + "/auth/login",
+			handler:      s.handleLogin,
+			methods:      post,
+			maxBodyBytes: authBody,
+		},
+		{
+			path:         APIVersionPrefix + "/auth/logout",
+			handler:      s.handleLogout,
+			methods:      post,
+			maxBodyBytes: authBody,
+		},
+		{
+			path:         APIVersionPrefix + "/auth/refresh",
+			handler:      s.handleRefreshToken,
+			methods:      post,
+			maxBodyBytes: authBody,
+		},
+		{
+			path:         APIVersionPrefix + "/auth/csrf",
+			handler:      s.handleCSRFToken,
+			methods:      get,
+			maxBodyBytes: authBody,
+		},
 		// Wave 3 (#85): MFA + WebAuthn endpoints.
-		{path: APIVersionPrefix + "/auth/login/totp", handler: s.handleLoginTOTP},
-		{path: APIVersionPrefix + "/auth/totp/setup", handler: s.handleTOTPSetup},
-		{path: APIVersionPrefix + "/auth/totp/verify", handler: s.handleTOTPVerify},
-		{path: APIVersionPrefix + "/auth/totp/disable", handler: s.handleTOTPDisable},
-		{path: APIVersionPrefix + "/auth/mfa/status", handler: s.handleMFAStatus},
-		{path: APIVersionPrefix + "/auth/webauthn/register/begin", handler: s.handleWebAuthnRegisterBegin},
-		{path: APIVersionPrefix + "/auth/webauthn/register/finish", handler: s.handleWebAuthnRegisterFinish},
-		{path: APIVersionPrefix + "/auth/webauthn/login/begin", handler: s.handleWebAuthnLoginBegin},
-		{path: APIVersionPrefix + "/auth/webauthn/login/finish", handler: s.handleWebAuthnLoginFinish},
-		{path: APIVersionPrefix + "/status", handler: s.handleStatus},
-		{path: APIVersionPrefix + "/settings", handler: s.handleSettings, minRole: op},
-		{path: APIVersionPrefix + "/settings/defaults", handler: s.handleSettingsDefaults, minRole: op},
-		{path: APIVersionPrefix + "/settings/link", handler: s.handleLinkSettings, minRole: op},
-		{path: APIVersionPrefix + "/settings/cable", handler: s.handleCableTestSettings, minRole: op},
-		{path: APIVersionPrefix + "/interfaces", handler: s.handleInterfaces},
-		{path: APIVersionPrefix + "/interface", handler: s.handleInterface},
-		{path: APIVersionPrefix + "/network/mtu", handler: s.handleSetMTU, minRole: op},
-		{path: APIVersionPrefix + "/config/backups", handler: s.handleConfigBackups},
-		{path: APIVersionPrefix + "/config/backup", handler: s.handleConfigBackupCreate, minRole: op},
-		{path: APIVersionPrefix + "/config/backup/delete", handler: s.handleConfigBackupDelete, minRole: op},
-		{path: APIVersionPrefix + "/config/restore", handler: s.handleConfigRestore, minRole: op},
-		{path: APIVersionPrefix + "/config/version", handler: s.handleConfigVersion},
-		{path: APIVersionPrefix + "/profiles", handler: s.handleProfiles, minRole: op},
-		{path: APIVersionPrefix + "/profiles/active", handler: s.handleActiveProfile, minRole: op},
-		{path: APIVersionPrefix + "/profiles/import", handler: s.handleImportProfiles, minRole: op},
-		{path: APIVersionPrefix + "/profiles/export", handler: s.handleExportProfiles},
-		{path: APIVersionPrefix + "/profiles/", handler: s.handleProfiles, minRole: op},
-		{path: APIVersionPrefix + "/setup/status", handler: s.handleSetupStatus},
-		{path: APIVersionPrefix + "/setup/complete", handler: s.handleSetupComplete},
-		{path: APIVersionPrefix + "/recovery/status", handler: s.handleRecoveryStatus},
-		{path: APIVersionPrefix + "/recovery/complete", handler: s.handleRecoveryComplete},
-		{path: APIVersionPrefix + "/recovery/instructions", handler: s.handleRecoveryInstructions},
-		{path: APIVersionPrefix + "/sso/providers", handler: s.handleSSOProviders},
-		{path: APIVersionPrefix + "/sso/login", handler: s.handleSSOLogin},
-		{path: APIVersionPrefix + "/sso/callback", handler: s.handleSSOCallback},
-		{path: APIVersionPrefix + "/sso/settings", handler: s.handleSSOSettings, minRole: op},
+		{
+			path:         APIVersionPrefix + "/auth/login/totp",
+			handler:      s.handleLoginTOTP,
+			methods:      post,
+			maxBodyBytes: authBody,
+		},
+		{
+			path:         APIVersionPrefix + "/auth/totp/setup",
+			handler:      s.handleTOTPSetup,
+			methods:      post,
+			maxBodyBytes: authBody,
+		},
+		{
+			path:         APIVersionPrefix + "/auth/totp/verify",
+			handler:      s.handleTOTPVerify,
+			methods:      post,
+			maxBodyBytes: authBody,
+		},
+		{
+			path:         APIVersionPrefix + "/auth/totp/disable",
+			handler:      s.handleTOTPDisable,
+			methods:      post,
+			maxBodyBytes: authBody,
+		},
+		{
+			path:         APIVersionPrefix + "/auth/mfa/status",
+			handler:      s.handleMFAStatus,
+			methods:      get,
+			maxBodyBytes: authBody,
+		},
+		{
+			path:         APIVersionPrefix + "/auth/webauthn/register/begin",
+			handler:      s.handleWebAuthnRegisterBegin,
+			methods:      post,
+			maxBodyBytes: authBody,
+		},
+		{
+			path:         APIVersionPrefix + "/auth/webauthn/register/finish",
+			handler:      s.handleWebAuthnRegisterFinish,
+			methods:      post,
+			maxBodyBytes: authBody,
+		},
+		{
+			path:         APIVersionPrefix + "/auth/webauthn/login/begin",
+			handler:      s.handleWebAuthnLoginBegin,
+			methods:      post,
+			maxBodyBytes: authBody,
+		},
+		{
+			path:         APIVersionPrefix + "/auth/webauthn/login/finish",
+			handler:      s.handleWebAuthnLoginFinish,
+			methods:      post,
+			maxBodyBytes: authBody,
+		},
+		{path: APIVersionPrefix + "/status", handler: s.handleStatus, methods: get},
+		{
+			path:         APIVersionPrefix + "/settings",
+			handler:      s.handleSettings,
+			methods:      getPut,
+			minRole:      op,
+			maxBodyBytes: cfgBody,
+		},
+		{
+			path:         APIVersionPrefix + "/settings/defaults",
+			handler:      s.handleSettingsDefaults,
+			methods:      get,
+			minRole:      op,
+			maxBodyBytes: cfgBody,
+		},
+		{
+			path:         APIVersionPrefix + "/settings/link",
+			handler:      s.handleLinkSettings,
+			methods:      getPut,
+			minRole:      op,
+			maxBodyBytes: cfgBody,
+		},
+		{
+			path:         APIVersionPrefix + "/settings/cable",
+			handler:      s.handleCableTestSettings,
+			methods:      getPut,
+			minRole:      op,
+			maxBodyBytes: cfgBody,
+		},
+		{path: APIVersionPrefix + "/interfaces", handler: s.handleInterfaces, methods: get},
+		{path: APIVersionPrefix + "/interface", handler: s.handleInterface, methods: getPut},
+		{
+			path:    APIVersionPrefix + "/network/mtu",
+			handler: s.handleSetMTU,
+			methods: post,
+			minRole: op,
+		},
+		{
+			path:         APIVersionPrefix + "/config/backups",
+			handler:      s.handleConfigBackups,
+			methods:      get,
+			maxBodyBytes: cfgBody,
+		},
+		{
+			path:         APIVersionPrefix + "/config/backup",
+			handler:      s.handleConfigBackupCreate,
+			methods:      post,
+			minRole:      op,
+			maxBodyBytes: cfgBody,
+		},
+		{
+			path:         APIVersionPrefix + "/config/backup/delete",
+			handler:      s.handleConfigBackupDelete,
+			methods:      del,
+			minRole:      op,
+			maxBodyBytes: cfgBody,
+		},
+		{
+			path:         APIVersionPrefix + "/config/restore",
+			handler:      s.handleConfigRestore,
+			methods:      post,
+			minRole:      op,
+			maxBodyBytes: cfgBody,
+		},
+		{
+			path:         APIVersionPrefix + "/config/version",
+			handler:      s.handleConfigVersion,
+			methods:      get,
+			maxBodyBytes: cfgBody,
+		},
+		{
+			path:    APIVersionPrefix + "/profiles",
+			handler: s.handleProfiles,
+			methods: crud,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/profiles/active",
+			handler: s.handleActiveProfile,
+			methods: getPostPut,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/profiles/import",
+			handler: s.handleImportProfiles,
+			methods: post,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/profiles/export",
+			handler: s.handleExportProfiles,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/profiles/",
+			handler: s.handleProfiles,
+			methods: crud,
+			minRole: op,
+		},
+		{path: APIVersionPrefix + "/setup/status", handler: s.handleSetupStatus, methods: get},
+		{path: APIVersionPrefix + "/setup/complete", handler: s.handleSetupComplete, methods: post},
+		{
+			path:    APIVersionPrefix + "/recovery/status",
+			handler: s.handleRecoveryStatus,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/recovery/complete",
+			handler: s.handleRecoveryComplete,
+			methods: post,
+		},
+		{
+			path:    APIVersionPrefix + "/recovery/instructions",
+			handler: s.handleRecoveryInstructions,
+			methods: get,
+		},
+		{path: APIVersionPrefix + "/sso/providers", handler: s.handleSSOProviders, methods: get},
+		{path: APIVersionPrefix + "/sso/login", handler: s.handleSSOLogin, methods: get},
+		{path: APIVersionPrefix + "/sso/callback", handler: s.handleSSOCallback, methods: get},
+		{
+			path:    APIVersionPrefix + "/sso/settings",
+			handler: s.handleSSOSettings,
+			methods: get,
+			minRole: op,
+		},
 		// SSO update is Pro-gated (requireFeature "sso", #1198) AND operator-gated.
 		// NORMALIZATION (ADR-0002): the registry composes canonical order
 		// requireFeature(writeGated(h)) — a viewer on Free now receives 402
 		// (feature) where the prior hand-wrapped writeGated(requireFeature(...))
 		// returned 403 (role) first. Operators and Pro tiers are unaffected.
-		{path: APIVersionPrefix + "/sso/update", handler: s.handleSSOUpdate, minRole: op, feature: "sso"},
-		{path: APIVersionPrefix + "/health", handler: s.handleHealth},
+		{
+			path:    APIVersionPrefix + "/sso/update",
+			handler: s.handleSSOUpdate,
+			methods: put,
+			minRole: op,
+			feature: "sso",
+		},
+		{path: APIVersionPrefix + "/health", handler: s.handleHealth, methods: get},
 	})
 }
 
 // setupTelemetryRoutes registers telemetry routes.
 func (s *Server) setupTelemetryRoutes() {
 	op := database.RoleOperator
+	get := []string{http.MethodGet}
+	post := []string{http.MethodPost}
+	getPost := []string{http.MethodGet, http.MethodPost}
+	getPut := []string{http.MethodGet, http.MethodPut}
+	getPostPut := []string{http.MethodGet, http.MethodPost, http.MethodPut}
 	s.registerAll([]route{
-		{path: APIVersionPrefix + "/telemetry/link", handler: s.handleLink},
-		{path: APIVersionPrefix + "/telemetry/cable", handler: s.handleCable},
-		{path: APIVersionPrefix + "/telemetry/dns", handler: s.handleDNS},
-		{path: APIVersionPrefix + "/telemetry/dns/security", handler: s.handleDNSSecurity},
+		{path: APIVersionPrefix + "/telemetry/link", handler: s.handleLink, methods: get},
+		{path: APIVersionPrefix + "/telemetry/cable", handler: s.handleCable, methods: get},
+		{path: APIVersionPrefix + "/telemetry/dns", handler: s.handleDNS, methods: getPost},
+		{
+			path:    APIVersionPrefix + "/telemetry/dns/security",
+			handler: s.handleDNSSecurity,
+			methods: getPost,
+		},
 		{
 			path:    APIVersionPrefix + "/telemetry/dns/security/settings",
 			handler: s.handleDNSSecuritySettings,
+			methods: getPut,
 			minRole: op,
 		},
-		{path: APIVersionPrefix + "/telemetry/gateway", handler: s.handleGateway},
-		{path: APIVersionPrefix + "/telemetry/dhcp/rogue", handler: s.handleRogueDHCP},
-		{path: APIVersionPrefix + "/telemetry/dhcp/rogue/servers", handler: s.handleRogueDHCPServers},
-		{path: APIVersionPrefix + "/telemetry/dhcp/rogue/config", handler: s.handleRogueDHCPConfig, minRole: op},
-		{path: APIVersionPrefix + "/telemetry/vlan", handler: s.handleVLAN},
-		{path: APIVersionPrefix + "/telemetry/vlan/traffic", handler: s.handleVLANTraffic},
-		{path: APIVersionPrefix + "/telemetry/vlan/interface", handler: s.handleVLANInterface},
-		{path: APIVersionPrefix + "/telemetry/speedtest", handler: s.handleSpeedtest, rateLimited: true},
-		{path: APIVersionPrefix + "/telemetry/speedtest/status", handler: s.handleSpeedtestStatus},
-		{path: APIVersionPrefix + "/telemetry/iperf/info", handler: s.handleIperfInfo},
-		{path: APIVersionPrefix + "/telemetry/iperf/client", handler: s.handleIperfClient, rateLimited: true},
-		{path: APIVersionPrefix + "/telemetry/iperf/client/status", handler: s.handleIperfClientStatus},
-		{path: APIVersionPrefix + "/telemetry/iperf/server", handler: s.handleIperfServer},
-		{path: APIVersionPrefix + "/telemetry/iperf/server/status", handler: s.handleIperfServerStatus},
-		{path: APIVersionPrefix + "/telemetry/iperf/suggestions", handler: s.handleIperfSuggestions},
+		{path: APIVersionPrefix + "/telemetry/gateway", handler: s.handleGateway, methods: get},
+		{
+			path:    APIVersionPrefix + "/telemetry/dhcp/rogue",
+			handler: s.handleRogueDHCP,
+			methods: getPost,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/dhcp/rogue/servers",
+			handler: s.handleRogueDHCPServers,
+			methods: getPost,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/dhcp/rogue/config",
+			handler: s.handleRogueDHCPConfig,
+			methods: getPut,
+			minRole: op,
+		},
+		{path: APIVersionPrefix + "/telemetry/vlan", handler: s.handleVLAN, methods: get},
+		{
+			path:    APIVersionPrefix + "/telemetry/vlan/traffic",
+			handler: s.handleVLANTraffic,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/vlan/interface",
+			handler: s.handleVLANInterface,
+			methods: getPostPut,
+		},
+		{
+			path:        APIVersionPrefix + "/telemetry/speedtest",
+			handler:     s.handleSpeedtest,
+			methods:     post,
+			rateLimited: true,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/speedtest/status",
+			handler: s.handleSpeedtestStatus,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/iperf/info",
+			handler: s.handleIperfInfo,
+			methods: get,
+		},
+		{
+			path:        APIVersionPrefix + "/telemetry/iperf/client",
+			handler:     s.handleIperfClient,
+			methods:     post,
+			rateLimited: true,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/iperf/client/status",
+			handler: s.handleIperfClientStatus,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/iperf/server",
+			handler: s.handleIperfServer,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/iperf/server/status",
+			handler: s.handleIperfServerStatus,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/iperf/suggestions",
+			handler: s.handleIperfSuggestions,
+			methods: get,
+		},
 		{
 			path:    APIVersionPrefix + "/telemetry/health-checks/settings",
 			handler: s.handleHealthChecksSettings,
+			methods: getPut,
 			minRole: op,
 		},
-		{path: APIVersionPrefix + "/telemetry/health-checks/run", handler: s.handleHealthChecks, rateLimited: true},
-		{path: APIVersionPrefix + "/telemetry/health-checks/results", handler: s.handleHealthCheckResults},
-		{path: APIVersionPrefix + "/telemetry/health-checks/history", handler: s.handleHealthCheckHistory},
-		{path: APIVersionPrefix + "/telemetry/health-checks/scores", handler: s.handleHealthCheckScores},
-		{path: APIVersionPrefix + "/telemetry/health-checks/sla", handler: s.handleHealthCheckSLA},
-		{path: APIVersionPrefix + "/telemetry/health-checks/alerts", handler: s.handleHealthCheckAlerts},
+		{
+			path:        APIVersionPrefix + "/telemetry/health-checks/run",
+			handler:     s.handleHealthChecks,
+			methods:     getPost,
+			rateLimited: true,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/health-checks/results",
+			handler: s.handleHealthCheckResults,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/health-checks/history",
+			handler: s.handleHealthCheckHistory,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/health-checks/scores",
+			handler: s.handleHealthCheckScores,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/health-checks/sla",
+			handler: s.handleHealthCheckSLA,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/health-checks/alerts",
+			handler: s.handleHealthCheckAlerts,
+			methods: get,
+		},
 		// Anomaly detection is Pro (LICENSE_STRATEGY §2); base results/history/alerts
 		// stay open to all tiers — only the trend/anomaly analysis is paid.
 		{
 			path:    APIVersionPrefix + "/telemetry/health-checks/anomalies",
 			handler: s.handleHealthCheckAnomalies,
+			methods: get,
 			feature: "anomaly_detection",
 		},
-		{path: APIVersionPrefix + "/telemetry/snmp/settings", handler: s.handleSNMPSettings, minRole: op},
-		{path: APIVersionPrefix + "/telemetry/system/health", handler: s.handleSystemHealth},
-		{path: APIVersionPrefix + "/telemetry/ipconfig", handler: s.handleIPConfig},
-		{path: APIVersionPrefix + "/telemetry/ipconfig/settings", handler: s.handleIPSettings, minRole: op},
-		{path: APIVersionPrefix + "/telemetry/publicip", handler: s.handlePublicIP},
+		{
+			path:    APIVersionPrefix + "/telemetry/snmp/settings",
+			handler: s.handleSNMPSettings,
+			methods: getPut,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/system/health",
+			handler: s.handleSystemHealth,
+			methods: get,
+		},
+		{path: APIVersionPrefix + "/telemetry/ipconfig", handler: s.handleIPConfig, methods: get},
+		{
+			path:    APIVersionPrefix + "/telemetry/ipconfig/settings",
+			handler: s.handleIPSettings,
+			methods: getPut,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/telemetry/publicip",
+			handler: s.handlePublicIP,
+			methods: getPostPut,
+		},
 	})
 }
 
 // setupSecurityRoutes registers security routes.
 func (s *Server) setupSecurityRoutes() {
 	op := database.RoleOperator
+	get := []string{http.MethodGet}
+	post := []string{http.MethodPost}
+	getPost := []string{http.MethodGet, http.MethodPost}
+	getPut := []string{http.MethodGet, http.MethodPut}
+	crud := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete}
 	s.registerAll([]route{
-		{path: APIVersionPrefix + "/security/discovery", handler: s.handleDiscovery},
-		{path: APIVersionPrefix + "/security/discovery/probe", handler: s.handleTCPProbe},
-		{path: APIVersionPrefix + "/security/discovery/portscan", handler: s.handlePortScan},
-		{path: APIVersionPrefix + "/security/discovery/options", handler: s.handleDiscoveryOptions},
-		{path: APIVersionPrefix + "/security/discovery/service/status", handler: s.handleDiscoveryServiceStatus},
-		{path: APIVersionPrefix + "/security/discovery/fingerprint", handler: s.handleAdvancedFingerprint},
-		{path: APIVersionPrefix + "/security/devices", handler: s.handleDevices},
-		{path: APIVersionPrefix + "/security/devices/scan", handler: s.handleDevicesScan, rateLimited: true},
-		{path: APIVersionPrefix + "/security/devices/status", handler: s.handleDevicesStatus},
-		{path: APIVersionPrefix + "/security/devices/settings", handler: s.handleDevicesSettings, minRole: op},
-		{path: APIVersionPrefix + "/security/devices/subnets", handler: s.handleDevicesSubnets},
+		{path: APIVersionPrefix + "/security/discovery", handler: s.handleDiscovery, methods: get},
+		{
+			path:    APIVersionPrefix + "/security/discovery/probe",
+			handler: s.handleTCPProbe,
+			methods: post,
+		},
+		{
+			path:    APIVersionPrefix + "/security/discovery/portscan",
+			handler: s.handlePortScan,
+			methods: post,
+		},
+		{
+			path:    APIVersionPrefix + "/security/discovery/options",
+			handler: s.handleDiscoveryOptions,
+			methods: getPut,
+		},
+		{
+			path:    APIVersionPrefix + "/security/discovery/service/status",
+			handler: s.handleDiscoveryServiceStatus,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/security/discovery/fingerprint",
+			handler: s.handleAdvancedFingerprint,
+			methods: post,
+		},
+		{path: APIVersionPrefix + "/security/devices", handler: s.handleDevices, methods: getPost},
+		{
+			path:        APIVersionPrefix + "/security/devices/scan",
+			handler:     s.handleDevicesScan,
+			methods:     post,
+			rateLimited: true,
+		},
+		{
+			path:    APIVersionPrefix + "/security/devices/status",
+			handler: s.handleDevicesStatus,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/security/devices/settings",
+			handler: s.handleDevicesSettings,
+			methods: getPut,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/security/devices/subnets",
+			handler: s.handleDevicesSubnets,
+			methods: crud,
+		},
 		// Vulnerability scan + guest-audit run are compliance_advanced (Pro,
 		// LICENSE_STRATEGY §2); read-only results/status/settings stay open so prior
 		// scan output remains visible to lower tiers.
 		{
 			path:        APIVersionPrefix + "/security/vulnerabilities/scan",
 			handler:     s.handleVulnerabilityScan,
+			methods:     post,
 			feature:     "compliance_advanced",
 			rateLimited: true,
 		},
-		{path: APIVersionPrefix + "/security/vulnerabilities/status", handler: s.handleVulnerabilityStatus},
-		{path: APIVersionPrefix + "/security/vulnerabilities/results", handler: s.handleVulnerabilityResults},
-		{path: APIVersionPrefix + "/security/vulnerabilities/device", handler: s.handleDeviceVulnerabilities},
+		{
+			path:    APIVersionPrefix + "/security/vulnerabilities/status",
+			handler: s.handleVulnerabilityStatus,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/security/vulnerabilities/results",
+			handler: s.handleVulnerabilityResults,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/security/vulnerabilities/device",
+			handler: s.handleDeviceVulnerabilities,
+			methods: get,
+		},
 		{
 			path:    APIVersionPrefix + "/security/vulnerabilities/settings",
 			handler: s.handleVulnerabilitySettings,
+			methods: getPut,
 			minRole: op,
 		},
-		{path: APIVersionPrefix + "/security/vulnerabilities/validate-api-key", handler: s.handleNVDAPIKeyValidate},
+		{
+			path:    APIVersionPrefix + "/security/vulnerabilities/validate-api-key",
+			handler: s.handleNVDAPIKeyValidate,
+			methods: post,
+		},
 		// Guest-network isolation audit (#397).
-		{path: APIVersionPrefix + "/security/guest-audit/settings", handler: s.handleGuestAuditSettings, minRole: op},
+		{
+			path:    APIVersionPrefix + "/security/guest-audit/settings",
+			handler: s.handleGuestAuditSettings,
+			methods: getPut,
+			minRole: op,
+		},
 		{
 			path:        APIVersionPrefix + "/security/guest-audit/run",
 			handler:     s.handleGuestAuditRun,
+			methods:     post,
 			feature:     "compliance_advanced",
 			rateLimited: true,
 		},
 		// Network problem detection.
-		{path: APIVersionPrefix + "/security/problems", handler: s.handleNetworkProblems},
-		{path: APIVersionPrefix + "/security/problems/scan", handler: s.handleProblemScan},
-		{path: APIVersionPrefix + "/security/problems/thresholds", handler: s.handleProblemThresholds, minRole: op},
+		{
+			path:    APIVersionPrefix + "/security/problems",
+			handler: s.handleNetworkProblems,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/security/problems/scan",
+			handler: s.handleProblemScan,
+			methods: post,
+		},
+		{
+			path:    APIVersionPrefix + "/security/problems/thresholds",
+			handler: s.handleProblemThresholds,
+			methods: getPut,
+			minRole: op,
+		},
 		// Bluetooth discovery.
-		{path: APIVersionPrefix + "/security/bluetooth/scan", handler: s.handleBluetoothScan},
-		{path: APIVersionPrefix + "/security/bluetooth/devices", handler: s.handleBluetoothDevices},
-		{path: APIVersionPrefix + "/security/bluetooth/stats", handler: s.handleBluetoothStats},
-		{path: APIVersionPrefix + "/security/bluetooth/status", handler: s.handleBluetoothStatus},
+		{
+			path:    APIVersionPrefix + "/security/bluetooth/scan",
+			handler: s.handleBluetoothScan,
+			methods: post,
+		},
+		{
+			path:    APIVersionPrefix + "/security/bluetooth/devices",
+			handler: s.handleBluetoothDevices,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/security/bluetooth/stats",
+			handler: s.handleBluetoothStats,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/security/bluetooth/status",
+			handler: s.handleBluetoothStatus,
+			methods: get,
+		},
 		// Enhanced WiFi discovery (unified).
-		{path: APIVersionPrefix + "/security/wifi/discovery/scan", handler: s.handleWiFiDiscoveryScan},
-		{path: APIVersionPrefix + "/security/wifi/discovery/networks", handler: s.handleWiFiDiscoveryNetworks},
-		{path: APIVersionPrefix + "/security/wifi/discovery/aps", handler: s.handleWiFiDiscoveryAPs},
-		{path: APIVersionPrefix + "/security/wifi/discovery/stats", handler: s.handleWiFiDiscoveryStats},
+		{
+			path:    APIVersionPrefix + "/security/wifi/discovery/scan",
+			handler: s.handleWiFiDiscoveryScan,
+			methods: post,
+		},
+		{
+			path:    APIVersionPrefix + "/security/wifi/discovery/networks",
+			handler: s.handleWiFiDiscoveryNetworks,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/security/wifi/discovery/aps",
+			handler: s.handleWiFiDiscoveryAPs,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/security/wifi/discovery/stats",
+			handler: s.handleWiFiDiscoveryStats,
+			methods: get,
+		},
 		// Discovery Engine (primary unified discovery system).
-		{path: APIVersionPrefix + "/discovery/engine", handler: s.handleEngineDiscovery},
-		{path: APIVersionPrefix + "/discovery/engine/scan", handler: s.handleEngineScan, rateLimited: true},
-		{path: APIVersionPrefix + "/discovery/engine/quick", handler: s.handleEngineQuickScan, rateLimited: true},
-		{path: APIVersionPrefix + "/discovery/engine/full", handler: s.handleEngineFullScan, rateLimited: true},
-		{path: APIVersionPrefix + "/discovery/engine/stats", handler: s.handleEngineStats},
-		{path: APIVersionPrefix + "/discovery/engine/capabilities", handler: s.handleEngineCapabilities},
-		{path: APIVersionPrefix + "/discovery/engine/device/", handler: s.handleEngineDevice},
-		{path: APIVersionPrefix + "/discovery/engine/events", handler: s.handleEngineEvents},
+		{
+			path:    APIVersionPrefix + "/discovery/engine",
+			handler: s.handleEngineDiscovery,
+			methods: get,
+		},
+		{
+			path:        APIVersionPrefix + "/discovery/engine/scan",
+			handler:     s.handleEngineScan,
+			methods:     post,
+			rateLimited: true,
+		},
+		{
+			path:        APIVersionPrefix + "/discovery/engine/quick",
+			handler:     s.handleEngineQuickScan,
+			methods:     post,
+			rateLimited: true,
+		},
+		{
+			path:        APIVersionPrefix + "/discovery/engine/full",
+			handler:     s.handleEngineFullScan,
+			methods:     post,
+			rateLimited: true,
+		},
+		{
+			path:    APIVersionPrefix + "/discovery/engine/stats",
+			handler: s.handleEngineStats,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/discovery/engine/capabilities",
+			handler: s.handleEngineCapabilities,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/discovery/engine/device/",
+			handler: s.handleEngineDevice,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/discovery/engine/events",
+			handler: s.handleEngineEvents,
+			methods: get,
+		},
 	})
 }
 
@@ -258,14 +740,21 @@ func (s *Server) setupSecurityRoutes() {
 // middleware still wraps traceroute so abuse remains capped even for
 // trial users.
 func (s *Server) setupPathRoutes() {
+	post := []string{http.MethodPost}
 	s.registerAll([]route{
 		{
 			path:        APIVersionPrefix + "/path/traceroute",
 			handler:     s.handleTraceroute,
+			methods:     post,
 			feature:     "path_analysis",
 			rateLimited: true,
 		},
-		{path: APIVersionPrefix + "/path/path", handler: s.handlePath, feature: "path_analysis"},
+		{
+			path:    APIVersionPrefix + "/path/path",
+			handler: s.handlePath,
+			methods: post,
+			feature: "path_analysis",
+		},
 	})
 }
 
@@ -275,44 +764,168 @@ func (s *Server) setupPathRoutes() {
 // Behavior is identical to the prior hand-wrapped form.
 func (s *Server) setupWiFiRoutes() {
 	op := database.RoleOperator
+	get := []string{http.MethodGet}
+	post := []string{http.MethodPost}
+	put := []string{http.MethodPut}
+	del := []string{http.MethodDelete}
+	getPut := []string{http.MethodGet, http.MethodPut}
+	getPostPut := []string{http.MethodGet, http.MethodPost, http.MethodPut}
+	floorBody := MaxBodySizeFloorPlan // 10 MB — floor-plan image uploads.
+	airBody := MaxBodySizeAirMapper   // 50 MB — AirMapper survey imports.
 	s.registerAll([]route{
-		{path: APIVersionPrefix + "/wifi/wifi", handler: s.handleWiFi},
-		{path: APIVersionPrefix + "/wifi/wifi/scan", handler: s.handleWiFiScan},
-		{path: APIVersionPrefix + "/wifi/wifi/status", handler: s.handleWiFiStatus},
-		{path: APIVersionPrefix + "/wifi/wifi/channel-graph", handler: s.handleWiFiChannelGraph},
-		{path: APIVersionPrefix + "/wifi/wifi/settings", handler: s.handleWiFiSettings, minRole: op},
-		{path: APIVersionPrefix + "/wifi/wifi/connect", handler: s.handleWiFiConnect, minRole: op},
-		{path: APIVersionPrefix + "/wifi/wifi/disconnect", handler: s.handleWiFiDisconnect, minRole: op},
-		{path: APIVersionPrefix + "/wifi/wifi/saved", handler: s.handleWiFiSavedNetworks},
-		{path: APIVersionPrefix + "/wifi/wifi/forget", handler: s.handleWiFiForgetNetwork, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/create", handler: s.createSurvey, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/list", handler: s.listSurveys},
-		{path: APIVersionPrefix + "/wifi/survey", handler: s.getSurvey},
-		{path: APIVersionPrefix + "/wifi/survey/delete", handler: s.deleteSurvey, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/start", handler: s.startSurvey, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/pause", handler: s.pauseSurvey, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/complete", handler: s.completeSurvey, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/sample", handler: s.addSurveySample, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/floorplan", handler: s.updateSurveyFloorPlan, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/settings", handler: s.updateSurveySettings, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/imported-data", handler: s.updateSurveyImportedData, minRole: op},
+		{path: APIVersionPrefix + "/wifi/wifi", handler: s.handleWiFi, methods: getPostPut},
+		{path: APIVersionPrefix + "/wifi/wifi/scan", handler: s.handleWiFiScan, methods: get},
+		{path: APIVersionPrefix + "/wifi/wifi/status", handler: s.handleWiFiStatus, methods: get},
+		{
+			path:    APIVersionPrefix + "/wifi/wifi/channel-graph",
+			handler: s.handleWiFiChannelGraph,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/wifi/settings",
+			handler: s.handleWiFiSettings,
+			methods: getPut,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/wifi/connect",
+			handler: s.handleWiFiConnect,
+			methods: post,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/wifi/disconnect",
+			handler: s.handleWiFiDisconnect,
+			methods: post,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/wifi/saved",
+			handler: s.handleWiFiSavedNetworks,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/wifi/forget",
+			handler: s.handleWiFiForgetNetwork,
+			methods: del,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/create",
+			handler: s.createSurvey,
+			methods: post,
+			minRole: op,
+		},
+		{path: APIVersionPrefix + "/wifi/survey/list", handler: s.listSurveys, methods: get},
+		{path: APIVersionPrefix + "/wifi/survey", handler: s.getSurvey, methods: get},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/delete",
+			handler: s.deleteSurvey,
+			methods: del,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/start",
+			handler: s.startSurvey,
+			methods: post,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/pause",
+			handler: s.pauseSurvey,
+			methods: post,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/complete",
+			handler: s.completeSurvey,
+			methods: post,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/sample",
+			handler: s.addSurveySample,
+			methods: post,
+			minRole: op,
+		},
+		{
+			path:         APIVersionPrefix + "/wifi/survey/floorplan",
+			handler:      s.updateSurveyFloorPlan,
+			methods:      put,
+			minRole:      op,
+			maxBodyBytes: floorBody,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/settings",
+			handler: s.updateSurveySettings,
+			methods: put,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/imported-data",
+			handler: s.updateSurveyImportedData,
+			methods: put,
+			minRole: op,
+		},
 		// AirMapper baseline-diff (Pro, LICENSE_STRATEGY §2): imports an AirMapper
 		// survey JSON and diffs it against the floor-plan baseline; rate-limited.
 		{
-			path:        APIVersionPrefix + "/wifi/survey/import/airmapper",
-			handler:     s.importAirMapper,
-			minRole:     op,
-			feature:     "airmapper_baseline_diff",
+			path:         APIVersionPrefix + "/wifi/survey/import/airmapper",
+			handler:      s.importAirMapper,
+			methods:      post,
+			minRole:      op,
+			feature:      "airmapper_baseline_diff",
+			rateLimited:  true,
+			maxBodyBytes: airBody,
+		},
+		{
+			path:        APIVersionPrefix + "/wifi/survey/heatmap",
+			handler:     s.getSurveyHeatmap,
+			methods:     get,
 			rateLimited: true,
 		},
-		{path: APIVersionPrefix + "/wifi/survey/heatmap", handler: s.getSurveyHeatmap, rateLimited: true},
-		{path: APIVersionPrefix + "/wifi/survey/dead-zones", handler: s.getSurveyDeadZones},
-		{path: APIVersionPrefix + "/wifi/survey/floors", handler: s.handleSurveyFloors, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/floor", handler: s.handleSurveyFloor, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/floor/floorplan", handler: s.updateFloorFloorPlan, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/floor/sample", handler: s.addFloorSample, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/active-floor", handler: s.setActiveFloor, minRole: op},
-		{path: APIVersionPrefix + "/wifi/survey/report", handler: s.generateSurveyReport, rateLimited: true},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/dead-zones",
+			handler: s.getSurveyDeadZones,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/floors",
+			handler: s.handleSurveyFloors,
+			methods: getPostPut,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/floor",
+			handler: s.handleSurveyFloor,
+			methods: getPostPut,
+			minRole: op,
+		},
+		{
+			path:         APIVersionPrefix + "/wifi/survey/floor/floorplan",
+			handler:      s.updateFloorFloorPlan,
+			methods:      put,
+			minRole:      op,
+			maxBodyBytes: floorBody,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/floor/sample",
+			handler: s.addFloorSample,
+			methods: post,
+			minRole: op,
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/survey/active-floor",
+			handler: s.setActiveFloor,
+			methods: put,
+			minRole: op,
+		},
+		{
+			path:        APIVersionPrefix + "/wifi/survey/report",
+			handler:     s.generateSurveyReport,
+			methods:     post,
+			rateLimited: true,
+		},
 	})
 }
 
@@ -323,13 +936,36 @@ func (s *Server) setupWiFiRoutes() {
 // every tier; only data extraction (the customer-facing reporting
 // surface) is paid.
 func (s *Server) setupReportingRoutes() {
+	get := []string{http.MethodGet}
+	post := []string{http.MethodPost}
 	s.registerAll([]route{
-		{path: APIVersionPrefix + "/reporting/export", handler: s.handleExport, feature: "export_csv_json"},
-		{path: APIVersionPrefix + "/reporting/logs", handler: s.handleLogs},
-		{path: APIVersionPrefix + "/reporting/logs/client", handler: s.handleClientLogs},
-		{path: APIVersionPrefix + "/reporting/logs/query", handler: s.handleLogsQuery},
-		{path: APIVersionPrefix + "/reporting/logs/stats", handler: s.handleLogsStats},
-		{path: APIVersionPrefix + "/reporting/logs/recent", handler: s.handleLogsRecent},
+		{
+			path:    APIVersionPrefix + "/reporting/export",
+			handler: s.handleExport,
+			methods: get,
+			feature: "export_csv_json",
+		},
+		{path: APIVersionPrefix + "/reporting/logs", handler: s.handleLogs, methods: get},
+		{
+			path:    APIVersionPrefix + "/reporting/logs/client",
+			handler: s.handleClientLogs,
+			methods: post,
+		},
+		{
+			path:    APIVersionPrefix + "/reporting/logs/query",
+			handler: s.handleLogsQuery,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/reporting/logs/stats",
+			handler: s.handleLogsStats,
+			methods: get,
+		},
+		{
+			path:    APIVersionPrefix + "/reporting/logs/recent",
+			handler: s.handleLogsRecent,
+			methods: get,
+		},
 	})
 }
 
@@ -342,7 +978,12 @@ func (s *Server) setupSSEAndStatic() {
 	// per-endpoint REST handlers without the WebSocket-like stream.
 	// `/discovery/engine/events` (the discovery-lifecycle SSE) is
 	// intentionally NOT gated here — discovery is a Free-tier surface.
-	s.register(route{path: APIVersionPrefix + "/events", handler: s.handleSSE, feature: "live_telemetry"})
+	s.register(route{
+		path:    APIVersionPrefix + "/events",
+		handler: s.handleSSE,
+		methods: []string{http.MethodGet},
+		feature: "live_telemetry",
+	})
 	frontendFS, err := getUIFS()
 	if err != nil {
 		logging.GetLogger().

--- a/internal/api/testdata/golden/capabilities.txt
+++ b/internal/api/testdata/golden/capabilities.txt
@@ -2,618 +2,1387 @@ status: 200
 body:
 [
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/auth/login"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/auth/logout"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/auth/refresh"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/auth/csrf"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/auth/login/totp"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/auth/totp/setup"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/auth/totp/verify"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/auth/totp/disable"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/auth/mfa/status"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/auth/webauthn/register/begin"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/auth/webauthn/register/finish"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/auth/webauthn/login/begin"
   },
   {
+    "maxBodyBytes": 1024,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/auth/webauthn/login/finish"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/status"
   },
   {
+    "maxBodyBytes": 65536,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/settings"
   },
   {
+    "maxBodyBytes": 65536,
+    "methods": [
+      "GET"
+    ],
     "minRole": "operator",
     "path": "/api/v1/settings/defaults"
   },
   {
+    "maxBodyBytes": 65536,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/settings/link"
   },
   {
+    "maxBodyBytes": 65536,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/settings/cable"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/interfaces"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "path": "/api/v1/interface"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/network/mtu"
   },
   {
+    "maxBodyBytes": 65536,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/config/backups"
   },
   {
+    "maxBodyBytes": 65536,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/config/backup"
   },
   {
+    "maxBodyBytes": 65536,
+    "methods": [
+      "DELETE"
+    ],
     "minRole": "operator",
     "path": "/api/v1/config/backup/delete"
   },
   {
+    "maxBodyBytes": 65536,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/config/restore"
   },
   {
+    "maxBodyBytes": 65536,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/config/version"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST",
+      "PUT",
+      "DELETE"
+    ],
     "minRole": "operator",
     "path": "/api/v1/profiles"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/profiles/active"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/profiles/import"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/profiles/export"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST",
+      "PUT",
+      "DELETE"
+    ],
     "minRole": "operator",
     "path": "/api/v1/profiles/"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/setup/status"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/setup/complete"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/recovery/status"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/recovery/complete"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/recovery/instructions"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/sso/providers"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/sso/login"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/sso/callback"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "minRole": "operator",
     "path": "/api/v1/sso/settings"
   },
   {
     "feature": "sso",
+    "maxBodyBytes": 262144,
+    "methods": [
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/sso/update"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/health"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/tokens"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "DELETE"
+    ],
     "minRole": "operator",
     "path": "/api/v1/tokens/"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/license"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/users/me"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST"
+    ],
     "path": "/api/v1/users"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PATCH",
+      "DELETE"
+    ],
     "path": "/api/v1/users/"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "GET /api/v1/updates/check"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "GET /api/v1/updates/status"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "GET /api/v1/updates/info"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "POST /api/v1/updates/download"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "POST /api/v1/updates/apply"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "POST /api/v1/updates/rollback"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "GET /api/v1/updates/config"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "PATCH"
+    ],
     "minRole": "operator",
     "path": "PATCH /api/v1/updates/config"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/link"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/cable"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST"
+    ],
     "path": "/api/v1/telemetry/dns"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST"
+    ],
     "path": "/api/v1/telemetry/dns/security"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/telemetry/dns/security/settings"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/gateway"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST"
+    ],
     "path": "/api/v1/telemetry/dhcp/rogue"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST"
+    ],
     "path": "/api/v1/telemetry/dhcp/rogue/servers"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/telemetry/dhcp/rogue/config"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/vlan"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/vlan/traffic"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST",
+      "PUT"
+    ],
     "path": "/api/v1/telemetry/vlan/interface"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/telemetry/speedtest",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/speedtest/status"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/iperf/info"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/telemetry/iperf/client",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/iperf/client/status"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/iperf/server"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/iperf/server/status"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/iperf/suggestions"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/telemetry/health-checks/settings"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST"
+    ],
     "path": "/api/v1/telemetry/health-checks/run",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/health-checks/results"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/health-checks/history"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/health-checks/scores"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/health-checks/sla"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/health-checks/alerts"
   },
   {
     "feature": "anomaly_detection",
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/health-checks/anomalies"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/telemetry/snmp/settings"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/system/health"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/telemetry/ipconfig"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/telemetry/ipconfig/settings"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST",
+      "PUT"
+    ],
     "path": "/api/v1/telemetry/publicip"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/discovery"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/security/discovery/probe"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/security/discovery/portscan"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "path": "/api/v1/security/discovery/options"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/discovery/service/status"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/security/discovery/fingerprint"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST"
+    ],
     "path": "/api/v1/security/devices"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/security/devices/scan",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/devices/status"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/security/devices/settings"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST",
+      "PUT",
+      "DELETE"
+    ],
     "path": "/api/v1/security/devices/subnets"
   },
   {
     "feature": "compliance_advanced",
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/security/vulnerabilities/scan",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/vulnerabilities/status"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/vulnerabilities/results"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/vulnerabilities/device"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/security/vulnerabilities/settings"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/security/vulnerabilities/validate-api-key"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/security/guest-audit/settings"
   },
   {
     "feature": "compliance_advanced",
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/security/guest-audit/run",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/problems"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/security/problems/scan"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/security/problems/thresholds"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/security/bluetooth/scan"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/bluetooth/devices"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/bluetooth/stats"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/bluetooth/status"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/security/wifi/discovery/scan"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/wifi/discovery/networks"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/wifi/discovery/aps"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/security/wifi/discovery/stats"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/discovery/engine"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/discovery/engine/scan",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/discovery/engine/quick",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/discovery/engine/full",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/discovery/engine/stats"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/discovery/engine/capabilities"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/discovery/engine/device/"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/discovery/engine/events"
   },
   {
     "feature": "path_analysis",
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/path/traceroute",
     "rateLimited": true
   },
   {
     "feature": "path_analysis",
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/path/path"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST",
+      "PUT"
+    ],
     "path": "/api/v1/wifi/wifi"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/wifi/wifi/scan"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/wifi/wifi/status"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/wifi/wifi/channel-graph"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/wifi/settings"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/wifi/connect"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/wifi/disconnect"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/wifi/wifi/saved"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "DELETE"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/wifi/forget"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/create"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/wifi/survey/list"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/wifi/survey"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "DELETE"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/delete"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/start"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/pause"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/complete"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/sample"
   },
   {
+    "maxBodyBytes": 10485760,
+    "methods": [
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/floorplan"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/settings"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/imported-data"
   },
   {
     "feature": "airmapper_baseline_diff",
+    "maxBodyBytes": 52428800,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/import/airmapper",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/wifi/survey/heatmap",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/wifi/survey/dead-zones"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/floors"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST",
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/floor"
   },
   {
+    "maxBodyBytes": 10485760,
+    "methods": [
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/floor/floorplan"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/floor/sample"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "PUT"
+    ],
     "minRole": "operator",
     "path": "/api/v1/wifi/survey/active-floor"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/wifi/survey/report",
     "rateLimited": true
   },
   {
     "feature": "export_csv_json",
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/reporting/export"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/reporting/logs"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "path": "/api/v1/reporting/logs/client"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/reporting/logs/query"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/reporting/logs/stats"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/reporting/logs/recent"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/topology/nodes"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/topology/nodes/"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/topology/links"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/topology/arp"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/alerts"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/alerts/"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/polling-targets"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT",
+      "DELETE"
+    ],
     "minRole": "operator",
     "path": "/api/v1/polling-targets/"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/engines"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/alert-rules"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "PUT",
+      "DELETE"
+    ],
     "minRole": "operator",
     "path": "/api/v1/alert-rules/"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "POST"
+    ],
     "minRole": "operator",
     "path": "/api/v1/jobs",
     "rateLimited": true
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/jobs/events"
   },
   {
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET",
+      "DELETE"
+    ],
     "minRole": "operator",
     "path": "/api/v1/jobs/"
   },
   {
     "feature": "live_telemetry",
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
     "path": "/api/v1/events"
   }
 ]


### PR DESCRIPTION
## What

Actions arch-review finding **#6**: HTTP **method** validation and request **body-size** limits are now declared per-route in the ADR-0002 capability registry and enforced by `register()`, instead of living in handlers + a separate path-switching middleware.

## Why

Method/body-limit policy was split across each handler's own `switch r.Method` / `MaxBytesReader` **and** a global path-switching `bodyLimitMiddleware` — two sources of truth that had already drifted: `/wifi/survey/floor/floorplan` wanted 10MB in-handler but the path-switch capped it at 256KB first (latent bug, fixed here).

## Change

- `route{}` gains `methods []string` + `maxBodyBytes int64`.
- `register()` composes: `rateLimit → methodGate → requireFeature → requireRole → bodyLimit → handler`.
  - **methodGate**: 405 + `Allow` header (project JSON envelope) for undeclared methods. Go 1.22 method-prefixed paths (the `updates/*` routes) stay ServeMux-enforced and leave `methods` empty.
  - **bodyLimit**: per-route `MaxBytesReader` (default 256KB; auth 1KB, config 64KB, floor-plan 10MB, AirMapper 50MB).
- `bodyLimitMiddleware` reduced to a backstop for **non-API** paths; `/api/v1` limits are the registry's (eliminates the drift).
- Methods populated per route from each handler's **actual** accepted set (audited).
- `/__capabilities` manifest now exposes `methods` + `maxBodyBytes` (camelCase, ADR-0010).

## Tests / verification

- **New `TestEveryAPIRouteDeclaresMethodAndBodyLimit`** — fails if any `/api/v1` route is registered without a declared method or body limit (the "no route bypasses the policy" guard #6 asks for).
- **New `TestMethodGateRejectsUndeclaredMethod`** — proves 405 + Allow for an undeclared method, 200 for the declared one.
- The **full `internal/api` suite** caught three audit misses during population (`devices/subnets` = full CRUD, `dns/security` = GET+POST not GET+PUT, `/interface` = GET+PUT) — corrected. Three tests that encoded now-changed behavior were updated (body-limit middleware scope; write-gate test uses PUT not POST on a GET/PUT route; path-gate test uses POST on the POST-only route).
- Capabilities golden regenerated. `golangci-lint` 0 issues (funlen relaxed for the `server_routes.go` route tables — data, not logic, same precedent as `cmd/seed-schema`). ADR-0002 amended.

## Note

Method gates on a few previously-**unguarded** routes (survey state-changes, `delete`, SSE) are an intentional hardening; the declared methods were verified against actual UI usage.