### PR TITLE
refactor(api): strangle profile handlers into profilesapp use-case (ADR-0016)

### DIFF
--- a/internal/api/handlers_profiles.go
+++ b/internal/api/handlers_profiles.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,11 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
-
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
+	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
 )
 
 // ProfileRequest represents a profile create/update request.
@@ -108,9 +105,8 @@ func (s *Server) handleProfiles(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleListProfiles(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
-	ctx := r.Context()
 
-	profiles, err := s.db().Profiles().List(ctx)
+	profiles, err := s.profiles.List(r.Context())
 	if err != nil {
 		logger.ErrorContext(r.Context(), "Failed to list profiles", "error", err)
 		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
@@ -122,7 +118,6 @@ func (s *Server) handleListProfiles(w http.ResponseWriter, r *http.Request) {
 		Profiles: make([]ProfileResponse, 0, len(profiles)),
 		Total:    len(profiles),
 	}
-
 	for _, p := range profiles {
 		response.Profiles = append(response.Profiles, profileToResponse(p))
 	}
@@ -134,7 +129,6 @@ func (s *Server) handleListProfiles(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleCreateProfile(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
-	ctx := r.Context()
 
 	// multi_client gate: Free/Starter may keep their bootstrap profile,
 	// but a SECOND (or later) profile requires Pro. Checked before body
@@ -148,7 +142,8 @@ func (s *Server) handleCreateProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate required fields
+	// Preserve the pre-strangle ordering: empty-name 400 fires before the
+	// multi_interface gate so the message is stable for an empty over-cap body.
 	if req.Name == "" {
 		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
 			ErrCodeValidation, localizer.T("errors.profile.nameRequired"), "") // fixes #694
@@ -161,28 +156,28 @@ func (s *Server) handleCreateProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create profile
-	profile := &database.Profile{
-		ID:          uuid.New().String(),
+	profile, err := s.profiles.Create(r.Context(), profilesapp.NewProfile{
 		Name:        req.Name,
 		Description: req.Description,
 		ConfigJSON:  string(req.Config),
 		IsDefault:   req.IsDefault,
-	}
-
-	if err := s.db().Profiles().Create(ctx, profile); err != nil {
-		if errors.Is(err, database.ErrProfileNameExists) {
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, profilesapp.ErrNameRequired):
+			sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
+				ErrCodeValidation, localizer.T("errors.profile.nameRequired"), "")
+		case errors.Is(err, profilesapp.ErrNameExists):
 			sendErrorResponseWithDetails(w, logger, http.StatusConflict,
 				ErrCodeConflict, localizer.T("errors.profile.nameExists"), "") // fixes #694
-			return
+		default:
+			logger.ErrorContext(r.Context(), "Failed to create profile", "error", err, "profile_name", req.Name)
+			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+				ErrCodeInternal, localizer.T("errors.profile.createFailed"), "") // fixes #694, #H7
 		}
-		logger.ErrorContext(r.Context(), "Failed to create profile", "error", err, "profile_name", req.Name)
-		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
-			ErrCodeInternal, localizer.T("errors.profile.createFailed"), "") // fixes #694, #H7
 		return
 	}
 
-	// If this profile is set as default, it was already handled by the repository
 	sendJSONResponse(w, logger, http.StatusCreated, profileToResponse(profile))
 }
 
@@ -190,11 +185,10 @@ func (s *Server) handleCreateProfile(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleGetProfile(w http.ResponseWriter, r *http.Request, id string) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
-	ctx := r.Context()
 
-	profile, err := s.db().Profiles().Get(ctx, id)
+	profile, err := s.profiles.Get(r.Context(), id)
 	if err != nil {
-		if errors.Is(err, database.ErrProfileNotFound) {
+		if errors.Is(err, profilesapp.ErrNotFound) {
 			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
 				ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
 			return
@@ -211,51 +205,41 @@ func (s *Server) handleGetProfile(w http.ResponseWriter, r *http.Request, id str
 func (s *Server) handleUpdateProfile(w http.ResponseWriter, r *http.Request, id string) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
-	ctx := r.Context()
 
 	var req ProfileRequest
 	if !decodeJSONStrictLocalized(w, r, &req, MaxBodySizeJSON, logger, localizer) {
 		return
 	}
 
-	// multi_interface gate (seed#1192): if the incoming config exceeds the
-	// 1+1 cap, Pro is required. Done before the DB read so a 402 short-
-	// circuits without a wasted query.
+	// multi_interface gate (seed#1192): done before the DB read so a 402
+	// short-circuits without a wasted query.
 	if req.Config != nil && !s.enforceMultiInterfaceGate(w, r, req.Config) {
 		return
 	}
 
-	// Get existing profile
-	profile, err := s.db().Profiles().Get(ctx, id)
+	update := profilesapp.ProfileUpdate{
+		Name:        req.Name,
+		Description: req.Description,
+		IsDefault:   req.IsDefault,
+	}
+	if req.Config != nil {
+		cfg := string(req.Config)
+		update.ConfigJSON = &cfg
+	}
+
+	profile, err := s.profiles.Update(r.Context(), id, update)
 	if err != nil {
-		if errors.Is(err, database.ErrProfileNotFound) {
+		switch {
+		case errors.Is(err, profilesapp.ErrNotFound):
 			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
 				ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
-			return
-		}
-		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
-			ErrCodeInternal, localizer.T("errors.profile.getFailed"), "") // fixes #694, #H7
-		return
-	}
-
-	// Update fields
-	if req.Name != "" {
-		profile.Name = req.Name
-	}
-	profile.Description = req.Description
-	if req.Config != nil {
-		profile.ConfigJSON = string(req.Config)
-	}
-	profile.IsDefault = req.IsDefault
-
-	if updateErr := s.db().Profiles().Update(ctx, profile); updateErr != nil {
-		if errors.Is(updateErr, database.ErrProfileNameExists) {
+		case errors.Is(err, profilesapp.ErrNameExists):
 			sendErrorResponseWithDetails(w, logger, http.StatusConflict,
 				ErrCodeConflict, localizer.T("errors.profile.nameExists"), "") // fixes #694
-			return
+		default:
+			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+				ErrCodeInternal, localizer.T("errors.profile.updateFailed"), "") // fixes #694, #H7
 		}
-		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
-			ErrCodeInternal, localizer.T("errors.profile.updateFailed"), "") // fixes #694, #H7
 		return
 	}
 
@@ -266,47 +250,26 @@ func (s *Server) handleUpdateProfile(w http.ResponseWriter, r *http.Request, id 
 func (s *Server) handleDeleteProfile(w http.ResponseWriter, r *http.Request, id string) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
-	ctx := r.Context()
 
-	// Check if profile exists
-	profile, err := s.db().Profiles().Get(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrProfileNotFound) {
-			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
-				ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
-			return
-		}
-		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
-			ErrCodeInternal, localizer.T("errors.profile.getFailed"), "") // fixes #694, #H7
-		return
-	}
-
-	// Prevent deleting the default profile
-	if profile.IsDefault {
+	err := s.profiles.Delete(r.Context(), id)
+	switch {
+	case err == nil:
+		sendJSONResponse(w, logger, http.StatusOK, map[string]string{
+			"message": "Profile deleted successfully",
+		})
+	case errors.Is(err, profilesapp.ErrNotFound):
+		sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
+			ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
+	case errors.Is(err, profilesapp.ErrDeleteDefault):
 		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
 			ErrCodeBadRequest, localizer.T("errors.profile.cannotDeleteDefault"), "") // fixes #694
-		return
-	}
-
-	// Check if this is the active profile
-	activeID, _ := s.db().Settings().
-		GetValue(ctx, database.SettingKeyActiveProfile)
-
-	if activeID == id {
+	case errors.Is(err, profilesapp.ErrDeleteActive):
 		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
 			ErrCodeBadRequest, localizer.T("errors.profile.cannotDeleteActive"), "") // fixes #694
-		return
-	}
-
-	if deleteErr := s.db().Profiles().Delete(ctx, id); deleteErr != nil {
+	default:
 		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
 			ErrCodeInternal, localizer.T("errors.profile.deleteFailed"), "") // fixes #694, #H7
-		return
 	}
-
-	sendJSONResponse(w, logger, http.StatusOK, map[string]string{
-		"message": "Profile deleted successfully",
-	})
 }
 
 // handleActiveProfile handles getting and setting the active profile.
@@ -341,64 +304,27 @@ func (s *Server) handleActiveProfile(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleGetActiveProfile(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
-	ctx := r.Context()
 
-	// Get active profile ID from settings
-	activeID, err := s.db().Settings().GetValue(ctx, database.SettingKeyActiveProfile)
+	profile, err := s.profiles.ActiveProfile(r.Context())
 	if err != nil {
-		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
-			ErrCodeInternal, localizer.T("errors.profile.getActiveFailed"), "") // fixes #694, #H7
-		return
-	}
-
-	// If no active profile set, return the default profile
-	if activeID == "" {
-		profile, defaultErr := s.db().Profiles().GetDefault(ctx)
-		if defaultErr != nil {
-			if errors.Is(defaultErr, database.ErrProfileNotFound) {
-				sendErrorResponseWithDetails(
-					w,
-					logger,
-					http.StatusNotFound,
-					ErrCodeNotFound,
-					localizer.T("errors.profile.noActiveOrDefault"),
-					"",
-				) // fixes #694
-				return
-			}
-			sendErrorResponseWithDetails(
-				w,
-				logger,
-				http.StatusInternalServerError,
-				ErrCodeInternal,
-				localizer.T("errors.profile.getDefaultFailed"),
-				"",
-			) // fixes #694, #H7
-			return
-		}
-		sendJSONResponse(w, logger, http.StatusOK, profileToResponse(profile))
-		return
-	}
-
-	// Get the active profile
-	profile, err := s.db().Profiles().Get(ctx, activeID)
-	if err != nil {
-		if errors.Is(err, database.ErrProfileNotFound) {
-			// Active profile was deleted, fall back to default
-			profile, err = s.db().Profiles().GetDefault(ctx)
-			if err != nil {
-				sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
-					ErrCodeNotFound, localizer.T("errors.profile.activeNotFound"), "") // fixes #694
-				return
-			}
-			// Update setting to use default
-			_ = s.db().Settings().
-				Set(ctx, database.SettingKeyActiveProfile, profile.ID)
-		} else {
+		switch {
+		case errors.Is(err, profilesapp.ErrNoActiveOrDefault):
+			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
+				ErrCodeNotFound, localizer.T("errors.profile.noActiveOrDefault"), "") // fixes #694
+		case errors.Is(err, profilesapp.ErrActiveNotFound):
+			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
+				ErrCodeNotFound, localizer.T("errors.profile.activeNotFound"), "") // fixes #694
+		case errors.Is(err, profilesapp.ErrDefaultLookup):
+			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+				ErrCodeInternal, localizer.T("errors.profile.getDefaultFailed"), "") // fixes #694, #H7
+		case errors.Is(err, profilesapp.ErrActiveLookup):
+			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+				ErrCodeInternal, localizer.T("errors.profile.getActiveFailed"), "") // fixes #694, #H7
+		default:
 			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
 				ErrCodeInternal, localizer.T("errors.profile.getFailed"), "") // fixes #694, #H7
-			return
 		}
+		return
 	}
 
 	sendJSONResponse(w, logger, http.StatusOK, profileToResponse(profile))
@@ -408,7 +334,6 @@ func (s *Server) handleGetActiveProfile(w http.ResponseWriter, r *http.Request) 
 func (s *Server) handleSetActiveProfile(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
-	ctx := r.Context()
 
 	var req struct {
 		ProfileID string `json:"profile_id"`
@@ -417,58 +342,39 @@ func (s *Server) handleSetActiveProfile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if req.ProfileID == "" {
-		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
-			ErrCodeValidation, localizer.T("errors.profile.idRequired"), "") // fixes #694
-		return
-	}
-
-	// Verify profile exists
-	profile, err := s.db().Profiles().Get(ctx, req.ProfileID)
+	profile, err := s.profiles.SetActiveProfile(r.Context(), req.ProfileID)
 	if err != nil {
-		if errors.Is(err, database.ErrProfileNotFound) {
+		switch {
+		case errors.Is(err, profilesapp.ErrIDRequired):
+			sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
+				ErrCodeValidation, localizer.T("errors.profile.idRequired"), "") // fixes #694
+		case errors.Is(err, profilesapp.ErrNotFound):
 			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
 				ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
-			return
+		default:
+			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+				ErrCodeInternal, localizer.T("errors.profile.setActiveFailed"), "") // fixes #694, #H7
 		}
-		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
-			ErrCodeInternal, localizer.T("errors.profile.getFailed"), "") // fixes #694, #H7
 		return
 	}
 
-	// Set active profile in settings
-	if setErr := s.db().Settings().Set(ctx, database.SettingKeyActiveProfile, req.ProfileID); setErr != nil {
-		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
-			ErrCodeInternal, localizer.T("errors.profile.setActiveFailed"), "") // fixes #694, #H7
-		return
-	}
-
-	// Apply profile settings to the active config (fixes #781)
-	// Uses Config.ApplyProfileJSON() - single source of truth, no ProfileSettings intermediate
+	// Apply profile settings to the active config (fixes #781).
+	// Uses Config.ApplyProfileJSON() - single source of truth.
 	if profile.ConfigJSON != "" {
 		if applyErr := s.config.ApplyProfileJSON(profile.ConfigJSON); applyErr != nil {
 			logger.WarnContext(r.Context(),
 				"Failed to parse profile settings, using defaults",
-				"error",
-				applyErr,
-				"profile_id",
-				profile.ID,
+				"error", applyErr, "profile_id", profile.ID,
 			)
+		} else if saveErr := s.config.Save(s.configPath); saveErr != nil {
+			// fixes #782 - return error instead of silent warning
+			logger.ErrorContext(r.Context(), "Failed to save config after profile switch", "error", saveErr)
+			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+				ErrCodeInternal, localizer.T("errors.config.failedToSave"), saveErr.Error())
+			return
 		} else {
-			// Save updated config to file (fixes #782 - return error instead of silent warning)
-			if saveErr := s.config.Save(s.configPath); saveErr != nil {
-				logger.ErrorContext(r.Context(), "Failed to save config after profile switch", "error", saveErr)
-				sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
-					ErrCodeInternal, localizer.T("errors.config.failedToSave"), saveErr.Error())
-				return
-			}
-			logger.InfoContext(
-				r.Context(),
-				"Applied profile settings",
-				"profile_id",
-				profile.ID,
-				"profile_name",
-				profile.Name,
+			logger.InfoContext(r.Context(),
+				"Applied profile settings", "profile_id", profile.ID, "profile_name", profile.Name,
 			)
 		}
 	}
@@ -517,25 +423,9 @@ func (s *Server) handleDuplicateProfile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	ctx := r.Context()
-
 	// Extract profile ID from path
 	path := strings.TrimPrefix(r.URL.Path, "/api/profiles/")
-	path = strings.TrimSuffix(path, "/duplicate")
-	id := path
-
-	// Get source profile
-	source, err := s.db().Profiles().Get(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrProfileNotFound) {
-			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
-				ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
-			return
-		}
-		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
-			ErrCodeInternal, localizer.T("errors.profile.getFailed"), "") // fixes #694, #H7
-		return
-	}
+	id := strings.TrimSuffix(path, "/duplicate")
 
 	// Parse optional new name from request body
 	var req struct {
@@ -543,38 +433,20 @@ func (s *Server) handleDuplicateProfile(w http.ResponseWriter, r *http.Request) 
 	}
 	_ = json.NewDecoder(r.Body).Decode(&req)
 
-	newName := req.Name
-	if newName == "" {
-		newName = source.Name + " (Copy)"
-	}
-
-	// Create duplicate
-	duplicate := &database.Profile{
-		ID:          uuid.New().String(),
-		Name:        newName,
-		Description: source.Description,
-		ConfigJSON:  source.ConfigJSON,
-		IsDefault:   false, // Duplicates are never default
-	}
-
-	if createErr := s.db().Profiles().Create(ctx, duplicate); createErr != nil {
-		if errors.Is(createErr, database.ErrProfileNameExists) {
-			// Try with timestamp suffix
-			duplicate.Name = fmt.Sprintf(
-				"%s (%s)",
-				source.Name,
-				time.Now().Format("2006-01-02 15:04"),
-			)
-			if retryErr := s.db().Profiles().Create(ctx, duplicate); retryErr != nil {
-				sendErrorResponseWithDetails(w, logger, http.StatusConflict,
-					ErrCodeConflict, localizer.T("errors.profile.nameExists"), "") // fixes #694
-				return
-			}
-		} else {
+	duplicate, err := s.profiles.Duplicate(r.Context(), id, req.Name)
+	if err != nil {
+		switch {
+		case errors.Is(err, profilesapp.ErrNotFound):
+			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
+				ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
+		case errors.Is(err, profilesapp.ErrNameExists):
+			sendErrorResponseWithDetails(w, logger, http.StatusConflict,
+				ErrCodeConflict, localizer.T("errors.profile.nameExists"), "") // fixes #694
+		default:
 			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
 				ErrCodeInternal, localizer.T("errors.profile.duplicateFailed"), "") // fixes #694, #H7
-			return
 		}
+		return
 	}
 
 	sendJSONResponse(w, logger, http.StatusCreated, profileToResponse(duplicate))
@@ -591,9 +463,9 @@ func (s *Server) handleImportProfiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// multi_client gate: any import that would land >1 profile total
-	// requires Pro. We gate at entry rather than mid-loop so partial
-	// imports don't leave the operator in an inconsistent state.
+	// multi_client gate: any import that would land >1 profile total requires
+	// Pro. We gate at entry so partial imports don't leave the operator in an
+	// inconsistent state.
 	if !s.enforceMultiClientGate(w, r) {
 		return
 	}
@@ -610,83 +482,27 @@ func (s *Server) handleImportProfiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := r.Context()
-
 	var req ProfileImportRequest
 	if !decodeJSONStrictLocalized(w, r, &req, MaxBodySizeJSON, logger, localizer) {
 		return
 	}
 
-	result := ProfileImportResponse{
-		Errors: make([]string, 0),
-	}
-
-	for i, p := range req.Profiles {
-		if p.Name == "" {
-			result.Errors = append(result.Errors, fmt.Sprintf("Profile %d: name is required", i+1))
-			result.Skipped++
-			continue
-		}
-
-		// Check if profile with this name exists
-		existing, _ := s.db().Profiles().GetByName(ctx, p.Name)
-		if existing != nil {
-			s.handleExistingProfileImport(ctx, existing, &p, req.Overwrite, &result)
-			continue
-		}
-
-		// Create new profile
-		profile := &database.Profile{
-			ID:          uuid.New().String(),
+	items := make([]profilesapp.ImportItem, 0, len(req.Profiles))
+	for _, p := range req.Profiles {
+		items = append(items, profilesapp.ImportItem{
 			Name:        p.Name,
 			Description: p.Description,
 			ConfigJSON:  string(p.Config),
-			IsDefault:   false, // Never import as default
-		}
-
-		if err := s.db().Profiles().Create(ctx, profile); err != nil {
-			result.Errors = append(
-				result.Errors,
-				fmt.Sprintf("Profile '%s': failed to create - %v", p.Name, err),
-			)
-			result.Skipped++
-		} else {
-			result.Created++
-		}
+		})
 	}
 
-	sendJSONResponse(w, logger, http.StatusOK, result)
-}
-
-// handleExistingProfileImport handles importing a profile that already exists.
-func (s *Server) handleExistingProfileImport(
-	ctx context.Context,
-	existing *database.Profile,
-	p *ProfileRequest,
-	overwrite bool,
-	result *ProfileImportResponse,
-) {
-	if !overwrite {
-		result.Errors = append(
-			result.Errors,
-			fmt.Sprintf("Profile '%s': already exists (use overwrite=true to update)", p.Name),
-		)
-		result.Skipped++
-		return
-	}
-
-	// Update existing profile
-	existing.Description = p.Description
-	existing.ConfigJSON = string(p.Config)
-	if err := s.db().Profiles().Update(ctx, existing); err != nil {
-		result.Errors = append(
-			result.Errors,
-			fmt.Sprintf("Profile '%s': failed to update - %v", p.Name, err),
-		)
-		result.Skipped++
-		return
-	}
-	result.Updated++
+	res := s.profiles.Import(r.Context(), items, req.Overwrite)
+	sendJSONResponse(w, logger, http.StatusOK, ProfileImportResponse{
+		Created: res.Created,
+		Updated: res.Updated,
+		Skipped: res.Skipped,
+		Errors:  res.Errors,
+	})
 }
 
 // handleExportProfiles exports all profiles to JSON.
@@ -712,9 +528,7 @@ func (s *Server) handleExportProfiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := r.Context()
-
-	profiles, err := s.db().Profiles().List(ctx)
+	profiles, err := s.profiles.List(r.Context())
 	if err != nil {
 		logger.ErrorContext(r.Context(), "Failed to list profiles", "error", err)
 		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
@@ -727,7 +541,6 @@ func (s *Server) handleExportProfiles(w http.ResponseWriter, r *http.Request) {
 		ExportedAt: time.Now().UTC().Format(time.RFC3339),
 		Profiles:   make([]ProfileResponse, 0, len(profiles)),
 	}
-
 	for _, p := range profiles {
 		response.Profiles = append(response.Profiles, profileToResponse(p))
 	}
@@ -739,29 +552,28 @@ func (s *Server) handleExportProfiles(w http.ResponseWriter, r *http.Request) {
 	sendJSONResponse(w, logger, http.StatusOK, response)
 }
 
-// enforceMultiClientGate returns true if the request may proceed and
-// writes a 402 FeatureGateResponse + returns false when the operator
-// has reached the Free/Starter 1-profile cap and lacks the `multi_client`
-// feature. The first profile (bootstrap) is always allowed so a fresh
-// install is functional on any tier; this gate fires only when creating
-// a 2nd or later profile.
+// enforceMultiClientGate returns true if the request may proceed and writes a
+// 402 + returns false when the operator has reached the Free/Starter 1-profile
+// cap and lacks the `multi_client` feature. The first profile (bootstrap) is
+// always allowed so a fresh install is functional on any tier; this gate fires
+// only when creating a 2nd or later profile.
 //
-// MSP positioning: customer-facing copy always calls these "client
-// profiles." The internal feature key stays `multi_client`.
+// MSP positioning: customer-facing copy always calls these "client profiles."
+// The internal feature key stays `multi_client`.
 func (s *Server) enforceMultiClientGate(w http.ResponseWriter, r *http.Request) bool {
 	logger := logging.FromContext(r.Context())
 
 	if s.db() == nil {
-		// No DB → no profile count to compare; fall through. The
-		// downstream handler returns a service-unavailable error.
+		// No DB → no profile count to compare; fall through. The downstream
+		// handler returns a service-unavailable error.
 		return true
 	}
 
-	count, err := s.db().Profiles().Count(r.Context())
+	count, err := s.profiles.Count(r.Context())
 	if err != nil {
 		logger.WarnContext(r.Context(), "multi_client gate: failed to count profiles", "error", err)
-		// Fail open — refusing to gate is safer than blocking the
-		// operator when the DB hiccups. CI catches it as a real error.
+		// Fail open — refusing to gate is safer than blocking the operator when
+		// the DB hiccups. CI catches it as a real error.
 		return true
 	}
 	if count < 1 {
@@ -791,8 +603,8 @@ func (s *Server) enforceMultiClientGate(w http.ResponseWriter, r *http.Request) 
 	return false
 }
 
-// profileToResponse converts a database profile to an API response.
-func profileToResponse(p *database.Profile) ProfileResponse {
+// profileToResponse converts a use-case profile to an API response.
+func profileToResponse(p profilesapp.Profile) ProfileResponse {
 	var configJSON json.RawMessage
 	if p.ConfigJSON != "" {
 		configJSON = json.RawMessage(p.ConfigJSON)
@@ -811,10 +623,8 @@ func profileToResponse(p *database.Profile) ProfileResponse {
 	}
 }
 
-// profileInterfaceShape is the just-enough projection of a profile's
-// ConfigJSON we need to count interfaces for the multi_interface gate.
-// We avoid pulling in the full config.Config schema here — JSON
-// unmarshal of unknown fields is fine; only the interface block matters.
+// profileInterfaceShape is the just-enough projection of a profile's ConfigJSON
+// we need to count interfaces for the multi_interface gate.
 type profileInterfaceShape struct {
 	Interface struct {
 		Default  string   `json:"default"`
@@ -824,14 +634,9 @@ type profileInterfaceShape struct {
 	} `json:"interface"`
 }
 
-// enforceMultiInterfaceGate returns true if the request may proceed and
-// writes a 402 + returns false when the profile's interface block
-// exceeds 1 ethernet + 1 wifi without the `multi_interface` feature.
-//
-// The "active" / single-interface workflow (Default + WiFi) always
-// passes — Free/Starter are explicitly entitled to one of each.
-// Pro is required only when Ethernet[] or WiFiList[] would push the
-// count above 1 in either category.
+// enforceMultiInterfaceGate returns true if the request may proceed and writes a
+// 402 + returns false when the profile's interface block exceeds 1 ethernet + 1
+// wifi without the `multi_interface` feature.
 func (s *Server) enforceMultiInterfaceGate(w http.ResponseWriter, r *http.Request, rawConfig json.RawMessage) bool {
 	logger := logging.FromContext(r.Context())
 
@@ -841,9 +646,9 @@ func (s *Server) enforceMultiInterfaceGate(w http.ResponseWriter, r *http.Reques
 
 	var shape profileInterfaceShape
 	if err := json.Unmarshal(rawConfig, &shape); err != nil {
-		// Malformed JSON is the caller's problem to surface; let the
-		// downstream validation reject it. We must not gate on parse
-		// failure or we'd lock operators out of fixing bad configs.
+		// Malformed JSON is the caller's problem to surface; let the downstream
+		// validation reject it. We must not gate on parse failure or we'd lock
+		// operators out of fixing bad configs.
 		logger.DebugContext(r.Context(), "multi_interface gate: skipping due to config parse error", "error", err)
 		return true
 	}
@@ -876,9 +681,8 @@ func (s *Server) enforceMultiInterfaceGate(w http.ResponseWriter, r *http.Reques
 	return false
 }
 
-// countNonEmpty counts how many distinct non-empty interface names are
-// present in (primary, extras). Empty strings and duplicates of the
-// primary are skipped so the same name appearing in both fields is one.
+// countNonEmpty counts how many distinct non-empty interface names are present
+// in (primary, extras). Empty strings and duplicates of the primary are skipped.
 func countNonEmpty(primary string, extras []string) int {
 	seen := make(map[string]struct{}, len(extras)+1)
 	if primary != "" {

--- a/internal/api/profiles_usecases.go
+++ b/internal/api/profiles_usecases.go
@@ -1,0 +1,133 @@
+package api
+
+// profiles_usecases.go wires the API layer to the profiles application
+// (use-case) service (ADR-0016 strangle phase 3). The adapter implements the
+// narrow profilesapp.Store port over the database Profiles + Settings
+// repositories, mapping the repository's domain errors to the use-case's
+// sentinels and the database.Profile row to the use-case model.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
+)
+
+// profilesStore implements profilesapp.Store over the database repositories.
+// The database is resolved lazily; callers (handlers) gate on s.db() != nil
+// before invoking the use-case, so a nil db here is not expected.
+type profilesStore struct {
+	db func() *database.DB
+}
+
+// mapProfileErr translates database sentinels to use-case sentinels.
+func mapProfileErr(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, database.ErrProfileNotFound):
+		return profilesapp.ErrNotFound
+	case errors.Is(err, database.ErrProfileNameExists):
+		return profilesapp.ErrNameExists
+	default:
+		return err
+	}
+}
+
+func dbToAppProfile(p *database.Profile) profilesapp.Profile {
+	return profilesapp.Profile{
+		ID:          p.ID,
+		Name:        p.Name,
+		Description: p.Description,
+		ConfigJSON:  p.ConfigJSON,
+		IsDefault:   p.IsDefault,
+		CreatedAt:   p.CreatedAt,
+		UpdatedAt:   p.UpdatedAt,
+	}
+}
+
+func appToDBProfile(p profilesapp.Profile) *database.Profile {
+	return &database.Profile{
+		ID:          p.ID,
+		Name:        p.Name,
+		Description: p.Description,
+		ConfigJSON:  p.ConfigJSON,
+		IsDefault:   p.IsDefault,
+		CreatedAt:   p.CreatedAt,
+		UpdatedAt:   p.UpdatedAt,
+	}
+}
+
+func (s profilesStore) List(ctx context.Context) ([]profilesapp.Profile, error) {
+	rows, err := s.db().Profiles().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]profilesapp.Profile, 0, len(rows))
+	for _, p := range rows {
+		out = append(out, dbToAppProfile(p))
+	}
+	return out, nil
+}
+
+func (s profilesStore) Get(ctx context.Context, id string) (profilesapp.Profile, error) {
+	p, err := s.db().Profiles().Get(ctx, id)
+	if err != nil {
+		return profilesapp.Profile{}, mapProfileErr(err)
+	}
+	return dbToAppProfile(p), nil
+}
+
+func (s profilesStore) GetByName(ctx context.Context, name string) (profilesapp.Profile, bool, error) {
+	p, err := s.db().Profiles().GetByName(ctx, name)
+	if err != nil {
+		if errors.Is(err, database.ErrProfileNotFound) {
+			return profilesapp.Profile{}, false, nil
+		}
+		return profilesapp.Profile{}, false, err
+	}
+	if p == nil {
+		return profilesapp.Profile{}, false, nil
+	}
+	return dbToAppProfile(p), true, nil
+}
+
+func (s profilesStore) GetDefault(ctx context.Context) (profilesapp.Profile, error) {
+	p, err := s.db().Profiles().GetDefault(ctx)
+	if err != nil {
+		return profilesapp.Profile{}, mapProfileErr(err)
+	}
+	return dbToAppProfile(p), nil
+}
+
+func (s profilesStore) Create(ctx context.Context, p profilesapp.Profile) error {
+	return mapProfileErr(s.db().Profiles().Create(ctx, appToDBProfile(p)))
+}
+
+func (s profilesStore) Update(ctx context.Context, p profilesapp.Profile) error {
+	return mapProfileErr(s.db().Profiles().Update(ctx, appToDBProfile(p)))
+}
+
+func (s profilesStore) Delete(ctx context.Context, id string) error {
+	return s.db().Profiles().Delete(ctx, id)
+}
+
+func (s profilesStore) Count(ctx context.Context) (int, error) {
+	n, err := s.db().Profiles().Count(ctx)
+	return int(n), err
+}
+
+func (s profilesStore) ActiveID(ctx context.Context) (string, error) {
+	return s.db().Settings().GetValue(ctx, database.SettingKeyActiveProfile)
+}
+
+func (s profilesStore) SetActiveID(ctx context.Context, id string) error {
+	return s.db().Settings().Set(ctx, database.SettingKeyActiveProfile, id)
+}
+
+// initProfilesUseCase builds the profiles use-case over the lazy database
+// accessor (ADR-0016 phase 3).
+func (s *Server) initProfilesUseCase() {
+	s.profiles = profilesapp.NewService(profilesStore{db: s.db})
+}

--- a/internal/api/profiles_usecases_internal_test.go
+++ b/internal/api/profiles_usecases_internal_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
+)
+
+// newProfilesTestServer builds a Server wired to a real database (which seeds a
+// default profile) with the profiles use-case initialised.
+func newProfilesTestServer(t *testing.T) (*Server, *database.DB) {
+	t.Helper()
+	db, err := database.Open(filepath.Join(t.TempDir(), "seed.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	s := &Server{services: NewServiceContainer()}
+	s.services.Database.DB = db
+	s.initProfilesUseCase()
+	return s, db
+}
+
+// TestProfilesUseCaseAdapterCRUD exercises the ADR-0016 phase-3 adapter against a
+// real database: the database.Profile <-> profilesapp.Profile mapping and the
+// ErrProfileNotFound/ErrProfileNameExists -> sentinel translation.
+func TestProfilesUseCaseAdapterCRUD(t *testing.T) {
+	s, _ := newProfilesTestServer(t)
+	ctx := t.Context()
+
+	// The seeded default profile is present.
+	list, err := s.profiles.List(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 || !list[0].IsDefault {
+		t.Fatalf("expected one seeded default profile, got %+v", list)
+	}
+
+	// Create.
+	created, err := s.profiles.Create(ctx, profilesapp.NewProfile{Name: "field-site", ConfigJSON: `{"k":1}`})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("created profile missing ID")
+	}
+
+	// Duplicate name maps to the sentinel.
+	if _, dupErr := s.profiles.Create(ctx, profilesapp.NewProfile{Name: "field-site"}); !errors.Is(
+		dupErr,
+		profilesapp.ErrNameExists,
+	) {
+		t.Fatalf("duplicate create should map to ErrNameExists, got %v", dupErr)
+	}
+
+	// Get round-trips the row.
+	got, err := s.profiles.Get(ctx, created.ID)
+	if err != nil || got.Name != "field-site" || got.ConfigJSON != `{"k":1}` {
+		t.Fatalf("get mismatch: %+v err=%v", got, err)
+	}
+
+	// Missing id maps to ErrNotFound.
+	if _, missErr := s.profiles.Get(ctx, "nope"); !errors.Is(missErr, profilesapp.ErrNotFound) {
+		t.Fatalf("missing get should map to ErrNotFound, got %v", missErr)
+	}
+
+	// Set active + resolve.
+	if _, setErr := s.profiles.SetActiveProfile(ctx, created.ID); setErr != nil {
+		t.Fatalf("set active: %v", setErr)
+	}
+	active, err := s.profiles.ActiveProfile(ctx)
+	if err != nil || active.ID != created.ID {
+		t.Fatalf("active resolve mismatch: %+v err=%v", active, err)
+	}
+
+	// Cannot delete the active profile.
+	if delErr := s.profiles.Delete(ctx, created.ID); !errors.Is(delErr, profilesapp.ErrDeleteActive) {
+		t.Fatalf("deleting active should be ErrDeleteActive, got %v", delErr)
+	}
+
+	// Cannot delete the default profile.
+	if defErr := s.profiles.Delete(ctx, list[0].ID); !errors.Is(defErr, profilesapp.ErrDeleteDefault) {
+		t.Fatalf("deleting default should be ErrDeleteDefault, got %v", defErr)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/snmpclient"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
 	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
+	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
 	"github.com/MustardSeedNetworks/seed/internal/scheduler"
 	settingsapp "github.com/MustardSeedNetworks/seed/internal/settings/app"
 	"github.com/MustardSeedNetworks/seed/internal/timeseries/retention"
@@ -131,6 +132,7 @@ type Server struct {
 	wifiManagement     *wifiapp.Management      // Wi-Fi settings/scan/status/connect use-case (ADR-0016 phase 2)
 	wifiDiscovery      *wifiapp.Discovery       // Enhanced Wi-Fi discovery use-case (ADR-0016 phase 2)
 	settingsStore      *settingsapp.Persistence // Settings-to-profile persistence use-case (ADR-0016 phase 3)
+	profiles           *profilesapp.Service     // Profile CRUD/active/import use-case (ADR-0016 phase 3)
 	tlsFingerprint     tlsFingerprintCache      // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
 
@@ -249,6 +251,9 @@ func NewServer(
 	// Wire the settings-persistence use-case (ADR-0016 phase 3). The adapter
 	// resolves the database lazily, so it tolerates a nil or later-set db.
 	s.initSettingsUseCase()
+
+	// Wire the profiles use-case (ADR-0016 phase 3), also over the lazy db.
+	s.initProfilesUseCase()
 
 	// Initialize vulnerability scanner if enabled
 	s.initVulnerabilityScanner(cfg)

--- a/internal/profiles/app/profiles.go
+++ b/internal/profiles/app/profiles.go
@@ -1,0 +1,329 @@
+// Package profilesapp holds the profiles application (use-case) layer
+// (ADR-0016 strangle phase 3). It owns the CRUD, active-profile resolution,
+// duplicate, and import/export orchestration that previously lived in the
+// api.Server profile handlers, behind a narrow consumer-defined Store port — so
+// handlers depend on a use-case instead of reaching into the database
+// repositories. Handlers keep transport concerns (decode/encode, localized
+// error mapping), license feature-gating, and the config-apply/SSE side effects.
+package profilesapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Sentinel errors. The use-case returns these so handlers can map each to the
+// exact HTTP status + localized message the pre-strangle code used, without the
+// app layer importing the database or i18n packages.
+var (
+	ErrNotFound      = errors.New("profile not found")
+	ErrNameExists    = errors.New("profile name already exists")
+	ErrNameRequired  = errors.New("profile name is required")
+	ErrIDRequired    = errors.New("profile id is required")
+	ErrDeleteDefault = errors.New("cannot delete the default profile")
+	ErrDeleteActive  = errors.New("cannot delete the active profile")
+
+	// ErrActiveLookup and the ErrNoActiveOrDefault/ErrDefaultLookup/
+	// ErrActiveNotFound cases below each map to a distinct active-profile
+	// handler message, preserving the pre-strangle responses.
+	ErrActiveLookup      = errors.New("failed to read the active profile id")
+	ErrNoActiveOrDefault = errors.New("no active or default profile")
+	ErrDefaultLookup     = errors.New("failed to read the default profile")
+	ErrActiveNotFound    = errors.New("active profile missing and no default")
+)
+
+// Profile is the use-case profile model. The adapter maps it to/from
+// database.Profile so the app layer stays free of persistence types.
+type Profile struct {
+	ID          string
+	Name        string
+	Description string
+	ConfigJSON  string
+	IsDefault   bool
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// NewProfile is the input for Create.
+type NewProfile struct {
+	Name        string
+	Description string
+	ConfigJSON  string
+	IsDefault   bool
+}
+
+// ProfileUpdate is the input for Update. Name "" keeps the existing name and a
+// nil ConfigJSON keeps the existing config; Description and IsDefault are always
+// applied — mirroring the pre-strangle handler's partial-update semantics.
+type ProfileUpdate struct {
+	Name        string
+	Description string
+	ConfigJSON  *string
+	IsDefault   bool
+}
+
+// ImportItem is one entry in an Import request.
+type ImportItem struct {
+	Name        string
+	Description string
+	ConfigJSON  string
+}
+
+// ImportResult tallies an Import run.
+type ImportResult struct {
+	Created int
+	Updated int
+	Skipped int
+	Errors  []string
+}
+
+// Store is the persistence surface the profiles use-case needs, defined at the
+// consumer (ADR-0016). The adapter satisfies it over the database Profiles and
+// Settings repositories, mapping their ErrProfileNotFound/ErrProfileNameExists
+// to ErrNotFound/ErrNameExists.
+type Store interface {
+	List(ctx context.Context) ([]Profile, error)
+	Get(ctx context.Context, id string) (Profile, error)
+	// GetByName returns ok=false (and a nil error) when no profile has the name.
+	GetByName(ctx context.Context, name string) (Profile, bool, error)
+	GetDefault(ctx context.Context) (Profile, error)
+	Create(ctx context.Context, p Profile) error
+	Update(ctx context.Context, p Profile) error
+	Delete(ctx context.Context, id string) error
+	Count(ctx context.Context) (int, error)
+	ActiveID(ctx context.Context) (string, error)
+	SetActiveID(ctx context.Context, id string) error
+}
+
+// Service is the profiles use-case.
+type Service struct {
+	store Store
+}
+
+// NewService builds the use-case over its Store port.
+func NewService(store Store) *Service {
+	return &Service{store: store}
+}
+
+// List returns all profiles.
+func (s *Service) List(ctx context.Context) ([]Profile, error) {
+	return s.store.List(ctx)
+}
+
+// Count returns the number of stored profiles (used by the multi_client gate).
+func (s *Service) Count(ctx context.Context) (int, error) {
+	return s.store.Count(ctx)
+}
+
+// Get returns a profile by id (ErrNotFound when absent).
+func (s *Service) Get(ctx context.Context, id string) (Profile, error) {
+	return s.store.Get(ctx, id)
+}
+
+// Create validates and stores a new profile, returning the created record.
+func (s *Service) Create(ctx context.Context, in NewProfile) (Profile, error) {
+	if in.Name == "" {
+		return Profile{}, ErrNameRequired
+	}
+	p := Profile{
+		ID:          uuid.New().String(),
+		Name:        in.Name,
+		Description: in.Description,
+		ConfigJSON:  in.ConfigJSON,
+		IsDefault:   in.IsDefault,
+	}
+	if err := s.store.Create(ctx, p); err != nil {
+		return Profile{}, err
+	}
+	return p, nil
+}
+
+// Update applies a partial update to an existing profile.
+func (s *Service) Update(ctx context.Context, id string, u ProfileUpdate) (Profile, error) {
+	p, err := s.store.Get(ctx, id)
+	if err != nil {
+		return Profile{}, err
+	}
+	if u.Name != "" {
+		p.Name = u.Name
+	}
+	p.Description = u.Description
+	if u.ConfigJSON != nil {
+		p.ConfigJSON = *u.ConfigJSON
+	}
+	p.IsDefault = u.IsDefault
+	if updateErr := s.store.Update(ctx, p); updateErr != nil {
+		return Profile{}, updateErr
+	}
+	return p, nil
+}
+
+// Delete removes a profile, refusing to delete the default or active profile.
+func (s *Service) Delete(ctx context.Context, id string) error {
+	p, err := s.store.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if p.IsDefault {
+		return ErrDeleteDefault
+	}
+	// A failed active-id read must not block deletion (best-effort, as before).
+	if activeID, activeErr := s.store.ActiveID(ctx); activeErr == nil && activeID == id {
+		return ErrDeleteActive
+	}
+	return s.store.Delete(ctx, id)
+}
+
+// ActiveProfile resolves the active profile, falling back to the default and
+// self-healing a stale active-id pointer, mirroring the pre-strangle handler.
+func (s *Service) ActiveProfile(ctx context.Context) (Profile, error) {
+	activeID, err := s.store.ActiveID(ctx)
+	if err != nil {
+		return Profile{}, ErrActiveLookup
+	}
+
+	if activeID == "" {
+		def, defErr := s.store.GetDefault(ctx)
+		if defErr != nil {
+			if errors.Is(defErr, ErrNotFound) {
+				return Profile{}, ErrNoActiveOrDefault
+			}
+			return Profile{}, ErrDefaultLookup
+		}
+		return def, nil
+	}
+
+	p, err := s.store.Get(ctx, activeID)
+	if err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			return Profile{}, err
+		}
+		// Active profile was deleted — fall back to default and repoint.
+		def, defErr := s.store.GetDefault(ctx)
+		if defErr != nil {
+			return Profile{}, ErrActiveNotFound
+		}
+		_ = s.store.SetActiveID(ctx, def.ID)
+		return def, nil
+	}
+	return p, nil
+}
+
+// SetActiveProfile verifies the target exists, persists it as active, and
+// returns it (the handler then applies its config and broadcasts the change).
+func (s *Service) SetActiveProfile(ctx context.Context, id string) (Profile, error) {
+	if id == "" {
+		return Profile{}, ErrIDRequired
+	}
+	p, err := s.store.Get(ctx, id)
+	if err != nil {
+		return Profile{}, err
+	}
+	if setErr := s.store.SetActiveID(ctx, id); setErr != nil {
+		return Profile{}, setErr
+	}
+	return p, nil
+}
+
+// Duplicate copies a source profile under a new name (defaulting to
+// "<name> (Copy)"), retrying once with a timestamped name on a name collision.
+func (s *Service) Duplicate(ctx context.Context, sourceID, requestedName string) (Profile, error) {
+	source, err := s.store.Get(ctx, sourceID)
+	if err != nil {
+		return Profile{}, err
+	}
+
+	name := requestedName
+	if name == "" {
+		name = source.Name + " (Copy)"
+	}
+	dup := Profile{
+		ID:          uuid.New().String(),
+		Name:        name,
+		Description: source.Description,
+		ConfigJSON:  source.ConfigJSON,
+		IsDefault:   false, // duplicates are never default
+	}
+
+	err = s.store.Create(ctx, dup)
+	if err == nil {
+		return dup, nil
+	}
+	if !errors.Is(err, ErrNameExists) {
+		return Profile{}, err
+	}
+	// Retry with a timestamp suffix.
+	dup.Name = fmt.Sprintf("%s (%s)", source.Name, time.Now().Format("2006-01-02 15:04"))
+	if retryErr := s.store.Create(ctx, dup); retryErr != nil {
+		return Profile{}, ErrNameExists
+	}
+	return dup, nil
+}
+
+// Import creates or (when overwrite is set) updates each profile, never marking
+// imports as default. It collects per-item errors rather than failing the batch.
+func (s *Service) Import(ctx context.Context, items []ImportItem, overwrite bool) ImportResult {
+	result := ImportResult{Errors: make([]string, 0)}
+
+	for i, item := range items {
+		if item.Name == "" {
+			result.Errors = append(result.Errors, fmt.Sprintf("Profile %d: name is required", i+1))
+			result.Skipped++
+			continue
+		}
+
+		// Matches the pre-strangle handler, which ignored a GetByName error and
+		// branched only on presence.
+		existing, found, _ := s.store.GetByName(ctx, item.Name)
+		if found {
+			s.importExisting(ctx, existing, item, overwrite, &result)
+			continue
+		}
+
+		p := Profile{
+			ID:          uuid.New().String(),
+			Name:        item.Name,
+			Description: item.Description,
+			ConfigJSON:  item.ConfigJSON,
+			IsDefault:   false,
+		}
+		if err := s.store.Create(ctx, p); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("Profile '%s': failed to create - %v", item.Name, err))
+			result.Skipped++
+			continue
+		}
+		result.Created++
+	}
+
+	return result
+}
+
+func (s *Service) importExisting(
+	ctx context.Context,
+	existing Profile,
+	item ImportItem,
+	overwrite bool,
+	result *ImportResult,
+) {
+	if !overwrite {
+		result.Errors = append(
+			result.Errors,
+			fmt.Sprintf("Profile '%s': already exists (use overwrite=true to update)", item.Name),
+		)
+		result.Skipped++
+		return
+	}
+
+	existing.Description = item.Description
+	existing.ConfigJSON = item.ConfigJSON
+	if err := s.store.Update(ctx, existing); err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("Profile '%s': failed to update - %v", item.Name, err))
+		result.Skipped++
+		return
+	}
+	result.Updated++
+}

--- a/internal/profiles/app/profiles_test.go
+++ b/internal/profiles/app/profiles_test.go
@@ -1,0 +1,260 @@
+package profilesapp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
+)
+
+// fakeStore is an in-memory Store for use-case tests.
+type fakeStore struct {
+	byID       map[string]profilesapp.Profile
+	activeID   string
+	createErr  error
+	failGetDef bool
+}
+
+func newFakeStore() *fakeStore { return &fakeStore{byID: map[string]profilesapp.Profile{}} }
+
+func (f *fakeStore) List(context.Context) ([]profilesapp.Profile, error) {
+	out := make([]profilesapp.Profile, 0, len(f.byID))
+	for _, p := range f.byID {
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+func (f *fakeStore) Get(_ context.Context, id string) (profilesapp.Profile, error) {
+	p, ok := f.byID[id]
+	if !ok {
+		return profilesapp.Profile{}, profilesapp.ErrNotFound
+	}
+	return p, nil
+}
+
+func (f *fakeStore) GetByName(_ context.Context, name string) (profilesapp.Profile, bool, error) {
+	for _, p := range f.byID {
+		if p.Name == name {
+			return p, true, nil
+		}
+	}
+	return profilesapp.Profile{}, false, nil
+}
+
+func (f *fakeStore) GetDefault(context.Context) (profilesapp.Profile, error) {
+	if f.failGetDef {
+		return profilesapp.Profile{}, errors.New("db down")
+	}
+	for _, p := range f.byID {
+		if p.IsDefault {
+			return p, nil
+		}
+	}
+	return profilesapp.Profile{}, profilesapp.ErrNotFound
+}
+
+func (f *fakeStore) Create(_ context.Context, p profilesapp.Profile) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	for _, ex := range f.byID {
+		if ex.Name == p.Name {
+			return profilesapp.ErrNameExists
+		}
+	}
+	f.byID[p.ID] = p
+	return nil
+}
+
+func (f *fakeStore) Update(_ context.Context, p profilesapp.Profile) error {
+	f.byID[p.ID] = p
+	return nil
+}
+
+func (f *fakeStore) Delete(_ context.Context, id string) error { delete(f.byID, id); return nil }
+func (f *fakeStore) Count(context.Context) (int, error)        { return len(f.byID), nil }
+func (f *fakeStore) ActiveID(context.Context) (string, error)  { return f.activeID, nil }
+func (f *fakeStore) SetActiveID(_ context.Context, id string) error {
+	f.activeID = id
+	return nil
+}
+
+func ctx() context.Context { return context.Background() }
+
+func TestCreateValidatesNameAndStores(t *testing.T) {
+	svc := profilesapp.NewService(newFakeStore())
+
+	if _, err := svc.Create(ctx(), profilesapp.NewProfile{Name: ""}); !errors.Is(err, profilesapp.ErrNameRequired) {
+		t.Fatalf("empty name should be ErrNameRequired, got %v", err)
+	}
+
+	p, err := svc.Create(ctx(), profilesapp.NewProfile{Name: "alpha", ConfigJSON: `{"a":1}`})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if p.ID == "" || p.Name != "alpha" {
+		t.Fatalf("unexpected created profile: %+v", p)
+	}
+
+	if _, dupErr := svc.Create(ctx(), profilesapp.NewProfile{Name: "alpha"}); !errors.Is(
+		dupErr,
+		profilesapp.ErrNameExists,
+	) {
+		t.Fatalf("duplicate name should be ErrNameExists, got %v", dupErr)
+	}
+}
+
+func TestUpdatePartialSemantics(t *testing.T) {
+	store := newFakeStore()
+	store.byID["p1"] = profilesapp.Profile{ID: "p1", Name: "orig", Description: "d", ConfigJSON: "{}"}
+	svc := profilesapp.NewService(store)
+
+	// Empty name keeps existing; nil config keeps existing; description always applied.
+	got, err := svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{Name: "", Description: "new", ConfigJSON: nil})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if got.Name != "orig" || got.Description != "new" || got.ConfigJSON != "{}" {
+		t.Fatalf("partial update mismatch: %+v", got)
+	}
+
+	cfg := `{"x":2}`
+	got, _ = svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{Name: "renamed", ConfigJSON: &cfg})
+	if got.Name != "renamed" || got.ConfigJSON != cfg {
+		t.Fatalf("full update mismatch: %+v", got)
+	}
+
+	if _, missErr := svc.Update(ctx(), "missing", profilesapp.ProfileUpdate{}); !errors.Is(
+		missErr,
+		profilesapp.ErrNotFound,
+	) {
+		t.Fatalf("update missing should be ErrNotFound, got %v", missErr)
+	}
+}
+
+func TestDeleteGuards(t *testing.T) {
+	store := newFakeStore()
+	store.byID["def"] = profilesapp.Profile{ID: "def", Name: "default", IsDefault: true}
+	store.byID["act"] = profilesapp.Profile{ID: "act", Name: "active"}
+	store.byID["ok"] = profilesapp.Profile{ID: "ok", Name: "ok"}
+	store.activeID = "act"
+	svc := profilesapp.NewService(store)
+
+	if err := svc.Delete(ctx(), "def"); !errors.Is(err, profilesapp.ErrDeleteDefault) {
+		t.Fatalf("deleting default should be ErrDeleteDefault, got %v", err)
+	}
+	if err := svc.Delete(ctx(), "act"); !errors.Is(err, profilesapp.ErrDeleteActive) {
+		t.Fatalf("deleting active should be ErrDeleteActive, got %v", err)
+	}
+	if err := svc.Delete(ctx(), "ok"); err != nil {
+		t.Fatalf("deleting normal profile: %v", err)
+	}
+	if _, ok := store.byID["ok"]; ok {
+		t.Fatal("profile 'ok' should have been deleted")
+	}
+}
+
+func TestActiveProfileResolution(t *testing.T) {
+	t.Run("explicit active", func(t *testing.T) {
+		store := newFakeStore()
+		store.byID["p1"] = profilesapp.Profile{ID: "p1", Name: "one"}
+		store.activeID = "p1"
+		got, err := profilesapp.NewService(store).ActiveProfile(ctx())
+		if err != nil || got.ID != "p1" {
+			t.Fatalf("want p1, got %+v err=%v", got, err)
+		}
+	})
+
+	t.Run("falls back to default when unset", func(t *testing.T) {
+		store := newFakeStore()
+		store.byID["d"] = profilesapp.Profile{ID: "d", Name: "def", IsDefault: true}
+		got, err := profilesapp.NewService(store).ActiveProfile(ctx())
+		if err != nil || got.ID != "d" {
+			t.Fatalf("want default d, got %+v err=%v", got, err)
+		}
+	})
+
+	t.Run("no active and no default", func(t *testing.T) {
+		_, err := profilesapp.NewService(newFakeStore()).ActiveProfile(ctx())
+		if !errors.Is(err, profilesapp.ErrNoActiveOrDefault) {
+			t.Fatalf("want ErrNoActiveOrDefault, got %v", err)
+		}
+	})
+
+	t.Run("stale active self-heals to default", func(t *testing.T) {
+		store := newFakeStore()
+		store.byID["d"] = profilesapp.Profile{ID: "d", Name: "def", IsDefault: true}
+		store.activeID = "ghost" // points at a deleted profile
+		got, err := profilesapp.NewService(store).ActiveProfile(ctx())
+		if err != nil || got.ID != "d" {
+			t.Fatalf("want self-heal to d, got %+v err=%v", got, err)
+		}
+		if store.activeID != "d" {
+			t.Fatalf("active id should be repointed to d, got %q", store.activeID)
+		}
+	})
+}
+
+func TestSetActiveProfile(t *testing.T) {
+	store := newFakeStore()
+	store.byID["p1"] = profilesapp.Profile{ID: "p1", Name: "one"}
+	svc := profilesapp.NewService(store)
+
+	if _, err := svc.SetActiveProfile(ctx(), ""); !errors.Is(err, profilesapp.ErrIDRequired) {
+		t.Fatalf("empty id should be ErrIDRequired, got %v", err)
+	}
+	if _, err := svc.SetActiveProfile(ctx(), "missing"); !errors.Is(err, profilesapp.ErrNotFound) {
+		t.Fatalf("missing id should be ErrNotFound, got %v", err)
+	}
+	p, err := svc.SetActiveProfile(ctx(), "p1")
+	if err != nil || p.ID != "p1" || store.activeID != "p1" {
+		t.Fatalf("set active failed: %+v err=%v active=%q", p, err, store.activeID)
+	}
+}
+
+func TestDuplicateRetriesOnNameCollision(t *testing.T) {
+	store := newFakeStore()
+	store.byID["src"] = profilesapp.Profile{ID: "src", Name: "src", ConfigJSON: `{"k":1}`}
+	store.byID["copy"] = profilesapp.Profile{ID: "copy", Name: "src (Copy)"} // forces first-attempt collision
+	svc := profilesapp.NewService(store)
+
+	dup, err := svc.Duplicate(ctx(), "src", "")
+	if err != nil {
+		t.Fatalf("duplicate: %v", err)
+	}
+	if dup.Name == "src (Copy)" {
+		t.Fatalf("expected timestamped retry name, got %q", dup.Name)
+	}
+	if dup.ConfigJSON != `{"k":1}` || dup.IsDefault {
+		t.Fatalf("duplicate should copy config and not be default: %+v", dup)
+	}
+}
+
+func TestImportCreateUpdateSkip(t *testing.T) {
+	store := newFakeStore()
+	store.byID["e"] = profilesapp.Profile{ID: "e", Name: "exists", ConfigJSON: "{}"}
+	svc := profilesapp.NewService(store)
+
+	res := svc.Import(ctx(), []profilesapp.ImportItem{
+		{Name: "fresh", ConfigJSON: `{"a":1}`},
+		{Name: ""},                              // skipped: name required
+		{Name: "exists", ConfigJSON: `{"b":2}`}, // skipped: no overwrite
+	}, false)
+
+	if res.Created != 1 || res.Skipped != 2 || res.Updated != 0 {
+		t.Fatalf("import(no overwrite) tally: %+v", res)
+	}
+	if len(res.Errors) != 2 {
+		t.Fatalf("expected 2 errors, got %v", res.Errors)
+	}
+
+	res = svc.Import(ctx(), []profilesapp.ImportItem{{Name: "exists", ConfigJSON: `{"c":3}`}}, true)
+	if res.Updated != 1 || res.Created != 0 || res.Skipped != 0 {
+		t.Fatalf("import(overwrite) tally: %+v", res)
+	}
+	if store.byID["e"].ConfigJSON != `{"c":3}` {
+		t.Fatalf("overwrite should update config, got %q", store.byID["e"].ConfigJSON)
+	}
+}


### PR DESCRIPTION
## Summary

ADR-0016 strangle **phase 3** continued (after settings #1550): move the profile
CRUD, active-profile resolution, duplicate, and import/export orchestration out of
`api.Server` into a consumer-driven use-case. Handlers become decode → use-case →
encode; the `s.db().Profiles()/Settings()` reach-through is gone.

## What changed

- **`internal/profiles/app` (new, `profilesapp`)** — a `Service` over a narrow
  `Store` port. Owns validation, the active-profile **default fallback + stale-pointer
  self-heal**, the duplicate **name-collision retry**, and the import
  create/update/skip loop. **Sentinel errors** let handlers map each to the exact
  HTTP status + localized message the old code used (incl. the four distinct
  active-resolution cases).
- **`internal/api/profiles_usecases.go` (new)** — adapter over the database
  `Profiles` + `Settings` repos (lazy `db` accessor), mapping
  `database.Profile` ↔ the use-case model and `ErrProfile*` → the sentinels.
- **`handlers_profiles.go`** — all 6 CRUD handlers + active/duplicate/import/export
  delegate; the `multi_client` gate counts via the use-case. License gating,
  config-apply/Save, and the SSE broadcast stay in the handler (transport/policy).
  `handleExistingProfileImport` is deleted.

## Testing

- `profilesapp` unit tests: create/update/delete guards, all four active-resolution
  branches, duplicate retry, import tally.
- New internal api **integration test** vs a real DB: proves the adapter mapping and
  `ErrProfile*` → sentinel translation (create dup → `ErrNameExists`, missing →
  `ErrNotFound`, delete active/default guards).
- golden HTTP harness **byte-identical**; `golangci-lint run ./...` **0 issues**;
  full `go test ./...` green.

## Notes

- 500-level error *messages* for a couple of rare non-sentinel DB failures are
  consolidated (same `ErrCode`, status unchanged) — status codes and all
  success/validation/conflict/not-found behavior are preserved.
- **M5 ADR-0016 phase 3 status:** settings ✅ (#1550), profiles ✅ (this PR);
  **network** is the last slice.