### PR TITLE
fix(database): enforce owner-only (0600) permissions on the database file

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -240,6 +241,29 @@ func matchIgnoreCase(a, b string) bool {
 	return true
 }
 
+// dbFileMode is the owner-only permission enforced on the database file and its
+// WAL/SHM sidecars (they hold tokens, credentials, and audit data).
+const dbFileMode = 0o600
+
+// restrictDBFileMode sets owner-only permissions on the database file and, when
+// present, its WAL/SHM sidecars. In-memory databases have no backing file and
+// are skipped. A missing sidecar is not an error (WAL/SHM are created lazily on
+// first write); only the main file is required to exist by call time.
+func restrictDBFileMode(path string) error {
+	if path == "" || path == ":memory:" || strings.Contains(path, ":memory:") {
+		return nil
+	}
+	if err := os.Chmod(path, dbFileMode); err != nil {
+		return err
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if err := os.Chmod(path+suffix, dbFileMode); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
 // OpenWithConfig creates a new database connection with custom configuration.
 func OpenWithConfig(cfg Config) (*DB, error) {
 	if cfg.Path == "" {
@@ -289,6 +313,15 @@ func OpenWithConfig(cfg Config) (*DB, error) {
 	if pingErr := conn.PingContext(ctx); pingErr != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("failed to ping database: %w", pingErr)
+	}
+
+	// Restrict the database file (and its WAL/SHM sidecars) to owner-only. The
+	// SQLite driver creates them honouring umask, which on most systems leaves
+	// them group/world-readable; the DB holds tokens, credentials, and audit
+	// data, so the mode is made explicit rather than left to the environment.
+	if chmodErr := restrictDBFileMode(cfg.Path); chmodErr != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to secure database file: %w", chmodErr)
 	}
 
 	db := &DB{

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -1,0 +1,36 @@
+package database_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// TestOpenRestrictsFileMode verifies the database file (and any WAL/SHM sidecars)
+// are created owner-only (0600). The DB holds tokens, credentials, and audit
+// data, so the mode must be explicit rather than left to the process umask.
+func TestOpenRestrictsFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file-mode semantics do not apply on Windows")
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "perm.db")
+	db, err := database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for _, p := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		info, statErr := os.Stat(p)
+		if statErr != nil {
+			continue // sidecars are created lazily; absence is fine
+		}
+		if mode := info.Mode().Perm(); mode != 0o600 {
+			t.Errorf("%s mode = %o, want 600", p, mode)
+		}
+	}
+}


### PR DESCRIPTION
## What

v1-readiness review **M6**. The SQLite driver creates the database file honouring the process umask, which on most systems leaves it group/world-readable. The DB holds session tokens, encrypted credentials, and audit data, so the mode is now made **explicit (0600)** rather than left to the environment. (Config files are already written 0600; this closes the DB gap.)

## How

- `restrictDBFileMode` chmods the main DB file plus its WAL/SHM sidecars after the connection is verified. In-memory DBs (no backing file) are skipped; a not-yet-created sidecar (WAL/SHM are lazy) is not an error.
- `OpenWithConfig` **fails closed** if the file cannot be secured.
- Test asserts the opened DB file (and any sidecars) are `0600` on Unix.

## Follow-up (noted, not in this PR)

The reviewer also asked for a **package-install test** asserting on-disk modes after `.deb`/`.rpm` install — that belongs in the deploy-validate harness and is tracked in `V1_READINESS_REVIEW_2026-06-06.md` (M6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)