### PR TITLE
ci: document the gosec gate posture (gate = golangci-lint, standalone = SARIF-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,23 @@ jobs:
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
 
-      - name: Run gosec
+      # gosec is ENFORCED (blocking) by the golangci-lint job: `gosec` is an
+      # enabled linter there, and high-signal rules fail the build — verified:
+      # G401/G501 (weak crypto), G101 literal secrets, etc. are caught. The
+      # taint/heuristic rules that are FP-prone by nature (G204 subprocess,
+      # G304 file-from-variable, G115 integer-conversion) are excluded from the
+      # gate via golangci-lint's `common-false-positives` preset (.golangci.yml,
+      # exclusions.presets) — a deliberate, documented decision: in this codebase
+      # those fire on safe dynamic paths, controlled network-tool args, and
+      # already-bounds-checked SNMP conversions.
+      #
+      # The standalone run below scans with the DEFAULT (un-pruned) rule set and
+      # exists ONLY to publish SARIF to the GitHub code-scanning / Security tab,
+      # so those taint-rule findings stay visible for review. It is intentionally
+      # continue-on-error (a visibility feed, not a second gate) and must not be
+      # promoted to blocking — that would gate on the known FP-prone rule set the
+      # golangci-lint gate intentionally excludes.
+      - name: Run gosec (SARIF visibility only — gate is golangci-lint)
         uses: securego/gosec@4a3bd8af174872c778439083ded7adbf3747e770 # v2.26.1
         continue-on-error: true
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,6 +84,12 @@ linters:
     - godot # checks if comments end in a period
     - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
     - goprintffuncname # checks that printf-like functions are named with f at the end
+    # gosec is the authoritative security gate (this job is blocking). High-signal
+    # rules fail the build (weak crypto G401/G501, literal secrets G101, etc.).
+    # The FP-prone taint/heuristic rules (G204 subprocess, G304 file-from-variable,
+    # G115 integer-conversion) are excluded from the gate by the
+    # `common-false-positives` preset (exclusions.presets below) and instead
+    # surfaced advisory-only as SARIF by the standalone gosec step in ci.yml.
     - gosec # inspects source code for security problems
     - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - iface # checks the incorrect use of interfaces, helping developers avoid interface pollution


### PR DESCRIPTION
## What

v1-readiness review **M2**. The reviewer flagged the standalone `securego/gosec` action as `continue-on-error` (advisory). Investigation showed it's a **second, redundant runner** — gosec is **already enforced (blocking) inside the golangci-lint job**.

## Proof

Injected violations into a scratch file and ran `golangci-lint run --enable-only gosec`:
- `G401`/`G501` (weak crypto) and `G101` (literal secrets) → **build fails** (exit 1). ✅ gate works.
- `G204` (subprocess-from-variable) → not caught — it's in golangci-lint's `common-false-positives` preset.

So the **dangerous** gosec rules block; the **FP-prone taint/heuristic** rules (G204 subprocess, G304 file-from-variable, G115 integer-conversion) are deliberately excluded from the gate. In this codebase those fire on safe dynamic paths, controlled network-tool args, and **already-bounds-checked** SNMP conversions (`intValue`/`uint32Value` clamp on overflow). The standalone scan (default rule set) surfaces them advisory-only as SARIF for the code-scanning tab.

## Why no code "fixes"

Per the owner's "real fix, not `//nolint` hack" standard, I triaged all ~90 standalone findings: they are gosec taint/heuristic **false-positives on already-correct or by-design code** that cannot be code-fixed without degrading the code or removing functionality — a TLS *prober* must `InsecureSkipVerify`; an executable must keep its exec bit; an i18n key named `…password…` is not a credential; `os.Open(var)` trips G304 regardless of validation. Fabricating suppressions to silence FPs would be the exact hack we're avoiding.

## Change

Documentation only — no behavior change, no churn:
- `ci.yml`: the standalone gosec step is labeled and commented as **SARIF visibility only; the gate is golangci-lint**, with a "do not promote to blocking" note.
- `.golangci.yml`: a comment at the `gosec` linter records which rules gate vs. are preset-excluded, and why.

So the posture is explicit and never gets re-flagged as an accidental advisory gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)