### PR TITLE
refactor(api): strangle alert-rule handlers into alertsapp use-case (ADR-0016)

### DIFF
--- a/internal/alerts/app/rules.go
+++ b/internal/alerts/app/rules.go
@@ -1,0 +1,111 @@
+// Package alertsapp holds the alerts application (use-case) layer (ADR-0016
+// strangle). It owns the operator-defined alert-rule orchestration (and, over
+// time, the alert acknowledge/resolve flow) that previously reached into the
+// database repositories from the api.Server handlers, behind a narrow
+// consumer-defined Store port. Handlers keep transport concerns: request
+// decode, field validation, JSON encoding, and error→HTTP mapping.
+package alertsapp
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrRuleNotFound is returned when no alert rule has the given id.
+var ErrRuleNotFound = errors.New("alert rule not found")
+
+// ValidationError carries a repository-level validation message verbatim so the
+// handler can echo it as a 400, preserving the pre-strangle response body.
+type ValidationError struct{ Msg string }
+
+func (e *ValidationError) Error() string { return e.Msg }
+
+// Rule is the use-case alert-rule model. The adapter maps it to/from
+// database.AlertRule so the app layer stays free of persistence types.
+type Rule struct {
+	ID                   int64
+	Name                 string
+	Enabled              bool
+	MatchKind            string
+	MatchSeverity        string
+	MatchPayloadContains string
+	AlertType            string
+	AlertSeverity        string
+	AlertTitle           string
+	AlertMessage         string
+	WindowSeconds        int
+	ThresholdCount       int
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+// RuleStore is the persistence surface the rule use-case needs, defined at the
+// consumer (ADR-0016). The adapter satisfies it over the database AlertRules
+// repository, mapping ErrAlertRuleNotFound -> ErrRuleNotFound and the repo's
+// "alert_rules:"-prefixed validation errors -> *ValidationError.
+type RuleStore interface {
+	List(ctx context.Context, enabledOnly bool) ([]Rule, error)
+	Get(ctx context.Context, id int64) (Rule, error)
+	// Create stores r and returns it with the generated ID + timestamps.
+	Create(ctx context.Context, r Rule) (Rule, error)
+	Update(ctx context.Context, r Rule) error
+	Delete(ctx context.Context, id int64) error
+}
+
+// RuleService is the alert-rule use-case.
+type RuleService struct {
+	store RuleStore
+}
+
+// NewRuleService builds the use-case over its Store port.
+func NewRuleService(store RuleStore) *RuleService {
+	return &RuleService{store: store}
+}
+
+// minThreshold mirrors the pre-strangle max(threshold, 1): a rule fires on the
+// first matching event unless a higher count is set.
+func minThreshold(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// List returns alert rules, optionally only the enabled ones.
+func (s *RuleService) List(ctx context.Context, enabledOnly bool) ([]Rule, error) {
+	return s.store.List(ctx, enabledOnly)
+}
+
+// Get returns one alert rule (ErrRuleNotFound when absent).
+func (s *RuleService) Get(ctx context.Context, id int64) (Rule, error) {
+	return s.store.Get(ctx, id)
+}
+
+// Create stores a new rule and returns the persisted row.
+func (s *RuleService) Create(ctx context.Context, r Rule) (Rule, error) {
+	r.ID = 0
+	r.ThresholdCount = minThreshold(r.ThresholdCount)
+	return s.store.Create(ctx, r)
+}
+
+// Update writes the rule at id and returns the freshly-read row so callers see
+// the new updated_at; on a post-write read failure it echoes the written rule.
+func (s *RuleService) Update(ctx context.Context, id int64, r Rule) (Rule, error) {
+	r.ID = id
+	r.ThresholdCount = minThreshold(r.ThresholdCount)
+	if err := s.store.Update(ctx, r); err != nil {
+		return Rule{}, err
+	}
+	// Best-effort re-read so the echo reflects updated_at; the write already
+	// succeeded, so a failed re-read falls back to the written rule.
+	if current, getErr := s.store.Get(ctx, id); getErr == nil {
+		return current, nil
+	}
+	return r, nil
+}
+
+// Delete removes the rule at id (ErrRuleNotFound when absent).
+func (s *RuleService) Delete(ctx context.Context, id int64) error {
+	return s.store.Delete(ctx, id)
+}

--- a/internal/alerts/app/rules_test.go
+++ b/internal/alerts/app/rules_test.go
@@ -1,0 +1,139 @@
+package alertsapp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	alertsapp "github.com/MustardSeedNetworks/seed/internal/alerts/app"
+)
+
+type fakeRuleStore struct {
+	byID      map[int64]alertsapp.Rule
+	nextID    int64
+	createErr error
+	updateErr error
+}
+
+func newFakeRuleStore() *fakeRuleStore {
+	return &fakeRuleStore{byID: map[int64]alertsapp.Rule{}, nextID: 1}
+}
+
+func (f *fakeRuleStore) List(_ context.Context, enabledOnly bool) ([]alertsapp.Rule, error) {
+	out := make([]alertsapp.Rule, 0, len(f.byID))
+	for _, r := range f.byID {
+		if enabledOnly && !r.Enabled {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+func (f *fakeRuleStore) Get(_ context.Context, id int64) (alertsapp.Rule, error) {
+	r, ok := f.byID[id]
+	if !ok {
+		return alertsapp.Rule{}, alertsapp.ErrRuleNotFound
+	}
+	return r, nil
+}
+
+func (f *fakeRuleStore) Create(_ context.Context, r alertsapp.Rule) (alertsapp.Rule, error) {
+	if f.createErr != nil {
+		return alertsapp.Rule{}, f.createErr
+	}
+	r.ID = f.nextID
+	f.nextID++
+	f.byID[r.ID] = r
+	return r, nil
+}
+
+func (f *fakeRuleStore) Update(_ context.Context, r alertsapp.Rule) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	if _, ok := f.byID[r.ID]; !ok {
+		return alertsapp.ErrRuleNotFound
+	}
+	f.byID[r.ID] = r
+	return nil
+}
+
+func (f *fakeRuleStore) Delete(_ context.Context, id int64) error {
+	if _, ok := f.byID[id]; !ok {
+		return alertsapp.ErrRuleNotFound
+	}
+	delete(f.byID, id)
+	return nil
+}
+
+func ctx() context.Context { return context.Background() }
+
+func TestCreateNormalizesThresholdAndIgnoresInputID(t *testing.T) {
+	store := newFakeRuleStore()
+	svc := alertsapp.NewRuleService(store)
+
+	got, err := svc.Create(ctx(), alertsapp.Rule{ID: 999, Name: "n", ThresholdCount: 0})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if got.ID != 1 {
+		t.Fatalf("store should assign id, got %d", got.ID)
+	}
+	if got.ThresholdCount != 1 {
+		t.Fatalf("threshold should normalize to 1, got %d", got.ThresholdCount)
+	}
+}
+
+func TestCreateErrorPropagates(t *testing.T) {
+	store := newFakeRuleStore()
+	store.createErr = &alertsapp.ValidationError{Msg: "alert_rules: bad matchKind"}
+	svc := alertsapp.NewRuleService(store)
+
+	_, err := svc.Create(ctx(), alertsapp.Rule{Name: "n"})
+	var ve *alertsapp.ValidationError
+	if !errors.As(err, &ve) || ve.Msg != "alert_rules: bad matchKind" {
+		t.Fatalf("want ValidationError carrying the message, got %v", err)
+	}
+}
+
+func TestUpdateReadsBackAndMaps(t *testing.T) {
+	store := newFakeRuleStore()
+	created, _ := store.Create(ctx(), alertsapp.Rule{Name: "orig", ThresholdCount: 3})
+	svc := alertsapp.NewRuleService(store)
+
+	got, err := svc.Update(ctx(), created.ID, alertsapp.Rule{Name: "updated", ThresholdCount: 0})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if got.Name != "updated" || got.ThresholdCount != 1 {
+		t.Fatalf("update mismatch: %+v", got)
+	}
+
+	if _, missErr := svc.Update(ctx(), 404, alertsapp.Rule{Name: "x"}); !errors.Is(missErr, alertsapp.ErrRuleNotFound) {
+		t.Fatalf("update missing should be ErrRuleNotFound, got %v", missErr)
+	}
+}
+
+func TestGetDeleteNotFound(t *testing.T) {
+	svc := alertsapp.NewRuleService(newFakeRuleStore())
+	if _, err := svc.Get(ctx(), 1); !errors.Is(err, alertsapp.ErrRuleNotFound) {
+		t.Fatalf("get missing: %v", err)
+	}
+	if err := svc.Delete(ctx(), 1); !errors.Is(err, alertsapp.ErrRuleNotFound) {
+		t.Fatalf("delete missing: %v", err)
+	}
+}
+
+func TestListEnabledOnly(t *testing.T) {
+	store := newFakeRuleStore()
+	_, _ = store.Create(ctx(), alertsapp.Rule{Name: "on", Enabled: true})
+	_, _ = store.Create(ctx(), alertsapp.Rule{Name: "off", Enabled: false})
+	svc := alertsapp.NewRuleService(store)
+
+	all, _ := svc.List(ctx(), false)
+	enabled, _ := svc.List(ctx(), true)
+	if len(all) != 2 || len(enabled) != 1 {
+		t.Fatalf("enabled filter: all=%d enabled=%d", len(all), len(enabled))
+	}
+}

--- a/internal/api/alerts_usecases.go
+++ b/internal/api/alerts_usecases.go
@@ -1,0 +1,114 @@
+package api
+
+// alerts_usecases.go wires the API layer to the alerts application (use-case)
+// service (ADR-0016 strangle). The adapter implements the narrow
+// alertsapp.RuleStore port over the database AlertRules repository, mapping the
+// database.AlertRule row to the use-case model and the repo's
+// ErrAlertRuleNotFound / "alert_rules:"-prefixed validation errors to the
+// use-case's sentinels.
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	alertsapp "github.com/MustardSeedNetworks/seed/internal/alerts/app"
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+// alertRuleStore implements alertsapp.RuleStore over the database repository.
+// The database is resolved lazily; handlers gate on s.db() != nil first.
+type alertRuleStore struct {
+	db func() *database.DB
+}
+
+func toAppRule(r *database.AlertRule) alertsapp.Rule {
+	return alertsapp.Rule{
+		ID:                   r.ID,
+		Name:                 r.Name,
+		Enabled:              r.Enabled,
+		MatchKind:            r.MatchKind,
+		MatchSeverity:        r.MatchSeverity,
+		MatchPayloadContains: r.MatchPayloadContains,
+		AlertType:            r.AlertType,
+		AlertSeverity:        r.AlertSeverity,
+		AlertTitle:           r.AlertTitle,
+		AlertMessage:         r.AlertMessage,
+		WindowSeconds:        r.WindowSeconds,
+		ThresholdCount:       r.ThresholdCount,
+		CreatedAt:            r.CreatedAt,
+		UpdatedAt:            r.UpdatedAt,
+	}
+}
+
+func toDBRule(r alertsapp.Rule) *database.AlertRule {
+	return &database.AlertRule{
+		ID:                   r.ID,
+		Name:                 r.Name,
+		Enabled:              r.Enabled,
+		MatchKind:            r.MatchKind,
+		MatchSeverity:        r.MatchSeverity,
+		MatchPayloadContains: r.MatchPayloadContains,
+		AlertType:            r.AlertType,
+		AlertSeverity:        r.AlertSeverity,
+		AlertTitle:           r.AlertTitle,
+		AlertMessage:         r.AlertMessage,
+		WindowSeconds:        r.WindowSeconds,
+		ThresholdCount:       r.ThresholdCount,
+		CreatedAt:            r.CreatedAt,
+		UpdatedAt:            r.UpdatedAt,
+	}
+}
+
+func mapAlertRuleErr(err error) error {
+	if errors.Is(err, database.ErrAlertRuleNotFound) {
+		return alertsapp.ErrRuleNotFound
+	}
+	return err
+}
+
+func (a alertRuleStore) List(ctx context.Context, enabledOnly bool) ([]alertsapp.Rule, error) {
+	rows, err := a.db().AlertRules().List(ctx, enabledOnly)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]alertsapp.Rule, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, toAppRule(r))
+	}
+	return out, nil
+}
+
+func (a alertRuleStore) Get(ctx context.Context, id int64) (alertsapp.Rule, error) {
+	r, err := a.db().AlertRules().Get(ctx, id)
+	if err != nil {
+		return alertsapp.Rule{}, mapAlertRuleErr(err)
+	}
+	return toAppRule(r), nil
+}
+
+func (a alertRuleStore) Create(ctx context.Context, r alertsapp.Rule) (alertsapp.Rule, error) {
+	row := toDBRule(r)
+	if err := a.db().AlertRules().Create(ctx, row); err != nil {
+		// The repo signals validation failures with an "alert_rules:" prefix;
+		// surface them verbatim so the handler returns a 400 with the message.
+		if strings.HasPrefix(err.Error(), "alert_rules:") {
+			return alertsapp.Rule{}, &alertsapp.ValidationError{Msg: err.Error()}
+		}
+		return alertsapp.Rule{}, err
+	}
+	return toAppRule(row), nil
+}
+
+func (a alertRuleStore) Update(ctx context.Context, r alertsapp.Rule) error {
+	return mapAlertRuleErr(a.db().AlertRules().Update(ctx, toDBRule(r)))
+}
+
+func (a alertRuleStore) Delete(ctx context.Context, id int64) error {
+	return mapAlertRuleErr(a.db().AlertRules().Delete(ctx, id))
+}
+
+// initAlertsUseCase builds the alert-rule use-case over the lazy db accessor.
+func (s *Server) initAlertsUseCase() {
+	s.alertRules = alertsapp.NewRuleService(alertRuleStore{db: s.db})
+}

--- a/internal/api/handlers_alert_rules.go
+++ b/internal/api/handlers_alert_rules.go
@@ -17,7 +17,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	alertsapp "github.com/MustardSeedNetworks/seed/internal/alerts/app"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
@@ -78,13 +78,12 @@ func (s *Server) handleAlertRuleByID(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) listAlertRules(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
+	if s.db() == nil {
 		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
 		return
 	}
 	enabledOnly := r.URL.Query().Get("enabled_only") == "true"
-	rules, err := db.AlertRules().List(r.Context(), enabledOnly)
+	rules, err := s.alertRules.List(r.Context(), enabledOnly)
 	if err != nil {
 		logger.ErrorContext(r.Context(), "list alert_rules failed", "error", err)
 		http.Error(w, "Failed to list rules", http.StatusInternalServerError)
@@ -98,14 +97,13 @@ func (s *Server) listAlertRules(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getAlertRule(w http.ResponseWriter, r *http.Request, id int64) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
+	if s.db() == nil {
 		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
 		return
 	}
-	rule, err := db.AlertRules().Get(r.Context(), id)
+	rule, err := s.alertRules.Get(r.Context(), id)
 	if err != nil {
-		if errors.Is(err, database.ErrAlertRuleNotFound) {
+		if errors.Is(err, alertsapp.ErrRuleNotFound) {
 			http.Error(w, "Rule not found", http.StatusNotFound)
 			return
 		}
@@ -118,8 +116,7 @@ func (s *Server) getAlertRule(w http.ResponseWriter, r *http.Request, id int64) 
 
 func (s *Server) createAlertRule(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
+	if s.db() == nil {
 		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
 		return
 	}
@@ -128,13 +125,14 @@ func (s *Server) createAlertRule(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	rule := inputToRule(in, 0)
-	if createErr := db.AlertRules().Create(r.Context(), rule); createErr != nil {
-		logger.ErrorContext(r.Context(), "create alert_rule failed", "error", createErr)
-		if strings.HasPrefix(createErr.Error(), "alert_rules:") {
-			http.Error(w, createErr.Error(), http.StatusBadRequest)
+	rule, createErr := s.alertRules.Create(r.Context(), inputToRule(in))
+	if createErr != nil {
+		var ve *alertsapp.ValidationError
+		if errors.As(createErr, &ve) {
+			http.Error(w, ve.Msg, http.StatusBadRequest)
 			return
 		}
+		logger.ErrorContext(r.Context(), "create alert_rule failed", "error", createErr)
 		http.Error(w, "Failed to create rule", http.StatusInternalServerError)
 		return
 	}
@@ -143,70 +141,39 @@ func (s *Server) createAlertRule(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) updateAlertRule(w http.ResponseWriter, r *http.Request, id int64) {
-	in, err := s.parseRuleUpdate(w, r)
-	if err != nil {
-		return
-	}
-	rule := inputToRule(in, id)
-	if !s.applyRuleUpdate(w, r, id, rule) {
-		return
-	}
-	// Echo the freshly-read row so the JSON reflects updated_at.
-	// Get failures fall back to echoing the request shape.
-	current, getErr := s.db().AlertRules().Get(r.Context(), id)
-	if getErr != nil || current == nil {
-		writeJSON(w, r, encodeAlertRule(rule))
-		return
-	}
-	writeJSON(w, r, encodeAlertRule(current))
-}
-
-// parseRuleUpdate consolidates the precondition checks (db ready +
-// body decode) the PUT handler shares with no other handler. Splits
-// out from updateAlertRule so the call site reads top-down and so
-// the structural shape doesn't mirror handlers_polling_targets.
-func (s *Server) parseRuleUpdate(w http.ResponseWriter, r *http.Request) (*alertRuleInput, error) {
+	logger := logging.FromContext(r.Context())
 	if s.db() == nil {
 		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return nil, errors.New("db not ready")
+		return
 	}
 	in, err := decodeAlertRuleInput(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		return nil, err
+		return
 	}
-	return in, nil
-}
-
-// applyRuleUpdate runs the repo Update + maps errors to HTTP
-// statuses. Returns true on success so the caller proceeds to
-// echo; false when an error response has already been written.
-func (s *Server) applyRuleUpdate(
-	w http.ResponseWriter, r *http.Request, id int64, rule *database.AlertRule,
-) bool {
-	logger := logging.FromContext(r.Context())
-	if err := s.db().AlertRules().Update(r.Context(), rule); err != nil {
-		if errors.Is(err, database.ErrAlertRuleNotFound) {
+	// The use-case writes the row and echoes the freshly-read record so the
+	// JSON reflects updated_at (falling back to the written shape on re-read).
+	rule, updateErr := s.alertRules.Update(r.Context(), id, inputToRule(in))
+	if updateErr != nil {
+		if errors.Is(updateErr, alertsapp.ErrRuleNotFound) {
 			http.Error(w, "Rule not found", http.StatusNotFound)
-			return false
+			return
 		}
-		logger.ErrorContext(r.Context(), "update alert_rule failed",
-			"id", id, "error", err)
+		logger.ErrorContext(r.Context(), "update alert_rule failed", "id", id, "error", updateErr)
 		http.Error(w, "Failed to update rule", http.StatusInternalServerError)
-		return false
+		return
 	}
-	return true
+	writeJSON(w, r, encodeAlertRule(rule))
 }
 
 func (s *Server) deleteAlertRule(w http.ResponseWriter, r *http.Request, id int64) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
+	if s.db() == nil {
 		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
 		return
 	}
-	if err := db.AlertRules().Delete(r.Context(), id); err != nil {
-		if errors.Is(err, database.ErrAlertRuleNotFound) {
+	if err := s.alertRules.Delete(r.Context(), id); err != nil {
+		if errors.Is(err, alertsapp.ErrRuleNotFound) {
 			http.Error(w, "Rule not found", http.StatusNotFound)
 			return
 		}
@@ -236,10 +203,10 @@ func decodeAlertRuleInput(r *http.Request) (*alertRuleInput, error) {
 	return &in, nil
 }
 
-func inputToRule(in *alertRuleInput, id int64) *database.AlertRule {
-	threshold := max(in.ThresholdCount, 1)
-	return &database.AlertRule{
-		ID:                   id,
+// inputToRule maps the wire input to the use-case model. The ThresholdCount
+// floor (>=1) is applied by the use-case, so it is passed through raw here.
+func inputToRule(in *alertRuleInput) alertsapp.Rule {
+	return alertsapp.Rule{
 		Name:                 in.Name,
 		Enabled:              in.Enabled,
 		MatchKind:            in.MatchKind,
@@ -250,11 +217,11 @@ func inputToRule(in *alertRuleInput, id int64) *database.AlertRule {
 		AlertTitle:           in.AlertTitle,
 		AlertMessage:         in.AlertMessage,
 		WindowSeconds:        in.WindowSeconds,
-		ThresholdCount:       threshold,
+		ThresholdCount:       in.ThresholdCount,
 	}
 }
 
-func encodeAlertRule(rule *database.AlertRule) map[string]any {
+func encodeAlertRule(rule alertsapp.Rule) map[string]any {
 	return map[string]any{
 		"id":                   rule.ID,
 		jsonKeyName:            rule.Name,
@@ -273,7 +240,7 @@ func encodeAlertRule(rule *database.AlertRule) map[string]any {
 	}
 }
 
-func encodeAlertRules(rules []*database.AlertRule) []map[string]any {
+func encodeAlertRules(rules []alertsapp.Rule) []map[string]any {
 	out := make([]map[string]any, 0, len(rules))
 	for _, r := range rules {
 		out = append(out, encodeAlertRule(r))

--- a/internal/api/handlers_alert_rules_internal_test.go
+++ b/internal/api/handlers_alert_rules_internal_test.go
@@ -17,6 +17,7 @@ func newAlertRulesTestServer(t *testing.T) *Server {
 	db := newTestDB(t)
 	s := &Server{services: NewServiceContainer()}
 	s.services.Database = &DatabaseServices{DB: db}
+	s.initAlertsUseCase()
 	return s
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"time"
 
+	alertsapp "github.com/MustardSeedNetworks/seed/internal/alerts/app"
 	alertpipeline "github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
 	"github.com/MustardSeedNetworks/seed/internal/auth"
 	"github.com/MustardSeedNetworks/seed/internal/config"
@@ -135,6 +136,7 @@ type Server struct {
 	settingsStore      *settingsapp.Persistence // Settings-to-profile persistence use-case (ADR-0016 phase 3)
 	profiles           *profilesapp.Service     // Profile CRUD/active/import use-case (ADR-0016 phase 3)
 	networkIP          *networkapp.IPService    // IP-config + MTU use-case (ADR-0016 phase 3)
+	alertRules         *alertsapp.RuleService   // Alert-rule CRUD use-case (ADR-0016)
 	tlsFingerprint     tlsFingerprintCache      // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
 
@@ -259,6 +261,9 @@ func NewServer(
 
 	// Wire the network IP-config + MTU use-case (ADR-0016 phase 3).
 	s.initNetworkUseCase()
+
+	// Wire the alert-rule use-case (ADR-0016), over the lazy db.
+	s.initAlertsUseCase()
 
 	// Initialize vulnerability scanner if enabled
 	s.initVulnerabilityScanner(cfg)

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -154,6 +154,7 @@ func NewTestServerWithConfig(cfg *config.Config) *Server {
 	s.initSettingsUseCase()
 	s.initProfilesUseCase()
 	s.initNetworkUseCase()
+	s.initAlertsUseCase()
 
 	// Setup routes
 	s.setupRoutes()


### PR DESCRIPTION
## Summary

ADR-0016 strangle, next slice: move operator alert-rule CRUD off the direct
`s.db().AlertRules()` reach-through into a use-case (after settings/profiles/network).

## What changed

- **`internal/alerts/app` (new, `alertsapp`)** — a `RuleService` over a narrow
  `RuleStore` port. Owns the `ThresholdCount>=1` floor and the update
  read-back-for-`updated_at` echo. Sentinel `ErrRuleNotFound` + `*ValidationError`
  (carrying the repo's `alert_rules:` message verbatim) reproduce the exact 404/400
  responses.
- **`internal/api/alerts_usecases.go` (new)** — adapter over the database
  `AlertRules` repo (lazy `db`), mapping `database.AlertRule` ↔ the use-case model
  and `ErrAlertRuleNotFound` / `alert_rules:`-prefixed errors → the sentinels;
  `initAlertsUseCase` wired in `NewServer` + test harness.
- **`handlers_alert_rules.go`** — list/get/create/update/delete become
  decode → use-case → encode; the per-handler repo calls and the
  `parseRuleUpdate`/`applyRuleUpdate` split are gone (db-availability guard stays as
  a transport check); `database` import dropped.

Package is `internal/alerts/app` so `handlers_alerts.go` (list/ack/resolve) can join
the same use-case package as a follow-up.

## Testing

- `alertsapp` unit tests: threshold floor, id-ignored-on-create, `ValidationError`
  propagation, update read-back, enabled-only filter, not-found paths.
- The existing `handlers_alert_rules_internal_test` suite passes **unchanged**;
  goldens byte-identical; `golangci-lint run ./...` **0 issues**; full `go test ./...` green.

## Phase-3 strangle progress
wifiapp (ph1–2) · settings · profiles · network · **alert-rules (this PR)**. Next candidates: alerts (ack/resolve), polling-targets, topology.