### PR TITLE
refactor(api): strangle wi-fi management + discovery handlers into wifiapp use-cases

### DIFF
--- a/internal/api/handlers_wifi.go
+++ b/internal/api/handlers_wifi.go
@@ -4,6 +4,7 @@ package api
 // Split from handlers_network.go for code organization (Plan F).
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/krisarmstrong/seed/internal/i18n"
 	"github.com/krisarmstrong/seed/internal/logging"
 	"github.com/krisarmstrong/seed/internal/wifi"
+	wifiapp "github.com/krisarmstrong/seed/internal/wifi/app"
 )
 
 // ============================================================================
@@ -63,29 +65,12 @@ func (s *Server) handleWiFiSettings(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getWiFiSettings(w http.ResponseWriter, _ *http.Request) {
-	// Get configured WLAN interface (or fall back to current) - IEEE 802.11
-	wlanIface := s.config.Interface.WiFi
-	if wlanIface == "" {
-		wlanIface = s.config.Interface.Default
-	}
-
-	// Get list of available wireless interfaces
-	availableWLAN := []string{}
-	if s.netManager() != nil {
-		for _, iface := range s.netManager().GetInterfaces() {
-			if s.netManager().IsWireless(iface.Name) {
-				availableWLAN = append(availableWLAN, iface.Name)
-			}
-		}
-	}
-
-	resp := WiFiSettingsResponse{
-		Interface:     wlanIface,
-		AvailableWiFi: availableWLAN,
-		IsWireless:    s.wifiManager() != nil && s.wifiManager().IsWireless(),
-	}
-
-	sendJSONResponse(w, nil, http.StatusOK, resp)
+	res := s.wifiManagement.Settings()
+	sendJSONResponse(w, nil, http.StatusOK, WiFiSettingsResponse{
+		Interface:     res.Interface,
+		AvailableWiFi: res.AvailableWiFi,
+		IsWireless:    res.IsWireless,
+	})
 }
 
 func (s *Server) updateWiFiSettings(
@@ -101,23 +86,7 @@ func (s *Server) updateWiFiSettings(
 		return
 	}
 
-	// Lock config for write access
-	// NOTE: Must unlock before Save() - Save() acquires RLock internally
-	s.config.Lock()
-
-	// Update WiFi interface in config
-	s.config.Interface.WiFi = req.Interface
-
-	// Update WiFi manager to use new interface
-	if s.wifiManager() != nil && req.Interface != "" {
-		s.wifiManager().SetInterface(req.Interface)
-	}
-
-	// Unlock before Save() to avoid deadlock - Save() acquires RLock internally
-	s.config.Unlock()
-
-	// Save config
-	if err := s.config.Save(s.configPath); err != nil {
+	if err := s.wifiManagement.UpdateInterface(req.Interface); err != nil {
 		logger.ErrorContext(r.Context(), "Failed to save config", "error", err)
 		sendErrorResponseWithDetails(
 			w,
@@ -224,134 +193,34 @@ func (s *Server) handleWiFi(w http.ResponseWriter, r *http.Request) {
 // ============================================================================
 
 // handleWiFiScan performs a WiFi network scan and returns discovered networks.
+// Thin handler (ADR-0016): it resolves the requested interface from the request
+// and delegates to the Wi-Fi management use-case, which owns the degrade logic.
 func (s *Server) handleWiFiScan(w http.ResponseWriter, r *http.Request) {
-	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
+	res := s.wifiManagement.Scan(s.getInterfaceFromRequest(r))
 
-	if r.Method != http.MethodGet {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusMethodNotAllowed,
-			ErrCodeMethodNotAllowed,
-			localizer.T("errors.api.methodNotAllowed"),
-			"",
-		)
-		return
+	resp := map[string]any{
+		"interface": res.Interface,
+		"available": res.Available,
+		"networks":  res.Networks,
 	}
-
-	// Get interface from query param or use current/default
-	wlanIface := s.getInterfaceFromRequest(r)
-	if wlanIface == "" {
-		wlanIface = s.config.Interface.WiFi
-		if wlanIface == "" {
-			wlanIface = s.config.Interface.Default
-		}
+	if res.Error != "" {
+		resp["error"] = res.Error
 	}
-
-	if s.wifiScanner() == nil {
-		sendJSONResponse(w, nil, http.StatusOK, map[string]any{
-			"interface": wlanIface,
-			"available": false,
-			"error":     "WiFi scanner not initialized",
-			"networks":  []any{},
-		})
-		return
-	}
-
-	// Check if interface is wireless
-	if s.wifiManager() == nil || !s.wifiManager().IsWireless() {
-		sendJSONResponse(w, nil, http.StatusOK, map[string]any{
-			"interface": wlanIface,
-			"available": false,
-			"error":     "No wireless adapter available. Connect a WiFi adapter to scan networks.",
-			"networks":  []any{},
-		})
-		return
-	}
-
-	// Perform scan
-	networks, err := s.wifiScanner().Scan()
-	if err != nil {
-		sendJSONResponse(w, nil, http.StatusOK, map[string]any{
-			"interface": wlanIface,
-			"available": true,
-			"error":     "Wi-Fi scan failed. Check permissions and interface availability.",
-			"networks":  []any{},
-		})
-		return
-	}
-
-	sendJSONResponse(w, nil, http.StatusOK, map[string]any{
-		"interface": wlanIface,
-		"available": true,
-		"networks":  networks,
-	})
+	sendJSONResponse(w, nil, http.StatusOK, resp)
 }
 
 // handleWiFiStatus returns the WiFi adapter status without performing a scan.
+// Thin handler (ADR-0016) delegating to the Wi-Fi management use-case.
 func (s *Server) handleWiFiStatus(w http.ResponseWriter, r *http.Request) {
-	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
-
-	if r.Method != http.MethodGet {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusMethodNotAllowed,
-			ErrCodeMethodNotAllowed,
-			localizer.T("errors.api.methodNotAllowed"),
-			"",
-		)
-		return
-	}
-
-	// Get list of available wireless interfaces
-	availableAdapters := []string{}
-	if s.netManager() != nil {
-		for _, iface := range s.netManager().GetInterfaces() {
-			if s.netManager().IsWireless(iface.Name) {
-				availableAdapters = append(availableAdapters, iface.Name)
-			}
-		}
-	}
-
-	// Get interface from query param or use current/default
-	currentInterface := s.getInterfaceFromRequest(r)
-	if currentInterface == "" {
-		currentInterface = s.config.Interface.WiFi
-		if currentInterface == "" {
-			currentInterface = s.config.Interface.Default
-		}
-	}
-
-	// Check if current interface is wireless
-	isWireless := false
-	if s.wifiManager() != nil {
-		isWireless = s.wifiManager().IsWireless()
-	}
-
-	// Determine status message
-	var status, message string
-	switch {
-	case len(availableAdapters) == 0:
-		status = "unavailable"
-		message = "No wireless adapter detected. Connect a WiFi adapter to perform surveys."
-	case !isWireless:
-		status = "available"
-		message = "Wireless adapter available but not selected as current interface."
-	default:
-		status = "ready"
-		message = "Wireless adapter ready for scanning."
-	}
+	res := s.wifiManagement.Status(s.getInterfaceFromRequest(r))
 
 	sendJSONResponse(w, nil, http.StatusOK, map[string]any{
-		"status":            status,
-		"message":           message,
-		"currentInterface":  currentInterface,
-		"isWireless":        isWireless,
-		"availableAdapters": availableAdapters,
-		"canScan":           isWireless && len(availableAdapters) > 0,
+		"status":            res.Status,
+		"message":           res.Message,
+		"currentInterface":  res.CurrentInterface,
+		"isWireless":        res.IsWireless,
+		"availableAdapters": res.AvailableAdapters,
+		"canScan":           res.CanScan,
 	})
 }
 
@@ -369,37 +238,12 @@ type WiFiConnectRequest struct {
 	Password string `json:"password,omitempty" validate:"omitempty,min=8"`       // WPA2 minimum is 8
 }
 
-// handleWiFiConnect handles WiFi connection requests.
+// handleWiFiConnect handles WiFi connection requests. Thin handler (ADR-0016):
+// decode the request, delegate to the management use-case, map domain errors to
+// status codes.
 func (s *Server) handleWiFiConnect(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
-
-	if r.Method != http.MethodPost {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusMethodNotAllowed,
-			ErrCodeMethodNotAllowed,
-			localizer.T("errors.api.methodNotAllowed"),
-			"",
-		)
-		return
-	}
-
-	if s.wifiManager() == nil {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"WiFi manager not available",
-			"",
-		)
-		return
-	}
-
-	// Parse request body
-	r.Body = http.MaxBytesReader(w, r.Body, MaxBodySizeJSON)
 
 	var req WiFiConnectRequest
 	if !decodeJSONStrictLocalized(w, r, &req, MaxBodySizeJSON, logger, localizer) {
@@ -418,9 +262,19 @@ func (s *Server) handleWiFiConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Attempt connection
-	result, err := s.wifiManager().Connect(req.SSID, req.Password)
-	if err != nil {
+	result, err := s.wifiManagement.Connect(req.SSID, req.Password)
+	switch {
+	case errors.Is(err, wifiapp.ErrRadioUnavailable):
+		sendErrorResponseWithDetails(
+			w,
+			logger,
+			http.StatusServiceUnavailable,
+			ErrCodeServiceUnavail,
+			"WiFi manager not available",
+			"",
+		)
+		return
+	case err != nil:
 		logger.ErrorContext(r.Context(), "WiFi connection failed", "error", err, "ssid", req.SSID)
 		sendErrorResponseWithDetails(
 			w,
@@ -436,24 +290,14 @@ func (s *Server) handleWiFiConnect(w http.ResponseWriter, r *http.Request) {
 	sendJSONResponse(w, logger, http.StatusOK, result)
 }
 
-// handleWiFiDisconnect handles WiFi disconnection requests.
+// handleWiFiDisconnect handles WiFi disconnection requests. Thin handler
+// (ADR-0016) delegating to the management use-case.
 func (s *Server) handleWiFiDisconnect(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
 
-	if r.Method != http.MethodPost {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusMethodNotAllowed,
-			ErrCodeMethodNotAllowed,
-			localizer.T("errors.api.methodNotAllowed"),
-			"",
-		)
-		return
-	}
-
-	if s.wifiManager() == nil {
+	result, err := s.wifiManagement.Disconnect()
+	switch {
+	case errors.Is(err, wifiapp.ErrRadioUnavailable):
 		sendErrorResponseWithDetails(
 			w,
 			logger,
@@ -463,11 +307,7 @@ func (s *Server) handleWiFiDisconnect(w http.ResponseWriter, r *http.Request) {
 			"",
 		)
 		return
-	}
-
-	// Attempt disconnection
-	result, err := s.wifiManager().Disconnect()
-	if err != nil {
+	case err != nil:
 		logger.ErrorContext(r.Context(), "WiFi disconnection failed", "error", err)
 		sendErrorResponseWithDetails(
 			w,
@@ -871,35 +711,13 @@ func toWiFiDiscoveryStats(stats *discovery.WiFiDiscoveryStats) *WiFiDiscoverySta
 // Response: 200 OK with WiFiDiscoveryScanResponse.
 func (s *Server) handleWiFiDiscoveryScan(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
 
-	if r.Method != http.MethodPost {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusMethodNotAllowed,
-			ErrCodeMethodNotAllowed,
-			localizer.T("errors.api.methodNotAllowed"),
-			"",
-		)
+	result, err := s.wifiDiscovery.Scan(r.Context())
+	switch {
+	case errors.Is(err, wifiapp.ErrDiscoveryUnavailable):
+		s.respondWiFiDiscoveryUnavailable(w, logger)
 		return
-	}
-
-	bridge := s.wifiBridge()
-	if bridge == nil {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"WiFi discovery bridge not available",
-			"",
-		)
-		return
-	}
-
-	result, err := bridge.Scan(r.Context())
-	if err != nil {
+	case err != nil:
 		logger.ErrorContext(r.Context(), "WiFi discovery scan failed", "error", err)
 		sendErrorResponseWithDetails(
 			w,
@@ -912,9 +730,20 @@ func (s *Server) handleWiFiDiscoveryScan(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	resp := toWiFiDiscoveryScanResponse(result)
+	sendJSONResponse(w, logger, http.StatusOK, toWiFiDiscoveryScanResponse(result))
+}
 
-	sendJSONResponse(w, logger, http.StatusOK, resp)
+// respondWiFiDiscoveryUnavailable emits the shared 503 for the enhanced Wi-Fi
+// discovery handlers when no bridge is wired.
+func (s *Server) respondWiFiDiscoveryUnavailable(w http.ResponseWriter, logger *slog.Logger) {
+	sendErrorResponseWithDetails(
+		w,
+		logger,
+		http.StatusServiceUnavailable,
+		ErrCodeServiceUnavail,
+		"WiFi discovery bridge not available",
+		"",
+	)
 }
 
 // toWiFiDiscoveryScanResponse maps a Wi-Fi scan result to the API wire shape.
@@ -939,34 +768,13 @@ func toWiFiDiscoveryScanResponse(result *discovery.WiFiScanResult) WiFiDiscovery
 // Response: 200 OK with WiFiDiscoveryNetworksResponse.
 func (s *Server) handleWiFiDiscoveryNetworks(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
 
-	if r.Method != http.MethodGet {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusMethodNotAllowed,
-			ErrCodeMethodNotAllowed,
-			localizer.T("errors.api.methodNotAllowed"),
-			"",
-		)
+	networks, err := s.wifiDiscovery.Networks()
+	if errors.Is(err, wifiapp.ErrDiscoveryUnavailable) {
+		s.respondWiFiDiscoveryUnavailable(w, logger)
 		return
 	}
 
-	bridge := s.wifiBridge()
-	if bridge == nil {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"WiFi discovery bridge not available",
-			"",
-		)
-		return
-	}
-
-	networks := bridge.GetNetworks()
 	sendJSONResponse(w, logger, http.StatusOK, WiFiDiscoveryNetworksResponse{
 		Networks: toWiFiNetworks(networks),
 		Total:    len(networks),
@@ -982,34 +790,13 @@ func (s *Server) handleWiFiDiscoveryNetworks(w http.ResponseWriter, r *http.Requ
 // Response: 200 OK with WiFiDiscoveryAPsResponse.
 func (s *Server) handleWiFiDiscoveryAPs(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
 
-	if r.Method != http.MethodGet {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusMethodNotAllowed,
-			ErrCodeMethodNotAllowed,
-			localizer.T("errors.api.methodNotAllowed"),
-			"",
-		)
+	aps, err := s.wifiDiscovery.AccessPoints()
+	if errors.Is(err, wifiapp.ErrDiscoveryUnavailable) {
+		s.respondWiFiDiscoveryUnavailable(w, logger)
 		return
 	}
 
-	bridge := s.wifiBridge()
-	if bridge == nil {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"WiFi discovery bridge not available",
-			"",
-		)
-		return
-	}
-
-	aps := bridge.GetAccessPoints()
 	sendJSONResponse(w, logger, http.StatusOK, WiFiDiscoveryAPsResponse{
 		AccessPoints: toWiFiAccessPoints(aps),
 		Total:        len(aps),
@@ -1025,34 +812,13 @@ func (s *Server) handleWiFiDiscoveryAPs(w http.ResponseWriter, r *http.Request) 
 // Response: 200 OK with WiFiDiscoveryStatsResponse.
 func (s *Server) handleWiFiDiscoveryStats(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
 
-	if r.Method != http.MethodGet {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusMethodNotAllowed,
-			ErrCodeMethodNotAllowed,
-			localizer.T("errors.api.methodNotAllowed"),
-			"",
-		)
+	stats, err := s.wifiDiscovery.Stats()
+	if errors.Is(err, wifiapp.ErrDiscoveryUnavailable) {
+		s.respondWiFiDiscoveryUnavailable(w, logger)
 		return
 	}
 
-	bridge := s.wifiBridge()
-	if bridge == nil {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"WiFi discovery bridge not available",
-			"",
-		)
-		return
-	}
-
-	stats := bridge.GetStats()
 	sendJSONResponse(w, logger, http.StatusOK, WiFiDiscoveryStatsResponse{
 		Stats: toWiFiDiscoveryStats(stats),
 	})

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -127,6 +127,8 @@ type Server struct {
 	setupModeStartTime time.Time             // Security fix #891: Track when setup mode started
 	background         *BackgroundComponents // Long-lived components with background lifecycle (report scheduler)
 	wifiQueries        *wifiapp.Queries      // Wi-Fi visibility read use-case (ADR-0016 strangle exemplar)
+	wifiManagement     *wifiapp.Management   // Wi-Fi settings/scan/status/connect use-case (ADR-0016 phase 2)
+	wifiDiscovery      *wifiapp.Discovery    // Enhanced Wi-Fi discovery use-case (ADR-0016 phase 2)
 	tlsFingerprint     tlsFingerprintCache   // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
 
@@ -238,6 +240,9 @@ func NewServer(
 
 	// Initialize discovery service and pipeline
 	s.initDiscovery(cfg)
+
+	// Wire the Wi-Fi use-cases now that the discovery bridge exists (ADR-0016).
+	s.initWiFiUseCases()
 
 	// Initialize vulnerability scanner if enabled
 	s.initVulnerabilityScanner(cfg)

--- a/internal/api/wifi_usecases.go
+++ b/internal/api/wifi_usecases.go
@@ -1,0 +1,126 @@
+package api
+
+// wifi_usecases.go wires the API layer to the Wi-Fi application (use-case)
+// services (ADR-0016 strangle phase 2). The adapters below implement the narrow
+// ports declared in internal/wifi/app over the concrete service-container
+// collaborators, so the handlers depend on use-cases instead of reaching into
+// ServiceContainer / Server.background directly.
+
+import (
+	"context"
+
+	"github.com/krisarmstrong/seed/internal/config"
+	"github.com/krisarmstrong/seed/internal/discovery"
+	"github.com/krisarmstrong/seed/internal/netif"
+	"github.com/krisarmstrong/seed/internal/wifi"
+	wifiapp "github.com/krisarmstrong/seed/internal/wifi/app"
+)
+
+// wifiHardwareAdapter implements wifiapp.Hardware over the Wi-Fi manager and
+// scanner. Availability reporters mirror the handlers' historic nil-guards.
+type wifiHardwareAdapter struct {
+	manager *wifi.Manager
+	scanner *wifi.Scanner
+}
+
+func (a wifiHardwareAdapter) ManagerAvailable() bool { return a.manager != nil }
+func (a wifiHardwareAdapter) ScannerAvailable() bool { return a.scanner != nil }
+
+func (a wifiHardwareAdapter) IsWireless() bool {
+	return a.manager != nil && a.manager.IsWireless()
+}
+
+func (a wifiHardwareAdapter) SetInterface(name string) {
+	if a.manager != nil {
+		a.manager.SetInterface(name)
+	}
+}
+
+func (a wifiHardwareAdapter) Scan() ([]*wifi.ScannedNetwork, error) { return a.scanner.Scan() }
+
+func (a wifiHardwareAdapter) Connect(ssid, password string) (*wifi.ConnectionResult, error) {
+	return a.manager.Connect(ssid, password)
+}
+
+func (a wifiHardwareAdapter) Disconnect() (*wifi.ConnectionResult, error) {
+	return a.manager.Disconnect()
+}
+
+// wifiInterfaceLister implements wifiapp.InterfaceLister over the network
+// interface manager, returning a non-nil slice even when no manager is present.
+type wifiInterfaceLister struct {
+	net *netif.Manager
+}
+
+func (l wifiInterfaceLister) WirelessInterfaceNames() []string {
+	names := []string{}
+	if l.net == nil {
+		return names
+	}
+	for _, iface := range l.net.GetInterfaces() {
+		if l.net.IsWireless(iface.Name) {
+			names = append(names, iface.Name)
+		}
+	}
+	return names
+}
+
+// wifiInterfaceStore implements wifiapp.InterfaceStore over the live config,
+// owning the lock + on-disk save that the port abstracts away.
+type wifiInterfaceStore struct {
+	cfg  *config.Config
+	path string
+}
+
+func (s wifiInterfaceStore) ResolvedWiFiInterface() string {
+	iface := s.cfg.Interface.WiFi
+	if iface == "" {
+		iface = s.cfg.Interface.Default
+	}
+	return iface
+}
+
+func (s wifiInterfaceStore) SaveWiFiInterface(name string) error {
+	// Lock for the in-memory mutation only; Save acquires its own RLock, so it
+	// must run unlocked to avoid the historic deadlock.
+	s.cfg.Lock()
+	s.cfg.Interface.WiFi = name
+	s.cfg.Unlock()
+	return s.cfg.Save(s.path)
+}
+
+// wifiBridgeSource adapts *discovery.WiFiBridge to wifiapp.DiscoverySource.
+type wifiBridgeSource struct {
+	bridge *discovery.WiFiBridge
+}
+
+func (b wifiBridgeSource) Scan(ctx context.Context) (*discovery.WiFiScanResult, error) {
+	return b.bridge.Scan(ctx)
+}
+func (b wifiBridgeSource) Networks() []discovery.WiFiNetwork { return b.bridge.GetNetworks() }
+func (b wifiBridgeSource) AccessPoints() []discovery.WiFiAccessPoint {
+	return b.bridge.GetAccessPoints()
+}
+func (b wifiBridgeSource) Stats() *discovery.WiFiDiscoveryStats { return b.bridge.GetStats() }
+
+// wifiDiscoverySource returns the discovery use-case source for the current
+// bridge, or a genuinely-nil interface when no bridge is wired so the use-case
+// degrades to ErrDiscoveryUnavailable rather than panicking on a typed nil.
+func wifiDiscoverySource(bridge *discovery.WiFiBridge) wifiapp.DiscoverySource {
+	if bridge == nil {
+		return nil
+	}
+	return wifiBridgeSource{bridge: bridge}
+}
+
+// initWiFiUseCases builds the Wi-Fi management + discovery use-cases from the
+// fully-wired services. Called from NewServer after initDiscovery so the
+// discovery bridge (assigned during initDiscovery) is captured.
+func (s *Server) initWiFiUseCases() {
+	s.wifiManagement = wifiapp.NewManagement(
+		wifiHardwareAdapter{manager: s.wifiManager(), scanner: s.wifiScanner()},
+		wifiInterfaceLister{net: s.netManager()},
+		wifiInterfaceStore{cfg: s.config, path: s.configPath},
+	)
+	s.wifiDiscovery = wifiapp.NewDiscovery(wifiDiscoverySource(s.wifiBridge()))
+}

--- a/internal/wifi/app/discovery.go
+++ b/internal/wifi/app/discovery.go
@@ -1,0 +1,65 @@
+package wifiapp
+
+import (
+	"context"
+	"errors"
+
+	"github.com/krisarmstrong/seed/internal/discovery"
+)
+
+// ErrDiscoveryUnavailable is returned by the discovery use-case when the Wi-Fi
+// discovery bridge is not wired. The handler maps it to a 503 Service
+// Unavailable, preserving the pre-strangle behavior.
+var ErrDiscoveryUnavailable = errors.New("wifi discovery bridge not available")
+
+// DiscoverySource is the narrow capability the enhanced Wi-Fi discovery
+// use-case needs from the discovery bridge. Defined here at the consumer
+// (ADR-0016) and satisfied by an adapter over *discovery.WiFiBridge.
+type DiscoverySource interface {
+	Scan(ctx context.Context) (*discovery.WiFiScanResult, error)
+	Networks() []discovery.WiFiNetwork
+	AccessPoints() []discovery.WiFiAccessPoint
+	Stats() *discovery.WiFiDiscoveryStats
+}
+
+// Discovery is the enhanced Wi-Fi discovery use-case (vendor lookup,
+// authorization, channel utilization) over the discovery bridge. A nil source
+// (bridge not wired) makes every method return ErrDiscoveryUnavailable.
+type Discovery struct {
+	src DiscoverySource
+}
+
+// NewDiscovery builds the discovery use-case over src.
+func NewDiscovery(src DiscoverySource) *Discovery { return &Discovery{src: src} }
+
+// Scan triggers an enhanced Wi-Fi scan.
+func (d *Discovery) Scan(ctx context.Context) (*discovery.WiFiScanResult, error) {
+	if d == nil || d.src == nil {
+		return nil, ErrDiscoveryUnavailable
+	}
+	return d.src.Scan(ctx)
+}
+
+// Networks returns the Wi-Fi networks from the most recent enhanced scan.
+func (d *Discovery) Networks() ([]discovery.WiFiNetwork, error) {
+	if d == nil || d.src == nil {
+		return nil, ErrDiscoveryUnavailable
+	}
+	return d.src.Networks(), nil
+}
+
+// AccessPoints returns the access points from the most recent enhanced scan.
+func (d *Discovery) AccessPoints() ([]discovery.WiFiAccessPoint, error) {
+	if d == nil || d.src == nil {
+		return nil, ErrDiscoveryUnavailable
+	}
+	return d.src.AccessPoints(), nil
+}
+
+// Stats returns the aggregated Wi-Fi discovery statistics.
+func (d *Discovery) Stats() (*discovery.WiFiDiscoveryStats, error) {
+	if d == nil || d.src == nil {
+		return nil, ErrDiscoveryUnavailable
+	}
+	return d.src.Stats(), nil
+}

--- a/internal/wifi/app/discovery_test.go
+++ b/internal/wifi/app/discovery_test.go
@@ -1,0 +1,69 @@
+package wifiapp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/discovery"
+	wifiapp "github.com/krisarmstrong/seed/internal/wifi/app"
+)
+
+type fakeDiscoverySource struct {
+	scanRes  *discovery.WiFiScanResult
+	scanErr  error
+	networks []discovery.WiFiNetwork
+	aps      []discovery.WiFiAccessPoint
+	stats    *discovery.WiFiDiscoveryStats
+}
+
+func (f fakeDiscoverySource) Scan(context.Context) (*discovery.WiFiScanResult, error) {
+	return f.scanRes, f.scanErr
+}
+func (f fakeDiscoverySource) Networks() []discovery.WiFiNetwork         { return f.networks }
+func (f fakeDiscoverySource) AccessPoints() []discovery.WiFiAccessPoint { return f.aps }
+func (f fakeDiscoverySource) Stats() *discovery.WiFiDiscoveryStats      { return f.stats }
+
+func TestDiscoveryNilSourceUnavailable(t *testing.T) {
+	d := wifiapp.NewDiscovery(nil)
+
+	if _, err := d.Scan(context.Background()); !errors.Is(err, wifiapp.ErrDiscoveryUnavailable) {
+		t.Errorf("Scan err = %v, want ErrDiscoveryUnavailable", err)
+	}
+	if _, err := d.Networks(); !errors.Is(err, wifiapp.ErrDiscoveryUnavailable) {
+		t.Errorf("Networks err = %v, want ErrDiscoveryUnavailable", err)
+	}
+	if _, err := d.AccessPoints(); !errors.Is(err, wifiapp.ErrDiscoveryUnavailable) {
+		t.Errorf("AccessPoints err = %v, want ErrDiscoveryUnavailable", err)
+	}
+	if _, err := d.Stats(); !errors.Is(err, wifiapp.ErrDiscoveryUnavailable) {
+		t.Errorf("Stats err = %v, want ErrDiscoveryUnavailable", err)
+	}
+}
+
+func TestDiscoveryDelegates(t *testing.T) {
+	src := fakeDiscoverySource{
+		scanRes:  &discovery.WiFiScanResult{Interface: "wlan0"},
+		networks: []discovery.WiFiNetwork{{SSID: "office"}},
+		aps:      []discovery.WiFiAccessPoint{{BSSID: "aa:bb"}},
+		stats:    &discovery.WiFiDiscoveryStats{TotalNetworks: 1},
+	}
+	d := wifiapp.NewDiscovery(src)
+
+	res, err := d.Scan(context.Background())
+	if err != nil || res.Interface != "wlan0" {
+		t.Fatalf("Scan = %v, %v", res, err)
+	}
+	nets, err := d.Networks()
+	if err != nil || len(nets) != 1 {
+		t.Fatalf("Networks = %v, %v", nets, err)
+	}
+	aps, err := d.AccessPoints()
+	if err != nil || len(aps) != 1 {
+		t.Fatalf("AccessPoints = %v, %v", aps, err)
+	}
+	stats, err := d.Stats()
+	if err != nil || stats.TotalNetworks != 1 {
+		t.Fatalf("Stats = %v, %v", stats, err)
+	}
+}

--- a/internal/wifi/app/management.go
+++ b/internal/wifi/app/management.go
@@ -1,0 +1,189 @@
+package wifiapp
+
+import (
+	"errors"
+
+	"github.com/krisarmstrong/seed/internal/wifi"
+)
+
+// ErrRadioUnavailable is returned by the management use-cases when the Wi-Fi
+// manager (radio control surface) is not present. The handler maps it to a
+// 503 Service Unavailable, preserving the pre-strangle behavior.
+var ErrRadioUnavailable = errors.New("wifi manager not available")
+
+// Hardware is the Wi-Fi radio + scan surface the management use-cases need. It
+// is defined here at the consumer (ADR-0016 interface-segregation) and satisfied
+// by an adapter over *wifi.Manager + *wifi.Scanner. The Available reporters let
+// the use-case mirror the "adapter not present" degraded responses without the
+// handler reaching into the service container.
+type Hardware interface {
+	ManagerAvailable() bool
+	ScannerAvailable() bool
+	IsWireless() bool
+	SetInterface(name string)
+	Scan() ([]*wifi.ScannedNetwork, error)
+	Connect(ssid, password string) (*wifi.ConnectionResult, error)
+	Disconnect() (*wifi.ConnectionResult, error)
+}
+
+// InterfaceLister enumerates the host's wireless interface names. Satisfied by
+// an adapter over the network interface manager.
+type InterfaceLister interface {
+	WirelessInterfaceNames() []string
+}
+
+// InterfaceStore reads and persists the configured Wi-Fi interface selection.
+// The port speaks only in strings so the use-case stays free of the config
+// package; the adapter owns the locking and on-disk save.
+type InterfaceStore interface {
+	// ResolvedWiFiInterface returns the configured Wi-Fi interface, falling back
+	// to the default interface when no dedicated Wi-Fi interface is set.
+	ResolvedWiFiInterface() string
+	// SaveWiFiInterface persists name as the Wi-Fi interface selection.
+	SaveWiFiInterface(name string) error
+}
+
+// Management is the Wi-Fi settings/scan/status/connect use-case. Handlers depend
+// on it instead of on the service container, the config, or the network manager.
+type Management struct {
+	hw     Hardware
+	lister InterfaceLister
+	store  InterfaceStore
+}
+
+// NewManagement builds the management use-case over its narrow dependencies.
+func NewManagement(hw Hardware, lister InterfaceLister, store InterfaceStore) *Management {
+	return &Management{hw: hw, lister: lister, store: store}
+}
+
+// SettingsResult is the Wi-Fi settings read model: the active interface, the
+// available wireless interfaces, and whether the active one is wireless.
+type SettingsResult struct {
+	Interface     string
+	AvailableWiFi []string
+	IsWireless    bool
+}
+
+// Settings returns the current Wi-Fi settings.
+func (m *Management) Settings() SettingsResult {
+	return SettingsResult{
+		Interface:     m.store.ResolvedWiFiInterface(),
+		AvailableWiFi: m.lister.WirelessInterfaceNames(),
+		IsWireless:    m.hw.ManagerAvailable() && m.hw.IsWireless(),
+	}
+}
+
+// UpdateInterface sets and persists the Wi-Fi interface selection, also pointing
+// the radio at the new interface when one is given.
+func (m *Management) UpdateInterface(name string) error {
+	if name != "" && m.hw.ManagerAvailable() {
+		m.hw.SetInterface(name)
+	}
+	return m.store.SaveWiFiInterface(name)
+}
+
+// ScanResult is the neighbor-scan read model. Error is empty on success; when
+// set it carries the user-facing reason the scan could not run or complete.
+// Networks is always non-nil so it serializes as [] rather than null.
+type ScanResult struct {
+	Interface string
+	Available bool
+	Error     string
+	Networks  []*wifi.ScannedNetwork
+}
+
+// Scan performs a neighbor-AP scan on the requested interface, falling back to
+// the configured interface when requestedIface is empty. It degrades (never
+// errors) to an Available=false / Error-bearing result when the scanner or a
+// wireless adapter is absent, mirroring the pre-strangle handler.
+func (m *Management) Scan(requestedIface string) ScanResult {
+	iface := requestedIface
+	if iface == "" {
+		iface = m.store.ResolvedWiFiInterface()
+	}
+	empty := []*wifi.ScannedNetwork{}
+
+	switch {
+	case !m.hw.ScannerAvailable():
+		return ScanResult{Interface: iface, Available: false, Error: "WiFi scanner not initialized", Networks: empty}
+	case !m.hw.ManagerAvailable() || !m.hw.IsWireless():
+		return ScanResult{
+			Interface: iface,
+			Available: false,
+			Error:     "No wireless adapter available. Connect a WiFi adapter to scan networks.",
+			Networks:  empty,
+		}
+	}
+
+	networks, err := m.hw.Scan()
+	if err != nil {
+		return ScanResult{
+			Interface: iface,
+			Available: true,
+			Error:     "Wi-Fi scan failed. Check permissions and interface availability.",
+			Networks:  empty,
+		}
+	}
+	return ScanResult{Interface: iface, Available: true, Networks: networks}
+}
+
+// StatusResult is the adapter-status read model returned by Status.
+type StatusResult struct {
+	Status            string
+	Message           string
+	CurrentInterface  string
+	IsWireless        bool
+	AvailableAdapters []string
+	CanScan           bool
+}
+
+// Status reports the wireless adapter state without performing a scan, resolving
+// the current interface the same way Scan does.
+func (m *Management) Status(requestedIface string) StatusResult {
+	adapters := m.lister.WirelessInterfaceNames()
+	iface := requestedIface
+	if iface == "" {
+		iface = m.store.ResolvedWiFiInterface()
+	}
+	isWireless := m.hw.ManagerAvailable() && m.hw.IsWireless()
+
+	var status, message string
+	switch {
+	case len(adapters) == 0:
+		status = "unavailable"
+		message = "No wireless adapter detected. Connect a WiFi adapter to perform surveys."
+	case !isWireless:
+		status = "available"
+		message = "Wireless adapter available but not selected as current interface."
+	default:
+		status = "ready"
+		message = "Wireless adapter ready for scanning."
+	}
+
+	return StatusResult{
+		Status:            status,
+		Message:           message,
+		CurrentInterface:  iface,
+		IsWireless:        isWireless,
+		AvailableAdapters: adapters,
+		CanScan:           isWireless && len(adapters) > 0,
+	}
+}
+
+// Connect attempts to join an SSID. It returns ErrRadioUnavailable when the
+// radio is absent; any other error is the underlying connect failure.
+func (m *Management) Connect(ssid, password string) (*wifi.ConnectionResult, error) {
+	if !m.hw.ManagerAvailable() {
+		return nil, ErrRadioUnavailable
+	}
+	return m.hw.Connect(ssid, password)
+}
+
+// Disconnect drops the current association, returning ErrRadioUnavailable when
+// the radio is absent.
+func (m *Management) Disconnect() (*wifi.ConnectionResult, error) {
+	if !m.hw.ManagerAvailable() {
+		return nil, ErrRadioUnavailable
+	}
+	return m.hw.Disconnect()
+}

--- a/internal/wifi/app/management_test.go
+++ b/internal/wifi/app/management_test.go
@@ -1,0 +1,252 @@
+package wifiapp_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/wifi"
+	wifiapp "github.com/krisarmstrong/seed/internal/wifi/app"
+)
+
+// fakeHardware is a configurable wifiapp.Hardware for the management tests.
+type fakeHardware struct {
+	managerAvail bool
+	scannerAvail bool
+	wireless     bool
+	setIface     string
+	scanNets     []*wifi.ScannedNetwork
+	scanErr      error
+	connectRes   *wifi.ConnectionResult
+	connectErr   error
+	disconnRes   *wifi.ConnectionResult
+	disconnErr   error
+}
+
+func (f *fakeHardware) ManagerAvailable() bool { return f.managerAvail }
+func (f *fakeHardware) ScannerAvailable() bool { return f.scannerAvail }
+func (f *fakeHardware) IsWireless() bool       { return f.wireless }
+func (f *fakeHardware) SetInterface(name string) {
+	f.setIface = name
+}
+
+func (f *fakeHardware) Scan() ([]*wifi.ScannedNetwork, error) { return f.scanNets, f.scanErr }
+func (f *fakeHardware) Connect(_, _ string) (*wifi.ConnectionResult, error) {
+	return f.connectRes, f.connectErr
+}
+
+func (f *fakeHardware) Disconnect() (*wifi.ConnectionResult, error) {
+	return f.disconnRes, f.disconnErr
+}
+
+type fakeLister struct{ names []string }
+
+func (f fakeLister) WirelessInterfaceNames() []string { return f.names }
+
+type fakeStore struct {
+	resolved string
+	saved    string
+	saveErr  error
+	saveCnt  int
+}
+
+func (f *fakeStore) ResolvedWiFiInterface() string { return f.resolved }
+func (f *fakeStore) SaveWiFiInterface(name string) error {
+	f.saved = name
+	f.saveCnt++
+	return f.saveErr
+}
+
+func TestSettings(t *testing.T) {
+	m := wifiapp.NewManagement(
+		&fakeHardware{managerAvail: true, wireless: true},
+		fakeLister{names: []string{"wlan0", "wlan1"}},
+		&fakeStore{resolved: "wlan0"},
+	)
+	got := m.Settings()
+	if got.Interface != "wlan0" {
+		t.Errorf("interface = %q, want wlan0", got.Interface)
+	}
+	if len(got.AvailableWiFi) != 2 {
+		t.Errorf("availableWiFi = %v, want 2 entries", got.AvailableWiFi)
+	}
+	if !got.IsWireless {
+		t.Error("isWireless = false, want true")
+	}
+}
+
+func TestSettingsNoManager(t *testing.T) {
+	m := wifiapp.NewManagement(
+		&fakeHardware{managerAvail: false, wireless: true},
+		fakeLister{},
+		&fakeStore{resolved: "eth0"},
+	)
+	if m.Settings().IsWireless {
+		t.Error("isWireless = true with no manager, want false")
+	}
+}
+
+func TestUpdateInterfaceSetsRadioAndSaves(t *testing.T) {
+	hw := &fakeHardware{managerAvail: true}
+	store := &fakeStore{}
+	m := wifiapp.NewManagement(hw, fakeLister{}, store)
+
+	if err := m.UpdateInterface("wlan2"); err != nil {
+		t.Fatalf("UpdateInterface: %v", err)
+	}
+	if hw.setIface != "wlan2" {
+		t.Errorf("radio interface = %q, want wlan2", hw.setIface)
+	}
+	if store.saved != "wlan2" || store.saveCnt != 1 {
+		t.Errorf("store saved = %q cnt=%d, want wlan2 cnt=1", store.saved, store.saveCnt)
+	}
+}
+
+func TestUpdateInterfaceEmptySkipsRadio(t *testing.T) {
+	hw := &fakeHardware{managerAvail: true}
+	store := &fakeStore{}
+	m := wifiapp.NewManagement(hw, fakeLister{}, store)
+
+	if err := m.UpdateInterface(""); err != nil {
+		t.Fatalf("UpdateInterface: %v", err)
+	}
+	if hw.setIface != "" {
+		t.Errorf("radio interface = %q, want unchanged", hw.setIface)
+	}
+	if store.saved != "" || store.saveCnt != 1 {
+		t.Errorf("store should still persist the empty selection once")
+	}
+}
+
+func TestScanResolvesAndSucceeds(t *testing.T) {
+	nets := []*wifi.ScannedNetwork{{SSID: "office"}}
+	m := wifiapp.NewManagement(
+		&fakeHardware{managerAvail: true, scannerAvail: true, wireless: true, scanNets: nets},
+		fakeLister{},
+		&fakeStore{resolved: "wlan0"},
+	)
+	got := m.Scan("")
+	if got.Interface != "wlan0" {
+		t.Errorf("interface = %q, want resolved wlan0", got.Interface)
+	}
+	if !got.Available || got.Error != "" {
+		t.Errorf("available=%v error=%q, want available no error", got.Available, got.Error)
+	}
+	if len(got.Networks) != 1 {
+		t.Errorf("networks = %v, want 1", got.Networks)
+	}
+}
+
+func TestScanDegrades(t *testing.T) {
+	tests := []struct {
+		name      string
+		hw        *fakeHardware
+		wantAvail bool
+		wantErr   string
+	}{
+		{
+			name:    "no scanner",
+			hw:      &fakeHardware{scannerAvail: false},
+			wantErr: "WiFi scanner not initialized",
+		},
+		{
+			name:    "no wireless adapter",
+			hw:      &fakeHardware{scannerAvail: true, managerAvail: true, wireless: false},
+			wantErr: "No wireless adapter available. Connect a WiFi adapter to scan networks.",
+		},
+		{
+			name: "scan failure",
+			hw: &fakeHardware{
+				scannerAvail: true,
+				managerAvail: true,
+				wireless:     true,
+				scanErr:      errors.New("boom"),
+			},
+			wantAvail: true,
+			wantErr:   "Wi-Fi scan failed. Check permissions and interface availability.",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := wifiapp.NewManagement(tc.hw, fakeLister{}, &fakeStore{resolved: "wlan0"})
+			got := m.Scan("wlan9")
+			if got.Interface != "wlan9" {
+				t.Errorf("interface = %q, want requested wlan9", got.Interface)
+			}
+			if got.Available != tc.wantAvail {
+				t.Errorf("available = %v, want %v", got.Available, tc.wantAvail)
+			}
+			if got.Error != tc.wantErr {
+				t.Errorf("error = %q, want %q", got.Error, tc.wantErr)
+			}
+			if got.Networks == nil {
+				t.Error("networks is nil, want non-nil empty slice")
+			}
+		})
+	}
+}
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		hw          *fakeHardware
+		adapters    []string
+		wantStatus  string
+		wantCanScan bool
+	}{
+		{name: "unavailable", hw: &fakeHardware{}, adapters: nil, wantStatus: "unavailable"},
+		{
+			name:       "available not selected",
+			hw:         &fakeHardware{managerAvail: true, wireless: false},
+			adapters:   []string{"wlan0"},
+			wantStatus: "available",
+		},
+		{
+			name:        "ready",
+			hw:          &fakeHardware{managerAvail: true, wireless: true},
+			adapters:    []string{"wlan0"},
+			wantStatus:  "ready",
+			wantCanScan: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := wifiapp.NewManagement(tc.hw, fakeLister{names: tc.adapters}, &fakeStore{resolved: "wlan0"})
+			got := m.Status("")
+			if got.Status != tc.wantStatus {
+				t.Errorf("status = %q, want %q", got.Status, tc.wantStatus)
+			}
+			if got.CanScan != tc.wantCanScan {
+				t.Errorf("canScan = %v, want %v", got.CanScan, tc.wantCanScan)
+			}
+			if got.CurrentInterface != "wlan0" {
+				t.Errorf("currentInterface = %q, want resolved wlan0", got.CurrentInterface)
+			}
+		})
+	}
+}
+
+func TestConnect(t *testing.T) {
+	res := &wifi.ConnectionResult{Success: true}
+	m := wifiapp.NewManagement(
+		&fakeHardware{managerAvail: true, connectRes: res},
+		fakeLister{}, &fakeStore{},
+	)
+	got, err := m.Connect("ssid", "pw")
+	if err != nil || got != res {
+		t.Fatalf("Connect = %v, %v; want result, nil", got, err)
+	}
+}
+
+func TestConnectNoRadio(t *testing.T) {
+	m := wifiapp.NewManagement(&fakeHardware{managerAvail: false}, fakeLister{}, &fakeStore{})
+	if _, err := m.Connect("ssid", ""); !errors.Is(err, wifiapp.ErrRadioUnavailable) {
+		t.Fatalf("err = %v, want ErrRadioUnavailable", err)
+	}
+}
+
+func TestDisconnectNoRadio(t *testing.T) {
+	m := wifiapp.NewManagement(&fakeHardware{managerAvail: false}, fakeLister{}, &fakeStore{})
+	if _, err := m.Disconnect(); !errors.Is(err, wifiapp.ErrRadioUnavailable) {
+		t.Fatalf("err = %v, want ErrRadioUnavailable", err)
+	}
+}


### PR DESCRIPTION
## What

ADR-0016 **strangle `internal/api` phase 2**. Migrates the fatter Wi-Fi handlers off `ServiceContainer` / `Server.background` reach-through into `internal/wifi/app` (`wifiapp`) use-cases. Handlers become thin: **decode → use-case → encode**, mapping domain errors to status codes.

Migrated (owner's list): `wifi/settings` (GET/PUT), `wifi/scan`, `wifi/status`, `wifi/connect`, `wifi/disconnect`, and discovery `scan`/`networks`/`aps`/`stats`.

## How

- **`wifiapp.Management`** over narrow `Hardware` / `InterfaceLister` / `InterfaceStore` ports (declared at the consumer per ADR-0016 interface-segregation). Owns the degrade logic (scanner/adapter absent, scan failure).
- **`wifiapp.Discovery`** over a `DiscoverySource` port; a nil source degrades to `ErrDiscoveryUnavailable` instead of a typed-nil panic.
- **API-side adapters** (`wifi_usecases.go`) implement the ports over the manager/scanner/netif/config/bridge; wired in `NewServer` after `initDiscovery` so the discovery bridge pointer is captured.
- **Dead in-handler method checks removed** — the route-level `methodGate` has been authoritative since #6; the in-handler checks were unreachable for declared methods.

`handlers_wifi.go`: 1059 → 825 lines.

## Behavior / safety

- **Wire shapes preserved byte-for-byte** (the `map[string]any` degrade responses and DTOs are reproduced exactly). No route or schema changes, so the `/__capabilities` golden is untouched.
- **Net-new unit coverage** for the use-cases — no handler tests existed before (321 LOC of table tests with fakes).
- Full `internal/api` suite, `TestGoldenHTTP*`, route-policy, json-casing, output-escaping gates all green; `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)