### PR TITLE
ci: make the frontend TypeScript check blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,6 @@ jobs:
         run: git diff --exit-code package-lock.json
 
       - name: Run TypeScript check
-        continue-on-error: true
         run: npx tsc --noEmit
 
       - name: Run Biome (lint + format)


### PR DESCRIPTION
## What

v1-readiness review **M3**. The `Run TypeScript check` step in the Frontend job was `continue-on-error: true`, so type errors were surfaced but couldn't fail the build — a type checker that can't gate isn't a gate.

## Safety

The repo is currently **tsc-clean** (`npx tsc --noEmit` passes locally), so making the step blocking introduces no new red; it only stops future type regressions from merging.

Scoped to the `tsc` step only — the design-token discipline gate is a separate step and is untouched (it remains as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)