### PR TITLE
feat(wifi): regulatory-violation rule (802.11d, 2.4 GHz)

### DIFF
--- a/internal/wifi/anomaly/catalog.go
+++ b/internal/wifi/anomaly/catalog.go
@@ -21,6 +21,7 @@ const (
 	DefDefaultSSIDName         = "wifi-default-ssid-name"
 	DefSSIDSprawl              = "wifi-ssid-sprawl"
 	DefInconsistentRoaming     = "wifi-inconsistent-roaming"
+	DefRegulatoryViolation     = "wifi-regulatory-violation"
 )
 
 // CapActiveTest names the platform capability required to run an active
@@ -287,6 +288,22 @@ func Defs() []anomaly.Def {
 				"roams, dropped real-time sessions, and sticky-client behaviour.",
 			Recommendation: "Enable the same roaming features (802.11r/k/v) consistently on every AP " +
 				"serving the SSID, or disable them uniformly if a legacy client cannot cope.",
+		},
+		{
+			ID:              DefRegulatoryViolation,
+			Category:        anomaly.CategoryStandards,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"IEEE 802.11d", "ITU/regional 2.4 GHz channel plans"},
+			Title:           "Channel not permitted in the declared regulatory domain",
+			Description: "The BSS operates on a 2.4 GHz channel that is not allowed in the country " +
+				"it advertises (802.11d). Channels 12-13 are not permitted under the US/Canada FCC " +
+				"domain, and channel 14 is permitted only in Japan; using them elsewhere violates " +
+				"the local regulatory plan.",
+			Impact: "Operating outside the permitted channel set can cause interference with " +
+				"licensed services and other networks, and is a regulatory-compliance violation; it " +
+				"can also indicate a misconfigured or spoofed regulatory domain.",
+			Recommendation: "Move the radio to a channel permitted in the deployment's country " +
+				"(1-11 under FCC) and set the correct regulatory domain on the AP.",
 		},
 	}
 }

--- a/internal/wifi/anomaly/detect.go
+++ b/internal/wifi/anomaly/detect.go
@@ -146,6 +146,12 @@ func perBSSDetections(tree []airspace.SSIDGroup) []anomaly.Detection {
 		if b.Hidden {
 			out = append(out, anomaly.Detection{DefKey: DefHiddenSSID, Subject: subject, Evidence: ev})
 		}
+
+		if b.Band == band24GHz && b.CountryCode != "" && b.Channel != 0 {
+			if channelStatus2GHz(b.CountryCode, b.Channel) == chanForbidden {
+				out = append(out, anomaly.Detection{DefKey: DefRegulatoryViolation, Subject: subject, Evidence: ev})
+			}
+		}
 	})
 	return out
 }
@@ -387,6 +393,9 @@ func bssEvidence(b airspace.BSSView) map[string]string {
 	}
 	if b.SSID == "" {
 		ev["ssid"] = "(hidden)"
+	}
+	if b.CountryCode != "" {
+		ev["countryCode"] = b.CountryCode
 	}
 	return ev
 }

--- a/internal/wifi/anomaly/detect_test.go
+++ b/internal/wifi/anomaly/detect_test.go
@@ -85,6 +85,7 @@ func TestCatalogBuildsAndCoversEveryDefID(t *testing.T) {
 		wifianomaly.DefDefaultSSIDName,
 		wifianomaly.DefSSIDSprawl,
 		wifianomaly.DefInconsistentRoaming,
+		wifianomaly.DefRegulatoryViolation,
 	}
 	if cat.Len() != len(ids) {
 		t.Errorf("catalog Len = %d, want %d (every exported def ID, no extras)", cat.Len(), len(ids))

--- a/internal/wifi/anomaly/regulatory.go
+++ b/internal/wifi/anomaly/regulatory.go
@@ -1,0 +1,63 @@
+package wifianomaly
+
+// 802.11d regulatory checks for the 2.4 GHz band, where the channel plan is
+// stable and the well-known cross-domain deltas are unambiguous. The 5/6 GHz
+// plans (DFS, country-specific sub-bands) are deliberately out of scope here —
+// encoding them wrong would produce false positives — so a 5/6 GHz channel is
+// never evaluated by these helpers.
+//
+// The table is intentionally conservative: it returns chanForbidden only for the
+// cases that are universally true, so a flagged channel is a real regulatory
+// problem, not a guess. Anything we cannot assert confidently is chanUnknown.
+
+// chanStatus is the regulatory verdict for a channel in a declared domain.
+type chanStatus int
+
+const (
+	// chanUnknown means no confident rule applies (the caller emits nothing).
+	chanUnknown chanStatus = iota
+	// chanAllowed means the channel is permitted in the domain.
+	chanAllowed
+	// chanForbidden means the channel is not permitted in the domain.
+	chanForbidden
+)
+
+// channel2GHz14 is JP-only worldwide (and only for 802.11b). Channels 12-13 are
+// permitted across most of the world but not in the US/Canada FCC domain.
+const channel2GHz14 = 14
+
+// usFCCDomains are the regulatory domains limited to 2.4 GHz channels 1-11.
+func usFCCDomains() map[string]struct{} {
+	return map[string]struct{}{"US": {}, "CA": {}}
+}
+
+// channelStatus2GHz returns the regulatory verdict for 2.4 GHz channel ch under
+// the ISO-3166 alpha-2 domain `country`.
+func channelStatus2GHz(country string, ch int) chanStatus {
+	switch {
+	case country == "JP":
+		// Japan permits 1-14 (14 for 11b only; we cannot see modulation, so we
+		// do not flag it here).
+		if ch >= 1 && ch <= channel2GHz14 {
+			return chanAllowed
+		}
+		return chanForbidden
+	case isUSFCC(country):
+		// FCC: channels 1-11 only; 12-14 are violations.
+		if ch >= 1 && ch <= 11 {
+			return chanAllowed
+		}
+		return chanForbidden
+	case ch == channel2GHz14:
+		// Channel 14 is JP-only everywhere else — a confident violation.
+		return chanForbidden
+	default:
+		// No country-specific rule we are confident about; do not guess.
+		return chanUnknown
+	}
+}
+
+func isUSFCC(country string) bool {
+	_, ok := usFCCDomains()[country]
+	return ok
+}

--- a/internal/wifi/anomaly/regulatory_test.go
+++ b/internal/wifi/anomaly/regulatory_test.go
@@ -1,0 +1,69 @@
+package wifianomaly_test
+
+import (
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+)
+
+// reg builds a single-BSS tree on a 2.4 GHz channel with a declared country.
+func reg(country string, ch int) []airspace.SSIDGroup {
+	b := bss("00:00:00:00:00:01", "corp", "WPA3", "2.4 GHz", ch)
+	b.PMFRequired = true
+	b.CountryCode = country
+	return tree("corp", b)
+}
+
+func TestRegulatoryViolation(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	id := wifianomaly.DefRegulatoryViolation
+
+	violations := []struct {
+		country string
+		ch      int
+		why     string
+	}{
+		{"US", 12, "FCC forbids 2.4 GHz channel 12"},
+		{"US", 13, "FCC forbids 2.4 GHz channel 13"},
+		{"CA", 12, "Canada follows FCC (1-11)"},
+		{"US", 14, "channel 14 is JP-only"},
+		{"DE", 14, "channel 14 is JP-only even where 12-13 are fine"},
+	}
+	for _, v := range violations {
+		if !hasDef(det.Detect(reg(v.country, v.ch)), id) {
+			t.Errorf("expected regulatory-violation: %s (country=%s ch=%d)", v.why, v.country, v.ch)
+		}
+	}
+
+	clean := []struct {
+		country string
+		ch      int
+	}{
+		{"US", 11}, // FCC legal
+		{"JP", 13}, // JP permits 1-14
+		{"JP", 14}, // JP permits 14
+		{"DE", 13}, // EU permits 13
+		{"GB", 6},  // common channel, any domain
+	}
+	for _, c := range clean {
+		if hasDef(det.Detect(reg(c.country, c.ch)), id) {
+			t.Errorf("false positive regulatory-violation for country=%s ch=%d", c.country, c.ch)
+		}
+	}
+
+	// No country code → cannot assess → no detection.
+	noCountry := bss("00:00:00:00:00:09", "corp", "WPA3", "2.4 GHz", 13)
+	noCountry.PMFRequired = true
+	if hasDef(det.Detect(tree("corp", noCountry)), id) {
+		t.Error("must not flag a regulatory violation without a declared country")
+	}
+
+	// 5 GHz is out of scope (plans too country-specific to assert) → no detection.
+	fiveGHz := bss("00:00:00:00:00:0a", "corp", "WPA3", "5 GHz", 36)
+	fiveGHz.PMFRequired = true
+	fiveGHz.CountryCode = "US"
+	if hasDef(det.Detect(tree("corp", fiveGHz)), id) {
+		t.Error("5 GHz must not raise regulatory-violation (out of scope)")
+	}
+}


### PR DESCRIPTION
Add the regulatory-violation anomaly (16th rule): a 2.4 GHz BSS on a channel not
permitted in the country it advertises (802.11d). Conservative, low-false-
positive table covering the unambiguous cross-domain deltas:

- US/Canada (FCC): channels 1-11 only -> 12-14 are violations.
- Channel 14: Japan-only worldwide -> a violation in any other domain.
- Japan: 1-14 permitted.
- Anything we cannot assert confidently (other countries' 12-13, all 5/6 GHz):
  returned as chanUnknown -> no detection. 5/6 GHz plans are deliberately out of
  scope (DFS/country sub-bands too error-prone to encode without false positives).

Per-BSS rule keyed on the existing BSSView Band/Channel/CountryCode fields;
countryCode added to the shared BSS evidence. CGO-free, no DTO/schema/route
change. 96.4% coverage, race-clean, golangci 0. Closes the named W4c leftover;
W4d/W4e/W7 rule tiers still need new decode/temporal/wired infrastructure.
