### PR TITLE
feat(wifi): pro-gated airspace + anomaly read API (W5b)

### DIFF
--- a/cmd/seed-schema/main.go
+++ b/cmd/seed-schema/main.go
@@ -104,6 +104,8 @@ func schemaTargets() []schemaTarget {
 		{&api.CableResponse{}, "cable-response.schema.json"},
 		{&api.VLANResponse{}, "vlan-response.schema.json"},
 		{&api.WiFiResponse{}, "wifi-response.schema.json"},
+		{&api.WiFiAirspaceResponse{}, "wifi-airspace-response.schema.json"},
+		{&api.WiFiAnomaliesResponse{}, "wifi-anomalies-response.schema.json"},
 		{&api.SpeedtestResponse{}, "speedtest-response.schema.json"},
 		{&api.RogueDHCPResponse{}, "rogue-dhcp-response.schema.json"},
 		{&api.IPConfigResponse{}, "ipconfig-response.schema.json"},

--- a/cmd/seed/cmd_serve.go
+++ b/cmd/seed/cmd_serve.go
@@ -113,6 +113,16 @@ func initializeBackgroundComponents(cfg *config.Config, db *database.DB) *api.Ba
 	components.Reporting = app.NewReporting(cfg, db)
 	logging.GetLogger().Info("Reporting module initialized")
 
+	// Wi-Fi airspace visibility: holds the live airspace + anomaly engine, fed by
+	// the monitor-mode capture source. A malformed catalog is a programming error
+	// — log and continue without the component (handlers degrade gracefully).
+	if wifiVis, err := app.NewWiFiVisibility(); err != nil {
+		logging.GetLogger().Error("Wi-Fi visibility init failed; feature disabled", "error", err)
+	} else {
+		components.WiFiVisibility = wifiVis
+		logging.GetLogger().Info("Wi-Fi visibility module initialized")
+	}
+
 	return components
 }
 

--- a/docs/schemas/api/wifi-airspace-response.schema.json
+++ b/docs/schemas/api/wifi-airspace-response.schema.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/wifi-airspace-response.schema.json",
+  "$ref": "#/$defs/WiFiAirspaceResponse",
+  "$defs": {
+    "APGroup": {
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "bsses": {
+          "items": {
+            "$ref": "#/$defs/BSSView"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "key",
+        "bsses"
+      ]
+    },
+    "BSSView": {
+      "properties": {
+        "bssid": {
+          "type": "string"
+        },
+        "ssid": {
+          "type": "string"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "band": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "integer"
+        },
+        "security": {
+          "type": "string"
+        },
+        "standard": {
+          "type": "string"
+        },
+        "countryCode": {
+          "type": "string"
+        },
+        "pmfRequired": {
+          "type": "boolean"
+        },
+        "rrmNeighbor": {
+          "type": "boolean"
+        },
+        "btmSupported": {
+          "type": "boolean"
+        },
+        "ftSupported": {
+          "type": "boolean"
+        },
+        "wpsEnabled": {
+          "type": "boolean"
+        },
+        "signalDbm": {
+          "type": "integer"
+        },
+        "beacons": {
+          "type": "integer"
+        },
+        "lastSeen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "stations": {
+          "items": {
+            "$ref": "#/$defs/StationView"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "bssid",
+        "ssid",
+        "hidden",
+        "band",
+        "channel",
+        "security",
+        "standard",
+        "pmfRequired",
+        "rrmNeighbor",
+        "btmSupported",
+        "ftSupported",
+        "wpsEnabled",
+        "signalDbm",
+        "beacons",
+        "lastSeen",
+        "stations"
+      ]
+    },
+    "SSIDGroup": {
+      "properties": {
+        "ssid": {
+          "type": "string"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "apCount": {
+          "type": "integer"
+        },
+        "bssCount": {
+          "type": "integer"
+        },
+        "stationCount": {
+          "type": "integer"
+        },
+        "aps": {
+          "items": {
+            "$ref": "#/$defs/APGroup"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ssid",
+        "hidden",
+        "apCount",
+        "bssCount",
+        "stationCount",
+        "aps"
+      ]
+    },
+    "StationView": {
+      "properties": {
+        "mac": {
+          "type": "string"
+        },
+        "signalDbm": {
+          "type": "integer"
+        },
+        "frames": {
+          "type": "integer"
+        },
+        "lastSeen": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mac",
+        "signalDbm",
+        "frames",
+        "lastSeen"
+      ]
+    },
+    "Status": {
+      "properties": {
+        "captureActive": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string"
+        },
+        "ssids": {
+          "type": "integer"
+        },
+        "aps": {
+          "type": "integer"
+        },
+        "bsses": {
+          "type": "integer"
+        },
+        "stations": {
+          "type": "integer"
+        },
+        "anomalies": {
+          "type": "integer"
+        },
+        "lastEvaluated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "captureActive",
+        "ssids",
+        "aps",
+        "bsses",
+        "stations",
+        "anomalies"
+      ]
+    },
+    "WiFiAirspaceResponse": {
+      "properties": {
+        "ssids": {
+          "items": {
+            "$ref": "#/$defs/SSIDGroup"
+          },
+          "type": "array"
+        },
+        "status": {
+          "$ref": "#/$defs/Status"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ssids",
+        "status"
+      ]
+    }
+  },
+  "title": "WiFiAirspaceResponse",
+  "description": "WiFiAirspaceResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/docs/schemas/api/wifi-anomalies-response.schema.json
+++ b/docs/schemas/api/wifi-anomalies-response.schema.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/krisarmstrong/seed/main/docs/schemas/api/wifi-anomalies-response.schema.json",
+  "$ref": "#/$defs/WiFiAnomaliesResponse",
+  "$defs": {
+    "Anomaly": {
+      "properties": {
+        "defKey": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/SubjectRef"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "impact": {
+          "type": "string"
+        },
+        "recommendation": {
+          "type": "string"
+        },
+        "standards": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "evidence": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "followUps": {
+          "items": {
+            "$ref": "#/$defs/FollowUp"
+          },
+          "type": "array"
+        },
+        "firstSeen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastSeen": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "defKey",
+        "category",
+        "severity",
+        "subject",
+        "title",
+        "description",
+        "recommendation",
+        "firstSeen",
+        "lastSeen",
+        "count"
+      ]
+    },
+    "FollowUp": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "action": {
+          "type": "string"
+        },
+        "capability": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind",
+        "label",
+        "action"
+      ]
+    },
+    "Status": {
+      "properties": {
+        "captureActive": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string"
+        },
+        "ssids": {
+          "type": "integer"
+        },
+        "aps": {
+          "type": "integer"
+        },
+        "bsses": {
+          "type": "integer"
+        },
+        "stations": {
+          "type": "integer"
+        },
+        "anomalies": {
+          "type": "integer"
+        },
+        "lastEvaluated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "captureActive",
+        "ssids",
+        "aps",
+        "bsses",
+        "stations",
+        "anomalies"
+      ]
+    },
+    "SubjectRef": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind",
+        "id"
+      ]
+    },
+    "WiFiAnomaliesResponse": {
+      "properties": {
+        "anomalies": {
+          "items": {
+            "$ref": "#/$defs/Anomaly"
+          },
+          "type": "array"
+        },
+        "status": {
+          "$ref": "#/$defs/Status"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "anomalies",
+        "status"
+      ]
+    }
+  },
+  "title": "WiFiAnomaliesResponse",
+  "description": "WiFiAnomaliesResponse — generated from the Go struct in internal/api; refresh with `make schema` after struct changes."
+}

--- a/internal/api/background.go
+++ b/internal/api/background.go
@@ -4,21 +4,29 @@ import (
 	"context"
 
 	"github.com/krisarmstrong/seed/internal/reporting"
+	"github.com/krisarmstrong/seed/internal/wifi/visibility"
 )
 
 // BackgroundComponents holds the long-lived components that own real background
 // lifecycle (Start/Stop). Stateless request/response logic lives in the handlers
 // and the api service groupings, built directly from the feature packages; only
-// components that own background work belong here. Currently that is the report
-// scheduler (internal/reporting).
+// components that own background work belong here: the report scheduler
+// (internal/reporting) and the Wi-Fi airspace visibility loop
+// (internal/wifi/visibility).
 type BackgroundComponents struct {
-	Reporting *reporting.Service
+	Reporting      *reporting.Service
+	WiFiVisibility *visibility.Service
 }
 
 // Start initializes and starts all background components.
 func (b *BackgroundComponents) Start(ctx context.Context) error {
 	if b.Reporting != nil {
 		if err := b.Reporting.Start(ctx); err != nil {
+			return err
+		}
+	}
+	if b.WiFiVisibility != nil {
+		if err := b.WiFiVisibility.Start(ctx); err != nil {
 			return err
 		}
 	}
@@ -29,6 +37,9 @@ func (b *BackgroundComponents) Start(ctx context.Context) error {
 func (b *BackgroundComponents) Stop() error {
 	if b.Reporting != nil {
 		_ = b.Reporting.Stop()
+	}
+	if b.WiFiVisibility != nil {
+		_ = b.WiFiVisibility.Stop()
 	}
 	return nil
 }

--- a/internal/api/handlers_wifi_airspace.go
+++ b/internal/api/handlers_wifi_airspace.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/krisarmstrong/seed/internal/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	"github.com/krisarmstrong/seed/internal/wifi/visibility"
+)
+
+// WiFiAirspaceResponse is the Pro-gated airspace read model: the cross-referenced
+// SSID → AP → BSSID → client tree plus a capture/entity-count status summary.
+type WiFiAirspaceResponse struct {
+	SSIDs  []airspace.SSIDGroup `json:"ssids"`
+	Status visibility.Status    `json:"status"`
+}
+
+// WiFiAnomaliesResponse is the Pro-gated Wi-Fi anomaly stream: the deduped,
+// severity-ranked detections plus the same status summary.
+type WiFiAnomaliesResponse struct {
+	Anomalies []anomaly.Anomaly `json:"anomalies"`
+	Status    visibility.Status `json:"status"`
+}
+
+// wifiVisibility returns the live visibility service, or nil when no capture
+// component is wired (e.g. no monitor-capable interface). Handlers degrade to an
+// empty-but-valid response in that case rather than erroring.
+func (s *Server) wifiVisibility() *visibility.Service {
+	if s.background == nil {
+		return nil
+	}
+	return s.background.WiFiVisibility
+}
+
+// handleWiFiAirspace serves GET /api/v1/wifi/airspace — the airspace tree. The
+// route is feature-gated (wifi_management_capture); an absent capture component
+// yields an empty tree with captureActive=false, not an error.
+func (s *Server) handleWiFiAirspace(w http.ResponseWriter, _ *http.Request) {
+	resp := WiFiAirspaceResponse{SSIDs: []airspace.SSIDGroup{}}
+	if svc := s.wifiVisibility(); svc != nil {
+		resp.SSIDs = svc.Tree()
+		resp.Status = svc.Status()
+	}
+	sendJSONResponse(w, nil, http.StatusOK, resp)
+}
+
+// handleWiFiAnomalies serves GET /api/v1/wifi/anomalies — the Wi-Fi anomaly
+// stream. Feature-gated (wifi_association_forensics); degrades to an empty
+// stream when no capture component is present.
+func (s *Server) handleWiFiAnomalies(w http.ResponseWriter, _ *http.Request) {
+	resp := WiFiAnomaliesResponse{Anomalies: []anomaly.Anomaly{}}
+	if svc := s.wifiVisibility(); svc != nil {
+		resp.Anomalies = svc.Anomalies()
+		resp.Status = svc.Status()
+	}
+	sendJSONResponse(w, nil, http.StatusOK, resp)
+}

--- a/internal/api/handlers_wifi_airspace_internal_test.go
+++ b/internal/api/handlers_wifi_airspace_internal_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/dot11"
+	"github.com/krisarmstrong/seed/internal/wifi/visibility"
+)
+
+// The feature-gate middleware is applied at route registration and exercised by
+// the authchain golden harness; these tests drive the handlers directly to
+// characterize their own logic — graceful empty response vs. populated read.
+
+func decodeJSON[T any](t *testing.T, rec *httptest.ResponseRecorder) T {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var out T
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}
+
+func openBeacon(t *testing.T) *dot11.Frame {
+	t.Helper()
+	mac, err := net.ParseMAC("00:11:22:33:44:55")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &dot11.Frame{
+		Kind:       dot11.KindBeacon,
+		BSSID:      mac,
+		Band:       dot11.Band24GHz,
+		ChannelNum: 6,
+		BSS:        &dot11.BSS{SSID: "guest", Security: dot11.SecurityOpen, Standard: dot11.Standard80211ac},
+	}
+}
+
+func TestHandleWiFiAirspaceEmptyWhenNoComponent(t *testing.T) {
+	// No background component wired → graceful empty response, never 500/null.
+	s := &Server{background: &BackgroundComponents{}}
+	rec := httptest.NewRecorder()
+	s.handleWiFiAirspace(rec, httptest.NewRequest(http.MethodGet, "/api/v1/wifi/airspace", nil))
+
+	resp := decodeJSON[WiFiAirspaceResponse](t, rec)
+	if resp.SSIDs == nil {
+		t.Error("ssids should serialize as [] not null")
+	}
+	if len(resp.SSIDs) != 0 || resp.Status.CaptureActive {
+		t.Errorf("expected empty inactive airspace, got %+v", resp)
+	}
+}
+
+func TestHandleWiFiAirspaceAndAnomaliesPopulated(t *testing.T) {
+	svc, err := visibility.New()
+	if err != nil {
+		t.Fatalf("visibility.New: %v", err)
+	}
+	svc.SetSource("monitor0")
+	svc.Ingest(openBeacon(t), time.Now())
+	svc.Evaluate(time.Now())
+	s := &Server{background: &BackgroundComponents{WiFiVisibility: svc}}
+
+	// Airspace tree is populated and reports the active source.
+	recA := httptest.NewRecorder()
+	s.handleWiFiAirspace(recA, httptest.NewRequest(http.MethodGet, "/api/v1/wifi/airspace", nil))
+	air := decodeJSON[WiFiAirspaceResponse](t, recA)
+	if len(air.SSIDs) == 0 {
+		t.Error("expected a populated airspace tree")
+	}
+	if !air.Status.CaptureActive || air.Status.Source != "monitor0" {
+		t.Errorf("status should reflect the active source: %+v", air.Status)
+	}
+
+	// Anomaly stream contains the open-network detection.
+	recN := httptest.NewRecorder()
+	s.handleWiFiAnomalies(recN, httptest.NewRequest(http.MethodGet, "/api/v1/wifi/anomalies", nil))
+	an := decodeJSON[WiFiAnomaliesResponse](t, recN)
+	found := false
+	for _, a := range an.Anomalies {
+		if a.DefKey == wifianomaly.DefOpenNetwork {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected %s in the anomaly stream, got %+v", wifianomaly.DefOpenNetwork, an.Anomalies)
+	}
+}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -781,6 +781,21 @@ func (s *Server) setupWiFiRoutes() {
 			handler: s.handleWiFiChannelGraph,
 			methods: get,
 		},
+		// Pro: monitor-mode airspace visibility + anomaly stream (W5). Read-only;
+		// the capture source feeds the model out-of-band. Feature-gated so the
+		// tree/forensics surface stays on the Pro tier (LICENSE_STRATEGY.md).
+		{
+			path:    APIVersionPrefix + "/wifi/airspace",
+			handler: s.handleWiFiAirspace,
+			methods: get,
+			feature: "wifi_management_capture",
+		},
+		{
+			path:    APIVersionPrefix + "/wifi/anomalies",
+			handler: s.handleWiFiAnomalies,
+			methods: get,
+			feature: "wifi_association_forensics",
+		},
 		{
 			path:    APIVersionPrefix + "/wifi/wifi/settings",
 			handler: s.handleWiFiSettings,

--- a/internal/api/testdata/golden/capabilities.txt
+++ b/internal/api/testdata/golden/capabilities.txt
@@ -1019,6 +1019,22 @@ body:
     "path": "/api/v1/wifi/wifi/channel-graph"
   },
   {
+    "feature": "wifi_management_capture",
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
+    "path": "/api/v1/wifi/airspace"
+  },
+  {
+    "feature": "wifi_association_forensics",
+    "maxBodyBytes": 262144,
+    "methods": [
+      "GET"
+    ],
+    "path": "/api/v1/wifi/anomalies"
+  },
+  {
     "maxBodyBytes": 262144,
     "methods": [
       "GET",

--- a/internal/app/wifi_visibility.go
+++ b/internal/app/wifi_visibility.go
@@ -1,0 +1,11 @@
+package app
+
+import "github.com/krisarmstrong/seed/internal/wifi/visibility"
+
+// NewWiFiVisibility builds the Wi-Fi airspace visibility component. It owns no
+// persistence (it is fed decoded frames by the capture source, not the DB), so
+// unlike NewReporting it takes no store adapters. It errors only if the Wi-Fi
+// anomaly catalog is malformed — a build-time programming error.
+func NewWiFiVisibility() (*visibility.Service, error) {
+	return visibility.New()
+}

--- a/ui/src/types/generated/wifi-airspace-response.ts
+++ b/ui/src/types/generated/wifi-airspace-response.ts
@@ -1,0 +1,59 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface WiFiAirspaceResponse {
+  ssids: SSIDGroup[];
+  status: Status;
+}
+export interface SSIDGroup {
+  ssid: string;
+  hidden: boolean;
+  apCount: number;
+  bssCount: number;
+  stationCount: number;
+  aps: APGroup[];
+}
+export interface APGroup {
+  key: string;
+  vendor?: string;
+  bsses: BSSView[];
+}
+export interface BSSView {
+  bssid: string;
+  ssid: string;
+  hidden: boolean;
+  band: string;
+  channel: number;
+  security: string;
+  standard: string;
+  countryCode?: string;
+  pmfRequired: boolean;
+  rrmNeighbor: boolean;
+  btmSupported: boolean;
+  ftSupported: boolean;
+  wpsEnabled: boolean;
+  signalDbm: number;
+  beacons: number;
+  lastSeen: string;
+  stations: StationView[];
+}
+export interface StationView {
+  mac: string;
+  signalDbm: number;
+  frames: number;
+  lastSeen: string;
+}
+export interface Status {
+  captureActive: boolean;
+  source?: string;
+  ssids: number;
+  aps: number;
+  bsses: number;
+  stations: number;
+  anomalies: number;
+  lastEvaluated?: string;
+}

--- a/ui/src/types/generated/wifi-anomalies-response.ts
+++ b/ui/src/types/generated/wifi-anomalies-response.ts
@@ -1,0 +1,49 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: `npm run gen-types` (or `make schema && npm run gen-types`
+ * after Go DTO changes). The schema source of truth lives at
+ * docs/schemas/api/; the Go DTO source lives at internal/api/.
+ */
+export interface WiFiAnomaliesResponse {
+  anomalies: Anomaly[];
+  status: Status;
+}
+export interface Anomaly {
+  defKey: string;
+  category: string;
+  severity: string;
+  subject: SubjectRef;
+  title: string;
+  description: string;
+  impact?: string;
+  recommendation: string;
+  standards?: string[];
+  evidence?: {
+    [k: string]: string;
+  };
+  followUps?: FollowUp[];
+  firstSeen: string;
+  lastSeen: string;
+  count: number;
+}
+export interface SubjectRef {
+  kind: string;
+  id: string;
+}
+export interface FollowUp {
+  kind: string;
+  label: string;
+  action: string;
+  capability?: string;
+}
+export interface Status {
+  captureActive: boolean;
+  source?: string;
+  ssids: number;
+  aps: number;
+  bsses: number;
+  stations: number;
+  anomalies: number;
+  lastEvaluated?: string;
+}


### PR DESCRIPTION
Wire the visibility service (W5a) into the app lifecycle and expose two
Pro-gated read endpoints.

- BackgroundComponents gains WiFiVisibility (Start/Stop); app.NewWiFiVisibility
  builds it (no DB — fed by the capture source); cmd_serve initializes it and
  degrades gracefully if the catalog is malformed.
- GET /api/v1/wifi/airspace (feature wifi_management_capture) returns the
  SSID->AP->BSSID->client tree + capture/entity status.
- GET /api/v1/wifi/anomalies (feature wifi_association_forensics) returns the
  deduped, severity-ranked Wi-Fi anomaly stream + status.
- Handlers degrade to an empty-but-valid response (ssids/anomalies as [], not
  null; captureActive=false) when no capture component is wired.
- DTOs registered code-first (camelCase, ADR-0010); schemas + TS types
  regenerated; /__capabilities golden updated with the two routes.

Capture (W3) feeds the model out-of-band; until then the endpoints serve an
empty tree. Handler + drift/casing/route-policy gates green.
