### PR TITLE
refactor(api): strangle ip-config + mtu handlers into networkapp (ADR-0016)

### DIFF
--- a/internal/api/handlers_network.go
+++ b/internal/api/handlers_network.go
@@ -5,14 +5,15 @@ package api
 // Related handlers moved to: handlers_wifi.go, handlers_vlan.go, handlers_cable.go
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 
-	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/dhcp"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/netif"
+	networkapp "github.com/MustardSeedNetworks/seed/internal/network/app"
 	"github.com/MustardSeedNetworks/seed/internal/phy"
 	"github.com/MustardSeedNetworks/seed/internal/validation"
 )
@@ -761,49 +762,14 @@ func (s *Server) handleIPSettings(w http.ResponseWriter, r *http.Request) {
 
 // handleIPSettingsGet returns the current IP configuration settings.
 func (s *Server) handleIPSettingsGet(w http.ResponseWriter, _ *http.Request) {
-	resp := IPSettingsResponse{
-		Mode: s.config.IP.Mode,
-	}
-
-	if s.config.IP.Static != nil {
-		resp.Address = s.config.IP.Static.Address
-		resp.Netmask = s.config.IP.Static.Netmask
-		resp.Gateway = s.config.IP.Static.Gateway
-		resp.DNS = s.config.IP.Static.DNS
-	}
-
-	sendJSONResponse(w, nil, http.StatusOK, resp)
-}
-
-// applyStaticIPConfig applies static IP configuration, returns error message on failure.
-func (s *Server) applyStaticIPConfig(
-	iface string,
-	req *IPSettingsRequest,
-	logger *slog.Logger,
-) error {
-	cfg := &netif.StaticIPConfig{
-		Address: req.Address, Netmask: req.Netmask, Gateway: req.Gateway, DNS: req.DNS,
-	}
-	if err := s.netManager().ConfigureStaticIP(iface, cfg); err != nil {
-		logger.Error("Failed to configure static IP", "error", err, "interface", iface)
-		return err
-	}
-	s.config.IP.Mode = ipModeStatic
-	s.config.IP.Static = &config.StaticIP{
-		Address: req.Address, Netmask: req.Netmask, Gateway: req.Gateway, DNS: req.DNS,
-	}
-	return nil
-}
-
-// applyDHCPConfig applies DHCP configuration, returns error on failure.
-func (s *Server) applyDHCPConfig(iface string, logger *slog.Logger) error {
-	if err := s.netManager().ConfigureDHCP(iface); err != nil {
-		logger.Error("Failed to configure DHCP", "error", err, "interface", iface)
-		return err
-	}
-	s.config.IP.Mode = ipModeDHCP
-	s.config.IP.Static = nil
-	return nil
+	st := s.networkIP.Settings()
+	sendJSONResponse(w, nil, http.StatusOK, IPSettingsResponse{
+		Mode:    st.Mode,
+		Address: st.Address,
+		Netmask: st.Netmask,
+		Gateway: st.Gateway,
+		DNS:     st.DNS,
+	})
 }
 
 // handleIPSettingsPut updates the IP configuration settings.
@@ -819,69 +785,12 @@ func (s *Server) handleIPSettingsPut(
 		return
 	}
 
-	if req.Mode != ipModeDHCP && req.Mode != ipModeStatic {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusBadRequest,
-			ErrCodeValidation,
-			localizer.T("errors.netif.invalidMode"),
-			"",
-		)
-		return
-	}
-
-	s.config.Lock()
-	currentIface := s.getInterfaceFromRequest(r)
-
-	var configErr error
-	if req.Mode == ipModeStatic {
-		configErr = s.applyStaticIPConfig(currentIface, &req, logger)
-	} else {
-		configErr = s.applyDHCPConfig(currentIface, logger)
-	}
-
-	s.config.Unlock()
-
-	if configErr != nil {
-		errMsg := localizer.T("errors.netif.staticConfigFailed")
-		if req.Mode == ipModeDHCP {
-			errMsg = localizer.T("errors.netif.dhcpConfigFailed")
-		}
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			errMsg,
-			"",
-		)
-		return
-	}
-
-	if err := s.config.Save(s.configPath); err != nil {
-		logger.ErrorContext(r.Context(), "Failed to save config", "error", err)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			localizer.T("errors.config.failedToSave"),
-			"",
-		)
-		return
-	}
-
-	if err := s.netManager().RefreshInterfaces(); err != nil {
-		logger.ErrorContext(r.Context(), "Failed to refresh interfaces", "error", err)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			localizer.T("errors.netif.refreshFailed"),
-			"",
-		)
+	iface := s.getInterfaceFromRequest(r)
+	err := s.networkIP.Apply(iface, req.Mode, networkapp.StaticIP{
+		Address: req.Address, Netmask: req.Netmask, Gateway: req.Gateway, DNS: req.DNS,
+	})
+	if err != nil {
+		s.writeIPApplyError(w, r, logger, localizer, err)
 		return
 	}
 
@@ -891,6 +800,36 @@ func (s *Server) handleIPSettingsPut(
 		http.StatusOK,
 		map[string]string{"status": statusSuccess, "message": "IP configuration updated"},
 	)
+}
+
+// writeIPApplyError maps an IPService.Apply sentinel to the pre-strangle HTTP
+// response (status + localized message).
+func (s *Server) writeIPApplyError(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	localizer *i18n.Localizer,
+	err error,
+) {
+	switch {
+	case errors.Is(err, networkapp.ErrInvalidMode):
+		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
+			ErrCodeValidation, localizer.T("errors.netif.invalidMode"), "")
+	case errors.Is(err, networkapp.ErrStaticConfig):
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, localizer.T("errors.netif.staticConfigFailed"), "")
+	case errors.Is(err, networkapp.ErrDHCPConfig):
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, localizer.T("errors.netif.dhcpConfigFailed"), "")
+	case errors.Is(err, networkapp.ErrSave):
+		logger.ErrorContext(r.Context(), "Failed to save config", "error", err)
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, localizer.T("errors.config.failedToSave"), "")
+	default: // ErrRefresh
+		logger.ErrorContext(r.Context(), "Failed to refresh interfaces", "error", err)
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, localizer.T("errors.netif.refreshFailed"), "")
+	}
 }
 
 // handleSetMTU handles POST requests to set interface MTU.
@@ -929,14 +868,10 @@ func (s *Server) handleSetMTU(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Use current interface if not specified
-	iface := req.Interface
-	if iface == "" {
-		iface = s.netManager().GetCurrentInterface()
-	}
-
-	// Set the MTU
-	if err := s.netManager().SetMTU(iface, req.MTU); err != nil {
+	// Set the MTU (the use-case resolves the current interface when unset and
+	// refreshes best-effort).
+	iface, err := s.networkIP.SetMTU(req.Interface, req.MTU)
+	if err != nil {
 		logger.ErrorContext(r.Context(), "Failed to set MTU", "error", err, "interface", iface, "mtu", req.MTU)
 		sendErrorResponseWithDetails(
 			w,
@@ -947,11 +882,6 @@ func (s *Server) handleSetMTU(w http.ResponseWriter, r *http.Request) {
 			"",
 		)
 		return
-	}
-
-	// Refresh interface data
-	if err := s.netManager().RefreshInterfaces(); err != nil {
-		logging.GetLogger().WarnContext(r.Context(), "Failed to refresh interfaces after MTU change", "error", err)
 	}
 
 	sendJSONResponse(w, nil, http.StatusOK, map[string]any{

--- a/internal/api/network_usecases.go
+++ b/internal/api/network_usecases.go
@@ -1,0 +1,87 @@
+package api
+
+// network_usecases.go wires the API layer to the network application (use-case)
+// service (ADR-0016 strangle phase 3). The adapters implement the narrow
+// networkapp ports over the netif manager and the live config, so the IP-config
+// and MTU handlers depend on a use-case instead of reaching into s.netManager()
+// and s.config directly.
+
+import (
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/netif"
+	networkapp "github.com/MustardSeedNetworks/seed/internal/network/app"
+)
+
+// networkHardware implements networkapp.Hardware over the netif manager. The
+// manager is resolved lazily so a later-set manager (tests) is honored.
+type networkHardware struct {
+	mgr func() *netif.Manager
+}
+
+func (a networkHardware) ConfigureStaticIP(iface string, ip networkapp.StaticIP) error {
+	return a.mgr().ConfigureStaticIP(iface, &netif.StaticIPConfig{
+		Address: ip.Address,
+		Netmask: ip.Netmask,
+		Gateway: ip.Gateway,
+		DNS:     ip.DNS,
+	})
+}
+
+func (a networkHardware) ConfigureDHCP(iface string) error { return a.mgr().ConfigureDHCP(iface) }
+func (a networkHardware) SetMTU(iface string, mtu int) error {
+	return a.mgr().SetMTU(iface, mtu)
+}
+func (a networkHardware) CurrentInterface() string { return a.mgr().GetCurrentInterface() }
+func (a networkHardware) RefreshInterfaces() error { return a.mgr().RefreshInterfaces() }
+
+// networkConfigStore implements networkapp.ConfigStore over the live config,
+// owning the lock + on-disk save the port abstracts away.
+type networkConfigStore struct {
+	cfg  *config.Config
+	path string
+}
+
+func (c networkConfigStore) IPSettings() networkapp.Settings {
+	c.cfg.RLock()
+	defer c.cfg.RUnlock()
+
+	s := networkapp.Settings{Mode: c.cfg.IP.Mode}
+	if c.cfg.IP.Static != nil {
+		s.Address = c.cfg.IP.Static.Address
+		s.Netmask = c.cfg.IP.Static.Netmask
+		s.Gateway = c.cfg.IP.Static.Gateway
+		s.DNS = c.cfg.IP.Static.DNS
+	}
+	return s
+}
+
+func (c networkConfigStore) PersistStatic(ip networkapp.StaticIP) error {
+	// Lock for the in-memory mutation only; Save acquires its own RLock and so
+	// must run unlocked to avoid the historic deadlock (fixes #783).
+	c.cfg.Lock()
+	c.cfg.IP.Mode = ipModeStatic
+	c.cfg.IP.Static = &config.StaticIP{
+		Address: ip.Address,
+		Netmask: ip.Netmask,
+		Gateway: ip.Gateway,
+		DNS:     ip.DNS,
+	}
+	c.cfg.Unlock()
+	return c.cfg.Save(c.path)
+}
+
+func (c networkConfigStore) PersistDHCP() error {
+	c.cfg.Lock()
+	c.cfg.IP.Mode = ipModeDHCP
+	c.cfg.IP.Static = nil
+	c.cfg.Unlock()
+	return c.cfg.Save(c.path)
+}
+
+// initNetworkUseCase builds the IP-config + MTU use-case (ADR-0016 phase 3).
+func (s *Server) initNetworkUseCase() {
+	s.networkIP = networkapp.NewIPService(
+		networkHardware{mgr: s.netManager},
+		networkConfigStore{cfg: s.config, path: s.configPath},
+	)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/mibdb"
 	"github.com/MustardSeedNetworks/seed/internal/netif"
+	networkapp "github.com/MustardSeedNetworks/seed/internal/network/app"
 	"github.com/MustardSeedNetworks/seed/internal/oauth"
 	"github.com/MustardSeedNetworks/seed/internal/paths"
 	"github.com/MustardSeedNetworks/seed/internal/pipeline/publicip"
@@ -133,6 +134,7 @@ type Server struct {
 	wifiDiscovery      *wifiapp.Discovery       // Enhanced Wi-Fi discovery use-case (ADR-0016 phase 2)
 	settingsStore      *settingsapp.Persistence // Settings-to-profile persistence use-case (ADR-0016 phase 3)
 	profiles           *profilesapp.Service     // Profile CRUD/active/import use-case (ADR-0016 phase 3)
+	networkIP          *networkapp.IPService    // IP-config + MTU use-case (ADR-0016 phase 3)
 	tlsFingerprint     tlsFingerprintCache      // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
 
@@ -254,6 +256,9 @@ func NewServer(
 
 	// Wire the profiles use-case (ADR-0016 phase 3), also over the lazy db.
 	s.initProfilesUseCase()
+
+	// Wire the network IP-config + MTU use-case (ADR-0016 phase 3).
+	s.initNetworkUseCase()
 
 	// Initialize vulnerability scanner if enabled
 	s.initVulnerabilityScanner(cfg)

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -149,6 +149,12 @@ func NewTestServerWithConfig(cfg *config.Config) *Server {
 	// Initialize SSE hub
 	s.services.RealTime.SSEHub = NewSSEHub()
 
+	// Wire the ADR-0016 use-cases the same way NewServer does, so handlers that
+	// depend on them work under the test harness.
+	s.initSettingsUseCase()
+	s.initProfilesUseCase()
+	s.initNetworkUseCase()
+
 	// Setup routes
 	s.setupRoutes()
 

--- a/internal/network/app/ipconfig.go
+++ b/internal/network/app/ipconfig.go
@@ -1,0 +1,122 @@
+// Package networkapp holds the network application (use-case) layer
+// (ADR-0016 strangle phase 3). It owns the IP-configuration and MTU
+// orchestration that previously lived in the api.Server network handlers —
+// the multi-step "configure the interface, persist the config, refresh"
+// sequence — behind narrow consumer-defined ports over the netif manager and
+// the config store. Handlers keep transport concerns: request decode, input
+// validation, interface-from-query resolution, and localized error mapping.
+package networkapp
+
+import "errors"
+
+// IP modes.
+const (
+	ModeDHCP   = "dhcp"
+	ModeStatic = "static"
+)
+
+// Sentinel errors, mapped by handlers to the pre-strangle HTTP responses.
+var (
+	ErrInvalidMode  = errors.New("invalid ip mode")
+	ErrStaticConfig = errors.New("static ip configuration failed")
+	ErrDHCPConfig   = errors.New("dhcp configuration failed")
+	ErrSave         = errors.New("failed to save configuration")
+	ErrRefresh      = errors.New("failed to refresh interfaces")
+	ErrSetMTU       = errors.New("failed to set mtu")
+)
+
+// StaticIP is the use-case static-IP model.
+type StaticIP struct {
+	Address string
+	Netmask string
+	Gateway string
+	DNS     []string
+}
+
+// Settings is the read model for the IP-settings GET.
+type Settings struct {
+	Mode    string
+	Address string
+	Netmask string
+	Gateway string
+	DNS     []string
+}
+
+// Hardware is the netif surface the use-case drives, defined at the consumer
+// (ADR-0016) and satisfied by an adapter over *netif.Manager.
+type Hardware interface {
+	ConfigureStaticIP(iface string, ip StaticIP) error
+	ConfigureDHCP(iface string) error
+	SetMTU(iface string, mtu int) error
+	CurrentInterface() string
+	RefreshInterfaces() error
+}
+
+// ConfigStore reads and persists the IP block. The adapter owns the config
+// locking and on-disk save.
+type ConfigStore interface {
+	IPSettings() Settings
+	PersistStatic(ip StaticIP) error
+	PersistDHCP() error
+}
+
+// IPService is the IP-configuration + MTU use-case.
+type IPService struct {
+	hw    Hardware
+	store ConfigStore
+}
+
+// NewIPService builds the use-case over its narrow dependencies.
+func NewIPService(hw Hardware, store ConfigStore) *IPService {
+	return &IPService{hw: hw, store: store}
+}
+
+// Settings returns the current IP configuration.
+func (s *IPService) Settings() Settings {
+	return s.store.IPSettings()
+}
+
+// Apply configures the interface for the requested mode, persists the resulting
+// config, then refreshes the interface table. Hardware configuration runs first
+// so the persisted config only changes after the interface accepts it; each step
+// maps to its own sentinel for faithful handler error mapping.
+func (s *IPService) Apply(iface, mode string, ip StaticIP) error {
+	switch mode {
+	case ModeStatic:
+		if err := s.hw.ConfigureStaticIP(iface, ip); err != nil {
+			return ErrStaticConfig
+		}
+		if err := s.store.PersistStatic(ip); err != nil {
+			return ErrSave
+		}
+	case ModeDHCP:
+		if err := s.hw.ConfigureDHCP(iface); err != nil {
+			return ErrDHCPConfig
+		}
+		if err := s.store.PersistDHCP(); err != nil {
+			return ErrSave
+		}
+	default:
+		return ErrInvalidMode
+	}
+
+	if err := s.hw.RefreshInterfaces(); err != nil {
+		return ErrRefresh
+	}
+	return nil
+}
+
+// SetMTU sets the interface MTU, defaulting to the current interface when iface
+// is empty, and refreshes interfaces best-effort. It returns the resolved
+// interface name so the handler can echo it.
+func (s *IPService) SetMTU(iface string, mtu int) (string, error) {
+	if iface == "" {
+		iface = s.hw.CurrentInterface()
+	}
+	if err := s.hw.SetMTU(iface, mtu); err != nil {
+		return iface, ErrSetMTU
+	}
+	// Refresh is best-effort: the MTU change already succeeded.
+	_ = s.hw.RefreshInterfaces()
+	return iface, nil
+}

--- a/internal/network/app/ipconfig_test.go
+++ b/internal/network/app/ipconfig_test.go
@@ -1,0 +1,149 @@
+package networkapp_test
+
+import (
+	"errors"
+	"testing"
+
+	networkapp "github.com/MustardSeedNetworks/seed/internal/network/app"
+)
+
+type fakeHW struct {
+	staticErr, dhcpErr, mtuErr, refreshErr error
+	staticIface, dhcpIface, mtuIface       string
+	mtu                                    int
+	current                                string
+	refreshed                              int
+}
+
+func (h *fakeHW) ConfigureStaticIP(iface string, _ networkapp.StaticIP) error {
+	h.staticIface = iface
+	return h.staticErr
+}
+
+func (h *fakeHW) ConfigureDHCP(iface string) error { h.dhcpIface = iface; return h.dhcpErr }
+
+func (h *fakeHW) SetMTU(iface string, mtu int) error {
+	h.mtuIface, h.mtu = iface, mtu
+	return h.mtuErr
+}
+func (h *fakeHW) CurrentInterface() string { return h.current }
+func (h *fakeHW) RefreshInterfaces() error { h.refreshed++; return h.refreshErr }
+
+type fakeStore struct {
+	settings    networkapp.Settings
+	persisted   string // "static" | "dhcp"
+	persistErr  error
+	persistedIP networkapp.StaticIP
+}
+
+func (s *fakeStore) IPSettings() networkapp.Settings { return s.settings }
+func (s *fakeStore) PersistStatic(ip networkapp.StaticIP) error {
+	s.persisted, s.persistedIP = "static", ip
+	return s.persistErr
+}
+func (s *fakeStore) PersistDHCP() error { s.persisted = "dhcp"; return s.persistErr }
+
+func TestApplyStaticHappyPath(t *testing.T) {
+	hw, store := &fakeHW{}, &fakeStore{}
+	svc := networkapp.NewIPService(hw, store)
+
+	err := svc.Apply("eth0", networkapp.ModeStatic, networkapp.StaticIP{Address: "10.0.0.5"})
+	if err != nil {
+		t.Fatalf("apply static: %v", err)
+	}
+	if hw.staticIface != "eth0" || store.persisted != "static" || hw.refreshed != 1 {
+		t.Fatalf(
+			"unexpected sequence: iface=%q persisted=%q refreshed=%d",
+			hw.staticIface,
+			store.persisted,
+			hw.refreshed,
+		)
+	}
+	if store.persistedIP.Address != "10.0.0.5" {
+		t.Fatalf("static ip not persisted: %+v", store.persistedIP)
+	}
+}
+
+func TestApplyDHCPHappyPath(t *testing.T) {
+	hw, store := &fakeHW{}, &fakeStore{}
+	if err := networkapp.NewIPService(hw, store).Apply("eth1", networkapp.ModeDHCP, networkapp.StaticIP{}); err != nil {
+		t.Fatalf("apply dhcp: %v", err)
+	}
+	if hw.dhcpIface != "eth1" || store.persisted != "dhcp" || hw.refreshed != 1 {
+		t.Fatalf("unexpected dhcp sequence")
+	}
+}
+
+func TestApplyErrorMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		hw   *fakeHW
+		st   *fakeStore
+		mode string
+		want error
+	}{
+		{"invalid mode", &fakeHW{}, &fakeStore{}, "bogus", networkapp.ErrInvalidMode},
+		{
+			"static hw fails",
+			&fakeHW{staticErr: errors.New("x")},
+			&fakeStore{},
+			networkapp.ModeStatic,
+			networkapp.ErrStaticConfig,
+		},
+		{
+			"dhcp hw fails",
+			&fakeHW{dhcpErr: errors.New("x")},
+			&fakeStore{},
+			networkapp.ModeDHCP,
+			networkapp.ErrDHCPConfig,
+		},
+		{
+			"persist fails",
+			&fakeHW{},
+			&fakeStore{persistErr: errors.New("x")},
+			networkapp.ModeStatic,
+			networkapp.ErrSave,
+		},
+		{
+			"refresh fails",
+			&fakeHW{refreshErr: errors.New("x")},
+			&fakeStore{},
+			networkapp.ModeStatic,
+			networkapp.ErrRefresh,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := networkapp.NewIPService(tc.hw, tc.st).Apply("eth0", tc.mode, networkapp.StaticIP{})
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("want %v, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestApplyDoesNotPersistWhenHardwareFails(t *testing.T) {
+	hw, store := &fakeHW{staticErr: errors.New("nope")}, &fakeStore{}
+	_ = networkapp.NewIPService(hw, store).Apply("eth0", networkapp.ModeStatic, networkapp.StaticIP{})
+	if store.persisted != "" {
+		t.Fatalf("config must not be persisted when hardware config fails, got %q", store.persisted)
+	}
+}
+
+func TestSetMTUResolvesCurrentInterface(t *testing.T) {
+	hw := &fakeHW{current: "wlan0"}
+	got, err := networkapp.NewIPService(hw, &fakeStore{}).SetMTU("", 9000)
+	if err != nil {
+		t.Fatalf("set mtu: %v", err)
+	}
+	if got != "wlan0" || hw.mtuIface != "wlan0" || hw.mtu != 9000 {
+		t.Fatalf("mtu resolution mismatch: got=%q iface=%q mtu=%d", got, hw.mtuIface, hw.mtu)
+	}
+}
+
+func TestSetMTUError(t *testing.T) {
+	hw := &fakeHW{mtuErr: errors.New("eio")}
+	if _, err := networkapp.NewIPService(hw, &fakeStore{}).SetMTU("eth0", 1500); !errors.Is(err, networkapp.ErrSetMTU) {
+		t.Fatalf("want ErrSetMTU, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

ADR-0016 strangle **phase 3 — final slice**. Moves the IP-configuration + MTU
orchestration out of `api.Server` into a use-case. Unlike settings/profiles, this
handler reaches into the **netif manager + config** (no database), so the use-case
wraps those.

## What changed

- **`internal/network/app` (new, `networkapp`)** — an `IPService` over narrow
  `Hardware` (netif) and `ConfigStore` (config) ports. `Apply()` runs the
  configure-interface → persist-config → refresh sequence **hardware-first** (config
  only changes once the interface accepts it); `SetMTU()` resolves the current
  interface and refreshes best-effort. Sentinel errors map to the exact pre-strangle
  HTTP responses.
- **`internal/api/network_usecases.go` (new)** — adapters over the netif manager
  (lazy accessor) and the live config (owning the `Lock`/`Save` the port hides);
  `initNetworkUseCase` wired in `NewServer` + the test harness.
- **`handlers_network.go`** — `handleIPSettingsGet/Put` + `handleSetMTU` become
  decode → use-case → encode; `applyStaticIPConfig`/`applyDHCPConfig` and the
  per-step `netManager()`/`config` reach-through are gone. The config lock now scopes
  the in-memory mutation only (not the hardware call) — a small correctness win over
  the previous over-broad lock.

## Scope note

The read-only interface-enumeration handlers (list/categorize/get/link) are thin
`netManager` passthroughs with no orchestration or db reach-through to strangle, so
they're intentionally left as-is (wrapping them would be ceremony without benefit).

## Testing

- `networkapp` unit tests: apply happy paths, the five `Apply` error mappings,
  **no-persist-on-hardware-failure**, MTU current-interface resolution.
- golden HTTP harness **byte-identical**; `golangci-lint run ./...` **0 issues**;
  full `go test ./...` green.

## M5 status: ADR-0016 phase 3 COMPLETE
settings ✅ (#1550) · profiles ✅ (#1554) · network ✅ (this PR).