### PR TITLE
feat(wifi): airspace visibility service (W5a)

### DIFF
--- a/internal/wifi/visibility/service.go
+++ b/internal/wifi/visibility/service.go
@@ -1,0 +1,247 @@
+// Package visibility is the runtime orchestrator for Wi-Fi airspace visibility
+// and anomaly detection. It owns the live cross-referenced airspace model
+// (internal/wifi/airspace), a persistent anomaly engine (internal/anomaly) seeded
+// with the Wi-Fi rule catalog (internal/wifi/anomaly), and the detector that
+// evaluates one against the other.
+//
+// A capture source (W3, libpcap/monitor-mode, built separately and CGO-tagged)
+// feeds decoded 802.11 frames in via Ingest; this package is itself CGO-free and
+// frame-source-agnostic, so it builds and tests everywhere. Start runs a periodic
+// evaluation loop (detector → engine), and Tree/Anomalies/Status are the read
+// model the API layer (W5b) serves Pro-gated.
+package visibility
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/dot11"
+)
+
+const (
+	// defaultEvalInterval is how often the background loop re-evaluates the
+	// airspace for anomalies.
+	defaultEvalInterval = 5 * time.Second
+	// defaultRetention is how long a BSS/station/anomaly survives without being
+	// re-observed before it is pruned (the condition is considered resolved).
+	defaultRetention = 5 * time.Minute
+)
+
+// Status is the read-model summary of the visibility service: whether a capture
+// source is feeding it, and the current entity/anomaly counts. Pure data with
+// camelCase wire tags (ADR-0010) so the API layer can serialize it directly.
+type Status struct {
+	CaptureActive bool      `json:"captureActive"`
+	Source        string    `json:"source,omitempty"`
+	SSIDs         int       `json:"ssids"`
+	APs           int       `json:"aps"`
+	BSSes         int       `json:"bsses"`
+	Stations      int       `json:"stations"`
+	Anomalies     int       `json:"anomalies"`
+	LastEvaluated time.Time `json:"lastEvaluated,omitzero"`
+}
+
+// Service owns the live airspace, the anomaly engine, and the evaluation loop.
+// All exported methods are safe for concurrent use.
+type Service struct {
+	air      *airspace.Airspace
+	engine   *anomaly.Engine
+	detector *wifianomaly.Detector
+
+	evalInterval time.Duration
+	retention    time.Duration
+
+	mu            sync.Mutex
+	source        string
+	lastEvaluated time.Time
+	cancel        context.CancelFunc
+	wg            sync.WaitGroup
+}
+
+// Option configures a Service.
+type Option func(*config)
+
+type config struct {
+	evalInterval time.Duration
+	retention    time.Duration
+	detector     *wifianomaly.Detector
+	capabilities []string
+}
+
+// WithEvalInterval sets the background evaluation cadence.
+func WithEvalInterval(d time.Duration) Option {
+	return func(c *config) {
+		if d > 0 {
+			c.evalInterval = d
+		}
+	}
+}
+
+// WithRetention sets how long entities/anomalies persist without re-observation.
+func WithRetention(d time.Duration) Option {
+	return func(c *config) {
+		if d > 0 {
+			c.retention = d
+		}
+	}
+}
+
+// WithDetector overrides the default Wi-Fi detector (e.g. tuned thresholds).
+func WithDetector(d *wifianomaly.Detector) Option {
+	return func(c *config) {
+		if d != nil {
+			c.detector = d
+		}
+	}
+}
+
+// WithCapabilities registers platform capabilities for the engine's auto
+// follow-ups (e.g. wifianomaly.CapActiveTest when active testing is available).
+func WithCapabilities(caps ...string) Option {
+	return func(c *config) { c.capabilities = append(c.capabilities, caps...) }
+}
+
+// New builds a visibility service. It errors only if the Wi-Fi anomaly catalog
+// is malformed — a programming error surfaced at startup, never at runtime.
+func New(opts ...Option) (*Service, error) {
+	cfg := config{evalInterval: defaultEvalInterval, retention: defaultRetention}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	cat, err := wifianomaly.Catalog()
+	if err != nil {
+		return nil, err
+	}
+	det := cfg.detector
+	if det == nil {
+		det = wifianomaly.NewDetector()
+	}
+	return &Service{
+		air:          airspace.New(),
+		engine:       anomaly.NewEngine(cat, anomaly.WithCapabilities(cfg.capabilities...)),
+		detector:     det,
+		evalInterval: cfg.evalInterval,
+		retention:    cfg.retention,
+	}, nil
+}
+
+// Ingest folds one decoded frame into the airspace at observation time `at`.
+// The capture source (W3) calls this for every frame; a nil frame is a no-op.
+func (s *Service) Ingest(f *dot11.Frame, at time.Time) {
+	s.air.Observe(f, at)
+}
+
+// Evaluate ages out stale entities, runs the Wi-Fi rules over the current
+// airspace, and folds the resulting detections into the persistent engine
+// (which coalesces, escalates on recurrence, and ages out resolved anomalies).
+func (s *Service) Evaluate(at time.Time) {
+	cutoff := at.Add(-s.retention)
+	s.air.Prune(cutoff)
+	for _, d := range s.detector.Detect(s.air.Tree()) {
+		// Observe only errors on an uncatalogued def or invalid severity; the
+		// detector emits neither, so the error is structurally impossible here.
+		_ = s.engine.Observe(d, at)
+	}
+	s.engine.Prune(cutoff)
+
+	s.mu.Lock()
+	s.lastEvaluated = at
+	s.mu.Unlock()
+}
+
+// Tree returns the current cross-referenced SSID → AP → BSSID → client view.
+func (s *Service) Tree() []airspace.SSIDGroup { return s.air.Tree() }
+
+// Anomalies returns the current anomaly stream, most urgent first.
+func (s *Service) Anomalies() []anomaly.Anomaly { return s.engine.Snapshot() }
+
+// SetSource records that a named capture source is actively feeding frames.
+func (s *Service) SetSource(name string) {
+	s.mu.Lock()
+	s.source = name
+	s.mu.Unlock()
+}
+
+// ClearSource records that capture has stopped (graceful degrade to OS scan).
+func (s *Service) ClearSource() {
+	s.mu.Lock()
+	s.source = ""
+	s.mu.Unlock()
+}
+
+// Status summarizes the live read model.
+func (s *Service) Status() Status {
+	tree := s.air.Tree()
+	apKeys := make(map[string]struct{})
+	bsses, stations := 0, 0
+	for _, g := range tree {
+		bsses += g.BSSCount
+		stations += g.StationCount
+		for _, ap := range g.APs {
+			apKeys[ap.Key] = struct{}{}
+		}
+	}
+
+	s.mu.Lock()
+	src, last := s.source, s.lastEvaluated
+	s.mu.Unlock()
+
+	return Status{
+		CaptureActive: src != "",
+		Source:        src,
+		SSIDs:         len(tree),
+		APs:           len(apKeys),
+		BSSes:         bsses,
+		Stations:      stations,
+		Anomalies:     s.engine.Len(),
+		LastEvaluated: last,
+	}
+}
+
+// Start launches the background evaluation loop. It is idempotent: a second
+// call while running is a no-op.
+func (s *Service) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.cancel != nil {
+		s.mu.Unlock()
+		return nil
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.mu.Unlock()
+
+	s.wg.Add(1)
+	go s.loop(loopCtx)
+	return nil
+}
+
+func (s *Service) loop(ctx context.Context) {
+	defer s.wg.Done()
+	ticker := time.NewTicker(s.evalInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.Evaluate(time.Now())
+		}
+	}
+}
+
+// Stop halts the background loop and waits for it to exit. Idempotent.
+func (s *Service) Stop() error {
+	s.mu.Lock()
+	cancel := s.cancel
+	s.cancel = nil
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	s.wg.Wait()
+	return nil
+}

--- a/internal/wifi/visibility/service_test.go
+++ b/internal/wifi/visibility/service_test.go
@@ -1,0 +1,201 @@
+package visibility_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/dot11"
+	"github.com/krisarmstrong/seed/internal/wifi/visibility"
+)
+
+func mac(t *testing.T, s string) net.HardwareAddr {
+	t.Helper()
+	h, err := net.ParseMAC(s)
+	if err != nil {
+		t.Fatalf("ParseMAC(%q): %v", s, err)
+	}
+	return h
+}
+
+// beacon builds a synthetic beacon frame advertising one BSS.
+func beacon(t *testing.T, bssid, ssid string, sec dot11.Security) *dot11.Frame {
+	t.Helper()
+	return &dot11.Frame{
+		Kind:       dot11.KindBeacon,
+		BSSID:      mac(t, bssid),
+		Band:       dot11.Band24GHz,
+		ChannelNum: 6,
+		BSS: &dot11.BSS{
+			SSID:     ssid,
+			Security: sec,
+			Standard: dot11.Standard80211ac,
+		},
+	}
+}
+
+func hasAnomaly(as []anomalyView, id string) bool {
+	for _, a := range as {
+		if a.DefKey == id {
+			return true
+		}
+	}
+	return false
+}
+
+// anomalyView is the minimal shape we assert on (mirrors anomaly.Anomaly).
+type anomalyView = struct {
+	DefKey string
+}
+
+func TestNewIsEmpty(t *testing.T) {
+	svc, err := visibility.New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := len(svc.Tree()); got != 0 {
+		t.Errorf("fresh Tree len = %d, want 0", got)
+	}
+	if got := len(svc.Anomalies()); got != 0 {
+		t.Errorf("fresh Anomalies len = %d, want 0", got)
+	}
+	st := svc.Status()
+	if st.CaptureActive {
+		t.Error("fresh service should not report capture active")
+	}
+}
+
+func TestIngestAndEvaluateProducesAnomaly(t *testing.T) {
+	svc, err := visibility.New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	now := time.Now()
+	// An open network on 2.4 GHz channel 6: trips wifi-open-network (and is on a
+	// valid non-overlapping channel, so no adjacent-channel noise).
+	svc.Ingest(beacon(t, "00:11:22:33:44:55", "guest", dot11.SecurityOpen), now)
+	svc.Evaluate(now)
+
+	if len(svc.Tree()) == 0 {
+		t.Fatal("Tree empty after ingesting a beacon")
+	}
+	got := svc.Anomalies()
+	views := make([]anomalyView, len(got))
+	for i, a := range got {
+		views[i] = anomalyView{DefKey: a.DefKey}
+	}
+	if !hasAnomaly(views, wifianomaly.DefOpenNetwork) {
+		t.Errorf("expected %s anomaly, got %+v", wifianomaly.DefOpenNetwork, got)
+	}
+	if svc.Status().Anomalies == 0 {
+		t.Error("Status.Anomalies should be > 0 after evaluate")
+	}
+}
+
+func TestEvaluateCoalesces(t *testing.T) {
+	svc, err := visibility.New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	now := time.Now()
+	b := beacon(t, "00:11:22:33:44:55", "guest", dot11.SecurityOpen)
+	svc.Ingest(b, now)
+	svc.Evaluate(now)
+	svc.Ingest(b, now.Add(time.Second))
+	svc.Evaluate(now.Add(time.Second))
+
+	open := 0
+	for _, a := range svc.Anomalies() {
+		if a.DefKey == wifianomaly.DefOpenNetwork {
+			open++
+			if a.Count < 2 {
+				t.Errorf("coalesced anomaly Count = %d, want >= 2", a.Count)
+			}
+		}
+	}
+	if open != 1 {
+		t.Errorf("open-network instances = %d, want exactly 1 (coalesced)", open)
+	}
+}
+
+func TestCustomDetectorAndOptions(t *testing.T) {
+	// A tuned detector (co-channel threshold 2) plus the non-default options, to
+	// exercise the option path and a multi-BSS evaluation.
+	det := wifianomaly.NewDetector(wifianomaly.WithCoChannelThreshold(2))
+	svc, err := visibility.New(
+		visibility.WithDetector(det),
+		visibility.WithRetention(time.Minute),
+		visibility.WithCapabilities(wifianomaly.CapActiveTest),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	now := time.Now()
+	// Two WPA3/PMF BSSes sharing 2.4 GHz channel 6 → co-channel contention.
+	for _, m := range []string{"00:11:22:33:44:01", "00:11:22:33:44:02"} {
+		b := beacon(t, m, "corp", dot11.SecurityWPA3)
+		b.BSS.PMFRequired = true
+		svc.Ingest(b, now)
+	}
+	svc.Evaluate(now)
+
+	found := false
+	for _, a := range svc.Anomalies() {
+		if a.DefKey == wifianomaly.DefCoChannelContention {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected co-channel-contention with threshold 2, got %+v", svc.Anomalies())
+	}
+	st := svc.Status()
+	if st.BSSes != 2 || st.APs == 0 {
+		t.Errorf("Status counts off: %+v", st)
+	}
+}
+
+func TestSourceToggle(t *testing.T) {
+	svc, err := visibility.New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	svc.SetSource("monitor0")
+	st := svc.Status()
+	if !st.CaptureActive || st.Source != "monitor0" {
+		t.Errorf("after SetSource: CaptureActive=%v Source=%q", st.CaptureActive, st.Source)
+	}
+	svc.ClearSource()
+	if svc.Status().CaptureActive {
+		t.Error("after ClearSource: capture should be inactive")
+	}
+}
+
+func TestStartStopLifecycle(t *testing.T) {
+	svc, err := visibility.New(visibility.WithEvalInterval(5 * time.Millisecond))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if startErr := svc.Start(t.Context()); startErr != nil {
+		t.Fatalf("Start: %v", startErr)
+	}
+	svc.Ingest(beacon(t, "00:11:22:33:44:55", "guest", dot11.SecurityOpen), time.Now())
+	// Give the ticker a few cycles to evaluate.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(svc.Anomalies()) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(svc.Anomalies()) == 0 {
+		t.Error("background loop did not evaluate ingested frames")
+	}
+	if stopErr := svc.Stop(); stopErr != nil {
+		t.Fatalf("Stop: %v", stopErr)
+	}
+	// Stop is idempotent.
+	if stopErr := svc.Stop(); stopErr != nil {
+		t.Fatalf("second Stop: %v", stopErr)
+	}
+}


### PR DESCRIPTION
Add internal/wifi/visibility — the CGO-free runtime orchestrator that owns the
live airspace model, a persistent anomaly engine seeded with the Wi-Fi rule
catalog, and the detector that evaluates one against the other.

- Ingest(frame, at) folds decoded 802.11 frames into the airspace; the W3
  capture source (libpcap/monitor-mode, built separately + CGO-tagged) is the
  only frame producer, so this package stays CGO-free and source-agnostic.
- Evaluate(at) prunes stale entities, runs the rules over the current tree, and
  folds detections into the engine (coalesce/escalate/age-out). Start runs it on
  a ticker; Stop is idempotent.
- Tree()/Anomalies()/Status() are the read model the Pro-gated API (W5b) serves.
  Status reports capture source + entity/anomaly counts (camelCase, ADR-0010).

Additive, no consumer yet (W5b wires the API + app/cmd lifecycle). 96% coverage,
race-clean, golangci 0.
