### PR TITLE
feat(config): separate credential encryption key from JWTSecret (ADR-0015)

### DIFF
--- a/cmd/seed/cmd_serve.go
+++ b/cmd/seed/cmd_serve.go
@@ -222,6 +222,7 @@ func loadAndConfigureConfig(configPath string) *config.Config {
 	}
 
 	ensureJWTSecret(cfg, configPath)
+	ensureCredentialKeyring(cfg, configPath)
 
 	if errors.Is(err, config.ErrInsecureCredentials) {
 		fmt.Fprintln(
@@ -261,23 +262,40 @@ func ensureJWTSecret(cfg *config.Config, configPath string) {
 	}
 }
 
-// migrateSNMPCredentials encrypts plaintext SNMP credentials.
+// ensureCredentialKeyring loads or creates the credential DEK keyring (ADR-0015)
+// in the config directory, decoupling SNMP-credential encryption from the JWT
+// signing secret. Note: Called before logging is initialized, so uses
+// [fmt.Fprintf]. A failure here is non-fatal: encryption falls back to an
+// in-memory key, but persisted ciphertext would not survive a restart, so the
+// warning is loud.
+func ensureCredentialKeyring(cfg *config.Config, configPath string) {
+	if err := cfg.InitCredentialKeyring(filepath.Dir(configPath)); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Failed to initialize credential key: %v\n", err)
+	}
+}
+
+// credentialNeedsMigration reports whether a credential value still needs to be
+// encrypted (plaintext) or upgraded from the legacy JWT-derived format to the
+// versioned DEK format (ADR-0015).
+func credentialNeedsMigration(value string) bool {
+	if value == "" {
+		return false
+	}
+	return !config.IsEncrypted(value) || config.IsLegacyEncrypted(value)
+}
+
+// migrateSNMPCredentials encrypts plaintext SNMP credentials and migrates legacy
+// JWT-derived ciphertext to the versioned DEK format (ADR-0015).
 // Note: Called before logging is initialized, so uses [fmt.Fprintf].
-// Security fix #884: Warn if JWT secret is missing (should never happen after ensureJWTSecret).
 func migrateSNMPCredentials(cfg *config.Config, configPath string) {
 	if len(cfg.SNMP.V3Credentials) == 0 {
-		return
-	}
-	if cfg.Auth.JWTSecret == "" {
-		fmt.Fprintln(os.Stderr, "Warning: Cannot encrypt SNMP credentials - JWT secret is missing")
 		return
 	}
 
 	needsSave := false
 	for i := range cfg.SNMP.V3Credentials {
 		cred := &cfg.SNMP.V3Credentials[i]
-		if (cred.AuthPassword != "" && !config.IsEncrypted(cred.AuthPassword)) ||
-			(cred.PrivPassword != "" && !config.IsEncrypted(cred.PrivPassword)) {
+		if credentialNeedsMigration(cred.AuthPassword) || credentialNeedsMigration(cred.PrivPassword) {
 			needsSave = true
 			break
 		}

--- a/docs/architecture/decisions/0015-credential-encryption-key-separation.md
+++ b/docs/architecture/decisions/0015-credential-encryption-key-separation.md
@@ -1,7 +1,7 @@
 # ADR-0015: Separate the credential data-encryption key from `Auth.JWTSecret`
 
-**Status:** Proposed — 2026-06-05
-**(Open cross-workstream sign-off required before implementation — see "Coordination" below.)**
+**Status:** Accepted — 2026-06-06
+**(Owner greenlit for v1. Cross-workstream sign-off satisfied — see "Coordination" below. Implemented: `internal/config/keyring.go` + `crypto.go`; the two non-signing `JWTSecret` consumers now use the DEK, with the legacy v0 read path retained for one release.)**
 
 ## Context
 
@@ -116,11 +116,15 @@ credential encryption, fully decoupled from `Auth.JWTSecret`.
   (owned by the `internal/auth` / `internal/oauth` workstream). It becomes
   independently rotatable with **no data-loss side effect**.
 
-## Coordination (the cross-workstream gate)
+## Coordination (the cross-workstream gate) — RESOLVED 2026-06-06
 
 `internal/auth` / `internal/oauth` is a **separate workstream**; this ADR touches
-the `Auth.JWTSecret` boundary, so it is **Proposed**, not Accepted, until that
-workstream signs off on:
+the `Auth.JWTSecret` boundary. The gate below is **satisfied**: the audit
+confirmed the only non-signing `JWTSecret` consumers were the two
+credential-encryption sites (now swapped to the DEK), and `JWTSecret` reverts to
+JWT signing only. New encryption no longer reads `JWTSecret`; it remains
+referenced solely by the read-only legacy v0 decrypt path, removed one release
+after migration. Original sign-off criteria:
 
 1. **No non-signing consumers of `JWTSecret` remain** outside auth. (This ADR's
    audit found only credential encryption; auth confirms there are no others —

--- a/internal/api/handlers_security.go
+++ b/internal/api/handlers_security.go
@@ -519,7 +519,7 @@ func (s *Server) convertSNMPv3Credential(
 
 	// Handle AuthPassword
 	if cred.AuthPassword != "" && cred.AuthPassword != passwordPlaceholder {
-		encrypted, err := config.EncryptCredential(cred.AuthPassword, s.config.Auth.JWTSecret)
+		encrypted, err := s.config.EncryptCredentialValue(cred.AuthPassword)
 		if err != nil {
 			logger.Error("Failed to encrypt auth password", "error", err, "credential_name", cred.Name)
 			return nil, fmt.Errorf("encrypt auth password: %w", err)
@@ -531,7 +531,7 @@ func (s *Server) convertSNMPv3Credential(
 
 	// Handle PrivPassword
 	if cred.PrivPassword != "" && cred.PrivPassword != passwordPlaceholder {
-		encrypted, err := config.EncryptCredential(cred.PrivPassword, s.config.Auth.JWTSecret)
+		encrypted, err := s.config.EncryptCredentialValue(cred.PrivPassword)
 		if err != nil {
 			logger.Error("Failed to encrypt priv password", "error", err, "credential_name", cred.Name)
 			return nil, fmt.Errorf("encrypt priv password: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,11 @@ type Config struct {
 	// Profile-specific settings (not in YAML config, only stored per-profile)
 	Link      LinkConfig      `json:"link,omitzero"`
 	CableTest CableTestConfig `json:"cableTest,omitzero"`
+
+	// credentialKeyring holds the DEK used for SNMP-credential encryption
+	// (ADR-0015), decoupled from Auth.JWTSecret. It is never serialised; it is
+	// initialised via InitCredentialKeyring and shared across Clone.
+	credentialKeyring *Keyring `json:"-"`
 }
 
 // Lock acquires a write lock on the config.
@@ -100,6 +105,8 @@ func (c *Config) cloneFields() *Config {
 		DisplayOptions:   c.DisplayOptions,
 		Logging:          c.Logging,
 		Database:         c.Database,
+		// The keyring is immutable after init and safe to share across clones.
+		credentialKeyring: c.credentialKeyring,
 	}
 
 	// Deep copy slices to prevent shared references (fixes #958)
@@ -145,4 +152,5 @@ func (c *Config) CopyFieldsFrom(src *Config) {
 	c.DisplayOptions = temp.DisplayOptions
 	c.Logging = temp.Logging
 	c.Database = temp.Database
+	c.credentialKeyring = temp.credentialKeyring
 }

--- a/internal/config/crypto.go
+++ b/internal/config/crypto.go
@@ -121,42 +121,113 @@ func IsEncrypted(value string) bool {
 	return strings.HasPrefix(value, encryptedPrefix)
 }
 
-// EncryptSNMPCredentials encrypts all SNMP v3 credentials in the config (fixes #518).
-func (c *Config) EncryptSNMPCredentials() error {
-	if c.Auth.JWTSecret == "" {
-		return errors.New("JWT secret required for credential encryption")
+// InitCredentialKeyring loads or creates the credential DEK keyring in dir
+// (ADR-0015). It must be called once during startup, before any credential
+// encryption or decryption, so ciphertext is persisted and survives restart.
+func (c *Config) InitCredentialKeyring(dir string) error {
+	kr, err := LoadOrCreateKeyring(dir)
+	if err != nil {
+		return err
+	}
+	c.credentialKeyring = kr
+	return nil
+}
+
+// ensureKeyring returns the configured keyring, lazily creating a non-persistent
+// ephemeral one if InitCredentialKeyring was never called. Production startup
+// always initialises a persistent keyring; the ephemeral fallback exists only
+// so unit tests and incidental code paths round-trip within a process.
+func (c *Config) ensureKeyring() (*Keyring, error) {
+	if c.credentialKeyring != nil {
+		return c.credentialKeyring, nil
+	}
+	kr, err := newEphemeralKeyring()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrKeyringUnavailable, err)
+	}
+	c.credentialKeyring = kr
+	return kr, nil
+}
+
+// EncryptCredentialValue encrypts a single credential value with the active DEK
+// version (ADR-0015). It replaces the JWT-derived EncryptCredential call sites.
+func (c *Config) EncryptCredentialValue(plaintext string) (string, error) {
+	kr, err := c.ensureKeyring()
+	if err != nil {
+		return "", err
+	}
+	return kr.EncryptValue(plaintext)
+}
+
+// reEncryptCredential normalises a credential value to the active DEK version.
+// Plaintext is encrypted; legacy v0 (JWT-derived) ciphertext is decrypted with
+// Auth.JWTSecret and re-encrypted with the DEK; already-versioned values are
+// returned unchanged. Legacy values are left intact (not lost) when JWTSecret is
+// unavailable.
+func (c *Config) reEncryptCredential(value string) (string, error) {
+	if value == "" || isVersionedCiphertext(value) {
+		return value, nil
 	}
 
+	plaintext := value
+	if IsLegacyEncrypted(value) {
+		if c.Auth.JWTSecret == "" {
+			return value, nil // cannot migrate without the legacy key; keep intact
+		}
+		decrypted, err := DecryptCredential(value, c.Auth.JWTSecret)
+		if err != nil {
+			return value, fmt.Errorf("decrypt legacy credential: %w", err)
+		}
+		plaintext = decrypted
+	}
+
+	return c.EncryptCredentialValue(plaintext)
+}
+
+// EncryptSNMPCredentials encrypts (and migrates legacy v0 values for) all SNMP
+// v3 credentials with the DEK keyring (fixes #518; ADR-0015).
+func (c *Config) EncryptSNMPCredentials() error {
 	for i := range c.SNMP.V3Credentials {
 		cred := &c.SNMP.V3Credentials[i]
 
-		// Encrypt AuthPassword if not already encrypted
-		if cred.AuthPassword != "" && !IsEncrypted(cred.AuthPassword) {
-			encrypted, err := EncryptCredential(cred.AuthPassword, c.Auth.JWTSecret)
-			if err != nil {
-				return fmt.Errorf("failed to encrypt auth password for %s: %w", cred.Name, err)
-			}
-			cred.AuthPassword = encrypted
+		authPw, err := c.reEncryptCredential(cred.AuthPassword)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt auth password for %s: %w", cred.Name, err)
 		}
+		cred.AuthPassword = authPw
 
-		// Encrypt PrivPassword if not already encrypted
-		if cred.PrivPassword != "" && !IsEncrypted(cred.PrivPassword) {
-			encrypted, err := EncryptCredential(cred.PrivPassword, c.Auth.JWTSecret)
-			if err != nil {
-				return fmt.Errorf("failed to encrypt priv password for %s: %w", cred.Name, err)
-			}
-			cred.PrivPassword = encrypted
+		privPw, err := c.reEncryptCredential(cred.PrivPassword)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt priv password for %s: %w", cred.Name, err)
 		}
+		cred.PrivPassword = privPw
 	}
 
 	return nil
 }
 
-// DecryptSNMPPassword decrypts an SNMP password for use (fixes #518).
+// DecryptSNMPPassword decrypts an SNMP password for use (fixes #518; ADR-0015).
+// Versioned ciphertext is decrypted with the DEK keyring; legacy unversioned
+// ciphertext falls back to the JWT-derived key (read-only migration path).
 func (c *Config) DecryptSNMPPassword(encrypted string) (string, error) {
-	if c.Auth.JWTSecret == "" {
-		return "", errors.New("JWT secret required for credential decryption")
+	if encrypted == "" {
+		return "", nil
+	}
+	if !IsEncrypted(encrypted) {
+		return encrypted, nil // plaintext, returned as-is for backward compatibility
 	}
 
+	if isVersionedCiphertext(encrypted) {
+		kr, err := c.ensureKeyring()
+		if err != nil {
+			return "", err
+		}
+		return kr.DecryptValue(encrypted)
+	}
+
+	// Legacy v0 (JWT-derived) — read-only path retained for migration.
+	if c.Auth.JWTSecret == "" {
+		return "", errors.New("JWT secret required to decrypt legacy credential")
+	}
 	return DecryptCredential(encrypted, c.Auth.JWTSecret)
 }

--- a/internal/config/keyring.go
+++ b/internal/config/keyring.go
@@ -1,0 +1,368 @@
+package config
+
+// keyring.go implements the credential Data-Encryption-Key (DEK) keyring
+// described in ADR-0015. It separates SNMP-credential encryption from
+// Auth.JWTSecret: the DEK is random key material persisted in a dedicated
+// key file (or supplied via SEED_CREDENTIAL_KEY), per-version AES-256 keys are
+// derived with HKDF-SHA256, and ciphertext carries an explicit version tag
+// ("enc:v<N>:...") so the key that produced it is always known and rotation is
+// possible. The legacy unversioned "enc:..." (JWT-derived) format remains
+// decryptable, read-only, for transparent migration.
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	// dekEnvVar supplies a base64-encoded 32-byte DEK master, taking
+	// precedence over the on-disk key file. It is never written to disk.
+	dekEnvVar = "SEED_CREDENTIAL_KEY"
+	// dekFileName is the dedicated key-file name under the data dir.
+	dekFileName = "credential.key"
+	// dekInfoFmt is the HKDF domain-separation label per version.
+	dekInfoFmt = "seed:snmp-credential-encryption:v%d"
+	// dekKDFName records the KDF used for a keyring version.
+	dekKDFName = "hkdf-sha256"
+
+	dekMasterLen = 32 // AES-256 master key material
+	dekSaltLen   = 16 // per-version HKDF salt
+	dekKeyLen    = 32 // derived AES-256 key
+
+	versionTag = "v" // the "v<N>" marker that follows encryptedPrefix
+)
+
+// ErrKeyringUnavailable is returned when credential encryption is attempted
+// without an initialised keyring and no ephemeral fallback could be created.
+var ErrKeyringUnavailable = errors.New("credential keyring unavailable")
+
+// Keyring derives versioned AES-256 keys for credential encryption (ADR-0015).
+// It is immutable after construction; EncryptValue/DecryptValue are safe for
+// concurrent use and never touch Auth.JWTSecret.
+type Keyring struct {
+	master   []byte
+	active   int
+	salts    map[int][]byte
+	path     string // "" => not persisted (env-only or ephemeral)
+	envBound bool   // master came from SEED_CREDENTIAL_KEY (do not persist it)
+}
+
+// keyringVersion is one persisted keyring entry.
+type keyringVersion struct {
+	Version int    `json:"version"`
+	Salt    string `json:"salt"` // base64 std
+	KDF     string `json:"kdf"`
+}
+
+// keyringFile is the on-disk JSON layout of credential.key.
+type keyringFile struct {
+	Active   int              `json:"active"`
+	Master   string           `json:"master,omitempty"` // omitted when env-supplied
+	Versions []keyringVersion `json:"versions"`
+}
+
+// LoadOrCreateKeyring resolves the DEK master (env override first, then the
+// key file under dir) and loads or creates the keyring, persisting a freshly
+// generated key file with 0600 permissions when none exists.
+func LoadOrCreateKeyring(dir string) (*Keyring, error) {
+	envMaster, envSet, err := masterFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(dir, dekFileName)
+	raw, readErr := os.ReadFile(path)
+	switch {
+	case readErr == nil:
+		return loadKeyring(raw, path, envMaster, envSet)
+	case errors.Is(readErr, os.ErrNotExist):
+		return createKeyring(dir, path, envMaster, envSet)
+	default:
+		return nil, fmt.Errorf("read credential key file: %w", readErr)
+	}
+}
+
+// newEphemeralKeyring builds an in-memory, non-persisted keyring with a random
+// master and a single active version. It is the safety-net used when no keyring
+// was initialised (e.g. tests); ciphertext it produces does not survive restart.
+func newEphemeralKeyring() (*Keyring, error) {
+	master := make([]byte, dekMasterLen)
+	if _, err := io.ReadFull(rand.Reader, master); err != nil {
+		return nil, fmt.Errorf("generate ephemeral DEK: %w", err)
+	}
+	salt := make([]byte, dekSaltLen)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return nil, fmt.Errorf("generate ephemeral salt: %w", err)
+	}
+	return &Keyring{
+		master: master,
+		active: 1,
+		salts:  map[int][]byte{1: salt},
+	}, nil
+}
+
+func masterFromEnv() ([]byte, bool, error) {
+	v := strings.TrimSpace(os.Getenv(dekEnvVar))
+	if v == "" {
+		return nil, false, nil
+	}
+	decoded, decErr := base64.StdEncoding.DecodeString(v)
+	if decErr != nil {
+		return nil, false, fmt.Errorf("%s: invalid base64: %w", dekEnvVar, decErr)
+	}
+	if len(decoded) != dekMasterLen {
+		return nil, false, fmt.Errorf(
+			"%s: must decode to %d bytes, got %d", dekEnvVar, dekMasterLen, len(decoded),
+		)
+	}
+	return decoded, true, nil
+}
+
+func loadKeyring(raw []byte, path string, envMaster []byte, envSet bool) (*Keyring, error) {
+	var file keyringFile
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return nil, fmt.Errorf("parse credential key file: %w", err)
+	}
+	if len(file.Versions) == 0 || file.Active < 1 {
+		return nil, errors.New("credential key file is missing version metadata")
+	}
+
+	salts := make(map[int][]byte, len(file.Versions))
+	for _, ver := range file.Versions {
+		salt, err := base64.StdEncoding.DecodeString(ver.Salt)
+		if err != nil {
+			return nil, fmt.Errorf("decode salt for v%d: %w", ver.Version, err)
+		}
+		salts[ver.Version] = salt
+	}
+	if _, ok := salts[file.Active]; !ok {
+		return nil, fmt.Errorf("active version v%d has no salt", file.Active)
+	}
+
+	master, err := resolveMaster(file.Master, envMaster, envSet)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Keyring{
+		master:   master,
+		active:   file.Active,
+		salts:    salts,
+		path:     path,
+		envBound: envSet,
+	}, nil
+}
+
+func resolveMaster(fileMaster string, envMaster []byte, envSet bool) ([]byte, error) {
+	if envSet {
+		return envMaster, nil
+	}
+	if fileMaster == "" {
+		return nil, errors.New(
+			"credential key file has no master and " + dekEnvVar + " is not set",
+		)
+	}
+	master, err := base64.StdEncoding.DecodeString(fileMaster)
+	if err != nil {
+		return nil, fmt.Errorf("decode credential master: %w", err)
+	}
+	if len(master) != dekMasterLen {
+		return nil, fmt.Errorf("credential master must be %d bytes, got %d", dekMasterLen, len(master))
+	}
+	return master, nil
+}
+
+func createKeyring(dir, path string, envMaster []byte, envSet bool) (*Keyring, error) {
+	master := envMaster
+	if !envSet {
+		master = make([]byte, dekMasterLen)
+		if _, err := io.ReadFull(rand.Reader, master); err != nil {
+			return nil, fmt.Errorf("generate DEK master: %w", err)
+		}
+	}
+
+	salt := make([]byte, dekSaltLen)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return nil, fmt.Errorf("generate DEK salt: %w", err)
+	}
+
+	kr := &Keyring{
+		master:   master,
+		active:   1,
+		salts:    map[int][]byte{1: salt},
+		path:     path,
+		envBound: envSet,
+	}
+	if err := kr.persist(dir); err != nil {
+		return nil, err
+	}
+	return kr, nil
+}
+
+// persist writes the keyring to its key file at 0600. The master is omitted
+// when it is env-supplied so secret material is never written to disk.
+func (kr *Keyring) persist(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create data directory: %w", err)
+	}
+
+	versions := make([]keyringVersion, 0, len(kr.salts))
+	for ver, salt := range kr.salts {
+		versions = append(versions, keyringVersion{
+			Version: ver,
+			Salt:    base64.StdEncoding.EncodeToString(salt),
+			KDF:     dekKDFName,
+		})
+	}
+
+	file := keyringFile{Active: kr.active, Versions: versions}
+	if !kr.envBound {
+		file.Master = base64.StdEncoding.EncodeToString(kr.master)
+	}
+
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal credential keyring: %w", err)
+	}
+	if writeErr := os.WriteFile(kr.path, data, 0o600); writeErr != nil {
+		return fmt.Errorf("write credential key file: %w", writeErr)
+	}
+	return nil
+}
+
+// deriveKey derives the AES-256 key for the given keyring version via
+// HKDF-SHA256 over the random master, the per-version salt, and a versioned
+// domain-separation label.
+func (kr *Keyring) deriveKey(version int) ([]byte, error) {
+	salt, ok := kr.salts[version]
+	if !ok {
+		return nil, fmt.Errorf("%w: unknown key version v%d", ErrInvalidCiphertext, version)
+	}
+	info := fmt.Sprintf(dekInfoFmt, version)
+	key, err := hkdf.Key(sha256.New, kr.master, salt, info, dekKeyLen)
+	if err != nil {
+		return nil, fmt.Errorf("derive credential key: %w", err)
+	}
+	return key, nil
+}
+
+// EncryptValue encrypts plaintext with the active key version, producing
+// "enc:v<active>:base64(nonce‖ciphertext‖tag)". Empty and already-encrypted
+// inputs are returned unchanged (idempotent).
+func (kr *Keyring) EncryptValue(plaintext string) (string, error) {
+	if plaintext == "" {
+		return "", nil
+	}
+	if IsEncrypted(plaintext) {
+		return plaintext, nil
+	}
+
+	key, err := kr.deriveKey(kr.active)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := newGCM(key)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, nonceErr := io.ReadFull(rand.Reader, nonce); nonceErr != nil {
+		return "", fmt.Errorf("failed to generate nonce: %w", nonceErr)
+	}
+	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+
+	encoded := base64.StdEncoding.EncodeToString(ciphertext)
+	return fmt.Sprintf("%s%s%d:%s", encryptedPrefix, versionTag, kr.active, encoded), nil
+}
+
+// DecryptValue decrypts a versioned ("enc:v<N>:...") credential.
+func (kr *Keyring) DecryptValue(encrypted string) (string, error) {
+	version, encoded, ok := parseVersioned(encrypted)
+	if !ok {
+		return "", fmt.Errorf("%w: not a versioned ciphertext", ErrInvalidCiphertext)
+	}
+
+	ciphertext, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("%w: invalid base64: %w", ErrInvalidCiphertext, err)
+	}
+
+	key, err := kr.deriveKey(version)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := newGCM(key)
+	if err != nil {
+		return "", err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return "", fmt.Errorf("%w: ciphertext too short", ErrInvalidCiphertext)
+	}
+	nonce, body := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, body, nil)
+	if err != nil {
+		return "", fmt.Errorf("%w: authentication failed: %w", ErrInvalidCiphertext, err)
+	}
+	return string(plaintext), nil
+}
+
+// newGCM builds an AES-256-GCM AEAD from a 32-byte key.
+func newGCM(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+	return gcm, nil
+}
+
+// parseVersioned splits "enc:v<N>:<base64>" into its version and payload. The
+// final bool is false for the legacy unversioned "enc:..." format.
+func parseVersioned(s string) (int, string, bool) {
+	if !strings.HasPrefix(s, encryptedPrefix) {
+		return 0, "", false
+	}
+	rest := s[len(encryptedPrefix):]
+	if !strings.HasPrefix(rest, versionTag) {
+		return 0, "", false
+	}
+	idx := strings.IndexByte(rest, ':')
+	if idx <= len(versionTag) {
+		return 0, "", false
+	}
+	n, err := strconv.Atoi(rest[len(versionTag):idx])
+	if err != nil || n < 1 {
+		return 0, "", false
+	}
+	return n, rest[idx+1:], true
+}
+
+// isVersionedCiphertext reports whether value uses the versioned DEK format.
+func isVersionedCiphertext(value string) bool {
+	_, _, ok := parseVersioned(value)
+	return ok
+}
+
+// IsLegacyEncrypted reports whether value is an encrypted credential in the
+// legacy unversioned ("enc:...", JWT-derived) format that must be migrated.
+func IsLegacyEncrypted(value string) bool {
+	return IsEncrypted(value) && !isVersionedCiphertext(value)
+}

--- a/internal/config/keyring_test.go
+++ b/internal/config/keyring_test.go
@@ -1,0 +1,208 @@
+package config_test
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/config"
+)
+
+// versionedPrefix is the on-the-wire prefix for DEK-encrypted credentials.
+const versionedPrefix = "enc:v1:"
+
+func newKeyedConfig(t *testing.T, dir string) *config.Config {
+	t.Helper()
+	cfg := &config.Config{
+		Auth: config.AuthConfig{JWTSecret: "jwt-secret-only-for-legacy-decrypt"},
+	}
+	if err := cfg.InitCredentialKeyring(dir); err != nil {
+		t.Fatalf("InitCredentialKeyring failed: %v", err)
+	}
+	return cfg
+}
+
+func TestCredentialKeyringRoundtrip(t *testing.T) {
+	cfg := newKeyedConfig(t, t.TempDir())
+
+	enc, err := cfg.EncryptCredentialValue("s3cr3t-snmp-pass")
+	if err != nil {
+		t.Fatalf("EncryptCredentialValue failed: %v", err)
+	}
+	if !strings.HasPrefix(enc, versionedPrefix) {
+		t.Fatalf("ciphertext should carry versioned prefix %q, got %q", versionedPrefix, enc)
+	}
+
+	got, err := cfg.DecryptSNMPPassword(enc)
+	if err != nil {
+		t.Fatalf("DecryptSNMPPassword failed: %v", err)
+	}
+	if got != "s3cr3t-snmp-pass" {
+		t.Fatalf("roundtrip mismatch: got %q", got)
+	}
+}
+
+// TestCredentialKeyringPersistsAcrossReload proves the DEK is persisted to the
+// key file (not regenerated) so ciphertext survives a process restart.
+func TestCredentialKeyringPersistsAcrossReload(t *testing.T) {
+	dir := t.TempDir()
+	cfg1 := newKeyedConfig(t, dir)
+
+	enc, err := cfg1.EncryptCredentialValue("persist-me")
+	if err != nil {
+		t.Fatalf("encrypt failed: %v", err)
+	}
+
+	// A fresh Config pointed at the same dir must decrypt the prior ciphertext.
+	cfg2 := newKeyedConfig(t, dir)
+	got, err := cfg2.DecryptSNMPPassword(enc)
+	if err != nil {
+		t.Fatalf("decrypt after reload failed: %v", err)
+	}
+	if got != "persist-me" {
+		t.Fatalf("reload roundtrip mismatch: got %q", got)
+	}
+}
+
+// TestCredentialKeyFilePerms verifies the key file is created 0600.
+func TestCredentialKeyFilePerms(t *testing.T) {
+	dir := t.TempDir()
+	_ = newKeyedConfig(t, dir)
+
+	info, err := os.Stat(filepath.Join(dir, "credential.key"))
+	if err != nil {
+		t.Fatalf("key file not created: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("key file perms = %o, want 0600", perm)
+	}
+}
+
+// TestCredentialEncryptionDecoupledFromJWT is the core ADR-0015 guarantee:
+// rotating Auth.JWTSecret must NOT make DEK-encrypted credentials undecryptable.
+func TestCredentialEncryptionDecoupledFromJWT(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newKeyedConfig(t, dir)
+
+	enc, err := cfg.EncryptCredentialValue("decoupled")
+	if err != nil {
+		t.Fatalf("encrypt failed: %v", err)
+	}
+
+	// Rotate the JWT signing secret — a routine auth operation.
+	cfg.Auth.JWTSecret = "a-completely-different-rotated-jwt-secret"
+
+	got, err := cfg.DecryptSNMPPassword(enc)
+	if err != nil {
+		t.Fatalf("decrypt after JWT rotation failed (still coupled?): %v", err)
+	}
+	if got != "decoupled" {
+		t.Fatalf("decrypt after JWT rotation mismatch: got %q", got)
+	}
+}
+
+// TestCredentialKeyEnvOverride verifies SEED_CREDENTIAL_KEY supplies the master
+// and is never written to the key file.
+func TestCredentialKeyEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	t.Setenv("SEED_CREDENTIAL_KEY", base64.StdEncoding.EncodeToString(master))
+
+	cfg := newKeyedConfig(t, dir)
+	enc, err := cfg.EncryptCredentialValue("byo-kms")
+	if err != nil {
+		t.Fatalf("encrypt failed: %v", err)
+	}
+
+	// The persisted key file must NOT contain the env-supplied master.
+	raw, err := os.ReadFile(filepath.Join(dir, "credential.key"))
+	if err != nil {
+		t.Fatalf("read key file: %v", err)
+	}
+	var file struct {
+		Master string `json:"master"`
+	}
+	if unmarshalErr := json.Unmarshal(raw, &file); unmarshalErr != nil {
+		t.Fatalf("parse key file: %v", unmarshalErr)
+	}
+	if file.Master != "" {
+		t.Fatalf("env-supplied master must not be written to disk, found %q", file.Master)
+	}
+
+	// Reload from env + on-disk salts must still decrypt.
+	cfg2 := newKeyedConfig(t, dir)
+	got, err := cfg2.DecryptSNMPPassword(enc)
+	if err != nil {
+		t.Fatalf("decrypt after env reload failed: %v", err)
+	}
+	if got != "byo-kms" {
+		t.Fatalf("env reload roundtrip mismatch: got %q", got)
+	}
+}
+
+// TestLegacyV0Migration proves a legacy JWT-derived ciphertext is transparently
+// re-encrypted to the versioned DEK format and remains decryptable throughout.
+func TestLegacyV0Migration(t *testing.T) {
+	dir := t.TempDir()
+	const jwt = "legacy-jwt-secret-used-for-v0-credentials"
+	const plain = "legacy-priv-pass"
+
+	// Craft a legacy v0 ciphertext exactly as the old code did.
+	v0, err := config.EncryptCredential(plain, jwt)
+	if err != nil {
+		t.Fatalf("legacy encrypt failed: %v", err)
+	}
+	if strings.HasPrefix(v0, versionedPrefix) {
+		t.Fatalf("legacy ciphertext should be unversioned, got %q", v0)
+	}
+	if !config.IsLegacyEncrypted(v0) {
+		t.Fatalf("v0 ciphertext should be detected as legacy-encrypted")
+	}
+
+	cfg := &config.Config{
+		Auth: config.AuthConfig{JWTSecret: jwt},
+		SNMP: config.SNMPConfig{
+			V3Credentials: []config.SNMPv3Credential{
+				{Name: "legacy", PrivPassword: v0},
+			},
+		},
+	}
+	if initErr := cfg.InitCredentialKeyring(dir); initErr != nil {
+		t.Fatalf("InitCredentialKeyring failed: %v", initErr)
+	}
+
+	// Migration must still read v0 directly (read-only legacy path).
+	pre, err := cfg.DecryptSNMPPassword(v0)
+	if err != nil {
+		t.Fatalf("legacy decrypt failed: %v", err)
+	}
+	if pre != plain {
+		t.Fatalf("legacy decrypt mismatch: got %q", pre)
+	}
+
+	// EncryptSNMPCredentials re-encrypts v0 -> v1.
+	if encErr := cfg.EncryptSNMPCredentials(); encErr != nil {
+		t.Fatalf("EncryptSNMPCredentials failed: %v", encErr)
+	}
+	migrated := cfg.SNMP.V3Credentials[0].PrivPassword
+	if !strings.HasPrefix(migrated, versionedPrefix) {
+		t.Fatalf("credential should be migrated to versioned format, got %q", migrated)
+	}
+
+	// Decryptable after migration.
+	post, err := cfg.DecryptSNMPPassword(migrated)
+	if err != nil {
+		t.Fatalf("post-migration decrypt failed: %v", err)
+	}
+	if post != plain {
+		t.Fatalf("post-migration mismatch: got %q", post)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **ADR-0015** (owner greenlit for v1): a dedicated, versioned
Data-Encryption Key (DEK) for SNMP-credential encryption, decoupled from
`Auth.JWTSecret`. Rotating the JWT signing secret no longer makes stored
credentials undecryptable — the two security domains are now separate.

## What changed

- **`internal/config/keyring.go` (new)** — 32-byte DEK loaded/created at
  `<datadir>/credential.key` (0600) or supplied via `SEED_CREDENTIAL_KEY`
  (never written to disk). Per-version AES-256 keys derived via
  **HKDF-SHA256** over a per-version random salt + versioned domain label.
- **Versioned ciphertext** `enc:v<N>:...` records which key produced it,
  making rotation possible. Legacy unversioned `enc:...` (JWT-derived)
  stays **decryptable, read-only**, and is transparently re-encrypted to
  the DEK on next save (lazy migration; one-release legacy window).
- **Call-site swap** — `EncryptSNMPCredentials` and the SNMP-settings
  handler (`convertSNMPv3Credential`) stop reading `Auth.JWTSecret`; new
  encryption uses the DEK. `JWTSecret` reverts to JWT signing only.
- **ADR-0015** flipped Proposed → Accepted; coordination gate recorded as
  resolved.

## Testing

Test-first (`keyring_test.go`): roundtrip, persistence across reload,
0600 file perms, **JWT-rotation decoupling**, `SEED_CREDENTIAL_KEY`
override (master not persisted), and **v0→v1 migration**. Existing
`crypto_test.go` unchanged and passing.

- `go test ./internal/config/... ./internal/api/... ./cmd/seed/...` — pass
- `golangci-lint run` — 0 issues (no suppressions added)
- Golden HTTP harness byte-identical (SNMP endpoints not exercised by goldens)
- No wire/DTO change

## Notes

- New operational surface: `credential.key` must be backed up + protected
  (losing it makes stored SNMP v3 creds unrecoverable — by design).
  `*.key` is already gitignored.
- `internal/license` device-fingerprint `deriveKey` is a separate domain,
  out of scope (per ADR).