### PR TITLE
feat(anomaly): general network-anomaly engine + data-driven catalog (W4a)

### DIFF
--- a/internal/anomaly/anomaly.go
+++ b/internal/anomaly/anomaly.go
@@ -1,0 +1,179 @@
+// Package anomaly is the general, network-wide anomaly engine (ADR-0011): one
+// typed stream of detections, a data-driven catalog of anomaly definitions, and
+// a source-neutral engine that dedups, escalates, ages out, and projects a
+// deterministic view. Wi-Fi is its first rule source (internal/wifi/anomaly),
+// but the engine has no dependency on any source — it is exercised entirely with
+// synthetic detections. CGO-free, no I/O, no hidden clock (callers pass time).
+package anomaly
+
+import "time"
+
+// Severity is the anomaly urgency, aligned with the fleet alert vocabulary
+// (internal/database AlertSeverity*). info < warning < critical.
+type Severity string
+
+const (
+	// SeverityInfo is advisory — worth surfacing, not urgent.
+	SeverityInfo Severity = "info"
+	// SeverityWarning is a degradation or risk that should be addressed.
+	SeverityWarning Severity = "warning"
+	// SeverityCritical is an active problem or security exposure.
+	SeverityCritical Severity = "critical"
+)
+
+// severity ranks order severities for escalation/coalescing (higher = more
+// urgent). rankNone is the zero value for an unknown/invalid severity.
+const (
+	rankNone = iota
+	rankInfo
+	rankWarning
+	rankCritical
+)
+
+// rank returns the ordering weight of s.
+func (s Severity) rank() int {
+	switch s {
+	case SeverityCritical:
+		return rankCritical
+	case SeverityWarning:
+		return rankWarning
+	case SeverityInfo:
+		return rankInfo
+	default:
+		return rankNone
+	}
+}
+
+// valid reports whether s is a known severity.
+func (s Severity) valid() bool { return s.rank() > 0 }
+
+// Category encodes the problem DOMAIN, not the data source — one stream is
+// filtered by category + severity (ADR-0011). Sources across Wi-Fi, wired/SNMP,
+// and test outcomes map their detections onto this shared set.
+type Category string
+
+const (
+	// CategorySecurity covers access-protection and attack exposure
+	// (open/WEP/WPS, evil-twin, deauth flood, PMF gaps).
+	CategorySecurity Category = "security"
+	// CategoryRF covers PHY/RF conditions (co-channel, overlap, retries, noise).
+	CategoryRF Category = "rf"
+	// CategoryRoaming covers 802.11k/v/r and client mobility problems.
+	CategoryRoaming Category = "roaming"
+	// CategoryCapacity covers saturation/overload (BSS load, association caps).
+	CategoryCapacity Category = "capacity"
+	// CategoryStandards covers capability/standard inconsistencies across a BSS set.
+	CategoryStandards Category = "standards"
+	// CategoryAuthorization covers the rogue/allowlist authorization framework.
+	CategoryAuthorization Category = "authorization"
+	// CategoryNetHealth covers wired/SNMP device health (future sources).
+	CategoryNetHealth Category = "nethealth"
+)
+
+// FollowUpKind selects how a follow-up narrows an ambiguous detection.
+type FollowUpKind string
+
+const (
+	// FollowUpAuto runs a deeper test automatically — only where the platform/
+	// adapter registers the named Capability; otherwise it degrades to a prompt.
+	FollowUpAuto FollowUpKind = "auto"
+	// FollowUpPrompt is a guided manual step for the user.
+	FollowUpPrompt FollowUpKind = "prompt"
+)
+
+// FollowUp narrows the diagnosis for an anomaly type. An "auto" follow-up is
+// capability-gated (ADR-0002): the engine degrades it to a prompt when its
+// Capability is not registered, so the guidance is always actionable.
+type FollowUp struct {
+	Kind  FollowUpKind `json:"kind"`
+	Label string       `json:"label"`
+	// Action is the test to run (auto) or the step to take (prompt).
+	Action string `json:"action"`
+	// Capability names the platform capability an "auto" follow-up needs; empty
+	// means always-auto. Ignored for prompt follow-ups.
+	Capability string `json:"capability,omitempty"`
+}
+
+// Def is a catalog entry: the definition of an anomaly TYPE, separate
+// from any single detection of it. Copy is authored originally with IEEE/802.11
+// citations (ADR-0011) and lives as data so it is tunable and reviewable.
+type Def struct {
+	ID              string     `json:"id"`
+	Category        Category   `json:"category"`
+	DefaultSeverity Severity   `json:"defaultSeverity"`
+	Standards       []string   `json:"standards,omitempty"`
+	Title           string     `json:"title"`
+	Description     string     `json:"description"`
+	Impact          string     `json:"impact"`
+	Recommendation  string     `json:"recommendation"`
+	FollowUps       []FollowUp `json:"followUps,omitempty"`
+}
+
+// SubjectKind classifies what an anomaly is about, so cross-source correlation
+// can key on the same subject (e.g. a BSSID also seen in the wired ARP table).
+type SubjectKind string
+
+const (
+	// SubjectSSID identifies an advertised network name.
+	SubjectSSID SubjectKind = "ssid"
+	// SubjectBSSID identifies one radio/BSSID.
+	SubjectBSSID SubjectKind = "bssid"
+	// SubjectClient identifies a client station MAC.
+	SubjectClient SubjectKind = "client"
+	// SubjectChannel identifies an RF channel.
+	SubjectChannel SubjectKind = "channel"
+	// SubjectDevice identifies a wired/discovered device (future sources).
+	SubjectDevice SubjectKind = "device"
+	// SubjectInterface identifies a device interface (future sources).
+	SubjectInterface SubjectKind = "interface"
+)
+
+// SubjectRef points at the entity an anomaly concerns.
+type SubjectRef struct {
+	Kind SubjectKind `json:"kind"`
+	ID   string      `json:"id"`
+}
+
+// Detection is what a rule source emits to the engine: which catalog entry
+// fired, about what subject, with the live evidence (measured values). An empty
+// Severity means "use the catalog default".
+type Detection struct {
+	DefKey   string
+	Subject  SubjectRef
+	Severity Severity
+	Evidence map[string]string
+}
+
+// key identifies the live instance a detection coalesces into: one per
+// (anomaly type, subject). Re-detecting the same pair updates the instance
+// rather than creating a duplicate.
+func (d Detection) key() instanceKey {
+	return instanceKey{def: d.DefKey, kind: d.Subject.Kind, id: d.Subject.ID}
+}
+
+type instanceKey struct {
+	def  string
+	kind SubjectKind
+	id   string
+}
+
+// Anomaly is the projected, JSON-serializable view of a live detection: the
+// catalog copy (title/description/recommendation/standards) merged with the
+// instance evidence and lifecycle (firstSeen/lastSeen/count). Wire tags are
+// camelCase (ADR-0010).
+type Anomaly struct {
+	DefKey         string            `json:"defKey"`
+	Category       Category          `json:"category"`
+	Severity       Severity          `json:"severity"`
+	Subject        SubjectRef        `json:"subject"`
+	Title          string            `json:"title"`
+	Description    string            `json:"description"`
+	Impact         string            `json:"impact,omitempty"`
+	Recommendation string            `json:"recommendation"`
+	Standards      []string          `json:"standards,omitempty"`
+	Evidence       map[string]string `json:"evidence,omitempty"`
+	FollowUps      []FollowUp        `json:"followUps,omitempty"`
+	FirstSeen      time.Time         `json:"firstSeen"`
+	LastSeen       time.Time         `json:"lastSeen"`
+	Count          int               `json:"count"`
+}

--- a/internal/anomaly/catalog.go
+++ b/internal/anomaly/catalog.go
@@ -1,0 +1,95 @@
+package anomaly
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Catalog is an immutable, validated set of Def entries keyed by ID. A
+// rule source registers its definitions once; the engine rejects detections that
+// reference an unknown ID, so a rule can never emit an undefined anomaly.
+type Catalog struct {
+	defs map[string]Def
+}
+
+// NewCatalog validates and indexes defs. It errors on a duplicate ID, a missing
+// required field (id/title/category/defaultSeverity/description/recommendation),
+// an unknown category or severity, or a malformed follow-up — so a typo in the
+// data-driven catalog fails fast at startup rather than shipping a blank card.
+func NewCatalog(defs ...Def) (*Catalog, error) {
+	c := &Catalog{defs: make(map[string]Def, len(defs))}
+	for _, d := range defs {
+		if err := validateDef(d); err != nil {
+			return nil, err
+		}
+		if _, dup := c.defs[d.ID]; dup {
+			return nil, fmt.Errorf("anomaly: duplicate catalog id %q", d.ID)
+		}
+		c.defs[d.ID] = d
+	}
+	return c, nil
+}
+
+func validateDef(d Def) error {
+	switch {
+	case d.ID == "":
+		return fmt.Errorf("anomaly: catalog entry missing id (title %q)", d.Title)
+	case d.Title == "":
+		return fmt.Errorf("anomaly: catalog entry %q missing title", d.ID)
+	case d.Description == "":
+		return fmt.Errorf("anomaly: catalog entry %q missing description", d.ID)
+	case d.Recommendation == "":
+		return fmt.Errorf("anomaly: catalog entry %q missing recommendation", d.ID)
+	case !validCategory(d.Category):
+		return fmt.Errorf("anomaly: catalog entry %q has unknown category %q", d.ID, d.Category)
+	case !d.DefaultSeverity.valid():
+		return fmt.Errorf(
+			"anomaly: catalog entry %q has invalid defaultSeverity %q",
+			d.ID,
+			d.DefaultSeverity,
+		)
+	}
+	for i, f := range d.FollowUps {
+		if f.Kind != FollowUpAuto && f.Kind != FollowUpPrompt {
+			return fmt.Errorf(
+				"anomaly: catalog entry %q follow-up %d has invalid kind %q",
+				d.ID,
+				i,
+				f.Kind,
+			)
+		}
+		if f.Label == "" {
+			return fmt.Errorf("anomaly: catalog entry %q follow-up %d missing label", d.ID, i)
+		}
+	}
+	return nil
+}
+
+func validCategory(c Category) bool {
+	switch c {
+	case CategorySecurity, CategoryRF, CategoryRoaming, CategoryCapacity,
+		CategoryStandards, CategoryAuthorization, CategoryNetHealth:
+		return true
+	default:
+		return false
+	}
+}
+
+// Lookup returns the definition for id.
+func (c *Catalog) Lookup(id string) (Def, bool) {
+	d, ok := c.defs[id]
+	return d, ok
+}
+
+// Defs returns all definitions sorted by ID (deterministic for tests/audit).
+func (c *Catalog) Defs() []Def {
+	out := make([]Def, 0, len(c.defs))
+	for _, d := range c.defs {
+		out = append(out, d)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// Len is the number of catalog entries.
+func (c *Catalog) Len() int { return len(c.defs) }

--- a/internal/anomaly/engine.go
+++ b/internal/anomaly/engine.go
@@ -1,0 +1,212 @@
+package anomaly
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// defaultEscalateAfter is the recurrence count at which a persistent detection
+// is escalated one severity level (info→warning→critical). A repeatedly
+// re-observed problem is more important than a one-off blip.
+const defaultEscalateAfter = 5
+
+// tracked is the live state of one coalesced detection instance.
+type tracked struct {
+	det          Detection
+	baseSeverity Severity
+	firstSeen    time.Time
+	lastSeen     time.Time
+	count        int
+}
+
+// Engine coalesces detections from any source into one deduped, escalating,
+// ageable stream. It is source-neutral: it knows only the catalog and the
+// detections fed to it. Safe for concurrent Observe/Snapshot/Prune.
+type Engine struct {
+	mu            sync.RWMutex
+	catalog       *Catalog
+	active        map[instanceKey]*tracked
+	capabilities  map[string]struct{}
+	escalateAfter int
+}
+
+// Option configures an Engine.
+type Option func(*Engine)
+
+// WithCapabilities registers the platform capabilities available for auto
+// follow-ups. An "auto" follow-up whose Capability is not registered is
+// degraded to a guided prompt in Snapshot (ADR-0011).
+func WithCapabilities(caps ...string) Option {
+	return func(e *Engine) {
+		for _, c := range caps {
+			e.capabilities[c] = struct{}{}
+		}
+	}
+}
+
+// WithEscalateAfter sets the recurrence count that escalates severity one level.
+// Zero disables escalation.
+func WithEscalateAfter(n int) Option {
+	return func(e *Engine) { e.escalateAfter = n }
+}
+
+// NewEngine returns an engine backed by catalog.
+func NewEngine(catalog *Catalog, opts ...Option) *Engine {
+	e := &Engine{
+		catalog:       catalog,
+		active:        make(map[instanceKey]*tracked),
+		capabilities:  make(map[string]struct{}),
+		escalateAfter: defaultEscalateAfter,
+	}
+	for _, o := range opts {
+		o(e)
+	}
+	return e
+}
+
+// Observe folds one detection into the stream at observation time `at`. A new
+// (type, subject) pair creates an instance; a repeat updates lastSeen and the
+// recurrence count (which can escalate severity). It errors if the detection's
+// DefKey is not in the catalog or its severity override is invalid — a rule
+// source must only emit defined anomalies.
+func (e *Engine) Observe(d Detection, at time.Time) error {
+	if _, ok := e.catalog.Lookup(d.DefKey); !ok {
+		return fmt.Errorf("anomaly: detection references unknown def %q", d.DefKey)
+	}
+	if d.Severity != "" && !d.Severity.valid() {
+		return fmt.Errorf("anomaly: detection for %q has invalid severity %q", d.DefKey, d.Severity)
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	k := d.key()
+	t, ok := e.active[k]
+	if !ok {
+		e.active[k] = &tracked{
+			det:          d,
+			baseSeverity: e.baseSeverity(d),
+			firstSeen:    at,
+			lastSeen:     at,
+			count:        1,
+		}
+		return nil
+	}
+	// Coalesce: refresh evidence + lifecycle, keep the earliest firstSeen.
+	t.det = d
+	t.baseSeverity = e.baseSeverity(d)
+	t.count++
+	if at.After(t.lastSeen) {
+		t.lastSeen = at
+	}
+	return nil
+}
+
+// baseSeverity is the detection's explicit severity, else the catalog default.
+func (e *Engine) baseSeverity(d Detection) Severity {
+	if d.Severity != "" {
+		return d.Severity
+	}
+	def, _ := e.catalog.Lookup(d.DefKey)
+	return def.DefaultSeverity
+}
+
+// effectiveSeverity applies recurrence escalation: a base severity bumps one
+// level once count reaches escalateAfter, capped at critical.
+func (e *Engine) effectiveSeverity(t *tracked) Severity {
+	if e.escalateAfter <= 0 || t.count < e.escalateAfter {
+		return t.baseSeverity
+	}
+	switch t.baseSeverity {
+	case SeverityInfo:
+		return SeverityWarning
+	case SeverityWarning:
+		return SeverityCritical
+	case SeverityCritical:
+		return SeverityCritical
+	default:
+		return t.baseSeverity
+	}
+}
+
+// Prune clears instances not re-observed since cutoff (the anomaly's condition
+// is considered resolved). Returns the number cleared.
+func (e *Engine) Prune(cutoff time.Time) int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	n := 0
+	for k, t := range e.active {
+		if t.lastSeen.Before(cutoff) {
+			delete(e.active, k)
+			n++
+		}
+	}
+	return n
+}
+
+// Snapshot projects the live stream as deterministically-ordered Anomaly views,
+// merging catalog copy with instance evidence/lifecycle and degrading
+// capability-gated auto follow-ups to prompts. Ordering: severity (most urgent
+// first), then defKey, then subject — stable for tests and UI.
+func (e *Engine) Snapshot() []Anomaly {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	out := make([]Anomaly, 0, len(e.active))
+	for _, t := range e.active {
+		def, _ := e.catalog.Lookup(t.det.DefKey)
+		out = append(out, Anomaly{
+			DefKey:         def.ID,
+			Category:       def.Category,
+			Severity:       e.effectiveSeverity(t),
+			Subject:        t.det.Subject,
+			Title:          def.Title,
+			Description:    def.Description,
+			Impact:         def.Impact,
+			Recommendation: def.Recommendation,
+			Standards:      def.Standards,
+			Evidence:       t.det.Evidence,
+			FollowUps:      e.projectFollowUps(def.FollowUps),
+			FirstSeen:      t.firstSeen,
+			LastSeen:       t.lastSeen,
+			Count:          t.count,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if ri, rj := out[i].Severity.rank(), out[j].Severity.rank(); ri != rj {
+			return ri > rj // most urgent first
+		}
+		if out[i].DefKey != out[j].DefKey {
+			return out[i].DefKey < out[j].DefKey
+		}
+		return out[i].Subject.ID < out[j].Subject.ID
+	})
+	return out
+}
+
+// projectFollowUps degrades an "auto" follow-up to a prompt when its required
+// capability is not registered, so the guidance is always actionable.
+func (e *Engine) projectFollowUps(fus []FollowUp) []FollowUp {
+	if len(fus) == 0 {
+		return nil
+	}
+	out := make([]FollowUp, 0, len(fus))
+	for _, f := range fus {
+		if f.Kind == FollowUpAuto && f.Capability != "" {
+			if _, ok := e.capabilities[f.Capability]; !ok {
+				f.Kind = FollowUpPrompt
+			}
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// Len is the number of live anomaly instances.
+func (e *Engine) Len() int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return len(e.active)
+}

--- a/internal/anomaly/engine_test.go
+++ b/internal/anomaly/engine_test.go
@@ -1,0 +1,245 @@
+package anomaly_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/anomaly"
+)
+
+func testCatalog(t *testing.T) *anomaly.Catalog {
+	t.Helper()
+	c, err := anomaly.NewCatalog(
+		anomaly.Def{
+			ID: "open-ssid", Category: anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"IEEE 802.11i-2004"},
+			Title:           "Open network", Description: "No encryption.",
+			Impact: "Traffic is cleartext.", Recommendation: "Enable WPA2/WPA3.",
+			FollowUps: []anomaly.FollowUp{
+				{
+					Kind:       anomaly.FollowUpAuto,
+					Label:      "Deauth-response test",
+					Action:     "pmf-probe",
+					Capability: "wifi-active-diag",
+				},
+				{Kind: anomaly.FollowUpAuto, Label: "Always-on check", Action: "recheck"},
+				{Kind: anomaly.FollowUpPrompt, Label: "Move closer", Action: "rescan"},
+			},
+		},
+		anomaly.Def{
+			ID: "co-channel", Category: anomaly.CategoryRF,
+			DefaultSeverity: anomaly.SeverityInfo,
+			Title:           "Co-channel contention", Description: "Many BSSes share a channel.",
+			Recommendation: "Re-plan channels.",
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewCatalog: %v", err)
+	}
+	return c
+}
+
+func bssid(id string) anomaly.SubjectRef {
+	return anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: id}
+}
+
+func TestCatalogValidation(t *testing.T) {
+	good := anomaly.Def{
+		ID: "x", Category: anomaly.CategorySecurity, DefaultSeverity: anomaly.SeverityInfo,
+		Title: "t", Description: "d", Recommendation: "r",
+	}
+	if _, err := anomaly.NewCatalog(good); err != nil {
+		t.Fatalf("valid def rejected: %v", err)
+	}
+
+	mut := func(f func(*anomaly.Def)) []anomaly.Def {
+		d := good
+		f(&d)
+		return []anomaly.Def{d}
+	}
+	cases := map[string][]anomaly.Def{
+		"missing id":    mut(func(d *anomaly.Def) { d.ID = "" }),
+		"missing title": mut(func(d *anomaly.Def) { d.Title = "" }),
+		"missing desc":  mut(func(d *anomaly.Def) { d.Description = "" }),
+		"missing rec":   mut(func(d *anomaly.Def) { d.Recommendation = "" }),
+		"bad category":  mut(func(d *anomaly.Def) { d.Category = "bogus" }),
+		"bad severity":  mut(func(d *anomaly.Def) { d.DefaultSeverity = "huge" }),
+		"bad followup": mut(
+			func(d *anomaly.Def) { d.FollowUps = []anomaly.FollowUp{{Kind: "weird", Label: "x"}} },
+		),
+		"followup no label": mut(func(d *anomaly.Def) {
+			d.FollowUps = []anomaly.FollowUp{{Kind: anomaly.FollowUpPrompt}}
+		}),
+	}
+	for name, defs := range cases {
+		if _, err := anomaly.NewCatalog(defs...); err == nil {
+			t.Errorf("%s: expected error, got nil", name)
+		}
+	}
+
+	if _, err := anomaly.NewCatalog(good, good); err == nil {
+		t.Error("duplicate id: expected error, got nil")
+	}
+}
+
+func TestObserveRejectsUnknownDef(t *testing.T) {
+	e := anomaly.NewEngine(testCatalog(t))
+	err := e.Observe(anomaly.Detection{DefKey: "nope", Subject: bssid("aa")}, time.Unix(0, 0))
+	if err == nil {
+		t.Fatal("expected error for unknown def")
+	}
+	if e.Len() != 0 {
+		t.Errorf("unknown def created an instance: Len=%d", e.Len())
+	}
+}
+
+func TestCoalesceByTypeAndSubject(t *testing.T) {
+	e := anomaly.NewEngine(testCatalog(t))
+	t0 := time.Unix(1000, 0)
+	t1 := time.Unix(2000, 0)
+
+	must(t, e.Observe(anomaly.Detection{DefKey: "open-ssid", Subject: bssid("aa:bb")}, t0))
+	must(t, e.Observe(anomaly.Detection{DefKey: "open-ssid", Subject: bssid("aa:bb")}, t1))
+	// Different subject -> distinct instance.
+	must(t, e.Observe(anomaly.Detection{DefKey: "open-ssid", Subject: bssid("cc:dd")}, t1))
+
+	if e.Len() != 2 {
+		t.Fatalf("Len = %d, want 2 (coalesced + distinct)", e.Len())
+	}
+	snap := e.Snapshot()
+	var coalesced anomaly.Anomaly
+	for _, a := range snap {
+		if a.Subject.ID == "aa:bb" {
+			coalesced = a
+		}
+	}
+	if coalesced.Count != 2 {
+		t.Errorf("count = %d, want 2", coalesced.Count)
+	}
+	if !coalesced.FirstSeen.Equal(t0) {
+		t.Errorf("firstSeen = %v, want %v (earliest preserved)", coalesced.FirstSeen, t0)
+	}
+	if !coalesced.LastSeen.Equal(t1) {
+		t.Errorf("lastSeen = %v, want %v", coalesced.LastSeen, t1)
+	}
+}
+
+func TestSeverityEscalationOnRecurrence(t *testing.T) {
+	e := anomaly.NewEngine(testCatalog(t), anomaly.WithEscalateAfter(3))
+	at := time.Unix(0, 0)
+	det := anomaly.Detection{DefKey: "open-ssid", Subject: bssid("aa")} // base = warning
+	for range 2 {
+		must(t, e.Observe(det, at))
+	}
+	if got := e.Snapshot()[0].Severity; got != anomaly.SeverityWarning {
+		t.Fatalf("before threshold: severity = %q, want warning", got)
+	}
+	must(t, e.Observe(det, at)) // count now 3 == threshold
+	if got := e.Snapshot()[0].Severity; got != anomaly.SeverityCritical {
+		t.Errorf("after threshold: severity = %q, want critical (escalated)", got)
+	}
+}
+
+func TestDetectionSeverityOverride(t *testing.T) {
+	e := anomaly.NewEngine(testCatalog(t))
+	// co-channel default is info; override to warning.
+	must(t, e.Observe(anomaly.Detection{
+		DefKey: "co-channel", Subject: anomaly.SubjectRef{Kind: anomaly.SubjectChannel, ID: "6"},
+		Severity: anomaly.SeverityWarning,
+	}, time.Unix(0, 0)))
+	if got := e.Snapshot()[0].Severity; got != anomaly.SeverityWarning {
+		t.Errorf("severity = %q, want warning (override)", got)
+	}
+
+	badSev := anomaly.Detection{DefKey: "co-channel", Subject: bssid("z"), Severity: "nope"}
+	if err := e.Observe(badSev, time.Unix(0, 0)); err == nil {
+		t.Error("invalid severity override: expected error")
+	}
+}
+
+func TestPruneClearsStale(t *testing.T) {
+	e := anomaly.NewEngine(testCatalog(t))
+	old := time.Unix(100, 0)
+	fresh := time.Unix(10000, 0)
+	must(t, e.Observe(anomaly.Detection{DefKey: "open-ssid", Subject: bssid("old")}, old))
+	must(t, e.Observe(anomaly.Detection{DefKey: "open-ssid", Subject: bssid("fresh")}, fresh))
+
+	cleared := e.Prune(time.Unix(5000, 0))
+	if cleared != 1 {
+		t.Fatalf("Prune cleared %d, want 1", cleared)
+	}
+	snap := e.Snapshot()
+	if len(snap) != 1 || snap[0].Subject.ID != "fresh" {
+		t.Errorf("after prune: %+v, want only 'fresh'", snap)
+	}
+}
+
+func TestSnapshotOrdering(t *testing.T) {
+	e := anomaly.NewEngine(testCatalog(t))
+	at := time.Unix(0, 0)
+	must(
+		t,
+		e.Observe(
+			anomaly.Detection{
+				DefKey:  "co-channel",
+				Subject: anomaly.SubjectRef{Kind: anomaly.SubjectChannel, ID: "11"},
+			},
+			at,
+		),
+	) // info
+	must(
+		t,
+		e.Observe(anomaly.Detection{DefKey: "open-ssid", Subject: bssid("bb")}, at),
+	) // warning
+	must(
+		t,
+		e.Observe(anomaly.Detection{DefKey: "open-ssid", Subject: bssid("aa")}, at),
+	) // warning
+
+	snap := e.Snapshot()
+	// Most urgent first: both warnings before the info; warnings tie-break by subject id.
+	if snap[0].Severity != anomaly.SeverityWarning || snap[0].Subject.ID != "aa" {
+		t.Errorf("snap[0] = %q/%s, want warning/aa", snap[0].Severity, snap[0].Subject.ID)
+	}
+	if snap[1].Subject.ID != "bb" {
+		t.Errorf("snap[1] subject = %s, want bb", snap[1].Subject.ID)
+	}
+	if snap[2].Severity != anomaly.SeverityInfo {
+		t.Errorf("snap[2] severity = %q, want info (least urgent last)", snap[2].Severity)
+	}
+}
+
+func TestFollowUpCapabilityDegradation(t *testing.T) {
+	at := time.Unix(0, 0)
+	det := anomaly.Detection{DefKey: "open-ssid", Subject: bssid("aa")}
+
+	// Without the capability: the gated auto follow-up degrades to a prompt; the
+	// always-on auto stays auto; the prompt stays prompt.
+	e := anomaly.NewEngine(testCatalog(t))
+	must(t, e.Observe(det, at))
+	fus := e.Snapshot()[0].FollowUps
+	if len(fus) != 3 {
+		t.Fatalf("follow-ups = %d, want 3", len(fus))
+	}
+	if fus[0].Kind != anomaly.FollowUpPrompt {
+		t.Errorf("gated auto without capability: kind = %q, want prompt (degraded)", fus[0].Kind)
+	}
+	if fus[1].Kind != anomaly.FollowUpAuto {
+		t.Errorf("ungated auto: kind = %q, want auto", fus[1].Kind)
+	}
+
+	// With the capability registered: the gated auto stays auto.
+	e2 := anomaly.NewEngine(testCatalog(t), anomaly.WithCapabilities("wifi-active-diag"))
+	must(t, e2.Observe(det, at))
+	if got := e2.Snapshot()[0].FollowUps[0].Kind; got != anomaly.FollowUpAuto {
+		t.Errorf("gated auto with capability: kind = %q, want auto", got)
+	}
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## What

First slice of the **W4** anomaly layer (ADR-0011): the general, **source-neutral** `internal/anomaly` engine + catalog framework. No rule source yet — additive foundation (same shipping model as the W1/W2 dormant merge in #1526). The Wi-Fi catalog + rules over the airspace model land next (W4b).

## `internal/anomaly`

- **`Def`** — data-driven catalog entry: `category`, `defaultSeverity`, IEEE `standards[]`, `title`/`description`/`impact`/`recommendation`, and capability-gated `followUps`. Copy authored originally (ADR-0011 — competitor prose is copyrighted); lives as data so it's tunable/reviewable.
- **`Catalog`** — validated, immutable, id-keyed. `NewCatalog` fails fast on duplicate id, missing required field, or unknown category/severity/follow-up kind — a catalog typo can't ship a blank card.
- **`Engine`** — one typed stream (ADR-0011's "not three buckets"):
  - `Observe` coalesces by `(defKey, subject)`, tracks `firstSeen`/`lastSeen`/`count`, **escalates severity on recurrence**, and **rejects detections referencing an undefined def** (a rule can't emit an undefined anomaly).
  - `Prune` clears resolved instances (TTL/clear).
  - `Snapshot` projects a deterministic view (severity desc → defKey → subject) and **degrades capability-gated auto follow-ups to prompts** when the capability isn't registered (ADR-0002), so guidance is always actionable.

## Tests / quality

CGO-free, no I/O, caller-supplied clock → fully unit-tested with **synthetic detections**: catalog validation (8 invalid shapes + dup id), unknown-def rejection, coalesce (count/firstSeen/lastSeen), recurrence escalation, severity override, prune/clear, snapshot ordering, follow-up capability degradation. `golangci-lint` 0 issues. No consumer yet, so no wire/schema/UI change.