### PR TITLE
feat(wifi): monitor-mode auto-enablement (W3 follow-up)

### DIFF
--- a/cmd/seed/cmd_serve.go
+++ b/cmd/seed/cmd_serve.go
@@ -128,8 +128,13 @@ func initializeBackgroundComponents(cfg *config.Config, db *database.DB) *api.Ba
 		// airspace; capture also degrades gracefully if the iface is not in
 		// monitor mode or libpcap is unavailable.
 		if iface := os.Getenv("SEED_WIFI_MONITOR_IFACE"); iface != "" {
-			components.WiFiCapture = app.NewWiFiCapture(wifiVis, iface)
-			logging.GetLogger().Info("Wi-Fi monitor capture configured", "iface", iface)
+			// SEED_WIFI_MONITOR_AUTO=1 also switches the interface into monitor
+			// mode on start (Linux iw/nl80211); otherwise it must already be in
+			// monitor mode (bring-your-own).
+			autoEnable := os.Getenv("SEED_WIFI_MONITOR_AUTO") == "1"
+			components.WiFiCapture = app.NewWiFiCapture(wifiVis, iface, autoEnable)
+			logging.GetLogger().Info("Wi-Fi monitor capture configured",
+				"iface", iface, "autoEnable", autoEnable)
 		}
 	}
 

--- a/internal/app/wifi_capture.go
+++ b/internal/app/wifi_capture.go
@@ -9,6 +9,14 @@ import (
 // service from iface. The libpcap-backed opener is selected by build tag
 // (wificapture.DefaultOpener); on CGO-free builds it is a no-op that disables
 // capture gracefully. An empty iface also disables capture.
-func NewWiFiCapture(sink *visibility.Service, iface string) *wificapture.Capture {
-	return wificapture.New(wificapture.DefaultOpener(), sink, iface)
+//
+// When autoEnable is set, the OS monitor-mode enabler (Linux iw/nl80211) switches
+// the interface into monitor mode on start and restores it on stop; otherwise
+// capture is bring-your-own monitor.
+func NewWiFiCapture(sink *visibility.Service, iface string, autoEnable bool) *wificapture.Capture {
+	var opts []wificapture.Option
+	if autoEnable {
+		opts = append(opts, wificapture.WithEnabler(wificapture.DefaultEnabler()))
+	}
+	return wificapture.New(wificapture.DefaultOpener(), sink, iface, opts...)
 }

--- a/internal/wifi/capture/capture.go
+++ b/internal/wifi/capture/capture.go
@@ -44,13 +44,15 @@ type Capture struct {
 	sink    Sink
 	iface   string
 	snapLen int32
+	enabler Enabler
 	now     func() time.Time
 	log     *slog.Logger
 
-	mu     sync.Mutex
-	handle capture.Handle
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	mu      sync.Mutex
+	handle  capture.Handle
+	cancel  context.CancelFunc
+	restore func() error
+	wg      sync.WaitGroup
 }
 
 // Option configures a Capture.
@@ -79,6 +81,17 @@ func WithSnapLen(n int32) Option {
 	return func(c *Capture) {
 		if n > 0 {
 			c.snapLen = n
+		}
+	}
+}
+
+// WithEnabler installs an Enabler that switches the interface into monitor mode
+// before capture and restores it afterwards. Without one, capture is
+// bring-your-own monitor (the interface must already be in monitor mode).
+func WithEnabler(e Enabler) Option {
+	return func(c *Capture) {
+		if e != nil {
+			c.enabler = e
 		}
 	}
 }
@@ -116,14 +129,30 @@ func (c *Capture) Start(ctx context.Context) error {
 		return nil
 	}
 
+	// Optionally switch the interface into monitor mode. A failure is not fatal —
+	// the interface may already be in monitor mode (bring-your-own), and the
+	// link-type guard below catches the case where it is not.
+	var restore func() error
+	if c.enabler != nil {
+		r, enErr := c.enabler.Enable(ctx, c.iface)
+		if enErr != nil {
+			c.log.WarnContext(ctx, "monitor-mode enable failed; trying interface as-is",
+				"iface", c.iface, "error", enErr)
+		} else {
+			restore = r
+		}
+	}
+
 	handle, err := c.opener.OpenLive(c.iface, c.snapLen, true, capture.BlockForever)
 	if err != nil {
+		runRestore(restore)
 		c.log.WarnContext(ctx, "wifi capture unavailable: cannot open interface",
 			"iface", c.iface, "error", err)
 		return nil
 	}
 	if lt := handle.LinkType(); lt != layers.LinkTypeIEEE80211Radio {
 		handle.Close()
+		runRestore(restore)
 		c.log.WarnContext(ctx, "wifi capture unavailable: interface is not in monitor mode (radiotap required)",
 			"iface", c.iface, "linkType", lt.String())
 		return nil
@@ -132,11 +161,20 @@ func (c *Capture) Start(ctx context.Context) error {
 	loopCtx, cancel := context.WithCancel(ctx)
 	c.cancel = cancel
 	c.handle = handle
+	c.restore = restore
 	c.sink.SetSource(c.iface)
 	c.wg.Add(1)
 	go c.loop(loopCtx, handle)
 	c.log.InfoContext(ctx, "wifi monitor capture started", "iface", c.iface)
 	return nil
+}
+
+// runRestore invokes a restore function if present, ignoring its error (best
+// effort during a degraded/abort path).
+func runRestore(restore func() error) {
+	if restore != nil {
+		_ = restore()
+	}
 }
 
 // loop reads frames until the handle is closed (by Stop) or a read error occurs.
@@ -166,8 +204,10 @@ func (c *Capture) Stop() error {
 	c.mu.Lock()
 	cancel := c.cancel
 	handle := c.handle
+	restore := c.restore
 	c.cancel = nil
 	c.handle = nil
+	c.restore = nil
 	c.mu.Unlock()
 
 	if cancel == nil {
@@ -179,5 +219,6 @@ func (c *Capture) Stop() error {
 	}
 	c.wg.Wait()
 	c.sink.ClearSource()
+	runRestore(restore) // revert the interface to its prior mode
 	return nil
 }

--- a/internal/wifi/capture/capture_test.go
+++ b/internal/wifi/capture/capture_test.go
@@ -1,6 +1,7 @@
 package wificapture_test
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"net"
@@ -188,6 +189,73 @@ func TestOptionsApplied(t *testing.T) {
 	waitFor(t, func() bool { return sink.frameCount() == 1 })
 	if err := c.Stop(); err != nil {
 		t.Fatalf("Stop: %v", err)
+	}
+}
+
+type fakeEnabler struct {
+	mu          sync.Mutex
+	enableCalls int
+	restoreHits int
+	err         error
+	restoreErr  error // returned by the restore closure (default nil)
+}
+
+func (e *fakeEnabler) Enable(context.Context, string) (func() error, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.enableCalls++
+	if e.err != nil {
+		return nil, e.err
+	}
+	return func() error {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		e.restoreHits++
+		return e.restoreErr
+	}, nil
+}
+
+func (e *fakeEnabler) counts() (int, int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.enableCalls, e.restoreHits
+}
+
+func TestCaptureEnablesMonitorAndRestores(t *testing.T) {
+	h := &fakeHandle{frames: [][]byte{beaconBytes("corp")}, linkType: layers.LinkTypeIEEE80211Radio}
+	en := &fakeEnabler{}
+	c := wificapture.New(&fakeOpener{handle: h}, &fakeSink{}, "wlan1", wificapture.WithEnabler(en))
+
+	if err := c.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if enabled, _ := en.counts(); enabled != 1 {
+		t.Errorf("Enable calls = %d, want 1 (before open)", enabled)
+	}
+	if err := c.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if _, restored := en.counts(); restored != 1 {
+		t.Errorf("restore calls = %d, want 1 (on stop)", restored)
+	}
+}
+
+func TestCaptureContinuesWhenEnableFails(t *testing.T) {
+	h := &fakeHandle{frames: [][]byte{beaconBytes("corp")}, linkType: layers.LinkTypeIEEE80211Radio}
+	en := &fakeEnabler{err: io.ErrClosedPipe}
+	sink := &fakeSink{}
+	c := wificapture.New(&fakeOpener{handle: h}, sink, "wlan1", wificapture.WithEnabler(en))
+
+	if err := c.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Enable failed, but the interface may already be monitor — capture proceeds.
+	waitFor(t, func() bool { return sink.frameCount() == 1 })
+	if err := c.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if _, restored := en.counts(); restored != 0 {
+		t.Errorf("a failed Enable must not register a restore, got %d", restored)
 	}
 }
 

--- a/internal/wifi/capture/enabler.go
+++ b/internal/wifi/capture/enabler.go
@@ -1,0 +1,63 @@
+package wificapture
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+)
+
+// Enabler optionally puts an interface into monitor mode before capture opens it
+// and restores the prior state afterwards. It is opt-in and invasive (it changes
+// the interface's operating mode), so the default build wires it only when the
+// operator asks for auto-enablement; otherwise capture is bring-your-own monitor.
+type Enabler interface {
+	// Enable puts iface into monitor mode and returns a restore function that
+	// undoes the change (never nil on success). It errors if it cannot switch the
+	// interface; the caller then falls back to opening the interface as-is.
+	Enable(ctx context.Context, iface string) (func() error, error)
+}
+
+// ifaceName guards interface names passed to the shell-out enabler against
+// injection: real interface names are short and alphanumeric with a few
+// separators.
+var ifaceName = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,32}$`)
+
+// nopEnabler does nothing — used on platforms without a monitor-mode path. Its
+// restore is a no-op so callers need no special-casing.
+type nopEnabler struct{}
+
+func (nopEnabler) Enable(context.Context, string) (func() error, error) {
+	return func() error { return nil }, nil
+}
+
+// runner executes a command, returning its error. Injected so the iw/ip
+// orchestration is unit-testable without touching the host.
+type runner func(ctx context.Context, name string, args ...string) error
+
+// cmdEnabler switches monitor mode via the iw/ip command-line tools (Linux). The
+// command construction is OS-agnostic and tested with a fake runner; only the
+// real exec runner is platform-bound.
+type cmdEnabler struct{ run runner }
+
+// newIWEnabler builds a cmdEnabler over run.
+func newIWEnabler(run runner) cmdEnabler { return cmdEnabler{run: run} }
+
+// Enable sets iface to monitor mode and brings it up, returning a restore that
+// reverts it to managed mode.
+func (e cmdEnabler) Enable(ctx context.Context, iface string) (func() error, error) {
+	if !ifaceName.MatchString(iface) {
+		return nil, fmt.Errorf("wificapture: unsafe interface name %q", iface)
+	}
+	if err := e.run(ctx, "iw", "dev", iface, "set", "type", "monitor"); err != nil {
+		return nil, fmt.Errorf("wificapture: set monitor on %s: %w", iface, err)
+	}
+	_ = e.run(ctx, "ip", "link", "set", iface, "up")
+
+	restore := func() error {
+		// Restore on a fresh context — the capture context is already cancelled
+		// by the time Stop runs the restore.
+		_ = e.run(context.Background(), "ip", "link", "set", iface, "down")
+		return e.run(context.Background(), "iw", "dev", iface, "set", "type", "managed")
+	}
+	return restore, nil
+}

--- a/internal/wifi/capture/enabler_internal_test.go
+++ b/internal/wifi/capture/enabler_internal_test.go
@@ -1,0 +1,70 @@
+package wificapture
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// recordingRunner captures the commands a cmdEnabler would run.
+type recordingRunner struct {
+	cmds   []string
+	failOn string // substring; matching command returns an error
+	calls  int
+}
+
+func (r *recordingRunner) run(_ context.Context, name string, args ...string) error {
+	cmd := name + " " + strings.Join(args, " ")
+	r.cmds = append(r.cmds, cmd)
+	r.calls++
+	if r.failOn != "" && strings.Contains(cmd, r.failOn) {
+		return errors.New("boom")
+	}
+	return nil
+}
+
+func TestCmdEnablerSetsMonitorAndRestores(t *testing.T) {
+	rr := &recordingRunner{}
+	restore, err := newIWEnabler(rr.run).Enable(context.Background(), "wlan1")
+	if err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+	if len(rr.cmds) < 2 || !strings.Contains(rr.cmds[0], "iw dev wlan1 set type monitor") {
+		t.Fatalf("expected monitor switch first, got %v", rr.cmds)
+	}
+	if rerr := restore(); rerr != nil {
+		t.Fatalf("restore: %v", rerr)
+	}
+	joined := strings.Join(rr.cmds, " | ")
+	if !strings.Contains(joined, "set type managed") {
+		t.Errorf("restore should revert to managed, got %v", rr.cmds)
+	}
+}
+
+func TestCmdEnablerRejectsUnsafeIface(t *testing.T) {
+	rr := &recordingRunner{}
+	if _, err := newIWEnabler(rr.run).Enable(context.Background(), "wlan1; rm -rf /"); err == nil {
+		t.Error("unsafe interface name must be rejected")
+	}
+	if rr.calls != 0 {
+		t.Error("no command should run for an unsafe interface name")
+	}
+}
+
+func TestCmdEnablerPropagatesSwitchError(t *testing.T) {
+	rr := &recordingRunner{failOn: "set type monitor"}
+	if _, err := newIWEnabler(rr.run).Enable(context.Background(), "wlan1"); err == nil {
+		t.Error("a failed monitor switch must surface an error")
+	}
+}
+
+func TestNopEnabler(t *testing.T) {
+	restore, err := nopEnabler{}.Enable(context.Background(), "anything")
+	if err != nil {
+		t.Fatalf("nop Enable: %v", err)
+	}
+	if rerr := restore(); rerr != nil {
+		t.Errorf("nop restore: %v", rerr)
+	}
+}

--- a/internal/wifi/capture/enabler_linux.go
+++ b/internal/wifi/capture/enabler_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package wificapture
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// DefaultEnabler returns the Linux monitor-mode enabler, which switches the
+// interface with the iw/ip tools (nl80211). It requires CAP_NET_ADMIN/root; if
+// the tools are missing or the call is unprivileged, Enable errors and capture
+// falls back to opening the interface as-is (bring-your-own monitor).
+func DefaultEnabler() Enabler { return newIWEnabler(execRunner) }
+
+// execRunner runs name+args, surfacing combined output on failure for diagnosis.
+func execRunner(ctx context.Context, name string, args ...string) error {
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w: %s", name, err, out)
+	}
+	return nil
+}

--- a/internal/wifi/capture/enabler_other.go
+++ b/internal/wifi/capture/enabler_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package wificapture
+
+// DefaultEnabler returns a no-op enabler on non-Linux platforms, where automatic
+// monitor-mode switching is not implemented. Capture there is bring-your-own
+// monitor: point SEED_WIFI_MONITOR_IFACE at an already-monitor interface.
+func DefaultEnabler() Enabler { return nopEnabler{} }


### PR DESCRIPTION
Remove the bring-your-own-monitor requirement on Linux: optionally switch the
capture interface into monitor mode on start and restore it on stop.

- Enabler seam: command construction (iw set type monitor + ip link up, restore
  to managed) is OS-agnostic and unit-tested with a fake runner; the real exec
  runner and DefaultEnabler are build-tagged (enabler_linux.go = iw/nl80211;
  enabler_other.go = no-op). Interface names are validated against injection
  before any shell-out.
- Capture integration: Enable runs before OpenLive; a failure is non-fatal (the
  interface may already be monitor — the radiotap link-type guard still applies);
  restore runs on Stop after the handle closes and on every degraded/abort path.
- Opt-in: SEED_WIFI_MONITOR_AUTO=1 alongside SEED_WIFI_MONITOR_IFACE wires the
  OS enabler; unset stays BYO. app.NewWiFiCapture gains the autoEnable flag.

CGO-free core, both CGO modes + linux build + GOOS=linux lint all clean. 96.7%
coverage, race-clean, golangci 0. No DTO/route/schema change.
