### PR TITLE
feat(wifi): anomaly catalog + airspace rules (W4b)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -592,6 +592,14 @@ linters:
       # cohesive table beats near-identical split functions (which dupl flags).
       - path: 'internal/api/server_routes\.go'
         linters: [ funlen ]
+      # Defs() in internal/wifi/anomaly/catalog.go is the Wi-Fi anomaly catalog:
+      # a single declarative table of anomaly definitions (originally-authored
+      # copy + 802.11 citations + recommendation per entry, ADR-0011). Its length
+      # is data, not logic complexity, and it grows by one entry per anomaly type.
+      # Same spirit as the seed-schema table above — keeping it as one cohesive
+      # catalog beats near-identical split functions (which dupl flags).
+      - path: 'internal/wifi/anomaly/catalog\.go'
+        linters: [ funlen ]
       # internal/license/fingerprint.go memoizes the device fingerprint for the
       # process lifetime via sync.OnceValues (a package-level var). This is a
       # required process-singleton: the fingerprint is a stable machine property,

--- a/internal/wifi/anomaly/catalog.go
+++ b/internal/wifi/anomaly/catalog.go
@@ -1,0 +1,229 @@
+package wifianomaly
+
+import "github.com/krisarmstrong/seed/internal/anomaly"
+
+// Exported def IDs are the stable catalog keys. Detections reference these, the
+// API/UI key off them, and tests assert against them — so they live as exported
+// constants rather than string literals scattered through the rules.
+const (
+	DefOpenNetwork            = "wifi-open-network"
+	DefWEPInUse               = "wifi-wep-in-use"
+	DefWPSEnabled             = "wifi-wps-enabled"
+	DefPMFNotRequired         = "wifi-pmf-not-required"
+	DefSecurityMismatch       = "wifi-security-mismatch"
+	DefEvilTwin               = "wifi-evil-twin"
+	DefCoChannelContention    = "wifi-co-channel-contention"
+	DefAdjacentChannelOverlap = "wifi-adjacent-channel-overlap"
+	DefHiddenSSID             = "wifi-hidden-ssid"
+	DefCountryConflict        = "wifi-country-conflict"
+	DefStandardMismatch       = "wifi-standard-mismatch"
+)
+
+// CapActiveTest names the platform capability required to run an active
+// follow-up that transmits frames (e.g. a controlled deauthentication probe to
+// confirm a PMF gap). Where the capture adapter does not register it — most
+// best-effort/monitor-only setups — the engine degrades the follow-up to a
+// guided manual prompt (ADR-0011).
+const CapActiveTest = "wifi_active_test"
+
+// Catalog builds and validates the Wi-Fi anomaly catalog. It fails fast if a
+// definition is malformed, so a typo in the data below cannot ship a blank card.
+func Catalog() (*anomaly.Catalog, error) {
+	return anomaly.NewCatalog(Defs()...)
+}
+
+// Defs returns the Wi-Fi anomaly definitions. The copy is authored originally
+// with 802.11 citations; severities are the catalog defaults (the engine may
+// escalate on recurrence, and a rule may override per detection).
+func Defs() []anomaly.Def {
+	return []anomaly.Def{
+		{
+			ID:              DefOpenNetwork,
+			Category:        anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"IEEE 802.11-2020 §12"},
+			Title:           "Open network (no encryption)",
+			Description: "The BSS advertises no robust security network (no RSN information " +
+				"element) and no privacy, so all traffic is transmitted in the clear and any " +
+				"device in range can join and read it.",
+			Impact: "Anyone within radio range can capture user traffic and associate without " +
+				"credentials. Acceptable only for a deliberately public/guest segment that is " +
+				"isolated from internal resources.",
+			Recommendation: "If this network is not intentionally public, enable WPA2-PSK at " +
+				"minimum and prefer WPA3-SAE. If it is a guest network, confirm it is firewalled " +
+				"off the internal LAN and consider OWE (Enhanced Open) for opportunistic encryption.",
+			FollowUps: []anomaly.FollowUp{{
+				Kind:   anomaly.FollowUpPrompt,
+				Label:  "Confirm intent",
+				Action: "Verify whether this open SSID is an intentional, isolated guest network.",
+			}},
+		},
+		{
+			ID:              DefWEPInUse,
+			Category:        anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityCritical,
+			Standards:       []string{"IEEE 802.11-2016 (WEP deprecated)"},
+			Title:           "WEP encryption in use",
+			Description: "The BSS sets the Privacy bit but advertises no RSN/WPA element, " +
+				"indicating Wired Equivalent Privacy. WEP's RC4 keystream and weak IV scheme " +
+				"are broken; its use was deprecated by 802.11 and the key is recoverable in minutes.",
+			Impact: "An attacker can passively recover the WEP key and decrypt all traffic, then " +
+				"join the network as a trusted device. WEP provides effectively no protection.",
+			Recommendation: "Retire WEP immediately. Reconfigure the AP for WPA2-PSK/802.1X or " +
+				"WPA3 and re-provision clients. If the hardware cannot do WPA2, replace it.",
+		},
+		{
+			ID:              DefWPSEnabled,
+			Category:        anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"Wi-Fi Simple Configuration (WPS)"},
+			Title:           "WPS enabled",
+			Description: "The BSS advertises Wi-Fi Protected Setup. The WPS external-registrar PIN " +
+				"is vulnerable to online brute force and to offline Pixie-Dust recovery of weak " +
+				"nonces, either of which yields the PSK regardless of its strength.",
+			Impact: "An attacker can recover the WPA passphrase by attacking WPS rather than the " +
+				"passphrase itself, bypassing an otherwise strong key.",
+			Recommendation: "Disable WPS on the AP. Provision clients with the passphrase or " +
+				"802.1X instead of the WPS PIN/push-button flow.",
+		},
+		{
+			ID:              DefPMFNotRequired,
+			Category:        anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"IEEE 802.11w-2009", "IEEE 802.11-2020 §12.2.7"},
+			Title:           "Protected Management Frames not required",
+			Description: "The BSS runs an RSN security suite but does not require Protected " +
+				"Management Frames (802.11w / MFPR=0), so deauthentication and disassociation " +
+				"management frames remain unauthenticated.",
+			Impact: "Forged deauth/disassoc frames can knock clients off the network, enabling " +
+				"denial of service and the disconnect step that evil-twin and handshake-capture " +
+				"attacks rely on.",
+			Recommendation: "Require PMF (MFPR=1) on the SSID. WPA3 mandates it; for WPA2 enable " +
+				"the 802.11w 'required' (not merely 'capable') setting once clients support it.",
+			FollowUps: []anomaly.FollowUp{{
+				Kind:       anomaly.FollowUpAuto,
+				Label:      "Deauth-response test",
+				Action:     "Transmit a spoofed deauthentication and observe whether associated clients drop.",
+				Capability: CapActiveTest,
+			}},
+		},
+		{
+			ID:              DefSecurityMismatch,
+			Category:        anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"IEEE 802.11i", "IEEE 802.11-2020 §12"},
+			Title:           "Inconsistent security across an SSID",
+			Description: "BSSes advertising the same SSID offer materially different security " +
+				"suites — at least one strong (WPA2/WPA3) and at least one weak (Open/WEP/WPA). " +
+				"A client may silently associate to the weakest radio, and the disparity can " +
+				"signal a rogue impersonator advertising a downgraded variant.",
+			Impact: "Users believe they are on the protected network while their device joins the " +
+				"weak BSS, exposing traffic and credentials to interception or to an attacker's AP.",
+			Recommendation: "Make the security configuration identical across every AP serving the " +
+				"SSID. If a weak BSS is not yours, treat it as a rogue/evil-twin and locate it.",
+			FollowUps: []anomaly.FollowUp{{
+				Kind:   anomaly.FollowUpPrompt,
+				Label:  "Audit AP configs",
+				Action: "Compare the security suite on every sanctioned AP advertising this SSID.",
+			}},
+		},
+		{
+			ID:              DefEvilTwin,
+			Category:        anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"IEEE 802.11 (BSSID/SSID semantics)"},
+			Title:           "Possible evil twin (vendor mismatch)",
+			Description: "One SSID is served by access points whose BSSIDs resolve to different " +
+				"hardware vendors (OUIs). A homogeneous enterprise WLAN is normally single-vendor; " +
+				"an outlier vendor advertising the same network name is a classic evil-twin / " +
+				"honeypot signature.",
+			Impact: "Clients may associate to an attacker-controlled AP impersonating the trusted " +
+				"SSID, exposing them to interception, captive-portal credential theft, and " +
+				"on-path attacks.",
+			Recommendation: "Verify every BSSID/vendor advertising this SSID against your sanctioned " +
+				"AP inventory. Investigate and physically locate any AP you do not recognize.",
+			FollowUps: []anomaly.FollowUp{{
+				Kind:   anomaly.FollowUpPrompt,
+				Label:  "Verify inventory",
+				Action: "Cross-check the BSSIDs and vendors for this SSID against the AP allowlist.",
+			}},
+		},
+		{
+			ID:              DefCoChannelContention,
+			Category:        anomaly.CategoryRF,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"IEEE 802.11 (CSMA/CA, DCF)"},
+			Title:           "Co-channel contention",
+			Description: "Several BSSes share one channel in the same band. Because 802.11 uses " +
+				"CSMA/CA, every radio on a channel contends for the same airtime and must defer " +
+				"to the others, so capacity is divided rather than added.",
+			Impact: "Throughput drops and latency/jitter rise for all networks on the channel as " +
+				"the count of co-channel radios grows — the dominant cause of poor Wi-Fi in dense " +
+				"deployments.",
+			Recommendation: "Re-plan channel assignments to spread APs across non-overlapping " +
+				"channels, reduce transmit power to shrink cells, or move capacity to 5/6 GHz.",
+		},
+		{
+			ID:              DefAdjacentChannelOverlap,
+			Category:        anomaly.CategoryRF,
+			DefaultSeverity: anomaly.SeverityInfo,
+			Standards:       []string{"IEEE 802.11 (2.4 GHz channel plan)"},
+			Title:           "Adjacent-channel overlap (2.4 GHz)",
+			Description: "A 2.4 GHz BSS operates on a channel other than 1, 6, or 11. In the " +
+				"2.4 GHz band a 20 MHz channel overlaps its neighbours, so any channel off the " +
+				"1/6/11 plan partially overlaps two non-overlapping channels at once.",
+			Impact: "Overlapping energy is treated as noise rather than decodable traffic, raising " +
+				"the noise floor and retransmissions for every nearby network — worse than clean " +
+				"co-channel sharing.",
+			Recommendation: "Move 2.4 GHz radios onto channels 1, 6, or 11 only, and avoid 40 MHz " +
+				"width in 2.4 GHz.",
+		},
+		{
+			ID:              DefHiddenSSID,
+			Category:        anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityInfo,
+			Standards:       []string{"IEEE 802.11 (SSID element)"},
+			Title:           "Hidden (cloaked) SSID",
+			Description: "The BSS beacons with a null/zero-length SSID. SSID cloaking is security " +
+				"through obscurity: the network name is still revealed in probe and association " +
+				"frames whenever a client connects, and it is trivially recovered by passive " +
+				"observation.",
+			Impact: "Cloaking provides no real protection while it forces clients to actively probe " +
+				"for the network — which leaks the SSID from the client side and can degrade " +
+				"battery life and roaming.",
+			Recommendation: "Do not rely on hiding the SSID for security. Broadcast the SSID and " +
+				"protect the network with WPA2/WPA3 and PMF instead.",
+		},
+		{
+			ID:              DefCountryConflict,
+			Category:        anomaly.CategoryStandards,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"IEEE 802.11d", "IEEE 802.11-2020 (Country element)"},
+			Title:           "Conflicting regulatory domain",
+			Description: "Access points in the same airspace advertise different 802.11d country " +
+				"codes. Co-located APs should agree on the regulatory domain; a disagreement " +
+				"indicates a misconfigured AP or one spoofing a different domain to use channels " +
+				"or power levels that are not permitted locally.",
+			Impact: "Clients honouring the wrong country element may use illegal channels or " +
+				"transmit power, causing interference and potential regulatory violation; a " +
+				"spoofed domain can also be a rogue-AP indicator.",
+			Recommendation: "Set the correct, identical country/regulatory domain on every AP. " +
+				"Investigate any AP advertising an unexpected country code.",
+		},
+		{
+			ID:              DefStandardMismatch,
+			Category:        anomaly.CategoryStandards,
+			DefaultSeverity: anomaly.SeverityInfo,
+			Standards:       []string{"IEEE 802.11n/ac/ax/be"},
+			Title:           "Mixed 802.11 generations across an SSID",
+			Description: "BSSes advertising the same SSID support different 802.11 generations " +
+				"(e.g. one 802.11n radio alongside an 802.11ax radio). Clients that land on the " +
+				"older radio get lower rates and fewer efficiency features (OFDMA, MU-MIMO).",
+			Impact: "Inconsistent performance and roaming across the WLAN; the slowest radios can " +
+				"also pull down airtime efficiency for the whole cell via protection mechanisms.",
+			Recommendation: "Standardise AP hardware/firmware where practical, or confirm the " +
+				"mixed generations are intentional and the older radios are scoped to legacy " +
+				"clients only.",
+		},
+	}
+}

--- a/internal/wifi/anomaly/detect.go
+++ b/internal/wifi/anomaly/detect.go
@@ -1,0 +1,272 @@
+package wifianomaly
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/krisarmstrong/seed/internal/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+)
+
+// defaultCoChannelThreshold is the number of BSSes sharing one channel at or
+// above which co-channel contention is reported. Four+ radios on a channel is
+// where CSMA/CA airtime division becomes a practical problem.
+const defaultCoChannelThreshold = 4
+
+// minCoChannelThreshold is the floor for a configured co-channel threshold (a
+// single radio cannot contend with itself).
+const minCoChannelThreshold = 2
+
+// minDistinctForMismatch is the number of distinct values (vendors, standards)
+// across one SSID that constitutes a mismatch.
+const minDistinctForMismatch = 2
+
+// Detector evaluates the airspace tree against the Wi-Fi rule set and returns
+// the detections to feed an [anomaly.Engine]. It is stateless apart from its
+// tuning thresholds; the engine owns coalescing, escalation, and ageing.
+type Detector struct {
+	coChannelThreshold int
+}
+
+// Option tunes a Detector.
+type Option func(*Detector)
+
+// WithCoChannelThreshold sets the co-channel-contention reporting threshold
+// (BSSes per channel). Values below 2 are clamped to 2.
+func WithCoChannelThreshold(n int) Option {
+	return func(d *Detector) {
+		if n < minCoChannelThreshold {
+			n = minCoChannelThreshold
+		}
+		d.coChannelThreshold = n
+	}
+}
+
+// NewDetector returns a Detector with the given options applied.
+func NewDetector(opts ...Option) *Detector {
+	d := &Detector{coChannelThreshold: defaultCoChannelThreshold}
+	for _, o := range opts {
+		o(d)
+	}
+	return d
+}
+
+// Detect runs every Wi-Fi rule over the airspace tree and returns the resulting
+// detections in a deterministic order (by def, then subject), so identical input
+// yields identical output. The engine, not Detect, decides severity escalation
+// and deduplication.
+func (d *Detector) Detect(tree []airspace.SSIDGroup) []anomaly.Detection {
+	var out []anomaly.Detection
+	out = append(out, perBSSDetections(tree)...)
+	out = append(out, ssidGroupDetections(tree)...)
+	out = append(out, d.coChannelDetections(tree)...)
+	out = append(out, countryConflictDetections(tree)...)
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].DefKey != out[j].DefKey {
+			return out[i].DefKey < out[j].DefKey
+		}
+		if out[i].Subject.Kind != out[j].Subject.Kind {
+			return out[i].Subject.Kind < out[j].Subject.Kind
+		}
+		return out[i].Subject.ID < out[j].Subject.ID
+	})
+	return out
+}
+
+// forEachBSS visits every BSS in the tree with its AP and SSID-group context.
+func forEachBSS(tree []airspace.SSIDGroup, fn func(g airspace.SSIDGroup, ap airspace.APGroup, b airspace.BSSView)) {
+	for _, g := range tree {
+		for _, ap := range g.APs {
+			for _, b := range ap.BSSes {
+				fn(g, ap, b)
+			}
+		}
+	}
+}
+
+// perBSSDetections runs the rules that judge a single BSS in isolation:
+// open/WEP/WPS, PMF-not-required, adjacent-channel overlap, and hidden SSID.
+func perBSSDetections(tree []airspace.SSIDGroup) []anomaly.Detection {
+	var out []anomaly.Detection
+	forEachBSS(tree, func(_ airspace.SSIDGroup, _ airspace.APGroup, b airspace.BSSView) {
+		subject := anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: b.BSSID}
+		ev := bssEvidence(b)
+
+		switch b.Security {
+		case secOpen:
+			out = append(out, anomaly.Detection{DefKey: DefOpenNetwork, Subject: subject, Evidence: ev})
+		case secWEP:
+			out = append(out, anomaly.Detection{DefKey: DefWEPInUse, Subject: subject, Evidence: ev})
+		}
+
+		if b.WPSEnabled {
+			out = append(out, anomaly.Detection{DefKey: DefWPSEnabled, Subject: subject, Evidence: ev})
+		}
+
+		// PMF (802.11w) is only defined for RSN suites; flag an RSN BSS that
+		// does not require it. Open/WEP/legacy-WPA carry no RSN, so PMF does
+		// not apply and must not be reported.
+		if securityTier(b.Security) == tierStrong && !b.PMFRequired {
+			out = append(out, anomaly.Detection{DefKey: DefPMFNotRequired, Subject: subject, Evidence: ev})
+		}
+
+		if b.Band == band24GHz && b.Channel != 0 && !is24NonOverlapping(b.Channel) {
+			out = append(out, anomaly.Detection{DefKey: DefAdjacentChannelOverlap, Subject: subject, Evidence: ev})
+		}
+
+		if b.Hidden {
+			out = append(out, anomaly.Detection{DefKey: DefHiddenSSID, Subject: subject, Evidence: ev})
+		}
+	})
+	return out
+}
+
+// ssidGroupDetections runs the rules that compare BSSes advertising the same
+// SSID: security mismatch, evil-twin (vendor mismatch), and standard mismatch.
+// The cloaked/empty-SSID bucket is skipped — its members are unrelated networks
+// grouped only by their absent name, so cross-BSS comparison there is meaningless.
+func ssidGroupDetections(tree []airspace.SSIDGroup) []anomaly.Detection {
+	var out []anomaly.Detection
+	for _, g := range tree {
+		if g.SSID == "" {
+			continue
+		}
+		subject := anomaly.SubjectRef{Kind: anomaly.SubjectSSID, ID: g.SSID}
+		facts := collectSSIDFacts(g)
+		securities, standards, vendors := facts.securities, facts.standards, facts.vendors
+
+		if hasWeakAndStrong(securities) {
+			out = append(out, anomaly.Detection{
+				DefKey: DefSecurityMismatch, Subject: subject,
+				Evidence: map[string]string{"securities": strings.Join(securities.sorted(), ", ")},
+			})
+		}
+		if vendors.len() >= minDistinctForMismatch {
+			out = append(out, anomaly.Detection{
+				DefKey: DefEvilTwin, Subject: subject,
+				Evidence: map[string]string{"vendors": strings.Join(vendors.sorted(), ", ")},
+			})
+		}
+		if standards.len() >= minDistinctForMismatch {
+			out = append(out, anomaly.Detection{
+				DefKey: DefStandardMismatch, Subject: subject,
+				Evidence: map[string]string{"standards": strings.Join(standards.sorted(), ", ")},
+			})
+		}
+	}
+	return out
+}
+
+// ssidFacts holds the distinct values advertised under one SSID group that the
+// cross-BSS rules compare.
+type ssidFacts struct {
+	securities *stringSet
+	standards  *stringSet
+	vendors    *stringSet
+}
+
+// collectSSIDFacts gathers the distinct classified security suites, known
+// 802.11 standards, and AP vendors advertised under one SSID group.
+func collectSSIDFacts(g airspace.SSIDGroup) ssidFacts {
+	f := ssidFacts{securities: newStringSet(), standards: newStringSet(), vendors: newStringSet()}
+	for _, ap := range g.APs {
+		if ap.Vendor != "" {
+			f.vendors.add(ap.Vendor)
+		}
+		for _, b := range ap.BSSes {
+			if t := securityTier(b.Security); t == tierWeak || t == tierStrong {
+				f.securities.add(b.Security)
+			}
+			if b.Standard != "" && b.Standard != stdUnknown {
+				f.standards.add(b.Standard)
+			}
+		}
+	}
+	return f
+}
+
+// coChannelDetections aggregates BSSes by (band, channel) across the whole
+// airspace and reports each channel carrying at least the threshold count.
+func (d *Detector) coChannelDetections(tree []airspace.SSIDGroup) []anomaly.Detection {
+	byChannel := map[string][]string{} // "band ch N" -> bssids
+	order := []string{}
+	forEachBSS(tree, func(_ airspace.SSIDGroup, _ airspace.APGroup, b airspace.BSSView) {
+		if b.Channel == 0 || b.Band == "" || b.Band == bandUnknown {
+			return
+		}
+		key := fmt.Sprintf("%s ch %d", b.Band, b.Channel)
+		if _, ok := byChannel[key]; !ok {
+			order = append(order, key)
+		}
+		byChannel[key] = append(byChannel[key], b.BSSID)
+	})
+
+	var out []anomaly.Detection
+	for _, key := range order {
+		bssids := byChannel[key]
+		if len(bssids) < d.coChannelThreshold {
+			continue
+		}
+		sort.Strings(bssids)
+		out = append(out, anomaly.Detection{
+			DefKey:  DefCoChannelContention,
+			Subject: anomaly.SubjectRef{Kind: anomaly.SubjectChannel, ID: key},
+			Evidence: map[string]string{
+				"count":  strconv.Itoa(len(bssids)),
+				"bssids": strings.Join(bssids, ", "),
+			},
+		})
+	}
+	return out
+}
+
+// countryConflictDetections reports an 802.11d regulatory-domain disagreement:
+// when more than one country code is advertised in the airspace, every BSS whose
+// country differs from the reference domain is flagged. The reference is the
+// lexicographically smallest code seen, chosen for determinism.
+func countryConflictDetections(tree []airspace.SSIDGroup) []anomaly.Detection {
+	countries := newStringSet()
+	forEachBSS(tree, func(_ airspace.SSIDGroup, _ airspace.APGroup, b airspace.BSSView) {
+		if b.CountryCode != "" {
+			countries.add(b.CountryCode)
+		}
+	})
+	if countries.len() < minDistinctForMismatch {
+		return nil
+	}
+	reference := countries.sorted()[0]
+
+	var out []anomaly.Detection
+	forEachBSS(tree, func(_ airspace.SSIDGroup, _ airspace.APGroup, b airspace.BSSView) {
+		if b.CountryCode == "" || b.CountryCode == reference {
+			return
+		}
+		out = append(out, anomaly.Detection{
+			DefKey:  DefCountryConflict,
+			Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: b.BSSID},
+			Evidence: map[string]string{
+				"countryCode":     b.CountryCode,
+				"referenceDomain": reference,
+				"domainsSeen":     strings.Join(countries.sorted(), ", "),
+			},
+		})
+	})
+	return out
+}
+
+// bssEvidence captures the live values a per-BSS detection should carry.
+func bssEvidence(b airspace.BSSView) map[string]string {
+	ev := map[string]string{
+		"ssid":     b.SSID,
+		"security": b.Security,
+		"band":     b.Band,
+		"channel":  strconv.Itoa(b.Channel),
+	}
+	if b.SSID == "" {
+		ev["ssid"] = "(hidden)"
+	}
+	return ev
+}

--- a/internal/wifi/anomaly/detect_test.go
+++ b/internal/wifi/anomaly/detect_test.go
@@ -1,0 +1,503 @@
+package wifianomaly_test
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/dot11"
+)
+
+// bss is a terse builder for an airspace.BSSView in tests.
+func bss(bssid, ssid, security, band string, channel int) airspace.BSSView {
+	return airspace.BSSView{
+		BSSID:    bssid,
+		SSID:     ssid,
+		Security: security,
+		Band:     band,
+		Channel:  channel,
+		Standard: "802.11ac (Wi-Fi 5)",
+	}
+}
+
+// bssStd builds a clean WPA2/PMF BSS on a given 802.11 standard, for the
+// standard-mismatch test.
+func bssStd(bssid, ssid, std string, ch int) airspace.BSSView {
+	b := bss(bssid, ssid, "WPA2", "5 GHz", ch)
+	b.Standard = std
+	b.PMFRequired = true
+	return b
+}
+
+// tree wraps a single SSID served by one AP (one vendor) holding the given BSSes.
+func tree(ssid string, bsses ...airspace.BSSView) []airspace.SSIDGroup {
+	return []airspace.SSIDGroup{{
+		SSID:    ssid,
+		APCount: 1,
+		APs:     []airspace.APGroup{{Key: "ap1", Vendor: "Cisco", BSSes: bsses}},
+	}}
+}
+
+// defKeys returns the sorted set of def keys present in the detections.
+func defKeys(dets []anomaly.Detection) []string {
+	seen := map[string]bool{}
+	for _, d := range dets {
+		seen[d.DefKey] = true
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func hasDef(dets []anomaly.Detection, id string) bool {
+	for _, d := range dets {
+		if d.DefKey == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCatalogBuildsAndCoversEveryDefID(t *testing.T) {
+	cat, err := wifianomaly.Catalog()
+	if err != nil {
+		t.Fatalf("Catalog() error: %v", err)
+	}
+	ids := []string{
+		wifianomaly.DefOpenNetwork,
+		wifianomaly.DefWEPInUse,
+		wifianomaly.DefWPSEnabled,
+		wifianomaly.DefPMFNotRequired,
+		wifianomaly.DefSecurityMismatch,
+		wifianomaly.DefEvilTwin,
+		wifianomaly.DefCoChannelContention,
+		wifianomaly.DefAdjacentChannelOverlap,
+		wifianomaly.DefHiddenSSID,
+		wifianomaly.DefCountryConflict,
+		wifianomaly.DefStandardMismatch,
+	}
+	if cat.Len() != len(ids) {
+		t.Errorf("catalog Len = %d, want %d (every exported def ID, no extras)", cat.Len(), len(ids))
+	}
+	for _, id := range ids {
+		if _, ok := cat.Lookup(id); !ok {
+			t.Errorf("catalog missing def %q", id)
+		}
+	}
+}
+
+// TestDetectionsAreAllCatalogued proves every rule emits only catalogued defs:
+// feeding all detections through the real engine must never error.
+func TestDetectionsAreAllCatalogued(t *testing.T) {
+	cat, err := wifianomaly.Catalog()
+	if err != nil {
+		t.Fatalf("Catalog(): %v", err)
+	}
+	eng := anomaly.NewEngine(cat)
+	dets := wifianomaly.NewDetector().Detect(everyAnomalyTree())
+	if len(dets) == 0 {
+		t.Fatal("expected detections from the kitchen-sink tree, got none")
+	}
+	now := time.Now()
+	for _, d := range dets {
+		if obsErr := eng.Observe(d, now); obsErr != nil {
+			t.Errorf("engine rejected detection %+v: %v", d, obsErr)
+		}
+	}
+}
+
+// everyAnomalyTree is a synthetic airspace engineered to trip every rule.
+func everyAnomalyTree() []airspace.SSIDGroup {
+	return []airspace.SSIDGroup{
+		// SSID with a strong + weak BSS (security-mismatch) served by two
+		// different vendors (evil-twin) on different standards (standard-mismatch).
+		{
+			SSID:    "corp",
+			APCount: 2,
+			APs: []airspace.APGroup{
+				{Key: "a", Vendor: "Cisco", BSSes: []airspace.BSSView{{
+					BSSID: "00:11:22:00:00:01", SSID: "corp", Security: "WPA2",
+					Band: "2.4 GHz", Channel: 6, Standard: "802.11ax (Wi-Fi 6)",
+					CountryCode: "US",
+				}}},
+				{Key: "b", Vendor: "Netgear", BSSes: []airspace.BSSView{{
+					BSSID: "aa:bb:cc:00:00:02", SSID: "corp", Security: "Open",
+					Band: "2.4 GHz", Channel: 3, Standard: "802.11n (Wi-Fi 4)",
+					CountryCode: "DE",
+				}}},
+			},
+		},
+		// A WEP BSS, a WPS BSS, an RSN-without-PMF BSS, a hidden BSS — and four
+		// BSSes packed onto 2.4 GHz channel 6 (co-channel-contention).
+		{
+			SSID:    "lab",
+			APCount: 1,
+			APs: []airspace.APGroup{{Key: "c", Vendor: "Aruba", BSSes: []airspace.BSSView{
+				{
+					BSSID:      "00:00:00:00:00:10",
+					SSID:       "lab",
+					Security:   "WEP",
+					Band:       "2.4 GHz",
+					Channel:    6,
+					Standard:   "802.11g",
+					WPSEnabled: true,
+				},
+				{
+					BSSID:       "00:00:00:00:00:11",
+					SSID:        "lab",
+					Security:    "WPA2",
+					Band:        "2.4 GHz",
+					Channel:     6,
+					Standard:    "802.11ac (Wi-Fi 5)",
+					PMFRequired: false,
+				},
+				{
+					BSSID:       "00:00:00:00:00:12",
+					SSID:        "lab",
+					Security:    "WPA3",
+					Band:        "2.4 GHz",
+					Channel:     6,
+					Standard:    "802.11ax (Wi-Fi 6)",
+					PMFRequired: true,
+				},
+				{
+					BSSID:       "00:00:00:00:00:13",
+					SSID:        "lab",
+					Security:    "WPA2",
+					Band:        "2.4 GHz",
+					Channel:     6,
+					Standard:    "802.11ac (Wi-Fi 5)",
+					PMFRequired: true,
+				},
+			}}},
+		},
+		// A cloaked SSID (hidden).
+		{
+			SSID:   "",
+			Hidden: true,
+			APs: []airspace.APGroup{{Key: "d", Vendor: "Ubiquiti", BSSes: []airspace.BSSView{
+				{
+					BSSID:       "00:00:00:00:00:20",
+					SSID:        "",
+					Hidden:      true,
+					Security:    "WPA2",
+					Band:        "5 GHz",
+					Channel:     36,
+					Standard:    "802.11ac (Wi-Fi 5)",
+					PMFRequired: true,
+				},
+			}}},
+		},
+	}
+}
+
+func TestOpenAndWEPAndWPS(t *testing.T) {
+	det := wifianomaly.NewDetector()
+
+	open := det.Detect(tree("guest", bss("00:00:00:00:00:01", "guest", "Open", "5 GHz", 36)))
+	if !hasDef(open, wifianomaly.DefOpenNetwork) {
+		t.Errorf("open network not detected: %v", defKeys(open))
+	}
+
+	wep := det.Detect(tree("legacy", bss("00:00:00:00:00:02", "legacy", "WEP", "2.4 GHz", 6)))
+	if !hasDef(wep, wifianomaly.DefWEPInUse) {
+		t.Errorf("WEP not detected: %v", defKeys(wep))
+	}
+
+	b := bss("00:00:00:00:00:03", "home", "WPA2", "5 GHz", 36)
+	b.WPSEnabled = true
+	b.PMFRequired = true
+	wps := det.Detect(tree("home", b))
+	if !hasDef(wps, wifianomaly.DefWPSEnabled) {
+		t.Errorf("WPS not detected: %v", defKeys(wps))
+	}
+}
+
+func TestPMFNotRequiredOnlyForRSN(t *testing.T) {
+	det := wifianomaly.NewDetector()
+
+	// WPA2 without PMF → flagged.
+	weak := bss("00:00:00:00:00:01", "corp", "WPA2", "5 GHz", 36)
+	weak.PMFRequired = false
+	if !hasDef(det.Detect(tree("corp", weak)), wifianomaly.DefPMFNotRequired) {
+		t.Error("WPA2 without PMF should be flagged")
+	}
+
+	// Open network is not RSN — PMF is undefined, must NOT be flagged.
+	if hasDef(
+		det.Detect(tree("guest", bss("00:00:00:00:00:02", "guest", "Open", "5 GHz", 36))),
+		wifianomaly.DefPMFNotRequired,
+	) {
+		t.Error("Open network must not raise pmf-not-required")
+	}
+
+	// WPA2 with PMF → clean.
+	ok := bss("00:00:00:00:00:03", "corp", "WPA2", "5 GHz", 36)
+	ok.PMFRequired = true
+	if hasDef(det.Detect(tree("corp", ok)), wifianomaly.DefPMFNotRequired) {
+		t.Error("WPA2 with PMF required must be clean")
+	}
+}
+
+func TestSecurityMismatchAcrossSSID(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	mixed := tree("corp",
+		bss("00:00:00:00:00:01", "corp", "WPA2", "5 GHz", 36),
+		bss("00:00:00:00:00:02", "corp", "Open", "5 GHz", 40),
+	)
+	if !hasDef(det.Detect(mixed), wifianomaly.DefSecurityMismatch) {
+		t.Error("WPA2 + Open under one SSID should be a security-mismatch")
+	}
+
+	// Consistent strong security → no mismatch.
+	consistent := tree("corp",
+		bss("00:00:00:00:00:03", "corp", "WPA2", "5 GHz", 36),
+		bss("00:00:00:00:00:04", "corp", "WPA2/WPA3", "5 GHz", 40),
+	)
+	if hasDef(det.Detect(consistent), wifianomaly.DefSecurityMismatch) {
+		t.Error("WPA2 + WPA2/WPA3 are both strong; not a mismatch")
+	}
+}
+
+func TestEvilTwinVendorMismatch(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	twin := []airspace.SSIDGroup{{
+		SSID:    "corp",
+		APCount: 2,
+		APs: []airspace.APGroup{
+			{
+				Key:    "a",
+				Vendor: "Cisco",
+				BSSes:  []airspace.BSSView{bss("00:00:00:00:00:01", "corp", "WPA2", "5 GHz", 36)},
+			},
+			{
+				Key:    "b",
+				Vendor: "TP-Link",
+				BSSes:  []airspace.BSSView{bss("de:ad:be:00:00:02", "corp", "WPA2", "5 GHz", 40)},
+			},
+		},
+	}}
+	if !hasDef(det.Detect(twin), wifianomaly.DefEvilTwin) {
+		t.Error("same SSID via two vendors should raise evil-twin")
+	}
+
+	// Single vendor across both APs → no evil-twin.
+	same := []airspace.SSIDGroup{{
+		SSID:    "corp",
+		APCount: 2,
+		APs: []airspace.APGroup{
+			{
+				Key:    "a",
+				Vendor: "Cisco",
+				BSSes:  []airspace.BSSView{bss("00:00:00:00:00:01", "corp", "WPA2", "5 GHz", 36)},
+			},
+			{
+				Key:    "b",
+				Vendor: "Cisco",
+				BSSes:  []airspace.BSSView{bss("00:00:00:00:00:02", "corp", "WPA2", "5 GHz", 40)},
+			},
+		},
+	}}
+	if hasDef(det.Detect(same), wifianomaly.DefEvilTwin) {
+		t.Error("one vendor is a normal multi-AP WLAN, not evil-twin")
+	}
+}
+
+func TestCoChannelContentionThreshold(t *testing.T) {
+	mk := func(n int) []airspace.SSIDGroup {
+		bsses := make([]airspace.BSSView, n)
+		for i := range bsses {
+			bsses[i] = bss("00:00:00:00:00:0"+string(rune('a'+i)), "n", "WPA2", "2.4 GHz", 6)
+			bsses[i].PMFRequired = true
+		}
+		return tree("n", bsses...)
+	}
+	det := wifianomaly.NewDetector(wifianomaly.WithCoChannelThreshold(3))
+	if hasDef(det.Detect(mk(2)), wifianomaly.DefCoChannelContention) {
+		t.Error("2 BSSes is below threshold 3")
+	}
+	if !hasDef(det.Detect(mk(3)), wifianomaly.DefCoChannelContention) {
+		t.Error("3 BSSes meets threshold 3")
+	}
+}
+
+func TestAdjacentChannelOverlap(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	for _, ch := range []int{2, 3, 4, 5, 7, 9} {
+		b := bss("00:00:00:00:00:01", "n", "WPA2", "2.4 GHz", ch)
+		b.PMFRequired = true
+		if !hasDef(det.Detect(tree("n", b)), wifianomaly.DefAdjacentChannelOverlap) {
+			t.Errorf("2.4 GHz channel %d should overlap (not 1/6/11)", ch)
+		}
+	}
+	for _, ch := range []int{1, 6, 11} {
+		b := bss("00:00:00:00:00:01", "n", "WPA2", "2.4 GHz", ch)
+		b.PMFRequired = true
+		if hasDef(det.Detect(tree("n", b)), wifianomaly.DefAdjacentChannelOverlap) {
+			t.Errorf("2.4 GHz channel %d is non-overlapping", ch)
+		}
+	}
+	// 5 GHz is exempt (all channels non-overlapping at 20 MHz).
+	b := bss("00:00:00:00:00:01", "n", "WPA2", "5 GHz", 44)
+	b.PMFRequired = true
+	if hasDef(det.Detect(tree("n", b)), wifianomaly.DefAdjacentChannelOverlap) {
+		t.Error("5 GHz must not raise adjacent-channel-overlap")
+	}
+}
+
+func TestHiddenSSID(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	b := airspace.BSSView{
+		BSSID:       "00:00:00:00:00:01",
+		SSID:        "",
+		Hidden:      true,
+		Security:    "WPA2",
+		Band:        "5 GHz",
+		Channel:     36,
+		Standard:    "802.11ac (Wi-Fi 5)",
+		PMFRequired: true,
+	}
+	hidden := []airspace.SSIDGroup{
+		{SSID: "", Hidden: true, APs: []airspace.APGroup{{Key: "a", Vendor: "Cisco", BSSes: []airspace.BSSView{b}}}},
+	}
+	if !hasDef(det.Detect(hidden), wifianomaly.DefHiddenSSID) {
+		t.Error("cloaked BSS should raise hidden-ssid")
+	}
+}
+
+func TestCountryConflict(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	conflict := []airspace.SSIDGroup{
+		{SSID: "a", APCount: 1, APs: []airspace.APGroup{{Key: "a", Vendor: "Cisco", BSSes: []airspace.BSSView{
+			{
+				BSSID:       "00:00:00:00:00:01",
+				SSID:        "a",
+				Security:    "WPA2",
+				Band:        "5 GHz",
+				Channel:     36,
+				Standard:    "802.11ac (Wi-Fi 5)",
+				CountryCode: "US",
+				PMFRequired: true,
+			},
+		}}}},
+		{SSID: "b", APCount: 1, APs: []airspace.APGroup{{Key: "b", Vendor: "Cisco", BSSes: []airspace.BSSView{
+			{
+				BSSID:       "00:00:00:00:00:02",
+				SSID:        "b",
+				Security:    "WPA2",
+				Band:        "5 GHz",
+				Channel:     40,
+				Standard:    "802.11ac (Wi-Fi 5)",
+				CountryCode: "JP",
+				PMFRequired: true,
+			},
+		}}}},
+	}
+	if !hasDef(det.Detect(conflict), wifianomaly.DefCountryConflict) {
+		t.Error("two regulatory domains in one airspace should raise country-conflict")
+	}
+
+	// Single consistent country → clean.
+	same := []airspace.SSIDGroup{
+		{SSID: "a", APCount: 1, APs: []airspace.APGroup{{Key: "a", Vendor: "Cisco", BSSes: []airspace.BSSView{
+			{
+				BSSID:       "00:00:00:00:00:01",
+				SSID:        "a",
+				Security:    "WPA2",
+				Band:        "5 GHz",
+				Channel:     36,
+				Standard:    "802.11ac (Wi-Fi 5)",
+				CountryCode: "US",
+				PMFRequired: true,
+			},
+		}}}},
+	}
+	if hasDef(det.Detect(same), wifianomaly.DefCountryConflict) {
+		t.Error("one country is not a conflict")
+	}
+}
+
+func TestStandardMismatch(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	mixed := tree("corp",
+		bssStd("00:00:00:00:00:01", "corp", "802.11n (Wi-Fi 4)", 36),
+		bssStd("00:00:00:00:00:02", "corp", "802.11ax (Wi-Fi 6)", 40),
+	)
+	if !hasDef(det.Detect(mixed), wifianomaly.DefStandardMismatch) {
+		t.Error("mixed 802.11 generations under one SSID should raise standard-mismatch")
+	}
+}
+
+func TestCleanAirspaceHasNoAnomalies(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	clean := []airspace.SSIDGroup{{
+		SSID:    "corp",
+		APCount: 1,
+		APs: []airspace.APGroup{{Key: "a", Vendor: "Cisco", BSSes: []airspace.BSSView{
+			{
+				BSSID:       "00:00:00:00:00:01",
+				SSID:        "corp",
+				Security:    "WPA3",
+				Band:        "5 GHz",
+				Channel:     36,
+				Standard:    "802.11ax (Wi-Fi 6)",
+				CountryCode: "US",
+				PMFRequired: true,
+			},
+			{
+				BSSID:       "00:00:00:00:00:02",
+				SSID:        "corp",
+				Security:    "WPA3",
+				Band:        "5 GHz",
+				Channel:     149,
+				Standard:    "802.11ax (Wi-Fi 6)",
+				CountryCode: "US",
+				PMFRequired: true,
+			},
+		}}},
+	}}
+	if dets := det.Detect(clean); len(dets) != 0 {
+		t.Errorf("clean WPA3 airspace should have zero anomalies, got %v", defKeys(dets))
+	}
+}
+
+// TestSecurityTierCoversEveryDot11Suite guards against drift between the
+// airspace Tree's stringified Security and the detector's string mapping: every
+// dot11.Security String() value must be classified (weak/strong/unknown), never
+// silently dropped.
+func TestSecurityTierCoversEveryDot11Suite(t *testing.T) {
+	suites := []dot11.Security{
+		dot11.SecurityOpen, dot11.SecurityWEP, dot11.SecurityWPA,
+		dot11.SecurityWPA2, dot11.SecurityWPA3, dot11.SecurityWPA2WPA3,
+	}
+	for _, s := range suites {
+		if !wifianomaly.SecurityRecognized(s.String()) {
+			t.Errorf("detector does not classify security suite %q", s.String())
+		}
+	}
+}
+
+// TestDeterministicOrder verifies Detect returns a stable order so callers and
+// tests see identical output for identical input.
+func TestDeterministicOrder(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	in := everyAnomalyTree()
+	first := det.Detect(in)
+	for i := range 5 {
+		got := det.Detect(in)
+		if len(got) != len(first) {
+			t.Fatalf("run %d length %d != %d", i, len(got), len(first))
+		}
+		for j := range got {
+			if got[j].DefKey != first[j].DefKey || got[j].Subject != first[j].Subject {
+				t.Fatalf("run %d index %d: %+v != %+v", i, j, got[j], first[j])
+			}
+		}
+	}
+}

--- a/internal/wifi/anomaly/doc.go
+++ b/internal/wifi/anomaly/doc.go
@@ -1,0 +1,16 @@
+// Package wifianomaly is the Wi-Fi rule source for the general network-anomaly
+// engine (internal/anomaly, ADR-0011). It contributes two things:
+//
+//   - a data-driven [anomaly.Catalog] of Wi-Fi anomaly definitions, each with
+//     originally-authored copy, IEEE 802.11 citations, an impact statement, a
+//     remediation recommendation, and capability-gated follow-ups; and
+//   - a [Detector] whose rules evaluate the cross-referenced airspace tree
+//     ([airspace.Airspace.Tree]) and emit [anomaly.Detection] values for the
+//     engine to coalesce, escalate, and project.
+//
+// The rules read only the deterministic, stringified Tree view (no live capture,
+// no packet handles), so the package is CGO-free and exercised entirely with
+// synthetic airspace trees. The directory is internal/wifi/anomaly; the package
+// is named wifianomaly so the general engine package can be referenced here as
+// the unqualified anomaly.
+package wifianomaly

--- a/internal/wifi/anomaly/tokens.go
+++ b/internal/wifi/anomaly/tokens.go
@@ -1,0 +1,91 @@
+package wifianomaly
+
+import "sort"
+
+// The airspace Tree exposes Security/Standard/Band as the strings produced by
+// dot11's String() methods (those nouns are kept verbatim — DNT). The rules
+// classify off those tokens, so the tokens live here as named constants and a
+// drift guard (SecurityRecognized + TestSecurityTierCoversEveryDot11Suite)
+// fails fast if dot11's vocabulary ever changes underneath us.
+const (
+	secOpen     = "Open"
+	secWEP      = "WEP"
+	secWPA      = "WPA"
+	secWPA2     = "WPA2"
+	secWPA3     = "WPA3"
+	secWPA2WPA3 = "WPA2/WPA3"
+
+	stdUnknown = "Unknown"
+
+	band24GHz   = "2.4 GHz"
+	bandUnknown = "Unknown"
+)
+
+// security strength tiers. tierUnknown is the zero value for an unclassified
+// suite; weak suites (Open/WEP/legacy WPA) and strong suites (WPA2/WPA3) are
+// the two that the mismatch rule compares.
+const (
+	tierUnknown = iota
+	tierWeak
+	tierStrong
+)
+
+// securityTier classifies a stringified security suite into weak/strong, or
+// tierUnknown if the token is not recognised.
+func securityTier(s string) int {
+	switch s {
+	case secOpen, secWEP, secWPA:
+		return tierWeak
+	case secWPA2, secWPA3, secWPA2WPA3:
+		return tierStrong
+	default:
+		return tierUnknown
+	}
+}
+
+// SecurityRecognized reports whether s is a security suite the detector knows
+// how to classify. It exists so a test can assert every dot11.Security String()
+// value is handled, catching drift between the decoder and these rules.
+func SecurityRecognized(s string) bool { return securityTier(s) != tierUnknown }
+
+// hasWeakAndStrong reports whether the set holds at least one weak and one
+// strong security suite — the security-mismatch condition.
+func hasWeakAndStrong(securities *stringSet) bool {
+	weak, strong := false, false
+	for _, s := range securities.sorted() {
+		switch securityTier(s) {
+		case tierWeak:
+			weak = true
+		case tierStrong:
+			strong = true
+		}
+	}
+	return weak && strong
+}
+
+// is24NonOverlapping reports whether ch is one of the 2.4 GHz non-overlapping
+// channels (1, 6, 11). Any other 2.4 GHz channel partially overlaps a neighbour.
+func is24NonOverlapping(ch int) bool {
+	return ch == 1 || ch == 6 || ch == 11
+}
+
+// stringSet is a tiny ordered-output set used to collect distinct evidence
+// values (securities, vendors, standards, countries) deterministically.
+type stringSet struct {
+	m map[string]struct{}
+}
+
+func newStringSet() *stringSet { return &stringSet{m: map[string]struct{}{}} }
+
+func (s *stringSet) add(v string) { s.m[v] = struct{}{} }
+
+func (s *stringSet) len() int { return len(s.m) }
+
+func (s *stringSet) sorted() []string {
+	out := make([]string, 0, len(s.m))
+	for v := range s.m {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
Add internal/wifi/anomaly (package wifianomaly): the Wi-Fi rule source for
the general network-anomaly engine (internal/anomaly, ADR-0011).

- Catalog: a data-driven []anomaly.Def of 11 Wi-Fi anomaly types with
  originally-authored copy, IEEE 802.11 citations, impact, recommendation,
  and capability-gated follow-ups (open/WEP/WPS, PMF-not-required,
  security-mismatch, evil-twin/vendor-mismatch, co-channel-contention,
  adjacent-channel-overlap, hidden-SSID, country-conflict, standard-mismatch
  — the owner-asked starter set).
- Detector: rules that evaluate the deterministic airspace.Tree() view and
  emit anomaly.Detection into the engine. CGO-free, no I/O, no live capture.
- Drift guard (SecurityRecognized) asserts the rules classify every
  dot11.Security String() value, so decoder vocabulary changes fail fast.

Additive — no consumer yet (W5 Pro-gated API + W6 UI wire it later), mirroring
the W4a engine drop. 96.7% coverage, race-clean, golangci 0.

funlen relaxed for catalog.go (declarative data table, same precedent as
cmd/seed-schema/main.go and internal/api/server_routes.go).
