### PR TITLE
feat(wifi): monitor-mode capture producer (W3)

### DIFF
--- a/cmd/seed/cmd_serve.go
+++ b/cmd/seed/cmd_serve.go
@@ -121,6 +121,16 @@ func initializeBackgroundComponents(cfg *config.Config, db *database.DB) *api.Ba
 	} else {
 		components.WiFiVisibility = wifiVis
 		logging.GetLogger().Info("Wi-Fi visibility module initialized")
+
+		// Monitor-mode capture is opt-in via a bring-your-own monitor interface
+		// (third-party adapter): set SEED_WIFI_MONITOR_IFACE to the iface name.
+		// Unset (the default) leaves the visibility endpoints serving an empty
+		// airspace; capture also degrades gracefully if the iface is not in
+		// monitor mode or libpcap is unavailable.
+		if iface := os.Getenv("SEED_WIFI_MONITOR_IFACE"); iface != "" {
+			components.WiFiCapture = app.NewWiFiCapture(wifiVis, iface)
+			logging.GetLogger().Info("Wi-Fi monitor capture configured", "iface", iface)
+		}
 	}
 
 	return components

--- a/internal/api/background.go
+++ b/internal/api/background.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/krisarmstrong/seed/internal/reporting"
+	wificapture "github.com/krisarmstrong/seed/internal/wifi/capture"
 	"github.com/krisarmstrong/seed/internal/wifi/visibility"
 )
 
@@ -11,14 +12,17 @@ import (
 // lifecycle (Start/Stop). Stateless request/response logic lives in the handlers
 // and the api service groupings, built directly from the feature packages; only
 // components that own background work belong here: the report scheduler
-// (internal/reporting) and the Wi-Fi airspace visibility loop
-// (internal/wifi/visibility).
+// (internal/reporting), the Wi-Fi airspace visibility loop
+// (internal/wifi/visibility), and the monitor-mode capture producer that feeds it
+// (internal/wifi/capture).
 type BackgroundComponents struct {
 	Reporting      *reporting.Service
 	WiFiVisibility *visibility.Service
+	WiFiCapture    *wificapture.Capture
 }
 
-// Start initializes and starts all background components.
+// Start initializes and starts all background components. The visibility loop
+// starts before the capture producer that feeds it.
 func (b *BackgroundComponents) Start(ctx context.Context) error {
 	if b.Reporting != nil {
 		if err := b.Reporting.Start(ctx); err != nil {
@@ -30,11 +34,20 @@ func (b *BackgroundComponents) Start(ctx context.Context) error {
 			return err
 		}
 	}
+	if b.WiFiCapture != nil {
+		if err := b.WiFiCapture.Start(ctx); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
-// Stop gracefully shuts down all background components.
+// Stop gracefully shuts down all background components. Capture stops before the
+// visibility loop it feeds (stop producing, then consuming).
 func (b *BackgroundComponents) Stop() error {
+	if b.WiFiCapture != nil {
+		_ = b.WiFiCapture.Stop()
+	}
 	if b.Reporting != nil {
 		_ = b.Reporting.Stop()
 	}

--- a/internal/app/wifi_capture.go
+++ b/internal/app/wifi_capture.go
@@ -1,0 +1,14 @@
+package app
+
+import (
+	wificapture "github.com/krisarmstrong/seed/internal/wifi/capture"
+	"github.com/krisarmstrong/seed/internal/wifi/visibility"
+)
+
+// NewWiFiCapture builds the monitor-mode capture producer feeding the visibility
+// service from iface. The libpcap-backed opener is selected by build tag
+// (wificapture.DefaultOpener); on CGO-free builds it is a no-op that disables
+// capture gracefully. An empty iface also disables capture.
+func NewWiFiCapture(sink *visibility.Service, iface string) *wificapture.Capture {
+	return wificapture.New(wificapture.DefaultOpener(), sink, iface)
+}

--- a/internal/wifi/capture/capture.go
+++ b/internal/wifi/capture/capture.go
@@ -1,0 +1,183 @@
+// Package wificapture is the monitor-mode 802.11 capture producer for the Wi-Fi
+// visibility feature. It opens a live-capture handle on a monitor-capable
+// interface (via the CGO-confined internal/capture port), reads radiotap frames,
+// decodes them with internal/wifi/dot11, and feeds the decoded frames to a sink
+// (the internal/wifi/visibility service).
+//
+// The package is CGO-free: the libpcap binding is injected as a capture.Opener
+// (DefaultOpener selects the real adapter on cgo/windows builds and a no-op stub
+// otherwise), so the read→decode→ingest loop is exercised with a fake handle in
+// tests. Capture degrades gracefully — a missing interface, an open failure, or a
+// non-monitor (non-radiotap) link type disables capture with a log line rather
+// than an error, leaving the visibility endpoints to serve an empty airspace.
+package wificapture
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/krisarmstrong/seed/internal/capture"
+	"github.com/krisarmstrong/seed/internal/wifi/dot11"
+)
+
+// defaultSnapLen is the per-packet capture length. Radiotap + a full management
+// frame with its information elements fits comfortably; data frames are captured
+// only far enough to attribute a client to its BSSID.
+const defaultSnapLen = 65535
+
+// Sink receives decoded frames and capture-source lifecycle signals. The
+// visibility service satisfies it.
+type Sink interface {
+	Ingest(f *dot11.Frame, at time.Time)
+	SetSource(name string)
+	ClearSource()
+}
+
+// Capture owns a monitor-mode read loop feeding a Sink. Lifecycle (Start/Stop)
+// mirrors the other background components; all methods are concurrency-safe.
+type Capture struct {
+	opener  capture.Opener
+	sink    Sink
+	iface   string
+	snapLen int32
+	now     func() time.Time
+	log     *slog.Logger
+
+	mu     sync.Mutex
+	handle capture.Handle
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// Option configures a Capture.
+type Option func(*Capture)
+
+// WithClock overrides the timestamp source (for tests).
+func WithClock(now func() time.Time) Option {
+	return func(c *Capture) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+// WithLogger sets the logger.
+func WithLogger(l *slog.Logger) Option {
+	return func(c *Capture) {
+		if l != nil {
+			c.log = l
+		}
+	}
+}
+
+// WithSnapLen overrides the per-packet capture length.
+func WithSnapLen(n int32) Option {
+	return func(c *Capture) {
+		if n > 0 {
+			c.snapLen = n
+		}
+	}
+}
+
+// New builds a capture bound to opener, feeding sink from iface (the monitor
+// interface name; empty disables capture).
+func New(opener capture.Opener, sink Sink, iface string, opts ...Option) *Capture {
+	c := &Capture{
+		opener:  opener,
+		sink:    sink,
+		iface:   iface,
+		snapLen: defaultSnapLen,
+		now:     time.Now,
+		log:     slog.Default(),
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// Start opens the capture handle and launches the read loop. It returns nil and
+// disables capture (with a log line) when no interface is configured, the handle
+// cannot be opened, or the interface is not in monitor mode — these are normal
+// degraded states, not startup failures. Idempotent: a second call while running
+// is a no-op.
+func (c *Capture) Start(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cancel != nil {
+		return nil
+	}
+	if c.iface == "" {
+		c.log.InfoContext(ctx, "wifi capture disabled: no monitor interface configured")
+		return nil
+	}
+
+	handle, err := c.opener.OpenLive(c.iface, c.snapLen, true, capture.BlockForever)
+	if err != nil {
+		c.log.WarnContext(ctx, "wifi capture unavailable: cannot open interface",
+			"iface", c.iface, "error", err)
+		return nil
+	}
+	if lt := handle.LinkType(); lt != layers.LinkTypeIEEE80211Radio {
+		handle.Close()
+		c.log.WarnContext(ctx, "wifi capture unavailable: interface is not in monitor mode (radiotap required)",
+			"iface", c.iface, "linkType", lt.String())
+		return nil
+	}
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	c.cancel = cancel
+	c.handle = handle
+	c.sink.SetSource(c.iface)
+	c.wg.Add(1)
+	go c.loop(loopCtx, handle)
+	c.log.InfoContext(ctx, "wifi monitor capture started", "iface", c.iface)
+	return nil
+}
+
+// loop reads frames until the handle is closed (by Stop) or a read error occurs.
+// Undecodable frames (non-802.11 / malformed) are skipped, never fatal.
+func (c *Capture) loop(ctx context.Context, handle capture.Handle) {
+	defer c.wg.Done()
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		data, _, err := handle.ReadPacketData()
+		if err != nil {
+			// Closed handle (Stop) or a fatal read error ends the loop.
+			return
+		}
+		frame, derr := dot11.Decode(data)
+		if derr != nil {
+			continue
+		}
+		c.sink.Ingest(frame, c.now())
+	}
+}
+
+// Stop ends the read loop, closes the handle, and clears the capture source.
+// Idempotent.
+func (c *Capture) Stop() error {
+	c.mu.Lock()
+	cancel := c.cancel
+	handle := c.handle
+	c.cancel = nil
+	c.handle = nil
+	c.mu.Unlock()
+
+	if cancel == nil {
+		return nil // not running
+	}
+	cancel()
+	if handle != nil {
+		handle.Close() // unblocks a blocked ReadPacketData
+	}
+	c.wg.Wait()
+	c.sink.ClearSource()
+	return nil
+}

--- a/internal/wifi/capture/capture_test.go
+++ b/internal/wifi/capture/capture_test.go
@@ -1,0 +1,206 @@
+package wificapture_test
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/krisarmstrong/seed/internal/capture"
+	wificapture "github.com/krisarmstrong/seed/internal/wifi/capture"
+	"github.com/krisarmstrong/seed/internal/wifi/dot11"
+)
+
+// --- fakes ----------------------------------------------------------------
+
+type fakeHandle struct {
+	mu       sync.Mutex
+	frames   [][]byte
+	idx      int
+	linkType layers.LinkType
+	closed   bool
+}
+
+func (h *fakeHandle) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed || h.idx >= len(h.frames) {
+		return nil, gopacket.CaptureInfo{}, io.EOF
+	}
+	d := h.frames[h.idx]
+	h.idx++
+	return d, gopacket.CaptureInfo{}, nil
+}
+
+func (h *fakeHandle) SetBPFFilter(string) error { return nil }
+func (h *fakeHandle) LinkType() layers.LinkType { return h.linkType }
+func (h *fakeHandle) Close()                    { h.mu.Lock(); h.closed = true; h.mu.Unlock() }
+
+type fakeOpener struct {
+	handle capture.Handle
+	err    error
+	calls  int
+}
+
+func (o *fakeOpener) OpenLive(string, int32, bool, time.Duration) (capture.Handle, error) {
+	o.calls++
+	return o.handle, o.err
+}
+
+type fakeSink struct {
+	mu       sync.Mutex
+	frames   []*dot11.Frame
+	setCalls int
+	source   string
+	cleared  bool
+}
+
+func (s *fakeSink) Ingest(f *dot11.Frame, _ time.Time) {
+	s.mu.Lock()
+	s.frames = append(s.frames, f)
+	s.mu.Unlock()
+}
+func (s *fakeSink) SetSource(n string) { s.mu.Lock(); s.setCalls++; s.source = n; s.mu.Unlock() }
+func (s *fakeSink) ClearSource()       { s.mu.Lock(); s.cleared = true; s.source = ""; s.mu.Unlock() }
+
+func (s *fakeSink) frameCount() int { s.mu.Lock(); defer s.mu.Unlock(); return len(s.frames) }
+
+// beaconBytes builds radiotap + an 802.11 beacon advertising ssid (mirrors the
+// frame format the dot11 decoder is tested against).
+func beaconBytes(ssid string) []byte {
+	bssid := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	frame := []byte{0x80, 0x00, 0x00, 0x00} // FC mgmt/beacon + duration
+	frame = append(frame, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff)
+	frame = append(frame, bssid...)
+	frame = append(frame, bssid...)
+	frame = append(frame, 0x00, 0x00)         // sequence control
+	frame = append(frame, make([]byte, 8)...) // timestamp
+	frame = append(frame, 0x64, 0x00)         // beacon interval
+	frame = append(frame, 0x01, 0x00)         // capability (ESS)
+	frame = append(frame, 0x00, byte(len(ssid)))
+	frame = append(frame, []byte(ssid)...) // SSID IE
+	frame = append(frame, 0xde, 0xad, 0xbe, 0xef)
+	radiotap := []byte{0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00}
+	return append(radiotap, frame...)
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}
+
+// --- tests ----------------------------------------------------------------
+
+func TestCaptureIngestsDecodedFramesAndSkipsGarbage(t *testing.T) {
+	h := &fakeHandle{
+		frames:   [][]byte{beaconBytes("corp"), {0x01, 0x02, 0x03}, beaconBytes("guest")},
+		linkType: layers.LinkTypeIEEE80211Radio,
+	}
+	sink := &fakeSink{}
+	c := wificapture.New(&fakeOpener{handle: h}, sink, "mon0")
+
+	if err := c.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitFor(t, func() bool { return sink.frameCount() == 2 })
+	if err := c.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if sink.frameCount() != 2 {
+		t.Errorf("ingested %d frames, want 2 (2 beacons, 1 garbage skipped)", sink.frameCount())
+	}
+	if sink.setCalls == 0 || !sink.cleared {
+		t.Errorf("expected SetSource on start and ClearSource on stop: set=%d cleared=%v", sink.setCalls, sink.cleared)
+	}
+}
+
+func TestCaptureRejectsNonMonitorInterface(t *testing.T) {
+	h := &fakeHandle{frames: [][]byte{beaconBytes("corp")}, linkType: layers.LinkTypeEthernet}
+	sink := &fakeSink{}
+	c := wificapture.New(&fakeOpener{handle: h}, sink, "eth0")
+
+	if err := c.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop() })
+
+	if sink.frameCount() != 0 {
+		t.Error("non-monitor interface must not ingest frames")
+	}
+	if sink.setCalls != 0 {
+		t.Error("non-monitor interface must not set a capture source")
+	}
+	h.mu.Lock()
+	closed := h.closed
+	h.mu.Unlock()
+	if !closed {
+		t.Error("the non-monitor handle should be closed")
+	}
+}
+
+func TestCaptureGracefulWhenOpenFails(t *testing.T) {
+	sink := &fakeSink{}
+	c := wificapture.New(&fakeOpener{err: io.ErrUnexpectedEOF}, sink, "mon0")
+	if err := c.Start(t.Context()); err != nil {
+		t.Fatalf("Start should degrade gracefully, got error: %v", err)
+	}
+	if sink.setCalls != 0 || sink.frameCount() != 0 {
+		t.Error("a failed open must not set a source or ingest frames")
+	}
+}
+
+func TestCaptureDisabledWithoutInterface(t *testing.T) {
+	op := &fakeOpener{}
+	c := wificapture.New(op, &fakeSink{}, "")
+	if err := c.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if op.calls != 0 {
+		t.Error("an empty interface must not attempt to open a handle")
+	}
+}
+
+func TestOptionsApplied(t *testing.T) {
+	h := &fakeHandle{frames: [][]byte{beaconBytes("corp")}, linkType: layers.LinkTypeIEEE80211Radio}
+	sink := &fakeSink{}
+	fixed := time.Unix(1700000000, 0).UTC()
+	c := wificapture.New(&fakeOpener{handle: h}, sink, "mon0",
+		wificapture.WithClock(func() time.Time { return fixed }),
+		wificapture.WithLogger(slog.New(slog.DiscardHandler)),
+		wificapture.WithSnapLen(2048),
+	)
+	if err := c.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitFor(t, func() bool { return sink.frameCount() == 1 })
+	if err := c.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestStopIdempotent(t *testing.T) {
+	h := &fakeHandle{frames: [][]byte{beaconBytes("corp")}, linkType: layers.LinkTypeIEEE80211Radio}
+	c := wificapture.New(&fakeOpener{handle: h}, &fakeSink{}, "mon0")
+	if err := c.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := c.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if err := c.Stop(); err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+}

--- a/internal/wifi/capture/opener_null.go
+++ b/internal/wifi/capture/opener_null.go
@@ -1,0 +1,14 @@
+//go:build !cgo && !windows
+
+package wificapture
+
+import (
+	"github.com/krisarmstrong/seed/internal/capture"
+	"github.com/krisarmstrong/seed/internal/capture/nullcapture"
+)
+
+// DefaultOpener returns the CGO-free no-op capture adapter, compiled only for
+// CGO_ENABLED=0 non-Windows builds where libpcap cannot be linked. OpenLive then
+// fails with nullcapture.ErrUnavailable and Capture.Start degrades gracefully.
+// Mirrors internal/api/wire_capture_null.go.
+func DefaultOpener() capture.Opener { return nullcapture.New() }

--- a/internal/wifi/capture/opener_real.go
+++ b/internal/wifi/capture/opener_real.go
@@ -1,0 +1,14 @@
+//go:build cgo || windows
+
+package wificapture
+
+import (
+	"github.com/krisarmstrong/seed/internal/capture"
+	"github.com/krisarmstrong/seed/internal/capture/pcap"
+)
+
+// DefaultOpener returns the libpcap-backed capture adapter. Compiled when CGO is
+// enabled (libpcap linkable on linux/darwin) or on Windows (gopacket/pcap is
+// CGO-free via wpcap). Mirrors internal/api/wire_capture_real.go so monitor-mode
+// capture works on every platform that supports live capture.
+func DefaultOpener() capture.Opener { return pcap.New() }


### PR DESCRIPTION
Add internal/wifi/capture (package wificapture): the producer that makes the
Wi-Fi visibility feature live. It opens a live-capture handle on a monitor
interface, reads radiotap frames, decodes them with internal/wifi/dot11, and
feeds them to the visibility service via Ingest.

- CGO-free core: the libpcap binding is injected as a capture.Opener (the same
  port the discovery captures use). DefaultOpener selects the real adapter on
  cgo/windows and a no-op stub otherwise (opener_real.go / opener_null.go),
  mirroring internal/api/wire_capture_*.go. The read->decode->ingest loop is
  fully unit-tested with a fake handle (no libpcap needed).
- Graceful degrade: a missing/empty interface, an open failure, or a
  non-monitor (non-radiotap) link type disables capture with a log line, never
  an error — the visibility endpoints keep serving an empty airspace.
- Lifecycle: Start opens + launches the read loop; Stop closes the handle (which
  unblocks the read) and clears the capture source. Idempotent.
- Wired as BackgroundComponents.WiFiCapture, started after the visibility loop
  and stopped before it. Opt-in via SEED_WIFI_MONITOR_IFACE (bring-your-own
  monitor adapter); unset leaves the feature dormant as before.

Monitor-mode ENABLEMENT (auto iw/nl80211 set-monitor per OS) is a deliberate
follow-up; this slice is BYO-monitor + capture/decode/ingest. 96.8% coverage on
the testable core, race-clean, both CGO modes, golangci 0. No DTO/route/schema
change.
