### PR TITLE
feat(wifi): add deauth/disassoc-flood anomaly rule (w4e)

### DIFF
--- a/docs/schemas/api/wifi-airspace-response.schema.json
+++ b/docs/schemas/api/wifi-airspace-response.schema.json
@@ -84,6 +84,9 @@
         "beacons": {
           "type": "integer"
         },
+        "recentDeauths": {
+          "type": "integer"
+        },
         "lastSeen": {
           "type": "string",
           "format": "date-time"
@@ -116,6 +119,7 @@
         "hasBssLoad",
         "signalDbm",
         "beacons",
+        "recentDeauths",
         "lastSeen",
         "stations"
       ]

--- a/internal/wifi/airspace/airspace.go
+++ b/internal/wifi/airspace/airspace.go
@@ -55,6 +55,10 @@ type bss struct {
 	lastSeen       time.Time
 	beacons        int
 	stations       map[string]*station
+	// deauthTimes holds the observation times of deauthentication/disassociation
+	// frames attributed to this BSSID, kept as a sliding window (Prune drops
+	// entries older than the cutoff). A spike feeds the deauth-flood rule (W4e).
+	deauthTimes []time.Time
 }
 
 // Airspace is the live aggregate of everything seen on the air. Safe for
@@ -83,7 +87,25 @@ func (a *Airspace) Observe(f *dot11.Frame, at time.Time) {
 	if f.BSS != nil {
 		a.applyBeacon(f, at)
 	}
+	if f.Kind == dot11.KindDeauth || f.Kind == dot11.KindDisassoc {
+		a.applyDeauth(f, at)
+	}
 	a.applyStation(f, at)
+}
+
+// applyDeauth records a deauthentication/disassociation frame against its BSS
+// (creating a thin entry if needed), keeping the sliding window the deauth-flood
+// rule reads. Frames that do not resolve to a BSSID are ignored.
+func (a *Airspace) applyDeauth(f *dot11.Frame, at time.Time) {
+	bssid := macKey(f.BSSIDOf())
+	if bssid == "" {
+		return
+	}
+	b := a.ensureBSS(bssid, at)
+	b.deauthTimes = append(b.deauthTimes, at)
+	if at.After(b.lastSeen) {
+		b.lastSeen = at
+	}
 }
 
 // applyBeacon upserts the BSS advertised by a beacon/probe-response.
@@ -170,10 +192,28 @@ func (a *Airspace) Prune(cutoff time.Time) {
 				delete(b.stations, mac)
 			}
 		}
-		if b.beacons == 0 && len(b.stations) == 0 && b.lastSeen.Before(cutoff) {
+		b.deauthTimes = pruneDeauthTimes(b.deauthTimes, cutoff)
+		if b.beacons == 0 && len(b.stations) == 0 && len(b.deauthTimes) == 0 &&
+			b.lastSeen.Before(cutoff) {
 			delete(a.bsses, key)
 		}
 	}
+}
+
+// pruneDeauthTimes drops deauth observations older than cutoff, sliding the
+// window forward. It compacts in place and returns nil once the window is empty
+// so a long-lived (beaconed) BSS does not accumulate stale timestamps.
+func pruneDeauthTimes(times []time.Time, cutoff time.Time) []time.Time {
+	kept := times[:0]
+	for _, t := range times {
+		if !t.Before(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	if len(kept) == 0 {
+		return nil
+	}
+	return kept
 }
 
 // macKey normalizes a hardware address to a lowercase string key, or "" if nil.

--- a/internal/wifi/airspace/deauth_test.go
+++ b/internal/wifi/airspace/deauth_test.go
@@ -1,0 +1,93 @@
+package airspace_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/seed/internal/wifi/airspace"
+	"github.com/krisarmstrong/seed/internal/wifi/dot11"
+)
+
+// deauth builds a deauthentication management frame from an AP (Address3=BSSID).
+func deauth(t *testing.T, bssid string) *dot11.Frame {
+	t.Helper()
+	return &dot11.Frame{
+		Kind:      dot11.KindDeauth,
+		BSSID:     mac(t, bssid),
+		Band:      dot11.Band24GHz,
+		SignalDBm: -55,
+	}
+}
+
+func bssRecentDeauths(t *testing.T, a *airspace.Airspace, bssid string) (int, bool) {
+	t.Helper()
+	for _, g := range a.Tree() {
+		for _, ap := range g.APs {
+			for _, b := range ap.BSSes {
+				if b.BSSID == bssid {
+					return b.RecentDeauths, true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func TestObserveCountsDeauths(t *testing.T) {
+	t.Parallel()
+	a := airspace.New()
+	const bssid = "00:11:22:33:44:01"
+	a.Observe(beacon(t, bssid, "CorpWiFi", dot11.BSS{Security: dot11.SecurityWPA2}), baseTime())
+	for i := range 3 {
+		a.Observe(deauth(t, bssid), baseTime().Add(time.Duration(i)*time.Second))
+	}
+
+	got, ok := bssRecentDeauths(t, a, bssid)
+	if !ok {
+		t.Fatalf("BSS %s not in tree", bssid)
+	}
+	if got != 3 {
+		t.Errorf("RecentDeauths = %d, want 3", got)
+	}
+}
+
+func TestDeauthOnlyBSSAppearsThenAgesOut(t *testing.T) {
+	t.Parallel()
+	a := airspace.New()
+	const bssid = "aa:bb:cc:00:00:01"
+	// No beacon ever decoded — a pure deauth burst still surfaces the BSSID.
+	a.Observe(deauth(t, bssid), baseTime())
+	a.Observe(deauth(t, bssid), baseTime().Add(time.Second))
+
+	if got, ok := bssRecentDeauths(t, a, bssid); !ok || got != 2 {
+		t.Fatalf("RecentDeauths = %d (ok=%v), want 2", got, ok)
+	}
+
+	// Prune with a cutoff after the deauths: the window empties and the
+	// beacon-less, station-less entry ages out entirely.
+	a.Prune(baseTime().Add(time.Minute))
+	if _, ok := bssRecentDeauths(t, a, bssid); ok {
+		t.Error("deauth-only BSS should age out once its window empties")
+	}
+}
+
+func TestPruneSlidesDeauthWindowOnBeaconedBSS(t *testing.T) {
+	t.Parallel()
+	a := airspace.New()
+	const bssid = "00:11:22:33:44:01"
+	a.Observe(beacon(t, bssid, "CorpWiFi", dot11.BSS{Security: dot11.SecurityWPA2}), baseTime())
+	a.Observe(deauth(t, bssid), baseTime())                     // old
+	a.Observe(deauth(t, bssid), baseTime().Add(10*time.Second)) // recent
+	a.Observe(beacon(t, bssid, "CorpWiFi", dot11.BSS{Security: dot11.SecurityWPA2}), baseTime().Add(20*time.Second))
+
+	// Cutoff drops the first deauth only; the beaconed BSS survives with the
+	// remaining one (the window slides even though the BSS itself stays alive).
+	a.Prune(baseTime().Add(5 * time.Second))
+	got, ok := bssRecentDeauths(t, a, bssid)
+	if !ok {
+		t.Fatalf("beaconed BSS %s should survive prune", bssid)
+	}
+	if got != 1 {
+		t.Errorf("RecentDeauths after slide = %d, want 1", got)
+	}
+}

--- a/internal/wifi/airspace/tree.go
+++ b/internal/wifi/airspace/tree.go
@@ -36,13 +36,16 @@ type BSSView struct {
 	ChannelWidthMHz int `json:"channelWidthMhz"`
 	// ChannelUtil is the BSS Load channel-utilization figure (0-255); valid only
 	// when HasBSSLoad. AdvertisedStations is the AP's advertised association count.
-	ChannelUtil        int           `json:"channelUtil"`
-	AdvertisedStations int           `json:"advertisedStations"`
-	HasBSSLoad         bool          `json:"hasBssLoad"`
-	SignalDBm          int           `json:"signalDbm"`
-	Beacons            int           `json:"beacons"`
-	LastSeen           time.Time     `json:"lastSeen"`
-	Stations           []StationView `json:"stations"`
+	ChannelUtil        int  `json:"channelUtil"`
+	AdvertisedStations int  `json:"advertisedStations"`
+	HasBSSLoad         bool `json:"hasBssLoad"`
+	SignalDBm          int  `json:"signalDbm"`
+	Beacons            int  `json:"beacons"`
+	// RecentDeauths is the number of deauth/disassoc frames seen for this BSSID
+	// within the current retention window; a spike feeds the deauth-flood rule.
+	RecentDeauths int           `json:"recentDeauths"`
+	LastSeen      time.Time     `json:"lastSeen"`
+	Stations      []StationView `json:"stations"`
 }
 
 // APGroup clusters the BSSIDs believed to belong to one physical AP.
@@ -165,6 +168,7 @@ func toBSSView(b *bss) BSSView {
 		HasBSSLoad:         b.hasBSSLoad,
 		SignalDBm:          int(b.signalDBm),
 		Beacons:            b.beacons,
+		RecentDeauths:      len(b.deauthTimes),
 		LastSeen:           b.lastSeen,
 		Stations:           make([]StationView, 0, len(b.stations)),
 	}

--- a/internal/wifi/anomaly/catalog.go
+++ b/internal/wifi/anomaly/catalog.go
@@ -25,6 +25,7 @@ const (
 	DefBSSLoadSaturation       = "wifi-bss-load-saturation"
 	DefWideChannel24GHz        = "wifi-wide-channel-2ghz"
 	DefChannelWidthMismatch    = "wifi-channel-width-mismatch"
+	DefDeauthFlood             = "wifi-deauth-flood"
 )
 
 // CapActiveTest names the platform capability required to run an active
@@ -349,6 +350,30 @@ func Defs() []anomaly.Def {
 				"wider radios may overlap channels the planning assumed were clear.",
 			Recommendation: "Standardise the channel width across APs serving the SSID per band, or " +
 				"confirm the mix is intentional for capacity tiering.",
+		},
+		{
+			ID:              DefDeauthFlood,
+			Category:        anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"IEEE 802.11-2020 §9.3.3.3", "IEEE 802.11w-2009"},
+			Title:           "Deauthentication/disassociation flood",
+			Description: "An unusually high number of deauthentication or disassociation management " +
+				"frames was attributed to this BSSID within a short window. On a BSS that does not " +
+				"require Protected Management Frames these frames are unauthenticated, so a burst is a " +
+				"classic management-frame denial-of-service — and the forced-disconnect step that " +
+				"evil-twin and handshake-capture attacks rely on.",
+			Impact: "Clients are repeatedly knocked off the network, causing dropped sessions and roam " +
+				"churn, and the disconnects create the window an attacker uses to capture handshakes or " +
+				"lure clients onto a rogue AP.",
+			Recommendation: "Require Protected Management Frames (802.11w) on the SSID to authenticate " +
+				"deauth/disassoc frames, and investigate the source — a misbehaving client/AP or an " +
+				"active attacker — using the BSSID and channel.",
+			FollowUps: []anomaly.FollowUp{{
+				Kind:  anomaly.FollowUpPrompt,
+				Label: "Locate the deauth source",
+				Action: "Watch the affected channel and correlate the deauth burst with a transmitter; " +
+					"confirm whether the BSS requires PMF.",
+			}},
 		},
 	}
 }

--- a/internal/wifi/anomaly/detect.go
+++ b/internal/wifi/anomaly/detect.go
@@ -38,12 +38,21 @@ const bssLoadSaturationThreshold = 191
 // a BSS is reported as using a wide (overlapping) channel.
 const wideChannel24MinMHz = 40
 
+// defaultDeauthFloodThreshold is the number of deauth/disassoc frames in the
+// retention window at or above which a BSS is reported as flooded. Normal roams
+// produce a handful; a sustained burst well above that signals a DoS.
+const defaultDeauthFloodThreshold = 5
+
+// minDeauthFloodThreshold is the floor for a configured deauth-flood threshold.
+const minDeauthFloodThreshold = 2
+
 // Detector evaluates the airspace tree against the Wi-Fi rule set and returns
 // the detections to feed an [anomaly.Engine]. It is stateless apart from its
 // tuning thresholds; the engine owns coalescing, escalation, and ageing.
 type Detector struct {
-	coChannelThreshold  int
-	ssidSprawlThreshold int
+	coChannelThreshold   int
+	ssidSprawlThreshold  int
+	deauthFloodThreshold int
 }
 
 // Option tunes a Detector.
@@ -71,11 +80,23 @@ func WithSSIDSprawlThreshold(n int) Option {
 	}
 }
 
+// WithDeauthFloodThreshold sets the deauth-flood reporting threshold (deauth/
+// disassoc frames per retention window). Values below 2 are clamped to 2.
+func WithDeauthFloodThreshold(n int) Option {
+	return func(d *Detector) {
+		if n < minDeauthFloodThreshold {
+			n = minDeauthFloodThreshold
+		}
+		d.deauthFloodThreshold = n
+	}
+}
+
 // NewDetector returns a Detector with the given options applied.
 func NewDetector(opts ...Option) *Detector {
 	d := &Detector{
-		coChannelThreshold:  defaultCoChannelThreshold,
-		ssidSprawlThreshold: defaultSSIDSprawlThreshold,
+		coChannelThreshold:   defaultCoChannelThreshold,
+		ssidSprawlThreshold:  defaultSSIDSprawlThreshold,
+		deauthFloodThreshold: defaultDeauthFloodThreshold,
 	}
 	for _, o := range opts {
 		o(d)
@@ -94,6 +115,7 @@ func (d *Detector) Detect(tree []airspace.SSIDGroup) []anomaly.Detection {
 	out = append(out, d.coChannelDetections(tree)...)
 	out = append(out, countryConflictDetections(tree)...)
 	out = append(out, d.ssidSprawlDetections(tree)...)
+	out = append(out, d.deauthFloodDetections(tree)...)
 
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].DefKey != out[j].DefKey {
@@ -311,6 +333,28 @@ func (d *Detector) ssidSprawlDetections(tree []airspace.SSIDGroup) []anomaly.Det
 			},
 		})
 	}
+	return out
+}
+
+// deauthFloodDetections reports each BSS whose recent deauth/disassoc count (a
+// sliding window maintained by the airspace model) reaches the threshold — a
+// management-frame DoS signal. It is a per-BSS security rule but lives on the
+// Detector because it is threshold-tuned. The empty/cloaked-SSID grouping does
+// not matter here: the subject is the BSSID, evaluated wherever it appears.
+func (d *Detector) deauthFloodDetections(tree []airspace.SSIDGroup) []anomaly.Detection {
+	var out []anomaly.Detection
+	forEachBSS(tree, func(_ airspace.SSIDGroup, _ airspace.APGroup, b airspace.BSSView) {
+		if b.RecentDeauths < d.deauthFloodThreshold {
+			return
+		}
+		ev := bssEvidence(b)
+		ev["deauthCount"] = strconv.Itoa(b.RecentDeauths)
+		out = append(out, anomaly.Detection{
+			DefKey:   DefDeauthFlood,
+			Subject:  anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: b.BSSID},
+			Evidence: ev,
+		})
+	})
 	return out
 }
 

--- a/internal/wifi/anomaly/detect_test.go
+++ b/internal/wifi/anomaly/detect_test.go
@@ -89,6 +89,7 @@ func TestCatalogBuildsAndCoversEveryDefID(t *testing.T) {
 		wifianomaly.DefBSSLoadSaturation,
 		wifianomaly.DefWideChannel24GHz,
 		wifianomaly.DefChannelWidthMismatch,
+		wifianomaly.DefDeauthFlood,
 	}
 	if cat.Len() != len(ids) {
 		t.Errorf("catalog Len = %d, want %d (every exported def ID, no extras)", cat.Len(), len(ids))

--- a/internal/wifi/anomaly/detect_w4e_test.go
+++ b/internal/wifi/anomaly/detect_w4e_test.go
@@ -1,0 +1,46 @@
+package wifianomaly_test
+
+import (
+	"testing"
+
+	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+)
+
+func TestDeauthFlood(t *testing.T) {
+	det := wifianomaly.NewDetector()
+
+	// At/above the default threshold (5) → flagged.
+	flooded := bss("00:00:00:00:00:01", "corp", "WPA3", "5 GHz", 36)
+	flooded.PMFRequired = true
+	flooded.RecentDeauths = 5
+	if !hasDef(det.Detect(tree("corp", flooded)), wifianomaly.DefDeauthFlood) {
+		t.Error("a deauth burst at the threshold should raise deauth-flood")
+	}
+
+	// Below threshold (normal roam churn) → not flagged.
+	calm := bss("00:00:00:00:00:02", "corp", "WPA3", "5 GHz", 40)
+	calm.PMFRequired = true
+	calm.RecentDeauths = 2
+	if hasDef(det.Detect(tree("corp", calm)), wifianomaly.DefDeauthFlood) {
+		t.Error("a handful of deauths must not raise deauth-flood")
+	}
+}
+
+func TestDeauthFloodThresholdConfigurable(t *testing.T) {
+	det := wifianomaly.NewDetector(wifianomaly.WithDeauthFloodThreshold(3))
+	b := bss("00:00:00:00:00:01", "corp", "WPA3", "5 GHz", 36)
+	b.PMFRequired = true
+	b.RecentDeauths = 3
+	if !hasDef(det.Detect(tree("corp", b)), wifianomaly.DefDeauthFlood) {
+		t.Error("lowered threshold should flag at 3 deauths")
+	}
+
+	// Threshold floor: values below 2 clamp to 2.
+	clamped := wifianomaly.NewDetector(wifianomaly.WithDeauthFloodThreshold(0))
+	one := bss("00:00:00:00:00:02", "corp", "WPA3", "5 GHz", 40)
+	one.PMFRequired = true
+	one.RecentDeauths = 1
+	if hasDef(clamped.Detect(tree("corp", one)), wifianomaly.DefDeauthFlood) {
+		t.Error("threshold must clamp to a floor of 2; a single deauth must not flag")
+	}
+}

--- a/ui/src/types/generated/wifi-airspace-response.ts
+++ b/ui/src/types/generated/wifi-airspace-response.ts
@@ -42,6 +42,7 @@ export interface BSSView {
   hasBssLoad: boolean;
   signalDbm: number;
   beacons: number;
+  recentDeauths: number;
   lastSeen: string;
   stations: StationView[];
 }


### PR DESCRIPTION
## What

The **first temporal Wi-Fi anomaly rule (W4e)**, unblocked now that capture streams frames. A burst of deauthentication/disassociation management frames against one BSSID is a classic **management-frame DoS** — and the forced-disconnect step that evil-twin and handshake-capture attacks rely on.

## How

- **`airspace.bss.deauthTimes`** sliding window: `Observe` records `KindDeauth`/`KindDisassoc` against the frame's BSSID (`ensureBSS`, updates `lastSeen`). `Prune` drops timestamps older than the cutoff **even on a beaconed BSS** (the window slides independently of the BSS lifetime); a deauth-only entry ages out once its window empties.
- **`BSSView.RecentDeauths`** exposes the window length to the rule layer.
- **`wifianomaly.DefDeauthFlood`** (security / warning; cites 802.11w-2009 + 802.11-2020 §9.3.3.3) + **`Detector.deauthFloodDetections`**, threshold-tuned (default **5**, floor 2) via `WithDeauthFloodThreshold`. Catalog is now **20 defs** (count test updated).
- Regenerated `wifi-airspace-response` schema + TS type (`recentDeauths`).

## Surfacing

No API/UI churn: the anomaly flows through the existing `/wifi/anomalies` endpoint and the anomaly-stream UI like every other rule. The new `recentDeauths` field rides the already-published airspace read model.

## Tests

airspace: deauth counting, deauth-only age-out, window-slide on a beaconed BSS. detector: rule fires at/above threshold, stays quiet on normal roam churn, threshold configurable + clamped. `golangci-lint` 0; race clean; schema/types/json-casing/output-escaping/route-policy gates green.

## Deferred (unchanged)

The exotic temporal rules (ping-pong-roaming, karma/pineapple, spoofed-bssid, dfs-csa) still need bespoke per-entity state and remain deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)