### PR TITLE
feat(wifi): add rogue-ap-on-lan cross-reference rule (w7)

### DIFF
--- a/internal/wifi/anomaly/catalog.go
+++ b/internal/wifi/anomaly/catalog.go
@@ -26,6 +26,7 @@ const (
 	DefWideChannel24GHz        = "wifi-wide-channel-2ghz"
 	DefChannelWidthMismatch    = "wifi-channel-width-mismatch"
 	DefDeauthFlood             = "wifi-deauth-flood"
+	DefRogueAPOnLAN            = "wifi-rogue-ap-on-lan"
 )
 
 // CapActiveTest names the platform capability required to run an active
@@ -373,6 +374,28 @@ func Defs() []anomaly.Def {
 				Label: "Locate the deauth source",
 				Action: "Watch the affected channel and correlate the deauth burst with a transmitter; " +
 					"confirm whether the BSS requires PMF.",
+			}},
+		},
+		{
+			ID:              DefRogueAPOnLAN,
+			Category:        anomaly.CategoryAuthorization,
+			DefaultSeverity: anomaly.SeverityCritical,
+			Standards:       []string{"IEEE 802.11", "IEEE 802.1X"},
+			Title:           "Rogue AP bridged to the wired LAN",
+			Description: "A BSSID observed over the air also appears in the wired network's known " +
+				"MAC set (e.g. the ARP/switch table from discovery). An access point whose radio " +
+				"MAC is present on the wired side is bridging Wi-Fi traffic onto the LAN — typically " +
+				"an unsanctioned AP plugged into a corporate port, not part of the managed wireless.",
+			Impact: "An unauthorized bridge exposes the internal network to anyone in radio range, " +
+				"bypassing perimeter controls, NAC, and the sanctioned SSID's security policy.",
+			Recommendation: "Confirm the BSSID is not a sanctioned AP, then locate the switch port it " +
+				"is connected to (by MAC) and disable it. Add the device to the authorization " +
+				"allowlist only if it is intentional.",
+			FollowUps: []anomaly.FollowUp{{
+				Kind:  anomaly.FollowUpPrompt,
+				Label: "Trace the switch port",
+				Action: "Look up the BSSID/MAC in the switch CAM table to find the access port, and " +
+					"verify whether the AP is sanctioned.",
 			}},
 		},
 	}

--- a/internal/wifi/anomaly/detect.go
+++ b/internal/wifi/anomaly/detect.go
@@ -53,6 +53,10 @@ type Detector struct {
 	coChannelThreshold   int
 	ssidSprawlThreshold  int
 	deauthFloodThreshold int
+	// wiredMACs is the set of MAC addresses known on the wired side (e.g. the
+	// discovery ARP/switch table), lowercased. A captured BSSID found here is an
+	// AP bridged to the LAN. Empty (the default) keeps the rogue-AP rule dormant.
+	wiredMACs map[string]struct{}
 }
 
 // Option tunes a Detector.
@@ -91,6 +95,27 @@ func WithDeauthFloodThreshold(n int) Option {
 	}
 }
 
+// WithWiredMACs supplies the set of MAC addresses known on the wired network
+// (e.g. from discovery's ARP/switch table). A captured BSSID in this set raises
+// the rogue-AP-on-LAN rule. Addresses are matched case-insensitively. With no
+// wired MACs the rule is dormant — the default, until a wired source is wired in.
+func WithWiredMACs(macs ...string) Option {
+	return func(d *Detector) {
+		if len(macs) == 0 {
+			return
+		}
+		if d.wiredMACs == nil {
+			d.wiredMACs = make(map[string]struct{}, len(macs))
+		}
+		for _, m := range macs {
+			if m == "" {
+				continue
+			}
+			d.wiredMACs[strings.ToLower(m)] = struct{}{}
+		}
+	}
+}
+
 // NewDetector returns a Detector with the given options applied.
 func NewDetector(opts ...Option) *Detector {
 	d := &Detector{
@@ -116,6 +141,7 @@ func (d *Detector) Detect(tree []airspace.SSIDGroup) []anomaly.Detection {
 	out = append(out, countryConflictDetections(tree)...)
 	out = append(out, d.ssidSprawlDetections(tree)...)
 	out = append(out, d.deauthFloodDetections(tree)...)
+	out = append(out, d.rogueAPOnLANDetections(tree)...)
 
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].DefKey != out[j].DefKey {
@@ -351,6 +377,31 @@ func (d *Detector) deauthFloodDetections(tree []airspace.SSIDGroup) []anomaly.De
 		ev["deauthCount"] = strconv.Itoa(b.RecentDeauths)
 		out = append(out, anomaly.Detection{
 			DefKey:   DefDeauthFlood,
+			Subject:  anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: b.BSSID},
+			Evidence: ev,
+		})
+	})
+	return out
+}
+
+// rogueAPOnLANDetections is the Wi-Fi × wired cross-reference: it flags any
+// captured BSSID whose MAC also appears in the injected wired-MAC set (the
+// discovery ARP/switch table) — an access point bridged onto the LAN. With no
+// wired set the rule emits nothing, so it stays dormant until a wired source is
+// supplied via WithWiredMACs.
+func (d *Detector) rogueAPOnLANDetections(tree []airspace.SSIDGroup) []anomaly.Detection {
+	if len(d.wiredMACs) == 0 {
+		return nil
+	}
+	var out []anomaly.Detection
+	forEachBSS(tree, func(_ airspace.SSIDGroup, _ airspace.APGroup, b airspace.BSSView) {
+		if _, ok := d.wiredMACs[strings.ToLower(b.BSSID)]; !ok {
+			return
+		}
+		ev := bssEvidence(b)
+		ev["wiredMatch"] = b.BSSID
+		out = append(out, anomaly.Detection{
+			DefKey:   DefRogueAPOnLAN,
 			Subject:  anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: b.BSSID},
 			Evidence: ev,
 		})

--- a/internal/wifi/anomaly/detect_test.go
+++ b/internal/wifi/anomaly/detect_test.go
@@ -90,6 +90,7 @@ func TestCatalogBuildsAndCoversEveryDefID(t *testing.T) {
 		wifianomaly.DefWideChannel24GHz,
 		wifianomaly.DefChannelWidthMismatch,
 		wifianomaly.DefDeauthFlood,
+		wifianomaly.DefRogueAPOnLAN,
 	}
 	if cat.Len() != len(ids) {
 		t.Errorf("catalog Len = %d, want %d (every exported def ID, no extras)", cat.Len(), len(ids))

--- a/internal/wifi/anomaly/detect_w7_test.go
+++ b/internal/wifi/anomaly/detect_w7_test.go
@@ -1,0 +1,34 @@
+package wifianomaly_test
+
+import (
+	"testing"
+
+	wifianomaly "github.com/krisarmstrong/seed/internal/wifi/anomaly"
+)
+
+func TestRogueAPOnLANDormantByDefault(t *testing.T) {
+	det := wifianomaly.NewDetector()
+	b := bss("aa:bb:cc:00:00:01", "corp", "WPA3", "5 GHz", 36)
+	b.PMFRequired = true
+	if hasDef(det.Detect(tree("corp", b)), wifianomaly.DefRogueAPOnLAN) {
+		t.Error("with no wired-MAC set the rogue-AP rule must stay dormant")
+	}
+}
+
+func TestRogueAPOnLANFlagsWiredBSSID(t *testing.T) {
+	// The captured BSSID is also present on the wired side → bridged rogue AP.
+	det := wifianomaly.NewDetector(wifianomaly.WithWiredMACs("AA:BB:CC:00:00:01", "11:22:33:44:55:66"))
+
+	rogue := bss("aa:bb:cc:00:00:01", "corp", "WPA3", "5 GHz", 36)
+	rogue.PMFRequired = true
+	if !hasDef(det.Detect(tree("corp", rogue)), wifianomaly.DefRogueAPOnLAN) {
+		t.Error("a BSSID present in the wired set should raise rogue-ap-on-lan (case-insensitive)")
+	}
+
+	// A BSSID not on the wired side must not flag.
+	clean := bss("de:ad:be:ef:00:99", "corp", "WPA3", "5 GHz", 40)
+	clean.PMFRequired = true
+	if hasDef(det.Detect(tree("corp", clean)), wifianomaly.DefRogueAPOnLAN) {
+		t.Error("a BSSID absent from the wired set must not be flagged")
+	}
+}


### PR DESCRIPTION
## What

The **Wi-Fi × wired correlation rule (W7)**. A captured BSSID whose MAC also appears on the wired side (discovery's ARP/switch table) is an access point **bridged onto the LAN** — typically an unsanctioned AP plugged into a corporate port, bypassing perimeter controls and NAC. This is the cross-source win the anomaly engine was designed for.

## How

- **`wifianomaly.DefRogueAPOnLAN`** — authorization category, **critical** severity. (`CategoryAuthorization` + `SubjectBSSID` already existed in `internal/anomaly`, so no changes there.)
- **`Detector`** gains an injected wired-MAC set via **`WithWiredMACs(...)`** (lowercased, case-insensitive match) + **`rogueAPOnLANDetections`**, which flags any captured BSSID present in the set. Catalog is now **21 defs** (count test updated).

## Dormant by default

With no wired MACs supplied the rule emits nothing — exactly as specified. The injection **seam is in place**; feeding discovery's live ARP/switch table into the set is the documented follow-up (`visibility.Service` would supply it, e.g. rebuilt per evaluation or via a future provider). No API / schema / UI change — the anomaly rides the existing `/wifi/anomalies` stream and anomaly-stream UI.

## Tests

dormant by default (no wired set), flags a wired BSSID (case-insensitive), ignores a BSSID absent from the set. `golangci-lint` 0; race clean; schema/types/json-casing/route-policy gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)