### PR TITLE
feat(profiles): row_version optimistic-concurrency token (Phase 5 hardening)

### DIFF
--- a/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
+++ b/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
@@ -465,15 +465,22 @@ between modules.
 
 ## 7. Persistence (`adapters/store`)
 
-> **STATUS (2026-06-07): Phase 5b — schema modernization — is DONE; two items
-> remain.** Done: `.sql` migrations embedded via `//go:embed` + the **goose**
-> runner (`internal/database/goose.go`), the **collapsed `0001_init.sql`
-> baseline** (61 STRICT tables), the migrate-from-empty drift gate
-> (`goose_baseline_test.go` / `schema_snapshot_test.go`), and a `WithTx`
-> transaction wrapper (`database.go`). **Remaining (feature-sized):**
-> (1) the **transactional outbox relay** (the `00002_jobs.sql` + `platform/events`
-> comments both note it is "layered on" later) and (2) **optimistic concurrency**
-> (version/ETag + `If-Match`) on the mutable resources — not yet implemented.
+> **STATUS (2026-06-07): Phase 5b — schema modernization — is DONE; optimistic
+> concurrency is DONE for both mutable resources; one item remains.** Done: `.sql`
+> migrations embedded via `//go:embed` + the **goose** runner
+> (`internal/database/goose.go`), the **collapsed `0001_init.sql` baseline** (61
+> STRICT tables), the migrate-from-empty drift gate (`goose_baseline_test.go` /
+> `schema_snapshot_test.go`), and a `WithTx` transaction wrapper (`database.go`).
+> **Optimistic concurrency (ETag + `If-Match` → 412, additive):** **profiles** —
+> the row-backed resource — uses a dedicated monotonic `row_version` column
+> (migration `00004`, bumped on every write, exact: a sub-second double-write is
+> caught; #1559 shipped the flow on `updated_at`, hardened here); **settings** —
+> file-backed (`config.json`) — uses a content-hash of the mutable subset
+> (`config.SettingsETag`, #1560), which is also exact and immune to unrelated
+> global-config writes. **Remaining (feature-sized):** the **transactional outbox
+> relay** (the `00002_jobs.sql` + `platform/events` comments both note it is
+> "layered on" later) — deferred (YAGNI: no consumer needs cross-restart durable
+> delivery; reconcilers re-derive on restart).
 > The repo-interfaces-as-domain-ports point below is piloted in
 > `internal/reporting/store` (ReportRepo/ScheduleRepo/MetricsRepo/ExportRepo);
 > generalizing it to all 21 repos is deliberately deferred — done bespoke per
@@ -489,9 +496,11 @@ between modules.
 - **Transactional outbox** table: domain writes + the event row commit together;
   a relay publishes to the bus post-commit. *(OPEN — the durability layer for
   `platform/events`.)*
-- **Optimistic concurrency:** version/ETag + `If-Match` on mutable resources
-  (config, profiles, settings) — multi-user is live; last-write-wins loses data.
-  *(OPEN — the highest-value remaining correctness item.)*
+- **Optimistic concurrency:** version/ETag + `If-Match` on mutable resources.
+  *(DONE — profiles via `row_version` (migration `00004`, #1559 + hardening);
+  settings via a mutable-subset content-hash (`config.SettingsETag`, #1560). Both
+  tokens are exact; an absent `If-Match` stays unconditional, so existing clients
+  are unaffected.)*
 - **Reference data** (OUI vendor DB, MIB defs, default config, NVD cache) is
   **embedded read-only**, never rows in the mutable DB.
 

--- a/internal/api/handlers_profiles.go
+++ b/internal/api/handlers_profiles.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -254,11 +255,11 @@ func (s *Server) handleUpdateProfile(w http.ResponseWriter, r *http.Request, id 
 	sendJSONResponse(w, logger, http.StatusOK, profileToResponse(profile))
 }
 
-// profileETag returns the strong ETag for a profile — its updated_at timestamp,
-// the optimistic-concurrency version token, in the same RFC3339 form the row is
-// stored as, wrapped in quotes per RFC 9110.
+// profileETag returns the strong ETag for a profile — its row_version, the
+// monotonic optimistic-concurrency token, wrapped in quotes per RFC 9110. Unlike
+// the prior updated_at token it is exact, so a sub-second double-write conflicts.
 func profileETag(p profilesapp.Profile) string {
-	return `"` + p.UpdatedAt.Format(time.RFC3339) + `"`
+	return `"` + strconv.FormatInt(p.RowVersion, 10) + `"`
 }
 
 // parseIfMatch returns the bare ETag value from the request's If-Match header,

--- a/internal/api/profiles_usecases.go
+++ b/internal/api/profiles_usecases.go
@@ -9,6 +9,7 @@ package api
 import (
 	"context"
 	"errors"
+	"strconv"
 
 	"github.com/MustardSeedNetworks/seed/internal/database"
 	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
@@ -46,6 +47,7 @@ func dbToAppProfile(p *database.Profile) profilesapp.Profile {
 		IsDefault:   p.IsDefault,
 		CreatedAt:   p.CreatedAt,
 		UpdatedAt:   p.UpdatedAt,
+		RowVersion:  p.RowVersion,
 	}
 }
 
@@ -58,6 +60,7 @@ func appToDBProfile(p profilesapp.Profile) *database.Profile {
 		IsDefault:   p.IsDefault,
 		CreatedAt:   p.CreatedAt,
 		UpdatedAt:   p.UpdatedAt,
+		RowVersion:  p.RowVersion,
 	}
 }
 
@@ -111,7 +114,14 @@ func (s profilesStore) Update(ctx context.Context, p profilesapp.Profile, ifMatc
 	if ifMatch == "" {
 		return mapProfileErr(s.db().Profiles().Update(ctx, appToDBProfile(p)))
 	}
-	return mapProfileErr(s.db().Profiles().UpdateIfMatch(ctx, appToDBProfile(p), ifMatch))
+	// The ETag is the row_version as a decimal string. A token that does not parse
+	// to an int64 cannot match any row's version, so it is a precondition failure
+	// (412), not a 500 — treat it as a conflict without touching the row.
+	expectedVersion, err := strconv.ParseInt(ifMatch, 10, 64)
+	if err != nil {
+		return profilesapp.ErrConflict
+	}
+	return mapProfileErr(s.db().Profiles().UpdateIfMatch(ctx, appToDBProfile(p), expectedVersion))
 }
 
 func (s profilesStore) Delete(ctx context.Context, id string) error {

--- a/internal/api/profiles_usecases_internal_test.go
+++ b/internal/api/profiles_usecases_internal_test.go
@@ -119,7 +119,7 @@ func TestProfileOptimisticConcurrencyHTTP(t *testing.T) {
 	// A stale If-Match is rejected with 412 and the row is untouched.
 	staleRec := httptest.NewRecorder()
 	staleReq := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body))
-	staleReq.Header.Set("If-Match", `"1999-01-01T00:00:00Z"`)
+	staleReq.Header.Set("If-Match", `"999999"`) // a row_version that cannot match
 	s.handleUpdateProfile(staleRec, staleReq, "p1")
 	if staleRec.Code != http.StatusPreconditionFailed {
 		t.Fatalf("stale If-Match status = %d, want 412", staleRec.Code)
@@ -136,8 +136,8 @@ func TestProfileOptimisticConcurrencyHTTP(t *testing.T) {
 	if okRec.Code != http.StatusOK {
 		t.Fatalf("matching If-Match status = %d, want 200 (body=%s)", okRec.Code, okRec.Body.String())
 	}
-	if okRec.Header().Get("ETag") == "" {
-		t.Fatal("successful PUT should emit a fresh ETag")
+	if fresh := okRec.Header().Get("ETag"); fresh == "" || fresh == etag {
+		t.Fatalf("successful PUT should emit a fresh ETag different from %q, got %q", etag, fresh)
 	}
 	if cur, _ := db.Profiles().Get(ctx, "p1"); cur.Name != "renamed" {
 		t.Fatalf("update should have persisted, got name=%q", cur.Name)

--- a/internal/database/migrations/00004_profile_row_version.sql
+++ b/internal/database/migrations/00004_profile_row_version.sql
@@ -1,0 +1,15 @@
+-- 00004_profile_row_version.sql — dedicated optimistic-concurrency token for
+-- profiles (ADR re-arch Phase 5 hardening). #1559 used updated_at (RFC3339,
+-- second precision) as the profile ETag, so two writes inside the same second
+-- shared a token and the conflict went undetected — degrading to last-write-wins
+-- in that sub-second window. A monotonic row_version, bumped on every write,
+-- closes the window: the token is exact, not time-derived. The NOT NULL DEFAULT
+-- backfills the single shipped/seeded profile to 1. STRICT-consistent with the
+-- 0001 baseline. Regenerate the gate golden:
+--   UPDATE_SCHEMA_GOLDEN=1 go test ./internal/database/ -run TestSchemaSnapshot
+
+-- +goose Up
+ALTER TABLE profiles ADD COLUMN row_version INTEGER NOT NULL DEFAULT 1;
+
+-- +goose Down
+ALTER TABLE profiles DROP COLUMN row_version;

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -41,6 +41,10 @@ type Profile struct {
 	IsDefault   bool      `json:"isDefault"`
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
+	// RowVersion is the optimistic-concurrency token: a monotonic counter bumped
+	// on every write (ADR re-arch Phase 5). It is the profile ETag — exact, so a
+	// sub-second double-write is still detected (unlike the prior updated_at).
+	RowVersion int64 `json:"-"`
 }
 
 // Metric represents a single metric data point.

--- a/internal/database/profiles_concurrency_test.go
+++ b/internal/database/profiles_concurrency_test.go
@@ -3,7 +3,6 @@ package database_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -11,7 +10,9 @@ import (
 )
 
 // TestProfileUpdateIfMatch covers the optimistic-concurrency variant: a wrong
-// ETag conflicts, the current ETag writes through, and a missing row is 404.
+// row_version conflicts, the current row_version writes through (and bumps the
+// version), and a missing row is 404. The token is the monotonic row_version
+// (not updated_at) so a sub-second double-write is still detected.
 func TestProfileUpdateIfMatch(t *testing.T) {
 	db, cleanup := testDB(t)
 	defer cleanup()
@@ -21,27 +22,37 @@ func TestProfileUpdateIfMatch(t *testing.T) {
 	require.NoError(t, repo.Create(ctx, &database.Profile{ID: "p1", Name: "orig", ConfigJSON: "{}"}))
 	cur, err := repo.Get(ctx, "p1")
 	require.NoError(t, err)
-	etag := cur.UpdatedAt.Format(time.RFC3339)
+	require.Equal(t, int64(1), cur.RowVersion, "a fresh profile starts at row_version 1")
 
-	// A stale/wrong ETag is a conflict — the row exists but has a different version.
+	// A stale/wrong version is a conflict — the row exists but has moved on.
 	staleErr := repo.UpdateIfMatch(
 		ctx,
 		&database.Profile{ID: "p1", Name: "x", ConfigJSON: "{}"},
-		"1999-01-01T00:00:00Z",
+		999,
 	)
 	require.ErrorIs(t, staleErr, database.ErrProfileConflict)
 
-	// The current ETag writes through.
-	require.NoError(
-		t,
-		repo.UpdateIfMatch(ctx, &database.Profile{ID: "p1", Name: "updated", ConfigJSON: `{"x":1}`}, etag),
-	)
+	// The current version writes through and bumps row_version.
+	updated := &database.Profile{ID: "p1", Name: "updated", ConfigJSON: `{"x":1}`}
+	require.NoError(t, repo.UpdateIfMatch(ctx, updated, cur.RowVersion))
+	require.Equal(t, int64(2), updated.RowVersion, "a write bumps the in-memory row_version")
+
 	got, err := repo.Get(ctx, "p1")
 	require.NoError(t, err)
 	require.Equal(t, "updated", got.Name)
 	require.JSONEq(t, `{"x":1}`, got.ConfigJSON)
+	require.Equal(t, int64(2), got.RowVersion, "the persisted row_version advanced")
+
+	// Re-using the now-stale version conflicts (the sub-second window #1559 left open).
+	reuseErr := repo.UpdateIfMatch(ctx, &database.Profile{ID: "p1", Name: "z", ConfigJSON: "{}"}, cur.RowVersion)
+	require.ErrorIs(t, reuseErr, database.ErrProfileConflict)
 
 	// A missing row is not-found, not a conflict.
-	missingErr := repo.UpdateIfMatch(ctx, &database.Profile{ID: "ghost", Name: "y", ConfigJSON: "{}"}, etag)
+	missingErr := repo.UpdateIfMatch(ctx, &database.Profile{ID: "ghost", Name: "y", ConfigJSON: "{}"}, 1)
 	require.ErrorIs(t, missingErr, database.ErrProfileNotFound)
+
+	// An unconditional Update also bumps the version (so a held token goes stale).
+	uncond := &database.Profile{ID: "p1", Name: "uncond", ConfigJSON: "{}"}
+	require.NoError(t, repo.Update(ctx, uncond))
+	require.Equal(t, int64(3), uncond.RowVersion)
 }

--- a/internal/database/repository_profiles.go
+++ b/internal/database/repository_profiles.go
@@ -34,6 +34,7 @@ func (r *ProfileRepository) Create(ctx context.Context, profile *Profile) error 
 	now := time.Now().UTC()
 	profile.CreatedAt = now
 	profile.UpdatedAt = now
+	profile.RowVersion = 1 // matches the column DEFAULT; the first version
 
 	_, err := r.db.Exec(
 		ctx,
@@ -64,7 +65,7 @@ func (r *ProfileRepository) Create(ctx context.Context, profile *Profile) error 
 // Get retrieves a profile by ID.
 func (r *ProfileRepository) Get(ctx context.Context, id string) (*Profile, error) {
 	row := r.db.QueryRow(ctx, `
-		SELECT id, name, description, config_json, is_default, created_at, updated_at
+		SELECT id, name, description, config_json, is_default, created_at, updated_at, row_version
 		FROM profiles WHERE id = ?
 	`, id)
 
@@ -74,7 +75,7 @@ func (r *ProfileRepository) Get(ctx context.Context, id string) (*Profile, error
 // GetByName retrieves a profile by name.
 func (r *ProfileRepository) GetByName(ctx context.Context, name string) (*Profile, error) {
 	row := r.db.QueryRow(ctx, `
-		SELECT id, name, description, config_json, is_default, created_at, updated_at
+		SELECT id, name, description, config_json, is_default, created_at, updated_at, row_version
 		FROM profiles WHERE name = ?
 	`, name)
 
@@ -84,7 +85,7 @@ func (r *ProfileRepository) GetByName(ctx context.Context, name string) (*Profil
 // GetDefault retrieves the default profile.
 func (r *ProfileRepository) GetDefault(ctx context.Context) (*Profile, error) {
 	row := r.db.QueryRow(ctx, `
-		SELECT id, name, description, config_json, is_default, created_at, updated_at
+		SELECT id, name, description, config_json, is_default, created_at, updated_at, row_version
 		FROM profiles WHERE is_default = 1 LIMIT 1
 	`)
 
@@ -94,7 +95,7 @@ func (r *ProfileRepository) GetDefault(ctx context.Context) (*Profile, error) {
 // List retrieves all profiles.
 func (r *ProfileRepository) List(ctx context.Context) ([]*Profile, error) {
 	rows, err := r.db.Query(ctx, `
-		SELECT id, name, description, config_json, is_default, created_at, updated_at
+		SELECT id, name, description, config_json, is_default, created_at, updated_at, row_version
 		FROM profiles ORDER BY name
 	`)
 	if err != nil {
@@ -114,72 +115,76 @@ func (r *ProfileRepository) List(ctx context.Context) ([]*Profile, error) {
 	return profiles, rows.Err()
 }
 
-// Update updates a profile.
+// Update updates a profile unconditionally, bumping row_version. The new version
+// is read back into profile.RowVersion (via RETURNING) so the in-memory row stays
+// consistent for a subsequent ETag.
 func (r *ProfileRepository) Update(ctx context.Context, profile *Profile) error {
 	profile.UpdatedAt = time.Now().UTC()
 
-	result, err := r.db.Exec(ctx, `
+	row := r.db.QueryRow(ctx, `
 		UPDATE profiles
-		SET name = ?, description = ?, config_json = ?, is_default = ?, updated_at = ?
+		SET name = ?, description = ?, config_json = ?, is_default = ?, updated_at = ?,
+			row_version = row_version + 1
 		WHERE id = ?
+		RETURNING row_version
 	`, profile.Name, profile.Description, profile.ConfigJSON,
 		boolToInt(profile.IsDefault), profile.UpdatedAt.Format(time.RFC3339), profile.ID)
-	if err != nil {
-		if isUniqueConstraintError(err) {
+
+	var newVersion int64
+	if err := row.Scan(&newVersion); err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			return ErrProfileNotFound
+		case isUniqueConstraintError(err):
 			return ErrProfileNameExists
+		default:
+			return fmt.Errorf("failed to update profile: %w", err)
 		}
-		return fmt.Errorf("failed to update profile: %w", err)
 	}
 
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
-
-	if rowsAffected == 0 {
-		return ErrProfileNotFound
-	}
-
+	profile.RowVersion = newVersion
 	return nil
 }
 
 // UpdateIfMatch is the optimistic-concurrency variant of Update: it writes the
-// profile only when the row's current updated_at equals expectedUpdatedAt
-// (the ETag the caller last read). It returns ErrProfileConflict when the row
+// profile only when the row's current row_version equals expectedVersion (the
+// ETag the caller last read). row_version is monotonic and bumped on every
+// write, so — unlike the prior second-precision updated_at token — a sub-second
+// double-write is still caught. It returns ErrProfileConflict when the row
 // exists but has moved on, ErrProfileNotFound when it no longer exists, and
 // ErrProfileNameExists on a name collision — mirroring Update otherwise.
 func (r *ProfileRepository) UpdateIfMatch(
-	ctx context.Context, profile *Profile, expectedUpdatedAt string,
+	ctx context.Context, profile *Profile, expectedVersion int64,
 ) error {
 	profile.UpdatedAt = time.Now().UTC()
 
-	result, err := r.db.Exec(ctx, `
+	row := r.db.QueryRow(ctx, `
 		UPDATE profiles
-		SET name = ?, description = ?, config_json = ?, is_default = ?, updated_at = ?
-		WHERE id = ? AND updated_at = ?
+		SET name = ?, description = ?, config_json = ?, is_default = ?, updated_at = ?,
+			row_version = row_version + 1
+		WHERE id = ? AND row_version = ?
+		RETURNING row_version
 	`, profile.Name, profile.Description, profile.ConfigJSON,
 		boolToInt(profile.IsDefault), profile.UpdatedAt.Format(time.RFC3339),
-		profile.ID, expectedUpdatedAt)
-	if err != nil {
+		profile.ID, expectedVersion)
+
+	var newVersion int64
+	if err := row.Scan(&newVersion); err != nil {
 		if isUniqueConstraintError(err) {
 			return ErrProfileNameExists
 		}
-		return fmt.Errorf("failed to update profile: %w", err)
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("failed to update profile: %w", err)
+		}
+		// 0 rows: distinguish a stale version (row exists) from a deleted row.
+		if _, getErr := r.Get(ctx, profile.ID); getErr != nil {
+			return ErrProfileNotFound // Get maps no-row to ErrProfileNotFound
+		}
+		return ErrProfileConflict
 	}
 
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
-	if rowsAffected > 0 {
-		return nil
-	}
-
-	// 0 rows: distinguish a stale ETag (row exists) from a deleted row.
-	if _, getErr := r.Get(ctx, profile.ID); getErr != nil {
-		return ErrProfileNotFound // Get maps no-row to ErrProfileNotFound
-	}
-	return ErrProfileConflict
+	profile.RowVersion = newVersion
+	return nil
 }
 
 // Delete deletes a profile by ID.
@@ -252,6 +257,7 @@ func (r *ProfileRepository) scanProfile(row *sql.Row) (*Profile, error) {
 		&isDefault,
 		&createdAt,
 		&updatedAt,
+		&p.RowVersion,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -285,6 +291,7 @@ func (r *ProfileRepository) scanProfileFromRows(rows *sql.Rows) (*Profile, error
 		&isDefault,
 		&createdAt,
 		&updatedAt,
+		&p.RowVersion,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan profile: %w", err)

--- a/internal/database/testdata/schema.sql
+++ b/internal/database/testdata/schema.sql
@@ -1286,7 +1286,7 @@ CREATE TABLE profiles (
 				is_default INTEGER DEFAULT 0 CHECK (is_default IN (0,1)),
 				created_at TEXT NOT NULL,
 				updated_at TEXT NOT NULL
-			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id)) STRICT;
+			, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id), row_version INTEGER NOT NULL DEFAULT 1) STRICT;
 
 -- table: reports
 CREATE TABLE reports (

--- a/internal/profiles/app/profiles.go
+++ b/internal/profiles/app/profiles.go
@@ -49,6 +49,9 @@ type Profile struct {
 	IsDefault   bool
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	// RowVersion is the optimistic-concurrency token surfaced as the ETag. It is
+	// opaque to the use-case (the ifMatch string is passed through to the Store).
+	RowVersion int64
 }
 
 // NewProfile is the input for Create.


### PR DESCRIPTION
#1559 gave profiles optimistic concurrency but keyed the ETag on updated_at at
RFC3339 second precision, so two writes inside the same second shared a token and
the conflict went undetected — degrading to last-write-wins in that sub-second
window. Replace the token with a dedicated monotonic row_version column so the
check is exact.

- Migration 00004 adds `row_version INTEGER NOT NULL DEFAULT 1` to profiles
  (backfills the seeded row to 1; STRICT-consistent with the 0001 baseline).
- ProfileRepository: every SELECT scans row_version; Create starts it at 1;
  Update and UpdateIfMatch `SET row_version = row_version + 1` and read the new
  value back via `RETURNING` (atomic, no separate read). UpdateIfMatch now keys
  on `WHERE id = ? AND row_version = ?` (int64) instead of the updated_at string;
  the 0-rows stale-vs-deleted disambiguation is unchanged.
- The profilesapp.Store port is unchanged: ifMatch stays an opaque string, so the
  use-case is untouched. The api adapter parses the string token to int64 and
  treats an unparseable token as a precondition failure (412), not a 500.
- profileETag now emits the row_version; database.Profile/profilesapp.Profile
  carry RowVersion (json:"-" — it is the ETag, never a body field, so the profile
  response DTO and its golden are unchanged).

A write now also bumps the version on the UNCONDITIONAL path, so any held token
goes stale after any write — closing the window in every direction.

Test-first: DB test asserts a fresh profile starts at 1, a wrong version
conflicts, the current version writes through and bumps to 2, re-using the now
stale version conflicts (the exact case #1559 missed), a missing row is 404, and
an unconditional Update bumps too. HTTP test stale-token -> 412 + untouched,
current -> 200 + a fresh DIFFERENT ETag. Schema golden regenerated (row_version
column only); both drift gates green; golangci 0. Blueprint §7 status updated.
