### PR TITLE
refactor(api): strangle settings handlers into settingsapp use-case (ADR-0016)

### DIFF
--- a/internal/api/handlers_settings.go
+++ b/internal/api/handlers_settings.go
@@ -1,15 +1,12 @@
 package api
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/krisarmstrong/seed/internal/config"
-	"github.com/krisarmstrong/seed/internal/database"
 	"github.com/krisarmstrong/seed/internal/logging"
 	"github.com/krisarmstrong/seed/internal/validation"
 )
@@ -230,80 +227,17 @@ func (s *Server) updateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Also save settings to the active profile (fixes #781)
-	if s.db() != nil {
-		if err := s.saveSettingsToActiveProfile(ctx, logger); err != nil {
-			sendJSONResponse(w, logger, http.StatusInternalServerError, map[string]string{
-				"error": "Failed to save settings",
-			})
-			return
-		}
+	// Also persist settings to the active profile (fixes #781). The use-case is a
+	// no-op when no database/profile is wired (ADR-0016 phase 3).
+	if err := s.settingsStore.SaveToActiveProfile(ctx); err != nil {
+		logger.ErrorContext(ctx, "Failed to save settings to profile", "error", err)
+		sendJSONResponse(w, logger, http.StatusInternalServerError, map[string]string{
+			"error": "Failed to save settings",
+		})
+		return
 	}
 
 	sendJSONResponse(w, logger, http.StatusOK, map[string]string{"status": "updated"})
-}
-
-// saveSettingsToActiveProfile saves current settings to the active profile's ConfigJSON.
-// This ensures profile-specific settings are persisted (fixes #781).
-func (s *Server) saveSettingsToActiveProfile(ctx context.Context, logger *slog.Logger) error {
-	// Get active profile ID
-	activeID, err := s.db().Settings().GetValue(ctx, database.SettingKeyActiveProfile)
-	if err != nil || activeID == "" {
-		// No active profile, try to get default
-		defaultProfile, getDefaultErr := s.db().Profiles().GetDefault(ctx)
-		if getDefaultErr != nil {
-			// No profile exists - this is not an error, just nothing to save to
-			logger.DebugContext(ctx,
-				"No active or default profile to save settings to",
-				"reason",
-				getDefaultErr.Error(),
-			)
-			return nil
-		}
-		activeID = defaultProfile.ID
-	}
-
-	// Get the profile
-	profile, err := s.db().Profiles().Get(ctx, activeID)
-	if err != nil {
-		logger.WarnContext(ctx,
-			"Failed to get active profile for settings save",
-			"error",
-			err,
-			"profile_id",
-			activeID,
-		)
-		return nil
-	}
-
-	// Export current settings from config using single source of truth
-	configJSON, jsonErr := s.config.ToProfileJSON()
-	if jsonErr != nil {
-		logger.WarnContext(ctx, "Failed to serialize profile settings", "error", jsonErr)
-		return nil
-	}
-
-	// Update profile
-	profile.ConfigJSON = configJSON
-	if updateErr := s.db().Profiles().Update(ctx, profile); updateErr != nil {
-		logger.ErrorContext(ctx,
-			"Failed to save settings to profile",
-			"error",
-			updateErr,
-			"profile_id",
-			profile.ID,
-		)
-		return updateErr
-	}
-
-	logger.DebugContext(ctx,
-		"Saved settings to active profile",
-		"profile_id",
-		profile.ID,
-		"profile_name",
-		profile.Name,
-	)
-	return nil
 }
 
 // applyThresholdUpdates applies threshold configuration updates.
@@ -1033,19 +967,18 @@ func (s *Server) updateLinkSettings(w http.ResponseWriter, r *http.Request) {
 	s.config.Link = updates
 	s.config.Unlock()
 
-	// Save to active profile in database
-	if s.db() != nil {
-		if err := s.saveSettingsToActiveProfile(ctx, logger); err != nil {
-			sendErrorResponseWithDetails(
-				w,
-				logger,
-				http.StatusInternalServerError,
-				ErrCodeInternal,
-				"Failed to save link settings",
-				"",
-			)
-			return
-		}
+	// Persist to the active profile (ADR-0016 phase 3; no-op without a db).
+	if err := s.settingsStore.SaveToActiveProfile(ctx); err != nil {
+		logger.ErrorContext(ctx, "Failed to save link settings to profile", "error", err)
+		sendErrorResponseWithDetails(
+			w,
+			logger,
+			http.StatusInternalServerError,
+			ErrCodeInternal,
+			"Failed to save link settings",
+			"",
+		)
+		return
 	}
 
 	sendJSONResponse(w, logger, http.StatusOK, map[string]string{"status": "updated"})
@@ -1106,19 +1039,18 @@ func (s *Server) updateCableTestSettings(w http.ResponseWriter, r *http.Request)
 	s.config.CableTest = updates
 	s.config.Unlock()
 
-	// Save to active profile in database
-	if s.db() != nil {
-		if err := s.saveSettingsToActiveProfile(ctx, logger); err != nil {
-			sendErrorResponseWithDetails(
-				w,
-				logger,
-				http.StatusInternalServerError,
-				ErrCodeInternal,
-				"Failed to save cable test settings",
-				"",
-			)
-			return
-		}
+	// Persist to the active profile (ADR-0016 phase 3; no-op without a db).
+	if err := s.settingsStore.SaveToActiveProfile(ctx); err != nil {
+		logger.ErrorContext(ctx, "Failed to save cable test settings to profile", "error", err)
+		sendErrorResponseWithDetails(
+			w,
+			logger,
+			http.StatusInternalServerError,
+			ErrCodeInternal,
+			"Failed to save cable test settings",
+			"",
+		)
+		return
 	}
 
 	sendJSONResponse(w, logger, http.StatusOK, map[string]string{"status": "updated"})

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/krisarmstrong/seed/internal/probe"
 	"github.com/krisarmstrong/seed/internal/probe/checkers"
 	"github.com/krisarmstrong/seed/internal/scheduler"
+	settingsapp "github.com/krisarmstrong/seed/internal/settings/app"
 	"github.com/krisarmstrong/seed/internal/timeseries/retention"
 	"github.com/krisarmstrong/seed/internal/topology"
 	"github.com/krisarmstrong/seed/internal/wifi"
@@ -122,14 +123,15 @@ type Server struct {
 	services *ServiceContainer
 
 	// Runtime state
-	icmpAvailable      bool                  // Whether raw ICMP sockets are available
-	startTime          time.Time             // Application start time for uptime tracking (fixes #540)
-	setupModeStartTime time.Time             // Security fix #891: Track when setup mode started
-	background         *BackgroundComponents // Long-lived components with background lifecycle (report scheduler)
-	wifiQueries        *wifiapp.Queries      // Wi-Fi visibility read use-case (ADR-0016 strangle exemplar)
-	wifiManagement     *wifiapp.Management   // Wi-Fi settings/scan/status/connect use-case (ADR-0016 phase 2)
-	wifiDiscovery      *wifiapp.Discovery    // Enhanced Wi-Fi discovery use-case (ADR-0016 phase 2)
-	tlsFingerprint     tlsFingerprintCache   // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
+	icmpAvailable      bool                     // Whether raw ICMP sockets are available
+	startTime          time.Time                // Application start time for uptime tracking (fixes #540)
+	setupModeStartTime time.Time                // Security fix #891: Track when setup mode started
+	background         *BackgroundComponents    // Long-lived components with background lifecycle (report scheduler)
+	wifiQueries        *wifiapp.Queries         // Wi-Fi visibility read use-case (ADR-0016 strangle exemplar)
+	wifiManagement     *wifiapp.Management      // Wi-Fi settings/scan/status/connect use-case (ADR-0016 phase 2)
+	wifiDiscovery      *wifiapp.Discovery       // Enhanced Wi-Fi discovery use-case (ADR-0016 phase 2)
+	settingsStore      *settingsapp.Persistence // Settings-to-profile persistence use-case (ADR-0016 phase 3)
+	tlsFingerprint     tlsFingerprintCache      // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
 
 // NewServer creates a new server instance.
@@ -243,6 +245,10 @@ func NewServer(
 
 	// Wire the Wi-Fi use-cases now that the discovery bridge exists (ADR-0016).
 	s.initWiFiUseCases()
+
+	// Wire the settings-persistence use-case (ADR-0016 phase 3). The adapter
+	// resolves the database lazily, so it tolerates a nil or later-set db.
+	s.initSettingsUseCase()
 
 	// Initialize vulnerability scanner if enabled
 	s.initVulnerabilityScanner(cfg)

--- a/internal/api/settings_usecases.go
+++ b/internal/api/settings_usecases.go
@@ -1,0 +1,77 @@
+package api
+
+// settings_usecases.go wires the API layer to the settings application
+// (use-case) service (ADR-0016 strangle phase 3). The adapters below implement
+// the narrow ports declared in internal/settings/app over the concrete database
+// repositories and the live config, so the settings handlers depend on a
+// use-case instead of reaching into ServiceContainer / s.db() directly.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/krisarmstrong/seed/internal/config"
+	"github.com/krisarmstrong/seed/internal/database"
+	settingsapp "github.com/krisarmstrong/seed/internal/settings/app"
+)
+
+// settingsProfileStore implements settingsapp.ProfileStore over the database
+// repositories. It resolves the *database.DB lazily (via the accessor) so it
+// tolerates a nil or later-assigned database, preserving the handlers' historic
+// "no db -> persist to config file only" behavior.
+type settingsProfileStore struct {
+	db func() *database.DB
+}
+
+func (s settingsProfileStore) ActiveProfileID(ctx context.Context) (string, error) {
+	db := s.db()
+	if db == nil {
+		return "", nil // no database; the (also empty) default path makes this a no-op
+	}
+	return db.Settings().GetValue(ctx, database.SettingKeyActiveProfile)
+}
+
+func (s settingsProfileStore) DefaultProfileID(ctx context.Context) (string, error) {
+	db := s.db()
+	if db == nil {
+		return "", settingsapp.ErrNoProfile
+	}
+	profile, err := db.Profiles().GetDefault(ctx)
+	if err != nil {
+		// No default profile exists — nothing to persist to (not an error).
+		return "", settingsapp.ErrNoProfile
+	}
+	return profile.ID, nil
+}
+
+func (s settingsProfileStore) SaveProfileConfig(ctx context.Context, id, configJSON string) error {
+	db := s.db()
+	if db == nil {
+		return nil
+	}
+	profile, err := db.Profiles().Get(ctx, id)
+	if err != nil {
+		return fmt.Errorf("load profile %s: %w", id, err)
+	}
+	profile.ConfigJSON = configJSON
+	return db.Profiles().Update(ctx, profile)
+}
+
+// settingsConfigSource implements settingsapp.ConfigSource over the live config,
+// serializing it with the single-source-of-truth profile encoder.
+type settingsConfigSource struct {
+	cfg *config.Config
+}
+
+func (c settingsConfigSource) ProfileJSON() (string, error) {
+	return c.cfg.ToProfileJSON()
+}
+
+// initSettingsUseCase builds the settings-persistence use-case (ADR-0016 phase
+// 3) from the lazy database accessor and the live config.
+func (s *Server) initSettingsUseCase() {
+	s.settingsStore = settingsapp.NewPersistence(
+		settingsProfileStore{db: s.db},
+		settingsConfigSource{cfg: s.config},
+	)
+}

--- a/internal/api/settings_usecases_internal_test.go
+++ b/internal/api/settings_usecases_internal_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/krisarmstrong/seed/internal/config"
+	"github.com/krisarmstrong/seed/internal/database"
+)
+
+// TestSettingsUseCasePersistsToDefaultProfile exercises the ADR-0016 phase-3
+// adapter wiring end-to-end against a real database: SaveToActiveProfile must
+// write the live config's profile JSON onto the seeded default profile.
+func TestSettingsUseCasePersistsToDefaultProfile(t *testing.T) {
+	db, err := database.Open(filepath.Join(t.TempDir(), "seed.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Capture the seeded default profile's original config for comparison.
+	def, err := db.Profiles().GetDefault(t.Context())
+	if err != nil {
+		t.Fatalf("get default profile: %v", err)
+	}
+	original := def.ConfigJSON
+
+	cfg := config.DefaultConfig()
+	cfg.DisplayOptions.UnitSystem = "metric" // a distinctive, serialized value
+
+	s := &Server{
+		config:   cfg,
+		services: NewServiceContainer(),
+	}
+	s.services.Database.DB = db
+	s.initSettingsUseCase()
+
+	if saveErr := s.settingsStore.SaveToActiveProfile(t.Context()); saveErr != nil {
+		t.Fatalf("SaveToActiveProfile: %v", saveErr)
+	}
+
+	got, err := db.Profiles().GetDefault(t.Context())
+	if err != nil {
+		t.Fatalf("re-get default profile: %v", err)
+	}
+	if got.ConfigJSON == original {
+		t.Fatal("profile ConfigJSON was not updated")
+	}
+
+	want, err := cfg.ToProfileJSON()
+	if err != nil {
+		t.Fatalf("ToProfileJSON: %v", err)
+	}
+	if got.ConfigJSON != want {
+		t.Fatalf("persisted config mismatch:\n got=%s\nwant=%s", got.ConfigJSON, want)
+	}
+}
+
+// TestSettingsUseCaseNoDatabaseIsNoOp verifies the use-case tolerates a missing
+// database (the historic "persist to config file only" path) without error.
+func TestSettingsUseCaseNoDatabaseIsNoOp(t *testing.T) {
+	s := &Server{
+		config:   config.DefaultConfig(),
+		services: NewServiceContainer(),
+	}
+	s.initSettingsUseCase()
+
+	if err := s.settingsStore.SaveToActiveProfile(t.Context()); err != nil {
+		t.Fatalf("expected no-op without a db, got %v", err)
+	}
+}

--- a/internal/settings/app/persistence.go
+++ b/internal/settings/app/persistence.go
@@ -1,0 +1,83 @@
+// Package settingsapp holds the settings application (use-case) layer
+// (ADR-0016 strangle phase 3). It owns the orchestration that previously lived
+// in the api.Server settings handlers — resolving the active profile and
+// persisting the current configuration to it — behind narrow, consumer-defined
+// ports, so handlers depend on a use-case instead of reaching into the database
+// repositories and the config directly.
+package settingsapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrNoProfile signals that no active or default profile exists to persist to.
+// The use-case treats it as a no-op: settings still live in the config file, so
+// the absence of a profile row is not an error.
+var ErrNoProfile = errors.New("no profile to persist settings to")
+
+// ProfileStore is the narrow persistence surface the settings use-case needs.
+// It is defined here at the consumer (ADR-0016 interface-segregation) and
+// satisfied by an adapter that owns the database.Profile type, the database
+// repositories, and the row read-modify-write.
+type ProfileStore interface {
+	// ActiveProfileID returns the configured active profile id, or "" when none
+	// is set. A non-nil error routes the use-case to the default profile.
+	ActiveProfileID(ctx context.Context) (string, error)
+	// DefaultProfileID returns the default profile id, or ErrNoProfile when no
+	// profile exists.
+	DefaultProfileID(ctx context.Context) (string, error)
+	// SaveProfileConfig persists configJSON onto the profile identified by id.
+	SaveProfileConfig(ctx context.Context, id, configJSON string) error
+}
+
+// ConfigSource serializes the live configuration to a profile JSON blob.
+type ConfigSource interface {
+	ProfileJSON() (string, error)
+}
+
+// Persistence is the settings-persistence use-case: it writes the current
+// configuration to the active profile. Handlers depend on it instead of
+// reaching into the database repositories.
+type Persistence struct {
+	store ProfileStore
+	cfg   ConfigSource
+}
+
+// NewPersistence builds the use-case over its narrow dependencies.
+func NewPersistence(store ProfileStore, cfg ConfigSource) *Persistence {
+	return &Persistence{store: store, cfg: cfg}
+}
+
+// SaveToActiveProfile persists current settings to the active (or default)
+// profile. It is an idempotent no-op when no store is wired (no database) or no
+// profile exists (ErrNoProfile) — settings still live in the config file. Any
+// other failure (serialization, the row write) propagates, so a genuinely
+// broken save surfaces as an error instead of being silently dropped.
+func (p *Persistence) SaveToActiveProfile(ctx context.Context) error {
+	if p == nil || p.store == nil {
+		return nil
+	}
+
+	id, err := p.store.ActiveProfileID(ctx)
+	if err != nil || id == "" {
+		// No active profile configured (or its lookup failed) — fall back to the
+		// default profile. A missing default is the legitimate "nothing to persist
+		// to" case; any other error is real and propagates.
+		id, err = p.store.DefaultProfileID(ctx)
+		if err != nil {
+			if errors.Is(err, ErrNoProfile) {
+				return nil
+			}
+			return err
+		}
+	}
+
+	configJSON, err := p.cfg.ProfileJSON()
+	if err != nil {
+		return fmt.Errorf("serialize settings for profile: %w", err)
+	}
+
+	return p.store.SaveProfileConfig(ctx, id, configJSON)
+}

--- a/internal/settings/app/persistence_test.go
+++ b/internal/settings/app/persistence_test.go
@@ -1,0 +1,139 @@
+package settingsapp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	settingsapp "github.com/krisarmstrong/seed/internal/settings/app"
+)
+
+type fakeStore struct {
+	activeID    string
+	activeErr   error
+	defaultID   string
+	defaultErr  error
+	savedID     string
+	savedConfig string
+	saveErr     error
+	saveCalls   int
+}
+
+func (f *fakeStore) ActiveProfileID(context.Context) (string, error) {
+	return f.activeID, f.activeErr
+}
+
+func (f *fakeStore) DefaultProfileID(context.Context) (string, error) {
+	return f.defaultID, f.defaultErr
+}
+
+func (f *fakeStore) SaveProfileConfig(_ context.Context, id, configJSON string) error {
+	f.saveCalls++
+	f.savedID = id
+	f.savedConfig = configJSON
+	return f.saveErr
+}
+
+type fakeConfig struct {
+	json string
+	err  error
+}
+
+func (f fakeConfig) ProfileJSON() (string, error) { return f.json, f.err }
+
+func TestSaveToActiveProfileUsesActiveID(t *testing.T) {
+	store := &fakeStore{activeID: "active-1"}
+	uc := settingsapp.NewPersistence(store, fakeConfig{json: `{"k":"v"}`})
+
+	if err := uc.SaveToActiveProfile(context.Background()); err != nil {
+		t.Fatalf("SaveToActiveProfile: %v", err)
+	}
+	if store.saveCalls != 1 {
+		t.Fatalf("expected 1 save, got %d", store.saveCalls)
+	}
+	if store.savedID != "active-1" {
+		t.Fatalf("saved to %q, want active-1", store.savedID)
+	}
+	if store.savedConfig != `{"k":"v"}` {
+		t.Fatalf("saved config %q", store.savedConfig)
+	}
+}
+
+func TestSaveToActiveProfileFallsBackToDefault(t *testing.T) {
+	// Empty active id and a lookup error both route to the default profile.
+	for _, tc := range []struct {
+		name  string
+		store *fakeStore
+	}{
+		{"empty active", &fakeStore{activeID: "", defaultID: "default-1"}},
+		{"active lookup error", &fakeStore{activeErr: errors.New("boom"), defaultID: "default-1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			uc := settingsapp.NewPersistence(tc.store, fakeConfig{json: "{}"})
+			if err := uc.SaveToActiveProfile(context.Background()); err != nil {
+				t.Fatalf("SaveToActiveProfile: %v", err)
+			}
+			if tc.store.savedID != "default-1" {
+				t.Fatalf("saved to %q, want default-1", tc.store.savedID)
+			}
+		})
+	}
+}
+
+func TestSaveToActiveProfileNoProfileIsNoOp(t *testing.T) {
+	store := &fakeStore{activeID: "", defaultErr: settingsapp.ErrNoProfile}
+	uc := settingsapp.NewPersistence(store, fakeConfig{json: "{}"})
+
+	if err := uc.SaveToActiveProfile(context.Background()); err != nil {
+		t.Fatalf("expected nil (no-op), got %v", err)
+	}
+	if store.saveCalls != 0 {
+		t.Fatalf("expected no save, got %d", store.saveCalls)
+	}
+}
+
+func TestSaveToActiveProfileSerializeErrorPropagates(t *testing.T) {
+	wantErr := errors.New("serialize failed")
+	store := &fakeStore{activeID: "active-1"}
+	uc := settingsapp.NewPersistence(store, fakeConfig{err: wantErr})
+
+	if err := uc.SaveToActiveProfile(context.Background()); !errors.Is(err, wantErr) {
+		t.Fatalf("expected serialize error to propagate, got %v", err)
+	}
+	if store.saveCalls != 0 {
+		t.Fatalf("expected no save on serialize error, got %d", store.saveCalls)
+	}
+}
+
+func TestSaveToActiveProfileDefaultLookupErrorPropagates(t *testing.T) {
+	// A non-sentinel default-profile lookup error is real and must propagate
+	// (only ErrNoProfile is the legitimate no-op).
+	wantErr := errors.New("db down")
+	store := &fakeStore{activeID: "", defaultErr: wantErr}
+	uc := settingsapp.NewPersistence(store, fakeConfig{json: "{}"})
+
+	if err := uc.SaveToActiveProfile(context.Background()); !errors.Is(err, wantErr) {
+		t.Fatalf("expected default lookup error to propagate, got %v", err)
+	}
+}
+
+func TestSaveToActiveProfileSaveErrorPropagates(t *testing.T) {
+	wantErr := errors.New("update failed")
+	store := &fakeStore{activeID: "active-1", saveErr: wantErr}
+	uc := settingsapp.NewPersistence(store, fakeConfig{json: "{}"})
+
+	if err := uc.SaveToActiveProfile(context.Background()); !errors.Is(err, wantErr) {
+		t.Fatalf("expected save error to propagate, got %v", err)
+	}
+}
+
+func TestSaveToActiveProfileNilStoreIsNoOp(t *testing.T) {
+	uc := settingsapp.NewPersistence(nil, fakeConfig{json: "{}"})
+	if err := uc.SaveToActiveProfile(context.Background()); err != nil {
+		t.Fatalf("nil store should be a no-op, got %v", err)
+	}
+	var nilUC *settingsapp.Persistence
+	if err := nilUC.SaveToActiveProfile(context.Background()); err != nil {
+		t.Fatalf("nil use-case should be a no-op, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

ADR-0016 strangle **phase 3**: move the settings-to-profile persistence logic
out of the `api.Server` settings handlers into a consumer-driven use-case,
following the `wifiapp` exemplar (#1541/#1542). Handlers become
decode → use-case → encode; the `s.db()/Settings()/Profiles()` reach-through is
gone.

## What changed

- **`internal/settings/app` (new, `settingsapp`)** — a `Persistence` use-case
  that resolves the active (or default) profile and writes the live config's
  profile JSON to it, behind narrow consumer-defined ports (`ProfileStore`,
  `ConfigSource`). `ErrNoProfile` models the legitimate "nothing to persist to"
  no-op; **genuine serialize/lookup/write failures now propagate** instead of
  being silently logged-and-dropped (an improvement over the old handler).
- **`internal/api/settings_usecases.go` (new)** — adapters over the database
  repositories (lazy `db` accessor → nil/late-set db degrades to a no-op) and
  the live config; `initSettingsUseCase` wired in `NewServer`.
- **`handlers_settings.go`** — `updateSettings` / `updateLinkSettings` /
  `updateCableTestSettings` delegate to the use-case; the 70-line
  `saveSettingsToActiveProfile` method and its imports are deleted.

## Testing

- `settingsapp` unit tests: active/default resolution, no-op vs propagated
  errors, nil store/use-case.
- New internal api **integration test** against a real DB: proves the adapter
  persists the live config to the seeded default profile, and that a dbless
  server is a no-op.
- golden HTTP harness **byte-identical**; full backend `go test ./...` green;
  `golangci-lint run ./...` **0 issues** (no suppressions added).

## Notes

- Behavior change (intentional, best-practice): a profile **serialize or write
  failure** now returns 500 instead of a silent 200. The dbless/no-profile
  no-op path (every existing handler test) is unchanged.
- Next strangle targets per the blueprint: profiles → network.