### PR TITLE
feat(wifi): airspace tree + anomaly stream UI (W6)

### DIFF
--- a/ui/src/components/wifi/WiFiAirspaceCard.tsx
+++ b/ui/src/components/wifi/WiFiAirspaceCard.tsx
@@ -1,0 +1,38 @@
+import { useWifiAirspace } from '../../hooks/useWifiVisibility';
+import { Card } from '../ui/card';
+import { WiFiAirspaceTree } from './WiFiAirspaceTree';
+import { WiFiCaptureStatus } from './WiFiCaptureStatus';
+
+/**
+ * WiFiAirspaceCard is the container for the live airspace tree: it polls the
+ * Pro-gated /wifi/airspace endpoint and renders the capture status plus the
+ * SSID -> AP -> BSSID -> client hierarchy.
+ */
+export function WiFiAirspaceCard() {
+  const { data, isLoading, isError } = useWifiAirspace();
+
+  const status = data?.status.captureActive ? 'success' : 'unknown';
+
+  return (
+    <Card
+      title="Wi-Fi Airspace"
+      subtitle="Live SSID / AP / BSSID / client map from 802.11 management-frame capture."
+      status={status}
+    >
+      {isLoading ? (
+        <p data-testid="wifi-airspace-loading" className="text-sm text-text-muted">
+          Loading airspace…
+        </p>
+      ) : isError || !data ? (
+        <p data-testid="wifi-airspace-error" className="text-sm text-text-muted">
+          Airspace data is unavailable.
+        </p>
+      ) : (
+        <div className="stack-md">
+          <WiFiCaptureStatus status={data.status} />
+          <WiFiAirspaceTree ssids={data.ssids} />
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/ui/src/components/wifi/WiFiAirspaceTree.test.tsx
+++ b/ui/src/components/wifi/WiFiAirspaceTree.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { SSIDGroup } from '../../types/generated/wifi-airspace-response';
+import { WiFiAirspaceTree } from './WiFiAirspaceTree';
+
+const group: SSIDGroup = {
+  ssid: 'corp',
+  hidden: false,
+  apCount: 1,
+  bssCount: 1,
+  stationCount: 1,
+  aps: [
+    {
+      key: 'ap1',
+      vendor: 'Cisco',
+      bsses: [
+        {
+          bssid: '00:11:22:33:44:55',
+          ssid: 'corp',
+          hidden: false,
+          band: '5 GHz',
+          channel: 36,
+          security: 'WPA3',
+          standard: '802.11ax (Wi-Fi 6)',
+          pmfRequired: true,
+          rrmNeighbor: false,
+          btmSupported: false,
+          ftSupported: false,
+          wpsEnabled: false,
+          signalDbm: -50,
+          beacons: 10,
+          lastSeen: '2026-01-01T00:00:00Z',
+          stations: [
+            {
+              mac: 'aa:bb:cc:dd:ee:ff',
+              signalDbm: -60,
+              frames: 5,
+              lastSeen: '2026-01-01T00:00:00Z',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('WiFiAirspaceTree', () => {
+  it('shows an empty state with no SSIDs', () => {
+    render(<WiFiAirspaceTree ssids={[]} />);
+    expect(screen.getByTestId('wifi-airspace-empty')).toBeInTheDocument();
+  });
+
+  it('renders the SSID -> AP -> BSSID -> client hierarchy', () => {
+    render(<WiFiAirspaceTree ssids={[group]} />);
+    expect(screen.getByTestId('wifi-airspace-tree')).toBeInTheDocument();
+    expect(screen.getByText('corp')).toBeInTheDocument();
+    expect(screen.getByTestId('wifi-bss')).toHaveTextContent('00:11:22:33:44:55');
+    expect(screen.getByTestId('wifi-station')).toHaveTextContent('aa:bb:cc:dd:ee:ff');
+  });
+
+  it('labels a cloaked SSID rather than showing a blank name', () => {
+    render(<WiFiAirspaceTree ssids={[{ ...group, ssid: '', hidden: true }]} />);
+    expect(screen.getByText('(hidden SSID)')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/wifi/WiFiAirspaceTree.tsx
+++ b/ui/src/components/wifi/WiFiAirspaceTree.tsx
@@ -1,0 +1,87 @@
+import type { APGroup, BSSView, SSIDGroup } from '../../types/generated/wifi-airspace-response';
+
+interface WiFiAirspaceTreeProps {
+  ssids: SSIDGroup[];
+}
+
+function ssidLabel(g: SSIDGroup): string {
+  if (g.ssid !== '') {
+    return g.ssid;
+  }
+  return g.hidden ? '(hidden SSID)' : '(unnamed)';
+}
+
+function StationRows({ bss }: { bss: BSSView }) {
+  if (bss.stations.length === 0) {
+    return null;
+  }
+  return (
+    <ul className="ml-4 stack-2xs">
+      {bss.stations.map((s) => (
+        <li key={s.mac} data-testid="wifi-station" className="text-xs text-text-muted">
+          <span className="font-mono">{s.mac}</span> · {s.signalDbm} dBm · {s.frames} frames
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function BSSRows({ ap }: { ap: APGroup }) {
+  return (
+    <ul className="ml-4 stack-2xs">
+      {ap.bsses.map((b) => (
+        <li key={b.bssid} data-testid="wifi-bss" className="stack-2xs">
+          <p className="text-xs text-text-secondary">
+            <span className="font-mono">{b.bssid}</span> · {b.band} ch {b.channel} · {b.security} ·{' '}
+            {b.standard} · {b.signalDbm} dBm
+          </p>
+          <StationRows bss={b} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * WiFiAirspaceTree renders the cross-referenced SSID -> AP -> BSSID -> client
+ * hierarchy as collapsible sections. Protocol terms (SSID, BSSID, dBm, 802.11
+ * standards) are shown verbatim.
+ */
+export function WiFiAirspaceTree({ ssids }: WiFiAirspaceTreeProps) {
+  if (ssids.length === 0) {
+    return (
+      <p data-testid="wifi-airspace-empty" className="text-sm text-text-muted">
+        No Wi-Fi networks observed yet.
+      </p>
+    );
+  }
+
+  return (
+    <div data-testid="wifi-airspace-tree" className="stack-xs">
+      {ssids.map((g) => (
+        <details
+          key={ssidLabel(g) + g.bssCount}
+          data-testid="wifi-ssid-group"
+          className="rounded-md border border-surface-border bg-surface-base p-2"
+        >
+          <summary className="cursor-pointer text-sm font-medium text-text-primary">
+            {ssidLabel(g)}{' '}
+            <span className="text-xs font-normal text-text-muted">
+              ({g.apCount} AP / {g.bssCount} BSSID / {g.stationCount} clients)
+            </span>
+          </summary>
+          <div className="mt-2 stack-xs">
+            {g.aps.map((ap) => (
+              <div key={ap.key} data-testid="wifi-ap-group" className="stack-2xs">
+                <p className="text-xs font-medium text-text-secondary">
+                  AP {ap.vendor ? `· ${ap.vendor}` : ''}
+                </p>
+                <BSSRows ap={ap} />
+              </div>
+            ))}
+          </div>
+        </details>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/wifi/WiFiAnomaliesCard.tsx
+++ b/ui/src/components/wifi/WiFiAnomaliesCard.tsx
@@ -1,0 +1,44 @@
+import { useWifiAnomalies } from '../../hooks/useWifiVisibility';
+import type { Anomaly } from '../../types/generated/wifi-anomalies-response';
+import { Card } from '../ui/card';
+import type { Status } from '../ui/statusConfig';
+import { WiFiAnomalyStream } from './WiFiAnomalyStream';
+
+// cardStatus reflects the most urgent anomaly severity in the card header.
+function cardStatus(anomalies: Anomaly[]): Status {
+  if (anomalies.some((a) => a.severity === 'critical')) {
+    return 'error';
+  }
+  if (anomalies.some((a) => a.severity === 'warning')) {
+    return 'warning';
+  }
+  return 'success';
+}
+
+/**
+ * WiFiAnomaliesCard is the container for the Wi-Fi anomaly stream: it polls the
+ * Pro-gated /wifi/anomalies endpoint and renders the severity-ranked detections.
+ */
+export function WiFiAnomaliesCard() {
+  const { data, isLoading, isError } = useWifiAnomalies();
+
+  return (
+    <Card
+      title="Wi-Fi Anomalies"
+      subtitle="Security, RF, roaming, and standards anomalies detected in the airspace."
+      status={data ? cardStatus(data.anomalies) : 'unknown'}
+    >
+      {isLoading ? (
+        <p data-testid="wifi-anomalies-loading" className="text-sm text-text-muted">
+          Loading anomalies…
+        </p>
+      ) : isError || !data ? (
+        <p data-testid="wifi-anomalies-error" className="text-sm text-text-muted">
+          Anomaly data is unavailable.
+        </p>
+      ) : (
+        <WiFiAnomalyStream anomalies={data.anomalies} />
+      )}
+    </Card>
+  );
+}

--- a/ui/src/components/wifi/WiFiAnomalyStream.test.tsx
+++ b/ui/src/components/wifi/WiFiAnomalyStream.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { Anomaly } from '../../types/generated/wifi-anomalies-response';
+import { WiFiAnomalyStream } from './WiFiAnomalyStream';
+
+function anomaly(overrides: Partial<Anomaly>): Anomaly {
+  return {
+    defKey: 'wifi-open-network',
+    category: 'security',
+    severity: 'warning',
+    subject: { kind: 'bssid', id: '00:11:22:33:44:55' },
+    title: 'Open network',
+    description: 'no encryption',
+    recommendation: 'enable WPA2/WPA3',
+    firstSeen: '2026-01-01T00:00:00Z',
+    lastSeen: '2026-01-01T00:00:00Z',
+    count: 1,
+    ...overrides,
+  };
+}
+
+describe('WiFiAnomalyStream', () => {
+  it('shows an empty state when there are no anomalies', () => {
+    render(<WiFiAnomalyStream anomalies={[]} />);
+    expect(screen.getByTestId('wifi-anomalies-empty')).toBeInTheDocument();
+  });
+
+  it('renders a row per anomaly with severity, title and subject', () => {
+    render(<WiFiAnomalyStream anomalies={[anomaly({})]} />);
+    expect(screen.getByTestId('wifi-anomaly-stream')).toBeInTheDocument();
+    expect(screen.getAllByTestId('wifi-anomaly-row')).toHaveLength(1);
+    expect(screen.getByText('Open network')).toBeInTheDocument();
+    expect(screen.getByText('00:11:22:33:44:55')).toBeInTheDocument();
+  });
+
+  it('orders critical before warning before info', () => {
+    render(
+      <WiFiAnomalyStream
+        anomalies={[
+          anomaly({ defKey: 'a', severity: 'info', title: 'Info one' }),
+          anomaly({ defKey: 'b', severity: 'critical', title: 'Critical one' }),
+          anomaly({ defKey: 'c', severity: 'warning', title: 'Warning one' }),
+        ]}
+      />,
+    );
+    const titles = screen.getAllByTestId('wifi-anomaly-row').map((r) => r.textContent ?? '');
+    expect(titles[0]).toContain('Critical one');
+    expect(titles[1]).toContain('Warning one');
+    expect(titles[2]).toContain('Info one');
+  });
+});

--- a/ui/src/components/wifi/WiFiAnomalyStream.tsx
+++ b/ui/src/components/wifi/WiFiAnomalyStream.tsx
@@ -1,0 +1,55 @@
+import type { Anomaly } from '../../types/generated/wifi-anomalies-response';
+import { severityStyle } from './severity';
+
+interface WiFiAnomalyStreamProps {
+  anomalies: Anomaly[];
+}
+
+/**
+ * WiFiAnomalyStream renders the deduped Wi-Fi anomaly stream, most urgent first.
+ * Each entry shows its severity, title, the subject it concerns, the
+ * recommendation, and how many times it has recurred. Protocol/standard terms
+ * (SSID, BSSID, 802.11, WPA3) are shown verbatim.
+ */
+export function WiFiAnomalyStream({ anomalies }: WiFiAnomalyStreamProps) {
+  if (anomalies.length === 0) {
+    return (
+      <p data-testid="wifi-anomalies-empty" className="text-sm text-text-muted">
+        No Wi-Fi anomalies detected.
+      </p>
+    );
+  }
+
+  const sorted = [...anomalies].sort(
+    (a, b) => severityStyle(b.severity).rank - severityStyle(a.severity).rank,
+  );
+
+  return (
+    <ul data-testid="wifi-anomaly-stream" className="stack-sm">
+      {sorted.map((a) => (
+        <li
+          key={`${a.defKey}:${a.subject.kind}:${a.subject.id}`}
+          data-testid="wifi-anomaly-row"
+          className="rounded-md border border-surface-border bg-surface-base p-3 stack-2xs"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <span
+                data-testid="wifi-anomaly-severity"
+                className={`rounded-full px-2 py-0.5 text-xs font-medium uppercase ${severityStyle(a.severity).badge}`}
+              >
+                {a.severity}
+              </span>
+              <span className="text-sm font-medium text-text-primary">{a.title}</span>
+            </div>
+            {a.count > 1 ? <span className="text-xs text-text-muted">x{a.count}</span> : null}
+          </div>
+          <p className="text-xs text-text-secondary">
+            {a.subject.kind}: <span className="font-mono">{a.subject.id}</span>
+          </p>
+          <p className="text-xs text-text-muted">{a.recommendation}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/ui/src/components/wifi/WiFiCaptureStatus.tsx
+++ b/ui/src/components/wifi/WiFiCaptureStatus.tsx
@@ -1,0 +1,54 @@
+import type { Status } from '../../types/generated/wifi-airspace-response';
+
+interface WiFiCaptureStatusProps {
+  status: Status;
+}
+
+interface Stat {
+  label: string;
+  value: number;
+}
+
+/**
+ * WiFiCaptureStatus is a compact header showing whether monitor-mode capture is
+ * active (and its source) plus the live entity counts. When capture is inactive
+ * it states so plainly rather than implying an empty network.
+ */
+export function WiFiCaptureStatus({ status }: WiFiCaptureStatusProps) {
+  const stats: Stat[] = [
+    { label: 'SSIDs', value: status.ssids },
+    { label: 'APs', value: status.aps },
+    { label: 'BSSIDs', value: status.bsses },
+    { label: 'Clients', value: status.stations },
+  ];
+
+  return (
+    <div data-testid="wifi-capture-status" className="stack-sm">
+      <div className="flex items-center gap-2">
+        <span
+          data-testid="wifi-capture-indicator"
+          className={`inline-block h-2 w-2 rounded-full ${
+            status.captureActive ? 'bg-status-success' : 'bg-text-muted'
+          }`}
+        />
+        <span className="text-sm text-text-secondary">
+          {status.captureActive ? (
+            <>
+              Live capture on <span className="font-medium text-text-primary">{status.source}</span>
+            </>
+          ) : (
+            'Monitor capture inactive — showing the last observed airspace'
+          )}
+        </span>
+      </div>
+      <dl className="flex flex-wrap gap-4">
+        {stats.map((s) => (
+          <div key={s.label} className="flex items-baseline gap-1">
+            <dd className="text-base font-semibold text-text-primary">{s.value}</dd>
+            <dt className="text-xs text-text-muted">{s.label}</dt>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/ui/src/components/wifi/severity.ts
+++ b/ui/src/components/wifi/severity.ts
@@ -1,0 +1,23 @@
+// Maps anomaly severities (info < warning < critical) to design-token classes.
+// Token-only — no raw colours — so the design-token CI gate stays green and the
+// badges are theme-aware.
+
+export interface SeverityStyle {
+  /** Tailwind classes for a severity pill (token colours only). */
+  badge: string;
+  /** Sort rank, most urgent first. */
+  rank: number;
+}
+
+const styles: Record<string, SeverityStyle> = {
+  critical: { badge: 'bg-status-error/10 text-status-error', rank: 3 },
+  warning: { badge: 'bg-status-warning/10 text-status-warning', rank: 2 },
+  info: { badge: 'bg-status-info/10 text-status-info', rank: 1 },
+};
+
+const fallback: SeverityStyle = { badge: 'bg-surface-sunken text-text-secondary', rank: 0 };
+
+/** severityStyle returns the token classes + rank for a severity string. */
+export function severityStyle(severity: string): SeverityStyle {
+  return styles[severity] ?? fallback;
+}

--- a/ui/src/hooks/useWifiVisibility.ts
+++ b/ui/src/hooks/useWifiVisibility.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../api/client';
+import type { WiFiAirspaceResponse } from '../types/generated/wifi-airspace-response';
+import type { WiFiAnomaliesResponse } from '../types/generated/wifi-anomalies-response';
+
+// Live read endpoints for the Pro-gated Wi-Fi visibility feature. Both poll on a
+// short interval so the airspace tree and anomaly stream track the capture loop.
+const airspaceEndpoint = '/api/v1/wifi/airspace';
+const anomaliesEndpoint = '/api/v1/wifi/anomalies';
+
+// refetchIntervalMs balances freshness against load; the backend evaluates the
+// airspace on a similar cadence.
+const refetchIntervalMs = 10_000;
+
+export const wifiVisibilityKeys = {
+  all: ['wifi-visibility'] as const,
+  airspace: () => [...wifiVisibilityKeys.all, 'airspace'] as const,
+  anomalies: () => [...wifiVisibilityKeys.all, 'anomalies'] as const,
+};
+
+/** useWifiAirspace polls the cross-referenced SSID -> AP -> BSSID -> client tree. */
+export function useWifiAirspace() {
+  return useQuery({
+    queryKey: wifiVisibilityKeys.airspace(),
+    queryFn: () => api.get<WiFiAirspaceResponse>(airspaceEndpoint),
+    refetchInterval: refetchIntervalMs,
+  });
+}
+
+/** useWifiAnomalies polls the deduped, severity-ranked Wi-Fi anomaly stream. */
+export function useWifiAnomalies() {
+  return useQuery({
+    queryKey: wifiVisibilityKeys.anomalies(),
+    queryFn: () => api.get<WiFiAnomaliesResponse>(anomaliesEndpoint),
+    refetchInterval: refetchIntervalMs,
+  });
+}

--- a/ui/src/pages/WifiPage.tsx
+++ b/ui/src/pages/WifiPage.tsx
@@ -5,6 +5,8 @@ import { WiFiSurveyCard } from '../components/cards/WiFiSurveyCard';
 import { BetaBadge } from '../components/ui/BetaBadge';
 import { Card } from '../components/ui/card';
 import { RequireFeature } from '../components/ui/RequireFeature';
+import { WiFiAirspaceCard } from '../components/wifi/WiFiAirspaceCard';
+import { WiFiAnomaliesCard } from '../components/wifi/WiFiAnomaliesCard';
 import { useAppContext } from '../contexts/AppContext';
 import { layout } from '../styles/theme';
 import { Breadcrumbs } from '../ui/Breadcrumbs';
@@ -34,22 +36,21 @@ export function WifiPage() {
           />
         ) : null}
 
-        {/* Phase 2.5 scaffolding — fills with real data when 802.11
-            management-frame capture lands. See
-            msn-docs-internal/01-Strategy/SEED_NMS_EXPANSION.md. */}
-        <RequireFeature feature="wifi_association_forensics">
-          <Card
-            title="Association Forensics"
-            subtitle="802.11 assoc / EAPOL handshake decode with status-code drill-down."
-            status="unknown"
-            headerAction={<BetaBadge />}
-          >
-            <p data-testid="wifi-assoc-forensics-pending" className="text-sm text-text-muted">
-              Capture lands in Seed v1.0 — see release notes when Phase 2.5 ships.
-            </p>
-          </Card>
+        {/* Wi-Fi visibility (W5/W6): live airspace tree + anomaly stream from
+            802.11 management-frame capture (internal/wifi/visibility). Each card
+            is Pro-gated and degrades to an empty/last-observed view when no
+            monitor-capable interface is feeding the capture loop. */}
+        <RequireFeature feature="wifi_management_capture">
+          <WiFiAirspaceCard />
         </RequireFeature>
 
+        <RequireFeature feature="wifi_association_forensics">
+          <WiFiAnomaliesCard />
+        </RequireFeature>
+
+        {/* Phase 2.5 scaffolding — fills with real data when per-client roam
+            correlation lands. See
+            msn-docs-internal/01-Strategy/SEED_NMS_EXPANSION.md. */}
         <RequireFeature feature="wifi_roam_analysis">
           <Card
             title="Roam Analysis"


### PR DESCRIPTION
Render the Wi-Fi visibility feature on the Wi-Fi page, consuming the Pro-gated
/wifi/airspace and /wifi/anomalies endpoints via the generated TS types.

- useWifiVisibility: two React Query hooks polling the endpoints (10s).
- WiFiAirspaceCard (gated wifi_management_capture): capture-status header
  (active/source + entity counts) + collapsible SSID -> AP -> BSSID -> client
  tree (WiFiCaptureStatus + WiFiAirspaceTree).
- WiFiAnomaliesCard (gated wifi_association_forensics): severity-ranked anomaly
  stream (critical > warning > info) with subject + recommendation.
- Replaces the stale "Association Forensics" Phase-2.5 placeholder (capture has
  landed); keeps the Roam Analysis placeholder (per-client roam correlation is
  still future).
- Token-clean (design-token gate passes on all new files), protocol terms shown
  verbatim (SSID/BSSID/802.11/WPA3/dBm), presentational components split from
  hook containers for testability.

tsc clean, Biome clean, 6 new component tests, full UI suite 200 green.
