### PR TITLE
feat(settings): optimistic concurrency via ETag / If-Match (Phase 5)

### DIFF
--- a/internal/api/handlers_settings.go
+++ b/internal/api/handlers_settings.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/validation"
 )
@@ -132,15 +134,18 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		"vlan":       map[string]any{jsonKeyEnabled: s.config.VLAN.Enabled, "id": s.config.VLAN.ID},
 		"ip":         map[string]any{"mode": s.config.IP.Mode},
 		"thresholds": s.buildThresholdSettings(),
+		// Reflect the live config — these were previously hardcoded, so a GET never
+		// echoed what a prior PUT wrote (and any concurrency token derived from them
+		// would be incoherent).
 		"healthChecks": map[string]any{
-			"runPerformance": true,
-			"runSpeedtest":   true,
-			"runIperf":       false,
-			"runDiscovery":   true,
+			"runPerformance": s.config.HealthChecks.RunPerformance,
+			"runSpeedtest":   s.config.HealthChecks.RunSpeedtest,
+			"runIperf":       s.config.HealthChecks.RunIperf,
+			"runDiscovery":   s.config.HealthChecks.RunDiscovery,
 		},
 		"speedtest": map[string]any{
 			"serverId":      s.config.Speedtest.ServerID,
-			"autoRunOnLink": true,
+			"autoRunOnLink": s.config.Speedtest.AutoRunOnLink,
 		},
 		"iperf": map[string]any{
 			"autoRunOnLink": s.config.Iperf.AutoRunOnLink, "server": s.config.Iperf.Server,
@@ -155,6 +160,10 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	// Optimistic-concurrency token (ADR re-arch Phase 5): a content-hash of the
+	// mutable-settings subset, so a subsequent conditional PUT can detect a
+	// concurrent edit. Computed under the RLock already held here.
+	w.Header().Set("ETag", s.config.SettingsETagLocked())
 	sendJSONResponse(w, logger, http.StatusOK, settings)
 }
 
@@ -170,9 +179,25 @@ func (s *Server) updateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Optimistic concurrency (ADR re-arch Phase 5): an If-Match ETag, when
+	// present, makes the write conditional on the mutable-settings subset not
+	// having changed since the caller read it. Absent (or "*") => unconditional,
+	// as before, so existing clients are unaffected (additive).
+	ifMatch := parseIfMatch(r)
+
 	// Lock config for write access
 	// NOTE: Must unlock before Save() - Save() acquires RLock internally (fixes #783)
 	s.config.Lock()
+
+	// Compare-and-apply is atomic under the write lock: a concurrent writer cannot
+	// slip between this check and the updates below.
+	if ifMatch != "" && ifMatch != strings.Trim(s.config.SettingsETagLocked(), `"`) {
+		s.config.Unlock()
+		localizer := i18n.FromRequest(r)
+		sendErrorResponseWithDetails(w, logger, http.StatusPreconditionFailed,
+			ErrCodeConflict, localizer.T("errors.settings.conflict"), "")
+		return
+	}
 
 	// Apply updates using helper functions (fixes #784 - return errors for invalid types)
 	var applyErrors []error
@@ -237,6 +262,8 @@ func (s *Server) updateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Emit the fresh token so the client can chain a subsequent conditional write.
+	w.Header().Set("ETag", s.config.SettingsETag())
 	sendJSONResponse(w, logger, http.StatusOK, map[string]string{"status": "updated"})
 }
 

--- a/internal/api/handlers_settings_test.go
+++ b/internal/api/handlers_settings_test.go
@@ -819,3 +819,104 @@ func TestSettingsThresholdDurationConversion(t *testing.T) {
 		t.Errorf("Expected dns.warning to be 500, got %v", warning)
 	}
 }
+
+// TestHandleSettingsETagReflectsConfig is the regression for the pre-existing
+// getSettings mismatch: GET must report the live config, not hardcoded values.
+// Under the default config RunIperf is true, so the response healthChecks.runIperf
+// must be true (it was previously hardcoded false).
+func TestHandleSettingsETagReflectsConfig(t *testing.T) {
+	server := api.NewTestServer()
+	defer server.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings", http.NoBody)
+	w := httptest.NewRecorder()
+	server.HandleSettings(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET settings: expected 200, got %d", w.Code)
+	}
+
+	// GET emits a quoted, non-empty ETag (optimistic-concurrency token).
+	etag := w.Header().Get("ETag")
+	if len(etag) < 3 || etag[0] != '"' || etag[len(etag)-1] != '"' {
+		t.Fatalf("GET settings: expected a quoted ETag, got %q", etag)
+	}
+	if want := server.Config().SettingsETag(); etag != want {
+		t.Fatalf("GET ETag %q != config SettingsETag %q", etag, want)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	health := resp["healthChecks"].(map[string]any)
+	if runIperf, ok := health["runIperf"].(bool); !ok || !runIperf {
+		t.Errorf("healthChecks.runIperf should reflect config (true), got %v", health["runIperf"])
+	}
+}
+
+// TestHandleSettingsIfMatch covers optimistic concurrency on PUT /settings:
+// a stale If-Match is rejected with 412 and leaves config untouched; the current
+// token writes through and returns a fresh (different) ETag; an absent header is
+// unconditional (prior behavior).
+func TestHandleSettingsIfMatch(t *testing.T) {
+	body := []byte(`{"thresholds":{"dns":{"good":777}}}`)
+
+	t.Run("stale If-Match -> 412, config untouched", func(t *testing.T) {
+		server := api.NewTestServer()
+		defer server.Close()
+
+		before := server.Config().Thresholds.DNS.Warning // "good" maps to DNS.Warning
+
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+		req.Header.Set("If-Match", `"stale-token"`)
+		w := httptest.NewRecorder()
+		server.HandleSettings(w, req)
+
+		if w.Code != http.StatusPreconditionFailed {
+			t.Fatalf("expected 412, got %d", w.Code)
+		}
+		if after := server.Config().Thresholds.DNS.Warning; after != before {
+			t.Errorf("config mutated on 412: before=%v after=%v", before, after)
+		}
+	})
+
+	t.Run("current If-Match -> 200 + fresh ETag", func(t *testing.T) {
+		server := api.NewTestServer()
+		defer server.Close()
+
+		current := server.Config().SettingsETag()
+
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+		req.Header.Set("If-Match", current)
+		w := httptest.NewRecorder()
+		server.HandleSettings(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (body %s)", w.Code, w.Body.String())
+		}
+		if got := server.Config().Thresholds.DNS.Warning; got != 777*time.Millisecond {
+			t.Errorf("threshold not applied: got %v", got)
+		}
+		fresh := w.Header().Get("ETag")
+		if fresh == "" || fresh == current {
+			t.Errorf("expected a fresh ETag different from %q, got %q", current, fresh)
+		}
+	})
+
+	t.Run("absent If-Match -> 200 unconditional", func(t *testing.T) {
+		server := api.NewTestServer()
+		defer server.Close()
+
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		server.HandleSettings(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		if got := server.Config().Thresholds.DNS.Warning; got != 777*time.Millisecond {
+			t.Errorf("threshold not applied: got %v", got)
+		}
+	})
+}

--- a/internal/api/testdata/golden/settings.txt
+++ b/internal/api/testdata/golden/settings.txt
@@ -53,7 +53,7 @@ body:
   },
   "healthChecks": {
     "runDiscovery": true,
-    "runIperf": false,
+    "runIperf": true,
     "runPerformance": true,
     "runSpeedtest": true
   },

--- a/internal/config/config_profile.go
+++ b/internal/config/config_profile.go
@@ -6,6 +6,8 @@ package config
 // Auth, Security, Logging, Database) are deliberately excluded.
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 )
@@ -27,14 +29,10 @@ type ProfileExportFields struct {
 	CableTest        CableTestConfig        `json:"cableTest,omitzero"`
 }
 
-// ToProfileJSON exports profile-specific settings as JSON.
-// Only settings that vary per-profile are included.
-// Global settings (Server, Auth, Security) are excluded.
-func (c *Config) ToProfileJSON() (string, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	export := ProfileExportFields{
+// profileExportLocked snapshots the per-profile (mutable-settings) subset.
+// The caller must already hold at least c.mu.RLock.
+func (c *Config) profileExportLocked() ProfileExportFields {
+	return ProfileExportFields{
 		Thresholds:       c.Thresholds,
 		HealthChecks:     c.HealthChecks,
 		Speedtest:        c.Speedtest,
@@ -47,12 +45,47 @@ func (c *Config) ToProfileJSON() (string, error) {
 		Link:             c.Link,
 		CableTest:        c.CableTest,
 	}
+}
 
-	data, err := json.Marshal(export)
+// ToProfileJSON exports profile-specific settings as JSON.
+// Only settings that vary per-profile are included.
+// Global settings (Server, Auth, Security) are excluded.
+func (c *Config) ToProfileJSON() (string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	data, err := json.Marshal(c.profileExportLocked())
 	if err != nil {
 		return "", fmt.Errorf("marshal profile settings: %w", err)
 	}
 	return string(data), nil
+}
+
+// SettingsETag returns the optimistic-concurrency version token for the
+// file-backed settings resource (ADR re-arch Phase 5): a strong ETag whose body
+// is the SHA-256 of the mutable-settings subset (the same ProfileExportFields
+// ToProfileJSON serializes), quoted per RFC 9110. It is a content-hash, not a
+// timestamp — so it is exact (no sub-second window) and is unaffected by writes
+// to the excluded GLOBAL config (Server/Auth/Security/Logging/Database).
+func (c *Config) SettingsETag() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.SettingsETagLocked()
+}
+
+// SettingsETagLocked is SettingsETag for callers that already hold the config
+// lock (the getSettings RLock path and the updateSettings write-lock
+// compare-and-apply). It performs no locking itself.
+func (c *Config) SettingsETagLocked() string {
+	// ProfileExportFields contains no map fields, so json.Marshal is
+	// deterministic and the hash is a stable token. A marshal error cannot
+	// arise from these plain structs; fall back to an empty body defensively.
+	data, err := json.Marshal(c.profileExportLocked())
+	if err != nil {
+		return `""`
+	}
+	sum := sha256.Sum256(data)
+	return `"` + hex.EncodeToString(sum[:]) + `"`
 }
 
 // ApplyProfileJSON applies profile settings from JSON to this config.

--- a/internal/config/settings_etag_test.go
+++ b/internal/config/settings_etag_test.go
@@ -1,0 +1,57 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+)
+
+// TestSettingsETag covers the optimistic-concurrency version token for the
+// file-backed settings resource (ADR re-arch Phase 5). The token is a strong
+// ETag: a content-hash of the mutable-settings subset (config.ProfileExportFields
+// via ToProfileJSON), quoted per RFC 9110. It must be deterministic, change when
+// a covered field changes, and stay stable when an excluded GLOBAL field changes.
+func TestSettingsETag(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	base := cfg.SettingsETag()
+
+	// Quoted strong validator (RFC 9110), non-empty hash body.
+	if !strings.HasPrefix(base, `"`) || !strings.HasSuffix(base, `"`) {
+		t.Fatalf("ETag not quoted: %q", base)
+	}
+	if len(strings.Trim(base, `"`)) == 0 {
+		t.Fatalf("ETag has empty hash body: %q", base)
+	}
+
+	// Deterministic: a second call on an unchanged config returns the same token.
+	if again := cfg.SettingsETag(); again != base {
+		t.Fatalf("ETag not deterministic: %q vs %q", base, again)
+	}
+
+	// Changing a COVERED field (a threshold) must change the token.
+	cfg.Thresholds.DNS.Warning += 5 * time.Millisecond
+	if changed := cfg.SettingsETag(); changed == base {
+		t.Fatalf("ETag unchanged after covered field changed: %q", changed)
+	}
+
+	// Changing an EXCLUDED global field (Auth) must NOT change the token: a
+	// JWT-secret rotation must not invalidate a pending settings-edit token.
+	afterCovered := cfg.SettingsETag()
+	cfg.Auth.JWTSecret = "a-completely-different-secret-value"
+	if global := cfg.SettingsETag(); global != afterCovered {
+		t.Fatalf("ETag changed after excluded global field changed: %q vs %q", afterCovered, global)
+	}
+}
+
+// TestSettingsETagLockedMatches asserts the no-lock variant (caller holds the
+// lock) agrees with the locking accessor, so the GET (RLock) and PUT (write Lock)
+// paths and the response accessor all derive the same token.
+func TestSettingsETagLockedMatches(t *testing.T) {
+	cfg := config.DefaultConfig()
+	if locked, unlocked := cfg.SettingsETagLocked(), cfg.SettingsETag(); locked != unlocked {
+		t.Fatalf("SettingsETagLocked %q != SettingsETag %q", locked, unlocked)
+	}
+}

--- a/internal/i18n/locales/en/errors.json
+++ b/internal/i18n/locales/en/errors.json
@@ -130,5 +130,8 @@
     "selfDeactivate": "You cannot deactivate your own account.",
     "selfDemote": "You cannot demote your own account from admin.",
     "featureRequired": "Adding additional users requires a Pro license."
+  },
+  "settings": {
+    "conflict": "This setting was changed by another user since you loaded it. Reload and apply your changes again."
   }
 }

--- a/internal/i18n/locales/es/errors.json
+++ b/internal/i18n/locales/es/errors.json
@@ -130,5 +130,8 @@
     "selfDeactivate": "No puede desactivar su propia cuenta.",
     "selfDemote": "No puede degradar su propia cuenta de administrador.",
     "featureRequired": "Agregar usuarios adicionales requiere una licencia Pro."
+  },
+  "settings": {
+    "conflict": "Otro usuario cambió esta configuración desde que la cargaste. Vuelve a cargarla y aplica tus cambios de nuevo."
   }
 }


### PR DESCRIPTION
Add the second slice of ADR re-architecture Phase 5 "optimistic concurrency":
PUT /api/v1/settings was last-write-wins, so with multi-user editing live a
second editor silently clobbered the first. Settings GET/PUT now speak ETags.
Unlike profiles (#1559, a DB row with updated_at), settings is file-backed
(config.json), so the version token is a content-hash of the mutable subset.

- GET /api/v1/settings emits an `ETag` header: a strong validator whose body is
  sha256 of the mutable-settings subset (config.ProfileExportFields, the same
  set ToProfileJSON serializes), quoted per RFC 9110. A content-hash is exact —
  no sub-second window like the profiles updated_at token — and is unaffected by
  writes to the excluded GLOBAL config (Server/Auth/Security/Logging/Database):
  a JWT-secret rotation must not invalidate a pending settings-edit token.
- PUT honors `If-Match`: present and not `*` makes the write conditional on the
  subset not having changed since the caller read it; a mismatch returns
  **412 Precondition Failed** and leaves config untouched. Absent/`*` =>
  unconditional, as before (additive, existing clients unaffected). The
  compare-and-apply is atomic under the config write lock. On success the
  response carries the fresh ETag.
- Fix a pre-existing getSettings mismatch: healthChecks.{runPerformance,
  runSpeedtest,runIperf,runDiscovery} and speedtest.autoRunOnLink were
  HARDCODED and never reflected config, so a GET never echoed a prior PUT (and
  any token derived from them was incoherent). They now read the live config.
  Intended golden change: runIperf flips false->true under DefaultConfig.
- New config.SettingsETag() (+ SettingsETagLocked() for callers already holding
  the lock); ToProfileJSON shares the unlocked profileExportLocked() snapshot.
- i18n errors.settings.conflict added to en + es; the 412 branch localizes.

No new use-case: settings GET/PUT-config has no orchestration to strangle, so a
content-hash needs no bespoke use-case (the ADR-0016 selection rule).

Test-first: config unit (token deterministic; changes on covered field; stable
on excluded global; locked==unlocked), and HTTP tests (GET emits ETag + reflects
config runIperf; stale If-Match -> 412 + config untouched; current -> 200 + fresh
ETag; absent -> 200 unconditional). golden /settings regenerated (one intended
flip); authchain golden byte-identical (ETag not snapshotted); golangci 0.
