### PR TITLE
refactor(api): strangle internal/api — ADR-0016 + Wi-Fi visibility phase 1

### DIFF
--- a/docs/architecture/decisions/0016-strangle-internal-api-into-use-cases.md
+++ b/docs/architecture/decisions/0016-strangle-internal-api-into-use-cases.md
@@ -1,0 +1,111 @@
+# ADR-0016: Strangle `internal/api` into per-domain use-case services
+
+**Status:** Accepted — 2026-06-06
+
+## Context
+
+The independent architecture review (2026-06-05, findings #2 and #3, both
+verified true) flagged `internal/api` as the last structural debt after the
+Phase 0–7 re-architecture:
+
+- **#2 — god layer.** `internal/api` is ~100 non-test files and ~30k LOC.
+  Individual handlers run 600–1100 lines and interleave four concerns in one
+  function: request decoding, authorization/validation, business logic, and
+  response encoding. The capability registry (ADR-0002) already made *routing*
+  policy declarative, but the *handlers* behind the routes are still fat.
+- **#3 — bag-of-services DI.** `ServiceContainer` (`internal/api/services.go`)
+  exposes db / discovery / diagnostics / auth / jobs / health / update / wifi to
+  every handler at once. Handlers also reach into `Server.background` directly
+  (e.g. `s.background.WiFiVisibility`). A handler can touch anything, so nothing
+  is isolated and the blast radius of a change is the whole package.
+
+The Phase 0–7 work established the target for the *domain* layer:
+capability-first `internal/<feature>` packages that are persistence-free, with
+ports at the I/O seam and a composition root in `internal/app`. `internal/api`
+never got the same treatment.
+
+This is explicitly **not a rewrite**. The package works, its security
+invariants are CI-gated, and the golden HTTP harness pins its behavior. We
+strangle it incrementally: each phase moves one cohesive slice behind the new
+structure while the goldens prove behavior is unchanged.
+
+## Decision
+
+Adopt the **thin-handler → use-case → encode** shape, backed by per-domain
+**application (use-case) packages** and **narrow, consumer-defined ports**.
+
+### Target structure
+
+```
+internal/api/handlers_*.go      thin: decode request → call a use-case → encode response
+        │  depends on (narrow interface, defined HERE at the consumer)
+        ▼
+internal/<domain>/app           use-case services: orchestrate the domain for one
+   (e.g. internal/wifi/app)     request shape; no net/http, no encoding, testable
+        │
+        ▼
+internal/<domain>/...           the persistence-free feature core (unchanged)
+```
+
+Rules:
+
+1. **Handlers do I/O translation only** — decode the HTTP request, call exactly
+   one use-case method, encode the result (and map domain errors to status
+   codes). No business logic, no multi-service orchestration in the handler.
+2. **Use-cases live in `internal/<domain>/app`** (package `<domain>app`, e.g.
+   `wifiapp`, to avoid clashing with the `internal/app` composition root). A
+   use-case takes the narrow dependencies it needs as constructor arguments.
+3. **Ports are defined at the consumer** (interface-segregation): the use-case
+   declares the small interface it needs; the composition root supplies the
+   concrete implementation. Handlers depend on the use-case (or a small
+   interface over it), **not** on `ServiceContainer` or `Server.background`.
+4. **The composition root wires it** — `internal/app` / `cmd/seed` build the
+   use-cases from the feature components and hand them to the API layer, the
+   same way `BackgroundComponents` are built today.
+5. **Behavior is pinned by the goldens** — every phase keeps
+   `TestGoldenHTTP*` byte-identical (or updates them as a reviewed diff only
+   when behavior is *intended* to change).
+
+### Phasing
+
+Each phase is one PR, one domain slice, goldens green:
+
+- **Phase 1 (this ADR's PR) — exemplar: Wi-Fi visibility reads.** Introduce
+  `internal/wifi/app` (`wifiapp`) with a `Queries` use-case over a narrow
+  `VisibilitySource` port, and convert the `/wifi/airspace` + `/wifi/anomalies`
+  handlers from reaching into `s.background.WiFiVisibility` (the #3 anti-pattern)
+  to calling the injected use-case. Small, self-contained, recently authored —
+  the lowest-risk place to establish the pattern and the `internal/wifi/app`
+  ring the later phases follow.
+- **Phase 2+ — fat handlers, by domain.** Migrate the heavier handlers
+  (wifi settings/connect, discovery, diagnostics, security, reporting) one
+  cohesive slice at a time into their `internal/<domain>/app` use-cases, pulling
+  each off `ServiceContainer` as it goes. Order by blast radius (smallest
+  first); each lands only when its goldens are green.
+- **Terminal — retire the bag.** When no handler reaches `ServiceContainer`
+  fields directly, replace it with the set of injected use-cases and delete the
+  god accessor.
+
+### Naming
+
+`internal/<domain>/app` packages are named `<domain>app` (`wifiapp`,
+`discoveryapp`, …) so the composition root (`internal/app`, package `app`) can
+import them without an alias collision — the same disambiguation already used by
+`wifianomaly` / `wificapture`.
+
+## Consequences
+
+- **Positive:** handlers become readable and unit-testable without HTTP;
+  business logic moves to packages that can be tested directly; the blast radius
+  of a change shrinks to one domain; `ServiceContainer` reach-through stops
+  spreading; new endpoints get a clear home.
+- **Cost:** one indirection layer per domain; a migration that spans many PRs.
+  Mitigated by doing it incrementally behind the golden harness — never a big-bang.
+- **Non-goal:** changing behavior, routes, or the capability registry. This is
+  a structural move only; ADR-0002 (routing policy) and the security invariants
+  are untouched.
+
+## Coordination
+
+Independent of the auth/oauth workstream and of ADR-0015 (credential DEK). The
+strangle touches handler wiring, not the `Auth.JWTSecret` boundary.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -23,3 +23,4 @@ See the [Re-Architecture Blueprint](../RE_ARCHITECTURE_BLUEPRINT.md) for the ful
 | [0013](0013-bluetooth-live-capture.md) | Bluetooth live-scan capture port | Accepted |
 | [0014](0014-config-validation-schema-is-a-constraints-validator.md) | config validation schema is a curated constraints validator, not a duplicate | Accepted |
 | [0015](0015-credential-encryption-key-separation.md) | Separate the credential data-encryption key from `Auth.JWTSecret` | Proposed |
+| [0016](0016-strangle-internal-api-into-use-cases.md) | Strangle `internal/api` into per-domain use-case services | Accepted |

--- a/internal/api/handlers_wifi_airspace.go
+++ b/internal/api/handlers_wifi_airspace.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/krisarmstrong/seed/internal/anomaly"
 	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	wifiapp "github.com/krisarmstrong/seed/internal/wifi/app"
 	"github.com/krisarmstrong/seed/internal/wifi/visibility"
 )
 
@@ -22,36 +23,29 @@ type WiFiAnomaliesResponse struct {
 	Status    visibility.Status `json:"status"`
 }
 
-// wifiVisibility returns the live visibility service, or nil when no capture
-// component is wired (e.g. no monitor-capable interface). Handlers degrade to an
-// empty-but-valid response in that case rather than erroring.
-func (s *Server) wifiVisibility() *visibility.Service {
-	if s.background == nil {
+// wifiVisibilitySource adapts the background visibility component to the use-case
+// port, returning a nil interface (not a typed-nil) when no capture component is
+// wired — so wifiapp.Queries sees a genuinely-absent source.
+func wifiVisibilitySource(bg *BackgroundComponents) wifiapp.VisibilitySource {
+	if bg == nil || bg.WiFiVisibility == nil {
 		return nil
 	}
-	return s.background.WiFiVisibility
+	return bg.WiFiVisibility
 }
 
-// handleWiFiAirspace serves GET /api/v1/wifi/airspace — the airspace tree. The
+// handleWiFiAirspace serves GET /api/v1/wifi/airspace. Thin handler (ADR-0016):
+// it delegates to the Wi-Fi visibility read use-case and encodes the result. The
 // route is feature-gated (wifi_management_capture); an absent capture component
 // yields an empty tree with captureActive=false, not an error.
 func (s *Server) handleWiFiAirspace(w http.ResponseWriter, _ *http.Request) {
-	resp := WiFiAirspaceResponse{SSIDs: []airspace.SSIDGroup{}}
-	if svc := s.wifiVisibility(); svc != nil {
-		resp.SSIDs = svc.Tree()
-		resp.Status = svc.Status()
-	}
-	sendJSONResponse(w, nil, http.StatusOK, resp)
+	res := s.wifiQueries.Airspace()
+	sendJSONResponse(w, nil, http.StatusOK, WiFiAirspaceResponse{SSIDs: res.SSIDs, Status: res.Status})
 }
 
-// handleWiFiAnomalies serves GET /api/v1/wifi/anomalies — the Wi-Fi anomaly
-// stream. Feature-gated (wifi_association_forensics); degrades to an empty
-// stream when no capture component is present.
+// handleWiFiAnomalies serves GET /api/v1/wifi/anomalies. Thin handler delegating
+// to the use-case; feature-gated (wifi_association_forensics); degrades to an
+// empty stream when no capture component is present.
 func (s *Server) handleWiFiAnomalies(w http.ResponseWriter, _ *http.Request) {
-	resp := WiFiAnomaliesResponse{Anomalies: []anomaly.Anomaly{}}
-	if svc := s.wifiVisibility(); svc != nil {
-		resp.Anomalies = svc.Anomalies()
-		resp.Status = svc.Status()
-	}
-	sendJSONResponse(w, nil, http.StatusOK, resp)
+	res := s.wifiQueries.Anomalies()
+	sendJSONResponse(w, nil, http.StatusOK, WiFiAnomaliesResponse{Anomalies: res.Anomalies, Status: res.Status})
 }

--- a/internal/api/handlers_wifi_airspace_internal_test.go
+++ b/internal/api/handlers_wifi_airspace_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+	wifiapp "github.com/krisarmstrong/seed/internal/wifi/app"
 	"github.com/krisarmstrong/seed/internal/wifi/dot11"
 	"github.com/krisarmstrong/seed/internal/wifi/visibility"
 )
@@ -45,8 +46,8 @@ func openBeacon(t *testing.T) *dot11.Frame {
 }
 
 func TestHandleWiFiAirspaceEmptyWhenNoComponent(t *testing.T) {
-	// No background component wired → graceful empty response, never 500/null.
-	s := &Server{background: &BackgroundComponents{}}
+	// No visibility source wired → graceful empty response, never 500/null.
+	s := &Server{wifiQueries: wifiapp.NewQueries(nil)}
 	rec := httptest.NewRecorder()
 	s.handleWiFiAirspace(rec, httptest.NewRequest(http.MethodGet, "/api/v1/wifi/airspace", nil))
 
@@ -67,7 +68,7 @@ func TestHandleWiFiAirspaceAndAnomaliesPopulated(t *testing.T) {
 	svc.SetSource("monitor0")
 	svc.Ingest(openBeacon(t), time.Now())
 	svc.Evaluate(time.Now())
-	s := &Server{background: &BackgroundComponents{WiFiVisibility: svc}}
+	s := &Server{wifiQueries: wifiapp.NewQueries(svc)}
 
 	// Airspace tree is populated and reports the active source.
 	recA := httptest.NewRecorder()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/krisarmstrong/seed/internal/timeseries/retention"
 	"github.com/krisarmstrong/seed/internal/topology"
 	"github.com/krisarmstrong/seed/internal/wifi"
+	wifiapp "github.com/krisarmstrong/seed/internal/wifi/app"
 	"github.com/krisarmstrong/seed/internal/wifi/survey"
 )
 
@@ -125,6 +126,7 @@ type Server struct {
 	startTime          time.Time             // Application start time for uptime tracking (fixes #540)
 	setupModeStartTime time.Time             // Security fix #891: Track when setup mode started
 	background         *BackgroundComponents // Long-lived components with background lifecycle (report scheduler)
+	wifiQueries        *wifiapp.Queries      // Wi-Fi visibility read use-case (ADR-0016 strangle exemplar)
 	tlsFingerprint     tlsFingerprintCache   // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
 
@@ -210,6 +212,7 @@ func NewServer(
 		icmpAvailable: icmpAvailable,
 		startTime:     time.Now(),
 		background:    background,
+		wifiQueries:   wifiapp.NewQueries(wifiVisibilitySource(background)),
 		services:      services,
 	}
 

--- a/internal/wifi/app/visibility.go
+++ b/internal/wifi/app/visibility.go
@@ -1,0 +1,63 @@
+// Package wifiapp holds the Wi-Fi application (use-case) services that the API
+// handlers call. It is the per-domain use-case layer from ADR-0016 (strangle
+// internal/api): handlers decode/encode and delegate here, instead of reaching
+// into the API service container or background components. The package name is
+// wifiapp (not app) so the internal/app composition root can import it without
+// an alias clash.
+package wifiapp
+
+import (
+	"github.com/krisarmstrong/seed/internal/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	"github.com/krisarmstrong/seed/internal/wifi/visibility"
+)
+
+// VisibilitySource is the narrow capability the read use-cases need from the
+// live visibility component. It is defined here, at the consumer (ADR-0016
+// interface-segregation), and satisfied by *visibility.Service.
+type VisibilitySource interface {
+	Tree() []airspace.SSIDGroup
+	Anomalies() []anomaly.Anomaly
+	Status() visibility.Status
+}
+
+// AirspaceResult is the airspace read use-case output: the tree plus the
+// capture/entity status. HTTP-agnostic — the handler maps it to the wire DTO.
+type AirspaceResult struct {
+	SSIDs  []airspace.SSIDGroup
+	Status visibility.Status
+}
+
+// AnomaliesResult is the anomaly read use-case output: the stream plus status.
+type AnomaliesResult struct {
+	Anomalies []anomaly.Anomaly
+	Status    visibility.Status
+}
+
+// Queries is the read use-case for Wi-Fi visibility. The API handlers depend on
+// it instead of on the background components directly.
+type Queries struct {
+	src VisibilitySource
+}
+
+// NewQueries builds the read use-case over src. A nil src (no capture component
+// wired) is valid: the queries then return empty-but-valid results.
+func NewQueries(src VisibilitySource) *Queries { return &Queries{src: src} }
+
+// Airspace returns the current airspace tree and status, degrading to an empty
+// tree (never nil) when no visibility source is present.
+func (q *Queries) Airspace() AirspaceResult {
+	if q == nil || q.src == nil {
+		return AirspaceResult{SSIDs: []airspace.SSIDGroup{}}
+	}
+	return AirspaceResult{SSIDs: q.src.Tree(), Status: q.src.Status()}
+}
+
+// Anomalies returns the current anomaly stream and status, degrading to an empty
+// stream (never nil) when no visibility source is present.
+func (q *Queries) Anomalies() AnomaliesResult {
+	if q == nil || q.src == nil {
+		return AnomaliesResult{Anomalies: []anomaly.Anomaly{}}
+	}
+	return AnomaliesResult{Anomalies: q.src.Anomalies(), Status: q.src.Status()}
+}

--- a/internal/wifi/app/visibility_test.go
+++ b/internal/wifi/app/visibility_test.go
@@ -1,0 +1,50 @@
+package wifiapp_test
+
+import (
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	wifiapp "github.com/krisarmstrong/seed/internal/wifi/app"
+	"github.com/krisarmstrong/seed/internal/wifi/visibility"
+)
+
+type fakeSource struct {
+	tree      []airspace.SSIDGroup
+	anomalies []anomaly.Anomaly
+	status    visibility.Status
+}
+
+func (f fakeSource) Tree() []airspace.SSIDGroup   { return f.tree }
+func (f fakeSource) Anomalies() []anomaly.Anomaly { return f.anomalies }
+func (f fakeSource) Status() visibility.Status    { return f.status }
+
+func TestQueriesNilSourceDegradesEmpty(t *testing.T) {
+	q := wifiapp.NewQueries(nil)
+	air := q.Airspace()
+	if air.SSIDs == nil || len(air.SSIDs) != 0 || air.Status.CaptureActive {
+		t.Errorf("nil source should yield empty inactive airspace, got %+v", air)
+	}
+	an := q.Anomalies()
+	if an.Anomalies == nil || len(an.Anomalies) != 0 {
+		t.Errorf("nil source should yield empty anomaly stream, got %+v", an)
+	}
+}
+
+func TestQueriesDelegatesToSource(t *testing.T) {
+	src := fakeSource{
+		tree:      []airspace.SSIDGroup{{SSID: "corp"}},
+		anomalies: []anomaly.Anomaly{{DefKey: "wifi-open-network"}},
+		status:    visibility.Status{CaptureActive: true, Source: "mon0", SSIDs: 1},
+	}
+	q := wifiapp.NewQueries(src)
+
+	air := q.Airspace()
+	if len(air.SSIDs) != 1 || air.SSIDs[0].SSID != "corp" || !air.Status.CaptureActive {
+		t.Errorf("Airspace did not delegate to the source: %+v", air)
+	}
+	an := q.Anomalies()
+	if len(an.Anomalies) != 1 || an.Anomalies[0].DefKey != "wifi-open-network" || an.Status.Source != "mon0" {
+		t.Errorf("Anomalies did not delegate to the source: %+v", an)
+	}
+}


### PR DESCRIPTION
Address arch-review findings #2 (internal/api god layer) and #3 (ServiceContainer
bag-of-DI) with an incremental strangle, not a rewrite.

- ADR-0016 (Accepted): thin handlers (decode → use-case → encode) backed by
  per-domain use-case packages internal/<domain>/app and narrow consumer-defined
  ports, replacing ServiceContainer/background reach-through. Phased, golden-gated.
- Phase 1 exemplar (Wi-Fi visibility reads): new internal/wifi/app (wifiapp) with
  a Queries use-case over a narrow VisibilitySource port. The /wifi/airspace and
  /wifi/anomalies handlers are now thin and call the injected use-case instead of
  reaching into s.background.WiFiVisibility. NewServer wires the use-case from the
  background component via a nil-safe adapter (avoids the typed-nil interface trap).

Behavior unchanged — same routes, DTOs, and responses; golden HTTP suite
byte-identical. New use-case + handler tests; golangci 0. Establishes the
internal/wifi/app ring + DI direction the later strangle phases follow.
