### PR TITLE
feat(wifi): four buildable-now anomaly rules (W4c)

### DIFF
--- a/internal/wifi/anomaly/catalog.go
+++ b/internal/wifi/anomaly/catalog.go
@@ -6,17 +6,21 @@ import "github.com/krisarmstrong/seed/internal/anomaly"
 // API/UI key off them, and tests assert against them — so they live as exported
 // constants rather than string literals scattered through the rules.
 const (
-	DefOpenNetwork            = "wifi-open-network"
-	DefWEPInUse               = "wifi-wep-in-use"
-	DefWPSEnabled             = "wifi-wps-enabled"
-	DefPMFNotRequired         = "wifi-pmf-not-required"
-	DefSecurityMismatch       = "wifi-security-mismatch"
-	DefEvilTwin               = "wifi-evil-twin"
-	DefCoChannelContention    = "wifi-co-channel-contention"
-	DefAdjacentChannelOverlap = "wifi-adjacent-channel-overlap"
-	DefHiddenSSID             = "wifi-hidden-ssid"
-	DefCountryConflict        = "wifi-country-conflict"
-	DefStandardMismatch       = "wifi-standard-mismatch"
+	DefOpenNetwork             = "wifi-open-network"
+	DefWEPInUse                = "wifi-wep-in-use"
+	DefWPSEnabled              = "wifi-wps-enabled"
+	DefPMFNotRequired          = "wifi-pmf-not-required"
+	DefSecurityMismatch        = "wifi-security-mismatch"
+	DefEvilTwin                = "wifi-evil-twin"
+	DefCoChannelContention     = "wifi-co-channel-contention"
+	DefAdjacentChannelOverlap  = "wifi-adjacent-channel-overlap"
+	DefHiddenSSID              = "wifi-hidden-ssid"
+	DefCountryConflict         = "wifi-country-conflict"
+	DefStandardMismatch        = "wifi-standard-mismatch"
+	DefWPA3TransitionDowngrade = "wifi-wpa3-transition-downgrade"
+	DefDefaultSSIDName         = "wifi-default-ssid-name"
+	DefSSIDSprawl              = "wifi-ssid-sprawl"
+	DefInconsistentRoaming     = "wifi-inconsistent-roaming"
 )
 
 // CapActiveTest names the platform capability required to run an active
@@ -224,6 +228,65 @@ func Defs() []anomaly.Def {
 			Recommendation: "Standardise AP hardware/firmware where practical, or confirm the " +
 				"mixed generations are intentional and the older radios are scoped to legacy " +
 				"clients only.",
+		},
+		{
+			ID:              DefWPA3TransitionDowngrade,
+			Category:        anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityInfo,
+			Standards:       []string{"WPA3 Specification (transition mode)", "IEEE 802.11-2020 §12"},
+			Title:           "WPA3 transition mode (downgrade-capable)",
+			Description: "The BSS runs WPA3/WPA2 transition mode, advertising both SAE (WPA3) and " +
+				"PSK (WPA2) so legacy clients can still join. An on-path attacker can strip the " +
+				"WPA3 offer and force a WPA2 association, defeating SAE's offline-dictionary " +
+				"resistance for that client.",
+			Impact: "Clients capable of WPA3 may be downgraded to WPA2, exposing the passphrase to " +
+				"offline cracking that pure WPA3-SAE would prevent.",
+			Recommendation: "Once all clients support WPA3, move the SSID to WPA3-only (SAE). Keep " +
+				"transition mode only as long as WPA2-only clients genuinely remain.",
+		},
+		{
+			ID:              DefDefaultSSIDName,
+			Category:        anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityInfo,
+			Standards:       []string{"IEEE 802.11 (SSID element)"},
+			Title:           "Default/manufacturer SSID name",
+			Description: "The SSID matches a well-known router/manufacturer default (e.g. " +
+				"\"linksys\", \"NETGEAR\", \"dlink\"). A default name signals an unconfigured or " +
+				"lightly-managed device and often correlates with default credentials and a " +
+				"vendor-derivable default passphrase.",
+			Impact: "Default-named networks advertise the hardware vendor to an attacker and are " +
+				"more likely to retain default management credentials and weak factory keys.",
+			Recommendation: "Rename the SSID to a non-identifying value and confirm the device's " +
+				"admin credentials and Wi-Fi passphrase have been changed from the factory defaults.",
+		},
+		{
+			ID:              DefSSIDSprawl,
+			Category:        anomaly.CategoryCapacity,
+			DefaultSeverity: anomaly.SeverityInfo,
+			Standards:       []string{"IEEE 802.11 (beacon/airtime)"},
+			Title:           "SSID sprawl on one AP",
+			Description: "A single access point advertises many SSIDs. Every SSID needs its own " +
+				"beacon at the beacon interval on every radio, so each extra SSID consumes fixed " +
+				"management airtime whether or not any client uses it.",
+			Impact: "Excess beacons reduce the airtime available for data, most noticeably in the " +
+				"2.4 GHz band and in dense deployments, degrading throughput for every nearby cell.",
+			Recommendation: "Consolidate SSIDs — use one or two with role-based VLANs/RADIUS rather " +
+				"than a separate SSID per purpose, and disable unused SSIDs.",
+		},
+		{
+			ID:              DefInconsistentRoaming,
+			Category:        anomaly.CategoryRoaming,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"IEEE 802.11r", "IEEE 802.11k", "IEEE 802.11v"},
+			Title:           "Inconsistent roaming support across an SSID",
+			Description: "BSSes advertising the same SSID disagree on roaming assistance: some " +
+				"advertise 802.11r (fast transition), 802.11k (neighbor reports), or 802.11v (BSS " +
+				"transition management) while others do not. Clients roam best when every AP in the " +
+				"WLAN offers the same assistance.",
+			Impact: "Clients moving between a supporting and a non-supporting AP get slow or failed " +
+				"roams, dropped real-time sessions, and sticky-client behaviour.",
+			Recommendation: "Enable the same roaming features (802.11r/k/v) consistently on every AP " +
+				"serving the SSID, or disable them uniformly if a legacy client cannot cope.",
 		},
 	}
 }

--- a/internal/wifi/anomaly/detect.go
+++ b/internal/wifi/anomaly/detect.go
@@ -23,11 +23,19 @@ const minCoChannelThreshold = 2
 // across one SSID that constitutes a mismatch.
 const minDistinctForMismatch = 2
 
+// defaultSSIDSprawlThreshold is the number of distinct SSIDs on one AP at or
+// above which beacon-airtime sprawl is reported.
+const defaultSSIDSprawlThreshold = 5
+
+// minSSIDSprawlThreshold is the floor for a configured sprawl threshold.
+const minSSIDSprawlThreshold = 2
+
 // Detector evaluates the airspace tree against the Wi-Fi rule set and returns
 // the detections to feed an [anomaly.Engine]. It is stateless apart from its
 // tuning thresholds; the engine owns coalescing, escalation, and ageing.
 type Detector struct {
-	coChannelThreshold int
+	coChannelThreshold  int
+	ssidSprawlThreshold int
 }
 
 // Option tunes a Detector.
@@ -44,9 +52,23 @@ func WithCoChannelThreshold(n int) Option {
 	}
 }
 
+// WithSSIDSprawlThreshold sets the SSID-sprawl reporting threshold (distinct
+// SSIDs per AP). Values below 2 are clamped to 2.
+func WithSSIDSprawlThreshold(n int) Option {
+	return func(d *Detector) {
+		if n < minSSIDSprawlThreshold {
+			n = minSSIDSprawlThreshold
+		}
+		d.ssidSprawlThreshold = n
+	}
+}
+
 // NewDetector returns a Detector with the given options applied.
 func NewDetector(opts ...Option) *Detector {
-	d := &Detector{coChannelThreshold: defaultCoChannelThreshold}
+	d := &Detector{
+		coChannelThreshold:  defaultCoChannelThreshold,
+		ssidSprawlThreshold: defaultSSIDSprawlThreshold,
+	}
 	for _, o := range opts {
 		o(d)
 	}
@@ -63,6 +85,7 @@ func (d *Detector) Detect(tree []airspace.SSIDGroup) []anomaly.Detection {
 	out = append(out, ssidGroupDetections(tree)...)
 	out = append(out, d.coChannelDetections(tree)...)
 	out = append(out, countryConflictDetections(tree)...)
+	out = append(out, d.ssidSprawlDetections(tree)...)
 
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].DefKey != out[j].DefKey {
@@ -88,7 +111,8 @@ func forEachBSS(tree []airspace.SSIDGroup, fn func(g airspace.SSIDGroup, ap airs
 }
 
 // perBSSDetections runs the rules that judge a single BSS in isolation:
-// open/WEP/WPS, PMF-not-required, adjacent-channel overlap, and hidden SSID.
+// open/WEP/WPS, WPA3 transition downgrade, PMF-not-required, adjacent-channel
+// overlap, and hidden SSID.
 func perBSSDetections(tree []airspace.SSIDGroup) []anomaly.Detection {
 	var out []anomaly.Detection
 	forEachBSS(tree, func(_ airspace.SSIDGroup, _ airspace.APGroup, b airspace.BSSView) {
@@ -100,6 +124,8 @@ func perBSSDetections(tree []airspace.SSIDGroup) []anomaly.Detection {
 			out = append(out, anomaly.Detection{DefKey: DefOpenNetwork, Subject: subject, Evidence: ev})
 		case secWEP:
 			out = append(out, anomaly.Detection{DefKey: DefWEPInUse, Subject: subject, Evidence: ev})
+		case secWPA2WPA3:
+			out = append(out, anomaly.Detection{DefKey: DefWPA3TransitionDowngrade, Subject: subject, Evidence: ev})
 		}
 
 		if b.WPSEnabled {
@@ -156,6 +182,100 @@ func ssidGroupDetections(tree []airspace.SSIDGroup) []anomaly.Detection {
 				Evidence: map[string]string{"standards": strings.Join(standards.sorted(), ", ")},
 			})
 		}
+		if isDefaultSSID(g.SSID) {
+			out = append(out, anomaly.Detection{
+				DefKey: DefDefaultSSIDName, Subject: subject,
+				Evidence: map[string]string{"ssid": g.SSID},
+			})
+		}
+		if mixed, ev := roamingInconsistency(g); mixed {
+			out = append(out, anomaly.Detection{
+				DefKey: DefInconsistentRoaming, Subject: subject, Evidence: ev,
+			})
+		}
+	}
+	return out
+}
+
+// roamingInconsistency reports whether the BSSes under one SSID disagree on any
+// roaming-assist feature (802.11r FT / 802.11k RRM / 802.11v BTM): at least one
+// BSS advertises it and at least one does not. It needs at least two BSSes to
+// have a disagreement. The evidence names the inconsistent features.
+func roamingInconsistency(g airspace.SSIDGroup) (bool, map[string]string) {
+	feats := map[string]*featureTally{"ft": {}, "rrm": {}, "btm": {}}
+	total := 0
+	for _, ap := range g.APs {
+		for _, b := range ap.BSSes {
+			total++
+			feats["ft"].add(b.FTSupported)
+			feats["rrm"].add(b.RRMNeighbor)
+			feats["btm"].add(b.BTMSupported)
+		}
+	}
+	if total < minDistinctForMismatch {
+		return false, nil
+	}
+	inconsistent := newStringSet()
+	for name, c := range feats {
+		if c.mixed() {
+			inconsistent.add(name)
+		}
+	}
+	if inconsistent.len() == 0 {
+		return false, nil
+	}
+	return true, map[string]string{"inconsistentFeatures": strings.Join(inconsistent.sorted(), ", ")}
+}
+
+// featureTally counts how many BSSes do and do not advertise one capability.
+type featureTally struct{ yes, no int }
+
+func (c *featureTally) add(supported bool) {
+	if supported {
+		c.yes++
+		return
+	}
+	c.no++
+}
+
+// mixed reports whether the capability is advertised by some BSSes but not all.
+func (c *featureTally) mixed() bool { return c.yes > 0 && c.no > 0 }
+
+// ssidSprawlDetections reports access points advertising many SSIDs (beacon
+// airtime tax). It aggregates distinct SSIDs per AP key across the whole tree —
+// an AP that serves several SSIDs appears once under each SSID group.
+func (d *Detector) ssidSprawlDetections(tree []airspace.SSIDGroup) []anomaly.Detection {
+	byAP := map[string]*stringSet{}
+	order := []string{}
+	for _, g := range tree {
+		if g.SSID == "" {
+			continue
+		}
+		for _, ap := range g.APs {
+			set, ok := byAP[ap.Key]
+			if !ok {
+				set = newStringSet()
+				byAP[ap.Key] = set
+				order = append(order, ap.Key)
+			}
+			set.add(g.SSID)
+		}
+	}
+
+	var out []anomaly.Detection
+	for _, key := range order {
+		ssids := byAP[key]
+		if ssids.len() < d.ssidSprawlThreshold {
+			continue
+		}
+		out = append(out, anomaly.Detection{
+			DefKey:  DefSSIDSprawl,
+			Subject: anomaly.SubjectRef{Kind: anomaly.SubjectDevice, ID: key},
+			Evidence: map[string]string{
+				"ssidCount": strconv.Itoa(ssids.len()),
+				"ssids":     strings.Join(ssids.sorted(), ", "),
+			},
+		})
 	}
 	return out
 }

--- a/internal/wifi/anomaly/detect_test.go
+++ b/internal/wifi/anomaly/detect_test.go
@@ -81,6 +81,10 @@ func TestCatalogBuildsAndCoversEveryDefID(t *testing.T) {
 		wifianomaly.DefHiddenSSID,
 		wifianomaly.DefCountryConflict,
 		wifianomaly.DefStandardMismatch,
+		wifianomaly.DefWPA3TransitionDowngrade,
+		wifianomaly.DefDefaultSSIDName,
+		wifianomaly.DefSSIDSprawl,
+		wifianomaly.DefInconsistentRoaming,
 	}
 	if cat.Len() != len(ids) {
 		t.Errorf("catalog Len = %d, want %d (every exported def ID, no extras)", cat.Len(), len(ids))

--- a/internal/wifi/anomaly/detect_w4c_test.go
+++ b/internal/wifi/anomaly/detect_w4c_test.go
@@ -1,0 +1,86 @@
+package wifianomaly_test
+
+import (
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+)
+
+func TestWPA3TransitionDowngrade(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	// Transition mode (WPA2/WPA3) → flagged; pure WPA3 → clean.
+	tm := bss("00:00:00:00:00:01", "corp", "WPA2/WPA3", "5 GHz", 36)
+	tm.PMFRequired = true
+	if !hasDef(det.Detect(tree("corp", tm)), wifianomaly.DefWPA3TransitionDowngrade) {
+		t.Error("WPA2/WPA3 transition mode should be flagged as downgrade-capable")
+	}
+	pure := bss("00:00:00:00:00:02", "corp", "WPA3", "5 GHz", 36)
+	pure.PMFRequired = true
+	if hasDef(det.Detect(tree("corp", pure)), wifianomaly.DefWPA3TransitionDowngrade) {
+		t.Error("pure WPA3 must not be flagged as transition downgrade")
+	}
+}
+
+func TestDefaultSSIDName(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	for _, name := range []string{"NETGEAR47", "linksys", "D-Link_2.4G", "default"} {
+		b := bss("00:00:00:00:00:01", name, "WPA2", "5 GHz", 36)
+		b.PMFRequired = true
+		if !hasDef(det.Detect(tree(name, b)), wifianomaly.DefDefaultSSIDName) {
+			t.Errorf("SSID %q should be flagged as a default name", name)
+		}
+	}
+	// A configured name is not a default.
+	b := bss("00:00:00:00:00:01", "AcmeCorp-Staff", "WPA2", "5 GHz", 36)
+	b.PMFRequired = true
+	if hasDef(det.Detect(tree("AcmeCorp-Staff", b)), wifianomaly.DefDefaultSSIDName) {
+		t.Error("a configured SSID must not be flagged as default")
+	}
+}
+
+func TestSSIDSprawl(t *testing.T) {
+	// One AP (shared key) advertising 3 SSIDs, threshold 3 → sprawl.
+	mkTree := func(ssids ...string) []airspace.SSIDGroup {
+		groups := make([]airspace.SSIDGroup, 0, len(ssids))
+		for i, s := range ssids {
+			b := bss("00:00:00:00:00:0"+string(rune('a'+i)), s, "WPA3", "5 GHz", 36)
+			b.PMFRequired = true
+			groups = append(groups, airspace.SSIDGroup{
+				SSID:    s,
+				APCount: 1,
+				APs:     []airspace.APGroup{{Key: "shared-ap", Vendor: "Cisco", BSSes: []airspace.BSSView{b}}},
+			})
+		}
+		return groups
+	}
+	det := wifianomaly.NewDetector(wifianomaly.WithSSIDSprawlThreshold(3))
+	if hasDef(det.Detect(mkTree("a", "b")), wifianomaly.DefSSIDSprawl) {
+		t.Error("2 SSIDs is below sprawl threshold 3")
+	}
+	if !hasDef(det.Detect(mkTree("a", "b", "c")), wifianomaly.DefSSIDSprawl) {
+		t.Error("3 SSIDs on one AP meets sprawl threshold 3")
+	}
+}
+
+func TestInconsistentRoaming(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	ftYes := bss("00:00:00:00:00:01", "corp", "WPA3", "5 GHz", 36)
+	ftYes.PMFRequired = true
+	ftYes.FTSupported = true
+	ftNo := bss("00:00:00:00:00:02", "corp", "WPA3", "5 GHz", 40)
+	ftNo.PMFRequired = true
+	ftNo.FTSupported = false
+	if !hasDef(det.Detect(tree("corp", ftYes, ftNo)), wifianomaly.DefInconsistentRoaming) {
+		t.Error("mixed 802.11r support across an SSID should be flagged")
+	}
+
+	// Uniform support → no inconsistency.
+	a := bss("00:00:00:00:00:03", "corp", "WPA3", "5 GHz", 36)
+	a.PMFRequired, a.FTSupported, a.RRMNeighbor, a.BTMSupported = true, true, true, true
+	b := bss("00:00:00:00:00:04", "corp", "WPA3", "5 GHz", 40)
+	b.PMFRequired, b.FTSupported, b.RRMNeighbor, b.BTMSupported = true, true, true, true
+	if hasDef(det.Detect(tree("corp", a, b)), wifianomaly.DefInconsistentRoaming) {
+		t.Error("uniform roaming support must not be flagged")
+	}
+}

--- a/internal/wifi/anomaly/tokens.go
+++ b/internal/wifi/anomaly/tokens.go
@@ -1,6 +1,9 @@
 package wifianomaly
 
-import "sort"
+import (
+	"sort"
+	"strings"
+)
 
 // The airspace Tree exposes Security/Standard/Band as the strings produced by
 // dot11's String() methods (those nouns are kept verbatim — DNT). The rules
@@ -67,6 +70,32 @@ func hasWeakAndStrong(securities *stringSet) bool {
 // channels (1, 6, 11). Any other 2.4 GHz channel partially overlaps a neighbour.
 func is24NonOverlapping(ch int) bool {
 	return ch == 1 || ch == 6 || ch == 11
+}
+
+// defaultSSIDPrefixes are well-known router/manufacturer default network-name
+// prefixes. Matching is conservative (prefix on a lower-cased, separator-stripped
+// SSID) to flag clearly-unconfigured devices without snaring intentional names.
+func defaultSSIDPrefixes() []string {
+	return []string{
+		"linksys", "netgear", "dlink", "tplink", "belkin",
+		"asus", "tendawifi", "default", "wireless",
+	}
+}
+
+// isDefaultSSID reports whether ssid looks like an unconfigured manufacturer
+// default. Empty/cloaked SSIDs are not considered defaults (handled elsewhere).
+func isDefaultSSID(ssid string) bool {
+	norm := strings.ToLower(ssid)
+	norm = strings.NewReplacer("-", "", "_", "", " ", "").Replace(norm)
+	if norm == "" {
+		return false
+	}
+	for _, p := range defaultSSIDPrefixes() {
+		if strings.HasPrefix(norm, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // stringSet is a tiny ordered-output set used to collect distinct evidence


### PR DESCRIPTION
Extend the Wi-Fi catalog + detector with rules computable from the existing
airspace tree fields (no new capture/decode). 11 -> 15 defs.

- wpa3-transition-downgrade (per-BSS): Security == WPA2/WPA3 transition mode is
  downgrade-capable; an on-path attacker can strip the WPA3 offer.
- default-ssid-name (per-SSID): SSID matches a known manufacturer default
  (linksys/NETGEAR/dlink/...) — signals an unconfigured device; conservative
  prefix match on a normalized SSID.
- ssid-sprawl (per-AP, airspace-wide): one AP advertising >= N distinct SSIDs
  (beacon airtime tax); configurable via WithSSIDSprawlThreshold (default 5).
- inconsistent-roaming (per-SSID): BSSes disagree on 802.11r/k/v support, which
  breaks roaming; needs >= 2 BSSes.

Each ships with original copy + IEEE cites + recommendation. CGO-free, no DTO/
schema/route change (pure catalog+rule data). 96.7% coverage, race-clean,
golangci 0.
