### PR TITLE
ci: run gitleaks via the CLI instead of the licensed action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,9 +366,15 @@ jobs:
       - name: Run gitleaks
         env:
           GITLEAKS_VERSION: "8.30.0"
+          # SHA-256 of gitleaks_8.30.0_linux_x64.tar.gz from the upstream
+          # checksums.txt. Rotate this together with GITLEAKS_VERSION on upgrade.
+          GITLEAKS_SHA256: "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e"
         run: |
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xzf - gitleaks
+          set -euo pipefail
+          curl -sSfL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
           ./gitleaks git . --config .gitleaks.toml --redact --no-banner --exit-code 1
 
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,10 +359,17 @@ jobs:
           npm ci
           npm audit --audit-level=high
 
+      # gitleaks-action requires a paid licence for organization repos. Use the
+      # MIT-licensed gitleaks CLI directly instead — same engine, same config,
+      # and identical to the version pinned in .pre-commit-config.yaml. Scans
+      # full history (the security job checks out with fetch-depth: 0).
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: "8.30.0"
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xzf - gitleaks
+          ./gitleaks git . --config .gitleaks.toml --redact --no-banner --exit-code 1
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0


### PR DESCRIPTION
## Problem

The org transfer broke **Security Scanning** on every push:

```
[MustardSeedNetworks] is an organization. License key is required.
🛑 missing gitleaks license.
```

`gitleaks/gitleaks-action` is free for personal accounts but requires a paid `GITLEAKS_LICENSE` for **organization** repos. It surfaced on the first post-transfer CI run (the module-rename PR #1551, admin-merged over it).

## Fix

Replace the licensed Action with a direct invocation of the **MIT-licensed gitleaks CLI** — same engine, same `.gitleaks.toml`, pinned to **v8.30.0** to match `.pre-commit-config.yaml`. The security job already checks out with `fetch-depth: 0`, so `gitleaks git` scans full history exactly as the action did.

No license, no recurring cost, no secret required.

## Verification

Ran the exact command locally: **1807 commits scanned, no leaks, exit 0.** YAML validated.

## Follow-up

Dependabot PR #1458 (bump `gitleaks-action` 2.3.9 → 3.0.0) is now moot — the action is removed; that PR should be closed.