### PR TITLE
feat(profiles): optimistic concurrency via ETag / If-Match (Phase 5)

### DIFF
--- a/internal/api/handlers_profiles.go
+++ b/internal/api/handlers_profiles.go
@@ -198,6 +198,7 @@ func (s *Server) handleGetProfile(w http.ResponseWriter, r *http.Request, id str
 		return
 	}
 
+	w.Header().Set("ETag", profileETag(profile))
 	sendJSONResponse(w, logger, http.StatusOK, profileToResponse(profile))
 }
 
@@ -227,7 +228,10 @@ func (s *Server) handleUpdateProfile(w http.ResponseWriter, r *http.Request, id 
 		update.ConfigJSON = &cfg
 	}
 
-	profile, err := s.profiles.Update(r.Context(), id, update)
+	// Optimistic concurrency (ADR re-arch Phase 5): an If-Match ETag, when
+	// present, makes the write conditional on the profile not having changed
+	// since the caller read it. Absent (or "*") => unconditional, as before.
+	profile, err := s.profiles.Update(r.Context(), id, update, parseIfMatch(r))
 	if err != nil {
 		switch {
 		case errors.Is(err, profilesapp.ErrNotFound):
@@ -236,6 +240,9 @@ func (s *Server) handleUpdateProfile(w http.ResponseWriter, r *http.Request, id 
 		case errors.Is(err, profilesapp.ErrNameExists):
 			sendErrorResponseWithDetails(w, logger, http.StatusConflict,
 				ErrCodeConflict, localizer.T("errors.profile.nameExists"), "") // fixes #694
+		case errors.Is(err, profilesapp.ErrConflict):
+			sendErrorResponseWithDetails(w, logger, http.StatusPreconditionFailed,
+				ErrCodeConflict, localizer.T("errors.profile.conflict"), "")
 		default:
 			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
 				ErrCodeInternal, localizer.T("errors.profile.updateFailed"), "") // fixes #694, #H7
@@ -243,7 +250,27 @@ func (s *Server) handleUpdateProfile(w http.ResponseWriter, r *http.Request, id 
 		return
 	}
 
+	w.Header().Set("ETag", profileETag(profile))
 	sendJSONResponse(w, logger, http.StatusOK, profileToResponse(profile))
+}
+
+// profileETag returns the strong ETag for a profile — its updated_at timestamp,
+// the optimistic-concurrency version token, in the same RFC3339 form the row is
+// stored as, wrapped in quotes per RFC 9110.
+func profileETag(p profilesapp.Profile) string {
+	return `"` + p.UpdatedAt.Format(time.RFC3339) + `"`
+}
+
+// parseIfMatch returns the bare ETag value from the request's If-Match header,
+// or "" when absent or "*" (i.e. unconditional). Surrounding quotes and an
+// optional weak-validator prefix are stripped.
+func parseIfMatch(r *http.Request) string {
+	v := strings.TrimSpace(r.Header.Get("If-Match"))
+	if v == "" || v == "*" {
+		return ""
+	}
+	v = strings.TrimPrefix(v, "W/")
+	return strings.Trim(v, `"`)
 }
 
 // handleDeleteProfile deletes a profile.
@@ -327,6 +354,7 @@ func (s *Server) handleGetActiveProfile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	w.Header().Set("ETag", profileETag(profile))
 	sendJSONResponse(w, logger, http.StatusOK, profileToResponse(profile))
 }
 

--- a/internal/api/profiles_usecases.go
+++ b/internal/api/profiles_usecases.go
@@ -30,6 +30,8 @@ func mapProfileErr(err error) error {
 		return profilesapp.ErrNotFound
 	case errors.Is(err, database.ErrProfileNameExists):
 		return profilesapp.ErrNameExists
+	case errors.Is(err, database.ErrProfileConflict):
+		return profilesapp.ErrConflict
 	default:
 		return err
 	}
@@ -105,8 +107,11 @@ func (s profilesStore) Create(ctx context.Context, p profilesapp.Profile) error 
 	return mapProfileErr(s.db().Profiles().Create(ctx, appToDBProfile(p)))
 }
 
-func (s profilesStore) Update(ctx context.Context, p profilesapp.Profile) error {
-	return mapProfileErr(s.db().Profiles().Update(ctx, appToDBProfile(p)))
+func (s profilesStore) Update(ctx context.Context, p profilesapp.Profile, ifMatch string) error {
+	if ifMatch == "" {
+		return mapProfileErr(s.db().Profiles().Update(ctx, appToDBProfile(p)))
+	}
+	return mapProfileErr(s.db().Profiles().UpdateIfMatch(ctx, appToDBProfile(p), ifMatch))
 }
 
 func (s profilesStore) Delete(ctx context.Context, id string) error {

--- a/internal/api/profiles_usecases_internal_test.go
+++ b/internal/api/profiles_usecases_internal_test.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/MustardSeedNetworks/seed/internal/database"
@@ -86,5 +89,57 @@ func TestProfilesUseCaseAdapterCRUD(t *testing.T) {
 	// Cannot delete the default profile.
 	if defErr := s.profiles.Delete(ctx, list[0].ID); !errors.Is(defErr, profilesapp.ErrDeleteDefault) {
 		t.Fatalf("deleting default should be ErrDeleteDefault, got %v", defErr)
+	}
+}
+
+// TestProfileOptimisticConcurrencyHTTP exercises the Phase-5 ETag/If-Match flow
+// through the handlers: GET emits an ETag, a stale If-Match yields 412, and the
+// current ETag updates and returns a fresh ETag.
+func TestProfileOptimisticConcurrencyHTTP(t *testing.T) {
+	s, db := newProfilesTestServer(t)
+	ctx := t.Context()
+
+	if err := db.Profiles().Create(ctx, &database.Profile{ID: "p1", Name: "orig", ConfigJSON: "{}"}); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+
+	// GET emits an ETag.
+	getRec := httptest.NewRecorder()
+	s.handleGetProfile(getRec, httptest.NewRequest(http.MethodGet, "/", http.NoBody), "p1")
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d", getRec.Code)
+	}
+	etag := getRec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("GET should emit an ETag header")
+	}
+
+	body := `{"name":"renamed","config":{"x":1}}`
+
+	// A stale If-Match is rejected with 412 and the row is untouched.
+	staleRec := httptest.NewRecorder()
+	staleReq := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body))
+	staleReq.Header.Set("If-Match", `"1999-01-01T00:00:00Z"`)
+	s.handleUpdateProfile(staleRec, staleReq, "p1")
+	if staleRec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("stale If-Match status = %d, want 412", staleRec.Code)
+	}
+	if cur, _ := db.Profiles().Get(ctx, "p1"); cur.Name != "orig" {
+		t.Fatalf("row should be unchanged after 412, got name=%q", cur.Name)
+	}
+
+	// The current ETag succeeds and returns a fresh ETag.
+	okRec := httptest.NewRecorder()
+	okReq := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body))
+	okReq.Header.Set("If-Match", etag)
+	s.handleUpdateProfile(okRec, okReq, "p1")
+	if okRec.Code != http.StatusOK {
+		t.Fatalf("matching If-Match status = %d, want 200 (body=%s)", okRec.Code, okRec.Body.String())
+	}
+	if okRec.Header().Get("ETag") == "" {
+		t.Fatal("successful PUT should emit a fresh ETag")
+	}
+	if cur, _ := db.Profiles().Get(ctx, "p1"); cur.Name != "renamed" {
+		t.Fatalf("update should have persisted, got name=%q", cur.Name)
 	}
 }

--- a/internal/database/profiles_concurrency_test.go
+++ b/internal/database/profiles_concurrency_test.go
@@ -1,0 +1,47 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+// TestProfileUpdateIfMatch covers the optimistic-concurrency variant: a wrong
+// ETag conflicts, the current ETag writes through, and a missing row is 404.
+func TestProfileUpdateIfMatch(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	repo := db.Profiles()
+
+	require.NoError(t, repo.Create(ctx, &database.Profile{ID: "p1", Name: "orig", ConfigJSON: "{}"}))
+	cur, err := repo.Get(ctx, "p1")
+	require.NoError(t, err)
+	etag := cur.UpdatedAt.Format(time.RFC3339)
+
+	// A stale/wrong ETag is a conflict — the row exists but has a different version.
+	staleErr := repo.UpdateIfMatch(
+		ctx,
+		&database.Profile{ID: "p1", Name: "x", ConfigJSON: "{}"},
+		"1999-01-01T00:00:00Z",
+	)
+	require.ErrorIs(t, staleErr, database.ErrProfileConflict)
+
+	// The current ETag writes through.
+	require.NoError(
+		t,
+		repo.UpdateIfMatch(ctx, &database.Profile{ID: "p1", Name: "updated", ConfigJSON: `{"x":1}`}, etag),
+	)
+	got, err := repo.Get(ctx, "p1")
+	require.NoError(t, err)
+	require.Equal(t, "updated", got.Name)
+	require.JSONEq(t, `{"x":1}`, got.ConfigJSON)
+
+	// A missing row is not-found, not a conflict.
+	missingErr := repo.UpdateIfMatch(ctx, &database.Profile{ID: "ghost", Name: "y", ConfigJSON: "{}"}, etag)
+	require.ErrorIs(t, missingErr, database.ErrProfileNotFound)
+}

--- a/internal/database/repository_profiles.go
+++ b/internal/database/repository_profiles.go
@@ -16,6 +16,11 @@ var ErrProfileNotFound = errors.New("profile not found")
 // ErrProfileNameExists is returned when a profile name already exists.
 var ErrProfileNameExists = errors.New("profile name already exists")
 
+// ErrProfileConflict is returned by UpdateIfMatch when the profile exists but
+// its current updated_at does not match the caller's expected value — an
+// optimistic-concurrency conflict (a concurrent writer moved the row first).
+var ErrProfileConflict = errors.New("profile was modified by another writer")
+
 // ProfileRepository provides CRUD operations for profiles.
 type ProfileRepository struct {
 	db *DB
@@ -136,6 +141,45 @@ func (r *ProfileRepository) Update(ctx context.Context, profile *Profile) error 
 	}
 
 	return nil
+}
+
+// UpdateIfMatch is the optimistic-concurrency variant of Update: it writes the
+// profile only when the row's current updated_at equals expectedUpdatedAt
+// (the ETag the caller last read). It returns ErrProfileConflict when the row
+// exists but has moved on, ErrProfileNotFound when it no longer exists, and
+// ErrProfileNameExists on a name collision — mirroring Update otherwise.
+func (r *ProfileRepository) UpdateIfMatch(
+	ctx context.Context, profile *Profile, expectedUpdatedAt string,
+) error {
+	profile.UpdatedAt = time.Now().UTC()
+
+	result, err := r.db.Exec(ctx, `
+		UPDATE profiles
+		SET name = ?, description = ?, config_json = ?, is_default = ?, updated_at = ?
+		WHERE id = ? AND updated_at = ?
+	`, profile.Name, profile.Description, profile.ConfigJSON,
+		boolToInt(profile.IsDefault), profile.UpdatedAt.Format(time.RFC3339),
+		profile.ID, expectedUpdatedAt)
+	if err != nil {
+		if isUniqueConstraintError(err) {
+			return ErrProfileNameExists
+		}
+		return fmt.Errorf("failed to update profile: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected > 0 {
+		return nil
+	}
+
+	// 0 rows: distinguish a stale ETag (row exists) from a deleted row.
+	if _, getErr := r.Get(ctx, profile.ID); getErr != nil {
+		return ErrProfileNotFound // Get maps no-row to ErrProfileNotFound
+	}
+	return ErrProfileConflict
 }
 
 // Delete deletes a profile by ID.

--- a/internal/i18n/locales/en/errors.json
+++ b/internal/i18n/locales/en/errors.json
@@ -114,7 +114,8 @@
   },
   "profile": {
     "multiClientRequired": "Free and Starter licenses allow 1 profile. Upgrade to Pro to manage configurations for multiple clients from a single Seed instance.",
-    "multiInterfaceRequired": "Free and Starter licenses allow at most 1 ethernet + 1 Wi-Fi interface per profile. Upgrade to Pro for unlimited concurrent interfaces."
+    "multiInterfaceRequired": "Free and Starter licenses allow at most 1 ethernet + 1 Wi-Fi interface per profile. Upgrade to Pro for unlimited concurrent interfaces.",
+    "conflict": "This profile was changed by another user since you loaded it. Reload and apply your changes again."
   },
   "sso": {
     "featureRequired": "Single Sign-On configuration requires a Pro license. Existing providers continue to accept logins on any tier; only enabling or editing providers is blocked."

--- a/internal/i18n/locales/es/errors.json
+++ b/internal/i18n/locales/es/errors.json
@@ -114,7 +114,8 @@
   },
   "profile": {
     "multiClientRequired": "Las licencias Free y Starter permiten 1 perfil. Actualice a Pro para administrar configuraciones de varios clientes desde una sola instancia de Seed.",
-    "multiInterfaceRequired": "Las licencias Free y Starter permiten como máximo 1 interfaz ethernet + 1 Wi-Fi por perfil. Actualice a Pro para interfaces concurrentes ilimitadas."
+    "multiInterfaceRequired": "Las licencias Free y Starter permiten como máximo 1 interfaz ethernet + 1 Wi-Fi por perfil. Actualice a Pro para interfaces concurrentes ilimitadas.",
+    "conflict": "Otro usuario modificó este perfil desde que lo cargó. Recárguelo y vuelva a aplicar sus cambios."
   },
   "sso": {
     "featureRequired": "La configuración de Single Sign-On requiere una licencia Pro. Los proveedores existentes siguen aceptando inicios de sesión en cualquier nivel; solo se bloquea habilitar o editar proveedores."

--- a/internal/profiles/app/profiles.go
+++ b/internal/profiles/app/profiles.go
@@ -26,6 +26,9 @@ var (
 	ErrIDRequired    = errors.New("profile id is required")
 	ErrDeleteDefault = errors.New("cannot delete the default profile")
 	ErrDeleteActive  = errors.New("cannot delete the active profile")
+	// ErrConflict is an optimistic-concurrency conflict: the caller's If-Match
+	// ETag no longer matches the stored profile (a concurrent writer won).
+	ErrConflict = errors.New("profile was modified by another writer")
 
 	// ErrActiveLookup and the ErrNoActiveOrDefault/ErrDefaultLookup/
 	// ErrActiveNotFound cases below each map to a distinct active-profile
@@ -92,7 +95,10 @@ type Store interface {
 	GetByName(ctx context.Context, name string) (Profile, bool, error)
 	GetDefault(ctx context.Context) (Profile, error)
 	Create(ctx context.Context, p Profile) error
-	Update(ctx context.Context, p Profile) error
+	// Update writes p. An empty ifMatch is unconditional; a non-empty ifMatch
+	// makes the write optimistic-concurrency-checked against that version
+	// (ETag), returning ErrConflict on mismatch.
+	Update(ctx context.Context, p Profile, ifMatch string) error
 	Delete(ctx context.Context, id string) error
 	Count(ctx context.Context) (int, error)
 	ActiveID(ctx context.Context) (string, error)
@@ -142,8 +148,12 @@ func (s *Service) Create(ctx context.Context, in NewProfile) (Profile, error) {
 	return p, nil
 }
 
-// Update applies a partial update to an existing profile.
-func (s *Service) Update(ctx context.Context, id string, u ProfileUpdate) (Profile, error) {
+// Update applies a partial update to an existing profile. When ifMatch is
+// non-empty the write is optimistic-concurrency-checked against that ETag
+// (ErrConflict on mismatch); an empty ifMatch performs an unconditional write,
+// preserving the prior behavior. It re-reads the row so the returned profile
+// carries the fresh updated_at (the new ETag).
+func (s *Service) Update(ctx context.Context, id string, u ProfileUpdate, ifMatch string) (Profile, error) {
 	p, err := s.store.Get(ctx, id)
 	if err != nil {
 		return Profile{}, err
@@ -156,8 +166,14 @@ func (s *Service) Update(ctx context.Context, id string, u ProfileUpdate) (Profi
 		p.ConfigJSON = *u.ConfigJSON
 	}
 	p.IsDefault = u.IsDefault
-	if updateErr := s.store.Update(ctx, p); updateErr != nil {
-		return Profile{}, updateErr
+
+	if err = s.store.Update(ctx, p, ifMatch); err != nil {
+		return Profile{}, err
+	}
+
+	// Re-read so the caller gets the persisted updated_at for the next ETag.
+	if current, getErr := s.store.Get(ctx, id); getErr == nil {
+		return current, nil
 	}
 	return p, nil
 }
@@ -320,7 +336,7 @@ func (s *Service) importExisting(
 
 	existing.Description = item.Description
 	existing.ConfigJSON = item.ConfigJSON
-	if err := s.store.Update(ctx, existing); err != nil {
+	if err := s.store.Update(ctx, existing, ""); err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("Profile '%s': failed to update - %v", item.Name, err))
 		result.Skipped++
 		return

--- a/internal/profiles/app/profiles_test.go
+++ b/internal/profiles/app/profiles_test.go
@@ -68,7 +68,16 @@ func (f *fakeStore) Create(_ context.Context, p profilesapp.Profile) error {
 	return nil
 }
 
-func (f *fakeStore) Update(_ context.Context, p profilesapp.Profile) error {
+func (f *fakeStore) Update(_ context.Context, p profilesapp.Profile, ifMatch string) error {
+	existing, ok := f.byID[p.ID]
+	if ifMatch != "" {
+		if !ok {
+			return profilesapp.ErrNotFound
+		}
+		if existing.ConfigJSON != ifMatch { // tests use ConfigJSON as the version token
+			return profilesapp.ErrConflict
+		}
+	}
 	f.byID[p.ID] = p
 	return nil
 }
@@ -112,7 +121,7 @@ func TestUpdatePartialSemantics(t *testing.T) {
 	svc := profilesapp.NewService(store)
 
 	// Empty name keeps existing; nil config keeps existing; description always applied.
-	got, err := svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{Name: "", Description: "new", ConfigJSON: nil})
+	got, err := svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{Name: "", Description: "new", ConfigJSON: nil}, "")
 	if err != nil {
 		t.Fatalf("update: %v", err)
 	}
@@ -121,16 +130,44 @@ func TestUpdatePartialSemantics(t *testing.T) {
 	}
 
 	cfg := `{"x":2}`
-	got, _ = svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{Name: "renamed", ConfigJSON: &cfg})
+	got, _ = svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{Name: "renamed", ConfigJSON: &cfg}, "")
 	if got.Name != "renamed" || got.ConfigJSON != cfg {
 		t.Fatalf("full update mismatch: %+v", got)
 	}
 
-	if _, missErr := svc.Update(ctx(), "missing", profilesapp.ProfileUpdate{}); !errors.Is(
+	if _, missErr := svc.Update(ctx(), "missing", profilesapp.ProfileUpdate{}, ""); !errors.Is(
 		missErr,
 		profilesapp.ErrNotFound,
 	) {
 		t.Fatalf("update missing should be ErrNotFound, got %v", missErr)
+	}
+}
+
+func TestUpdateIfMatch(t *testing.T) {
+	store := newFakeStore()
+	// fakeStore.UpdateIfMatch treats ConfigJSON as the version token.
+	store.byID["p1"] = profilesapp.Profile{ID: "p1", Name: "n", ConfigJSON: "v1"}
+	svc := profilesapp.NewService(store)
+
+	// Matching ETag writes through.
+	upd := `v2`
+	if _, err := svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{ConfigJSON: &upd}, "v1"); err != nil {
+		t.Fatalf("matching if-match should succeed: %v", err)
+	}
+
+	// Stale ETag (the row is now "v2") conflicts.
+	again := `v3`
+	if _, err := svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{ConfigJSON: &again}, "v1"); !errors.Is(
+		err,
+		profilesapp.ErrConflict,
+	) {
+		t.Fatalf("stale if-match should be ErrConflict, got %v", err)
+	}
+
+	// Empty if-match stays unconditional.
+	last := `v4`
+	if _, err := svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{ConfigJSON: &last}, ""); err != nil {
+		t.Fatalf("unconditional update should succeed: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

First slice of the ADR re-architecture **Phase 5 "optimistic concurrency"** item.
Multi-user profile editing is live and the API was **last-write-wins** — a second
editor silently clobbered the first. Profile GET/PUT now speak ETags.

## Behaviour

- **GET** `/profiles/{id}` (and the active-profile GET) emit an `ETag` header —
  the profile's `updated_at` (the version token), quoted per RFC 9110.
- **PUT** honors `If-Match`: when present (and not `*`), the write is conditional
  on the row not having changed since the caller read it. A mismatch →
  **412 Precondition Failed**, row untouched. Absent/`*` → prior unconditional
  behavior, so **existing clients are unaffected (additive)**.

## Layers

- `database.ProfileRepository.UpdateIfMatch` — conditional `UPDATE … WHERE id=? AND
  updated_at=?` + `ErrProfileConflict`, disambiguating stale-ETag vs deleted-row.
- `profilesapp.Service.Update` gains an `ifMatch` arg + `ErrConflict`, and now
  **re-reads** the row so the response carries the fresh ETag — which also fixes a
  latent stale-`updated_at` echo introduced when the handler was strangled in #1554.
- Store's `Update`/`UpdateIfMatch` merged into one `Update(p, ifMatch)` (empty =
  unconditional) to keep the port ≤10 methods (`interfacebloat`).
- i18n `errors.profile.conflict` (en + es).

## Known limitation (documented in the commit)

The ETag is `updated_at` at **second precision** → two writes within the same
second share a token, so that sub-second window degrades to today's
last-write-wins (**never worse** — strictly an improvement for the common case).
A dedicated `row_version` column is the future hardening; settings/config
(file-backed) need a content-hash token and follow separately.

## Testing

- DB: wrong-ETag conflict / current-ETag write-through / missing-row 404.
- Use-case: ifMatch matrix (match / stale-conflict / unconditional).
- HTTP: GET emits ETag, stale `If-Match` → 412 + row untouched, current ETag →
  200 + fresh ETag.
- golden harness byte-identical; `golangci-lint run ./...` **0 issues**; full `go test ./...` green.