### PR TITLE
feat(wifi): run the anomaly engine over wi-fi survey samples

### DIFF
--- a/internal/wifi/airspace/tree.go
+++ b/internal/wifi/airspace/tree.go
@@ -82,21 +82,57 @@ func (a *Airspace) Tree() []SSIDGroup {
 
 	groups := make([]SSIDGroup, 0, len(bySSID))
 	for ssid, apBuckets := range bySSID {
-		groups = append(groups, buildSSIDGroup(ssid, apBuckets))
+		// Convert the internal BSSes to views, then assemble with the shared
+		// builder so the live Tree and TreeFromBSSViews stay identical.
+		viewBuckets := make(map[string][]BSSView, len(apBuckets))
+		for key, bsses := range apBuckets {
+			views := make([]BSSView, 0, len(bsses))
+			for _, b := range bsses {
+				views = append(views, toBSSView(b))
+			}
+			viewBuckets[key] = views
+		}
+		groups = append(groups, assembleSSIDGroup(ssid, viewBuckets))
 	}
 	sort.Slice(groups, func(i, j int) bool { return groups[i].SSID < groups[j].SSID })
 	return groups
 }
 
-func buildSSIDGroup(ssid string, apBuckets map[string][]*bss) SSIDGroup {
+// TreeFromBSSViews assembles the sorted SSID → AP → BSSID hierarchy from a flat
+// set of BSS views (e.g. captured during a site survey), using the same
+// AP-clustering and ordering as the live Tree. Stations are carried through from
+// each view as-is. It is a pure function of its input — no airspace state.
+func TreeFromBSSViews(bsses []BSSView) []SSIDGroup {
+	bySSID := make(map[string]map[string][]BSSView)
+	for _, b := range bsses {
+		apBuckets, ok := bySSID[b.SSID]
+		if !ok {
+			apBuckets = make(map[string][]BSSView)
+			bySSID[b.SSID] = apBuckets
+		}
+		k := apKey(b.BSSID)
+		apBuckets[k] = append(apBuckets[k], b)
+	}
+
+	groups := make([]SSIDGroup, 0, len(bySSID))
+	for ssid, apBuckets := range bySSID {
+		groups = append(groups, assembleSSIDGroup(ssid, apBuckets))
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].SSID < groups[j].SSID })
+	return groups
+}
+
+// assembleSSIDGroup builds one SSIDGroup from AP-keyed BSS views, applying the
+// deterministic BSS/AP ordering and the cross-reference counts.
+func assembleSSIDGroup(ssid string, apBuckets map[string][]BSSView) SSIDGroup {
 	g := SSIDGroup{SSID: ssid}
-	for key, bsses := range apBuckets {
+	for key, views := range apBuckets {
 		ap := APGroup{Key: key, Vendor: vendorOUI(key)}
-		for _, b := range bsses {
-			ap.BSSes = append(ap.BSSes, toBSSView(b))
+		for _, v := range views {
+			ap.BSSes = append(ap.BSSes, v)
 			g.BSSCount++
-			g.StationCount += len(b.stations)
-			if b.hidden {
+			g.StationCount += len(v.Stations)
+			if v.Hidden {
 				g.Hidden = true
 			}
 		}

--- a/internal/wifi/app/analysis.go
+++ b/internal/wifi/app/analysis.go
@@ -1,0 +1,44 @@
+package wifiapp
+
+import (
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+)
+
+// AnalyzeBSSes runs the Wi-Fi anomaly rules over a flat set of observed BSSes
+// (e.g. captured during a site survey) and returns the resulting anomalies.
+//
+// It is a pure function of its inputs: it builds a transient airspace tree from
+// bsses, runs the detector, and folds the detections through a fresh, single-use
+// anomaly engine — no shared or persistent state with the live visibility
+// engine. This lets callers that hold a point-in-time set of BSSes (the survey
+// path) reuse the same rule catalog the streaming capture path uses.
+//
+// detector may be nil, in which case the default Wi-Fi detector is used. at
+// timestamps the synthetic observations, so the returned anomalies' first/last
+// seen reflect when the BSSes were measured.
+func AnalyzeBSSes(
+	bsses []airspace.BSSView,
+	detector *wifianomaly.Detector,
+	at time.Time,
+) ([]anomaly.Anomaly, error) {
+	if detector == nil {
+		detector = wifianomaly.NewDetector()
+	}
+	catalog, err := wifianomaly.Catalog()
+	if err != nil {
+		return nil, err
+	}
+
+	engine := anomaly.NewEngine(catalog)
+	tree := airspace.TreeFromBSSViews(bsses)
+	for _, det := range detector.Detect(tree) {
+		if obsErr := engine.Observe(det, at); obsErr != nil {
+			return nil, obsErr
+		}
+	}
+	return engine.Snapshot(), nil
+}

--- a/internal/wifi/app/analysis_test.go
+++ b/internal/wifi/app/analysis_test.go
@@ -1,0 +1,79 @@
+package wifiapp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+	wifiapp "github.com/krisarmstrong/seed/internal/wifi/app"
+)
+
+func hasDef(anoms []anomaly.Anomaly, defKey string) bool {
+	for _, a := range anoms {
+		if a.DefKey == defKey {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAnalyzeBSSesEmpty(t *testing.T) {
+	got, err := wifiapp.AnalyzeBSSes(nil, nil, time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("AnalyzeBSSes: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("anomalies = %v, want none", got)
+	}
+}
+
+func TestAnalyzeBSSesOpenNetwork(t *testing.T) {
+	bsses := []airspace.BSSView{
+		{BSSID: "aa:bb:cc:00:00:01", SSID: "guest", Band: "2.4 GHz", Channel: 6, Security: "Open"},
+	}
+	got, err := wifiapp.AnalyzeBSSes(bsses, nil, time.Unix(100, 0))
+	if err != nil {
+		t.Fatalf("AnalyzeBSSes: %v", err)
+	}
+	if !hasDef(got, wifianomaly.DefOpenNetwork) {
+		t.Errorf("expected %s anomaly, got %+v", wifianomaly.DefOpenNetwork, got)
+	}
+}
+
+func TestAnalyzeBSSesSecurityMismatch(t *testing.T) {
+	// One SSID advertised by a weak (Open) and a strong (WPA2) BSS.
+	bsses := []airspace.BSSView{
+		{BSSID: "aa:bb:cc:00:00:01", SSID: "corp", Band: "5 GHz", Channel: 36, Security: "Open"},
+		{BSSID: "dd:ee:ff:00:00:02", SSID: "corp", Band: "5 GHz", Channel: 40, Security: "WPA2"},
+	}
+	got, err := wifiapp.AnalyzeBSSes(bsses, nil, time.Unix(100, 0))
+	if err != nil {
+		t.Fatalf("AnalyzeBSSes: %v", err)
+	}
+	if !hasDef(got, wifianomaly.DefSecurityMismatch) {
+		t.Errorf("expected %s anomaly, got %+v", wifianomaly.DefSecurityMismatch, got)
+	}
+}
+
+func TestAnalyzeBSSesDeterministic(t *testing.T) {
+	bsses := []airspace.BSSView{
+		{BSSID: "aa:bb:cc:00:00:01", SSID: "guest", Band: "2.4 GHz", Channel: 6, Security: "Open"},
+		{BSSID: "aa:bb:cc:00:00:02", SSID: "guest2", Band: "2.4 GHz", Channel: 6, Security: "WEP"},
+	}
+	at := time.Unix(100, 0)
+	first, err := wifiapp.AnalyzeBSSes(bsses, nil, at)
+	if err != nil {
+		t.Fatalf("AnalyzeBSSes: %v", err)
+	}
+	second, _ := wifiapp.AnalyzeBSSes(bsses, nil, at)
+	if len(first) != len(second) {
+		t.Fatalf("non-deterministic length: %d vs %d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i].DefKey != second[i].DefKey || first[i].Subject != second[i].Subject {
+			t.Errorf("order differs at %d: %v vs %v", i, first[i], second[i])
+		}
+	}
+}

--- a/internal/wifi/survey/analysis.go
+++ b/internal/wifi/survey/analysis.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+
+	"github.com/krisarmstrong/seed/internal/anomaly"
 )
 
 // DeadZone represents a detected area of poor WiFi coverage.
@@ -19,11 +21,12 @@ type DeadZone struct {
 
 // DeadZoneAnalysis contains the results of dead zone detection analysis.
 type DeadZoneAnalysis struct {
-	SurveyID        string     `json:"survey_id"`
-	ThresholdDBm    int        `json:"threshold_dbm"`
-	DeadZones       []DeadZone `json:"dead_zones"`
-	CoverageScore   float64    `json:"coverage_score"` // 0-100
-	Recommendations []string   `json:"recommendations"`
+	SurveyID        string            `json:"survey_id"`
+	ThresholdDBm    int               `json:"threshold_dbm"`
+	DeadZones       []DeadZone        `json:"dead_zones"`
+	CoverageScore   float64           `json:"coverage_score"` // 0-100
+	Recommendations []string          `json:"recommendations"`
+	Anomalies       []anomaly.Anomaly `json:"anomalies"` // Wi-Fi anomalies detected from the survey's passive AP observations
 }
 
 // Coverage level thresholds in dBm.
@@ -125,12 +128,20 @@ func DetectDeadZones(survey *Survey, threshold int) (*DeadZoneAnalysis, error) {
 	// Generate recommendations
 	recommendations := generateRecommendations(deadZones, coverageScore, len(samples))
 
+	// Surface Wi-Fi anomalies (security/RF/standards) from the same survey's
+	// passive AP observations, alongside the coverage analysis.
+	anomalies, err := AnalyzeAnomalies(survey)
+	if err != nil {
+		return nil, fmt.Errorf("analyze survey anomalies: %w", err)
+	}
+
 	return &DeadZoneAnalysis{
 		SurveyID:        survey.ID,
 		ThresholdDBm:    threshold,
 		DeadZones:       deadZones,
 		CoverageScore:   coverageScore,
 		Recommendations: recommendations,
+		Anomalies:       anomalies,
 	}, nil
 }
 

--- a/internal/wifi/survey/anomaly.go
+++ b/internal/wifi/survey/anomaly.go
@@ -1,0 +1,118 @@
+package survey
+
+import (
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/anomaly"
+	"github.com/krisarmstrong/seed/internal/wifi"
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	wifiapp "github.com/krisarmstrong/seed/internal/wifi/app"
+)
+
+// Band boundary frequencies in MHz used to label a scanned network's band so the
+// anomaly rules (which classify off the airspace band string) see the same
+// tokens the live capture path produces.
+const (
+	band24MinMHz = 2400
+	band24MaxMHz = 2500
+	band5MinMHz  = 4900
+	band5MaxMHz  = 5900
+	channel24Max = 14 // highest 2.4 GHz channel, used when a scan omits frequency
+)
+
+// AnalyzeAnomalies runs the Wi-Fi anomaly engine over the access points captured
+// in a survey's passive samples and returns the detected anomalies. It reuses
+// the same rule catalog as the live visibility capture path (via
+// wifiapp.AnalyzeBSSes), so a site survey surfaces security/RF/standards
+// problems alongside its coverage (dead-zone) analysis.
+//
+// A survey with no passive AP observations yields no anomalies (and no error).
+func AnalyzeAnomalies(survey *Survey) ([]anomaly.Anomaly, error) {
+	if survey == nil {
+		return nil, nil
+	}
+	bsses, at := surveyBSSViews(survey)
+	if len(bsses) == 0 {
+		return nil, nil
+	}
+	if at.IsZero() {
+		at = survey.UpdatedAt
+	}
+	return wifiapp.AnalyzeBSSes(bsses, nil, at)
+}
+
+// surveyBSSViews flattens a survey's passive-scan observations into the airspace
+// BSS view the anomaly detector consumes, de-duplicated by BSSID keeping the
+// strongest-signal sighting. It also returns the most recent passive-sample
+// timestamp so the caller can stamp the synthetic observations.
+func surveyBSSViews(survey *Survey) ([]airspace.BSSView, time.Time) {
+	type seen struct {
+		view   airspace.BSSView
+		signal int
+	}
+	byBSSID := make(map[string]seen)
+	var latest time.Time
+
+	for _, sp := range survey.GetAllSamples() {
+		passive := getPassiveSampleFromPoint(sp)
+		if passive == nil {
+			continue
+		}
+		if sp.Timestamp.After(latest) {
+			latest = sp.Timestamp
+		}
+		for _, n := range passive.Networks {
+			if n == nil || n.BSSID == "" {
+				continue
+			}
+			// Keep the strongest sighting; signals are negative dBm, so a larger
+			// (closer to zero) value is stronger.
+			if prev, ok := byBSSID[n.BSSID]; ok && n.Signal <= prev.signal {
+				continue
+			}
+			byBSSID[n.BSSID] = seen{view: scannedNetworkToBSSView(n), signal: n.Signal}
+		}
+	}
+
+	views := make([]airspace.BSSView, 0, len(byBSSID))
+	for _, s := range byBSSID {
+		views = append(views, s.view)
+	}
+	return views, latest
+}
+
+// scannedNetworkToBSSView maps one OS-scan result onto the airspace BSS view.
+// Fields a passive OS scan cannot observe (PMF/RRM/BTM/FT/BSS-Load/country, the
+// decoded 802.11 standard) are left at their zero values, so the rules that need
+// them simply do not fire — passive surveys flag the security/RF/channel issues
+// they can actually see without false positives. Security is passed through
+// verbatim; recognition is best-effort against the detector's known suites.
+func scannedNetworkToBSSView(n *wifi.ScannedNetwork) airspace.BSSView {
+	return airspace.BSSView{
+		BSSID:           n.BSSID,
+		SSID:            n.SSID,
+		Hidden:          n.SSID == "",
+		Band:            bandLabel(n.Frequency, n.Channel),
+		Channel:         n.Channel,
+		Security:        n.Security,
+		ChannelWidthMHz: n.ChannelWidth,
+		SignalDBm:       n.Signal,
+	}
+}
+
+// bandLabel maps a scanned network's frequency (with a channel fallback) onto
+// the airspace band token ("2.4 GHz" / "5 GHz" / "6 GHz" / "Unknown").
+func bandLabel(freqMHz, channel int) string {
+	switch {
+	case freqMHz >= band24MinMHz && freqMHz < band24MaxMHz:
+		return "2.4 GHz"
+	case freqMHz >= band5MinMHz && freqMHz < band5MaxMHz:
+		return "5 GHz"
+	case freqMHz >= band5MaxMHz:
+		return "6 GHz"
+	case freqMHz == 0 && channel >= 1 && channel <= channel24Max:
+		return "2.4 GHz"
+	default:
+		return "Unknown"
+	}
+}

--- a/internal/wifi/survey/anomaly_internal_test.go
+++ b/internal/wifi/survey/anomaly_internal_test.go
@@ -1,0 +1,102 @@
+package survey
+
+import (
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/wifi"
+	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+)
+
+func TestBandLabel(t *testing.T) {
+	tests := []struct {
+		freq, ch int
+		want     string
+	}{
+		{2412, 1, "2.4 GHz"},
+		{2484, 14, "2.4 GHz"},
+		{5180, 36, "5 GHz"},
+		{5955, 1, "6 GHz"},
+		{0, 6, "2.4 GHz"},  // frequency missing, channel fallback
+		{0, 36, "Unknown"}, // missing frequency, non-2.4 channel
+		{3000, 0, "Unknown"},
+	}
+	for _, tc := range tests {
+		if got := bandLabel(tc.freq, tc.ch); got != tc.want {
+			t.Errorf("bandLabel(%d,%d) = %q, want %q", tc.freq, tc.ch, got, tc.want)
+		}
+	}
+}
+
+func surveyWith(samples ...*SamplePoint) *Survey {
+	floor := &Floor{ID: "f1", Name: "Floor 1", Level: 1, Samples: samples}
+	return &Survey{
+		ID:            "s1",
+		Floors:        []*Floor{floor},
+		ActiveFloorID: floor.ID,
+		UpdatedAt:     time.Unix(500, 0),
+	}
+}
+
+func TestSurveyBSSViewsDedupKeepsStrongest(t *testing.T) {
+	now := time.Unix(1000, 0)
+	later := time.Unix(2000, 0)
+	s := surveyWith(
+		&SamplePoint{Timestamp: now, SampleData: &PassiveSample{Networks: []*wifi.ScannedNetwork{
+			{SSID: "corp", BSSID: "aa:bb:cc:00:00:01", Signal: -80, Channel: 6, Frequency: 2437, Security: "WPA2"},
+		}}},
+		&SamplePoint{Timestamp: later, SampleData: &PassiveSample{Networks: []*wifi.ScannedNetwork{
+			{SSID: "corp", BSSID: "aa:bb:cc:00:00:01", Signal: -55, Channel: 6, Frequency: 2437, Security: "WPA2"},
+		}}},
+	)
+
+	views, at := surveyBSSViews(s)
+	if len(views) != 1 {
+		t.Fatalf("views = %d, want 1 (deduped by BSSID)", len(views))
+	}
+	if views[0].SignalDBm != -55 {
+		t.Errorf("kept signal = %d, want strongest -55", views[0].SignalDBm)
+	}
+	if views[0].Band != "2.4 GHz" {
+		t.Errorf("band = %q, want 2.4 GHz", views[0].Band)
+	}
+	if !at.Equal(later) {
+		t.Errorf("latest timestamp = %v, want %v", at, later)
+	}
+}
+
+func TestAnalyzeAnomaliesDetectsOpenNetwork(t *testing.T) {
+	s := surveyWith(
+		&SamplePoint{Timestamp: time.Unix(1000, 0), SampleData: &PassiveSample{Networks: []*wifi.ScannedNetwork{
+			{SSID: "guest", BSSID: "aa:bb:cc:00:00:01", Signal: -60, Channel: 1, Frequency: 2412, Security: "Open"},
+		}}},
+	)
+
+	anoms, err := AnalyzeAnomalies(s)
+	if err != nil {
+		t.Fatalf("AnalyzeAnomalies: %v", err)
+	}
+	found := false
+	for _, a := range anoms {
+		if a.DefKey == wifianomaly.DefOpenNetwork {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected %s anomaly, got %+v", wifianomaly.DefOpenNetwork, anoms)
+	}
+}
+
+func TestAnalyzeAnomaliesNoPassiveSamples(t *testing.T) {
+	s := surveyWith(&SamplePoint{
+		Timestamp:  time.Unix(1000, 0),
+		SampleData: &ActiveSample{SSID: "corp", BSSID: "aa:bb:cc:00:00:01", RSSI: -50},
+	})
+	anoms, err := AnalyzeAnomalies(s)
+	if err != nil {
+		t.Fatalf("AnalyzeAnomalies: %v", err)
+	}
+	if len(anoms) != 0 {
+		t.Errorf("anomalies = %v, want none (no passive APs)", anoms)
+	}
+}


### PR DESCRIPTION
## What

Owner ask: **the Wi-Fi Survey should leverage the anomaly engine.** A site survey already captures passive AP observations; this folds them through the **same rule catalog** the live visibility capture path uses, so a survey surfaces security/RF/standards anomalies alongside its coverage (dead-zone) analysis.

## How

- **`airspace.TreeFromBSSViews`** — assembles the `SSID → AP → BSSID` tree from a flat set of BSS views, sharing AP-clustering + ordering with the live `Tree()` (refactored both onto a common `assembleSSIDGroup`; **live `Tree()` output is unchanged** — verified by the airspace tests).
- **`wifiapp.AnalyzeBSSes`** — a pure function: build a transient tree, run the `wifianomaly` detector, fold detections through a **fresh single-use `anomaly.Engine`**, return the snapshot. No shared/persistent state with the live visibility engine.
- **`survey.AnalyzeAnomalies`** — flattens a survey's passive samples into BSS views (deduped by BSSID keeping the strongest sighting; band labelled to match the detector's tokens), then calls `AnalyzeBSSes`. Surfaced on `DeadZoneAnalysis` via a new `Anomalies []anomaly.Anomaly` field, so `/api/survey/dead-zones` returns them alongside coverage.

## Fidelity / no false positives

Fields a passive OS scan cannot observe (PMF/RRM/FT/BSS-Load/country/decoded 802.11 standard) are left at zero, so rules needing them simply don't fire. Security is passed through verbatim — recognition is best-effort against the detector's known suites (`Open`/`WEP`/`WPA`/`WPA2`/`WPA3`/`WPA2/WPA3`); unrecognized suites classify as unknown rather than misreporting. The rules that meaningfully fire from a survey: open-network, wep-in-use, co-channel-contention, adjacent-channel-overlap, security-mismatch, evil-twin, wpa3-transition-downgrade, default-ssid-name, ssid-sprawl, wide-channel-2ghz, channel-width-mismatch.

## Scope note

**UI/PDF wiring deferred (deliberate):** the survey UI panel (`SurveyAnalysisPanel.tsx`) computes its analysis **client-side** and does not consume the `/api/survey/dead-zones` endpoint at all. Surfacing the new anomalies in the UI is therefore a separate data-source migration, not a clean add — out of scope for this focused PR. The backend now exposes them on the endpoint and via the reusable `AnalyzeAnomalies` function.

## Tests

`AnalyzeBSSes` (open-network, security-mismatch, determinism, empty); survey band labelling, BSSID dedup keeps strongest, open-network detection, no-passive-samples. `golangci-lint` 0 issues; race clean; full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)