### PR TITLE
feat(outbox): transactional outbox relay for durable event delivery (ADR-0017)

### DIFF
--- a/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
+++ b/docs/architecture/RE_ARCHITECTURE_BLUEPRINT.md
@@ -455,7 +455,11 @@ other; they publish/subscribe typed events.
 - **Ephemeral by default**; **audit events are durable** (→ `platform/audit`).
 - **Subscribers registered before publishers start** (supervisor ordering).
 - **Transactional outbox** (→ [§7](#7-persistence)): events emit only *after* the DB
-  commit, so a rolled-back op never fires an "it happened" event.
+  commit, so a rolled-back op never fires an "it happened" event. **DONE (ADR-0017,
+  2026-06-07):** `internal/platform/outbox` — producers `Enqueue` in-transaction,
+  the `Relay` republishes post-commit onto this bus on the original topic;
+  at-least-once with `Dedupe` for idempotent consumers. Additive — the jobs runner
+  still publishes directly (its durability is its store + `Recover`).
 
 Example fan-out: `shell` emits `DeviceDiscovered` → `sap/health` starts monitoring,
 `harvest` records it, `sap/alerts` evaluates thresholds — with zero import edges
@@ -465,8 +469,9 @@ between modules.
 
 ## 7. Persistence (`adapters/store`)
 
-> **STATUS (2026-06-07): Phase 5b — schema modernization — is DONE; optimistic
-> concurrency is DONE for both mutable resources; one item remains.** Done: `.sql`
+> **STATUS (2026-06-07): Phase 5 is COMPLETE.** Schema modernization (5b),
+> optimistic concurrency on both mutable resources, AND the transactional outbox
+> relay (ADR-0017) have all landed. Done: `.sql`
 > migrations embedded via `//go:embed` + the **goose** runner
 > (`internal/database/goose.go`), the **collapsed `0001_init.sql` baseline** (61
 > STRICT tables), the migrate-from-empty drift gate (`goose_baseline_test.go` /
@@ -477,10 +482,15 @@ between modules.
 > caught; #1559 shipped the flow on `updated_at`, hardened here); **settings** —
 > file-backed (`config.json`) — uses a content-hash of the mutable subset
 > (`config.SettingsETag`, #1560), which is also exact and immune to unrelated
-> global-config writes. **Remaining (feature-sized):** the **transactional outbox
-> relay** (the `00002_jobs.sql` + `platform/events` comments both note it is
-> "layered on" later) — deferred (YAGNI: no consumer needs cross-restart durable
-> delivery; reconcilers re-derive on restart).
+> global-config writes. **Transactional outbox relay — DONE (ADR-0017):**
+> `internal/platform/outbox` + migration `00005_outbox.sql`. A producer enqueues
+> an event in the SAME transaction as its domain write
+> (`database.OutboxRepository.Enqueue` on the caller's `*sql.Tx`); a post-commit
+> `Relay` drains pending rows, republishes each onto the bus on its original
+> topic, marks them published, and prunes delivered rows on the maintenance loop.
+> At-least-once + `Dedupe` for idempotent consumers. The seam is additive and
+> dormant until a producer opts in — the jobs runner keeps publishing directly
+> (its durability is its store + `Recover`, not the outbox).
 > The repo-interfaces-as-domain-ports point below is piloted in
 > `internal/reporting/store` (ReportRepo/ScheduleRepo/MetricsRepo/ExportRepo);
 > generalizing it to all 21 repos is deliberately deferred — done bespoke per
@@ -494,8 +504,9 @@ between modules.
 - **UnitOfWork / Tx** abstraction for multi-table atomicity. *(`DB.WithTx` exists;
   a typed UnitOfWork over the domain ports is the open generalization.)*
 - **Transactional outbox** table: domain writes + the event row commit together;
-  a relay publishes to the bus post-commit. *(OPEN — the durability layer for
-  `platform/events`.)*
+  a relay publishes to the bus post-commit. *(DONE — ADR-0017. `outbox` table
+  (migration `00005`) + `internal/platform/outbox.Relay`; the durability layer for
+  `platform/events`, additive and dormant until a producer enqueues.)*
 - **Optimistic concurrency:** version/ETag + `If-Match` on mutable resources.
   *(DONE — profiles via `row_version` (migration `00004`, #1559 + hardening);
   settings via a mutable-subset content-hash (`config.SettingsETag`, #1560). Both

--- a/docs/architecture/decisions/0004-event-bus.md
+++ b/docs/architecture/decisions/0004-event-bus.md
@@ -1,7 +1,7 @@
 # ADR-0004: In-process domain event bus
 
 **Status:** Accepted — 2026-05-31 · Core implemented (Phase 4) — 2026-06-02 ·
-Outbox deferred (Phase 5c) — 2026-06-03
+Outbox deferred (Phase 5c) — 2026-06-03 · Outbox built (ADR-0017) — 2026-06-07
 
 ## Context
 
@@ -81,3 +81,14 @@ becomes true — at which point the dual-write gap gains an observable victim:
 
 Until then the in-process bus + durable, queryable job state is the correct design.
 ADR-0005's "events emit post-commit via outbox" line is governed by this amendment.
+
+## Update (2026-06-07): outbox **built** — see ADR-0017
+
+The transactional outbox relay was subsequently built (**ADR-0017**) to close the
+Phase-5 persistence track, providing the durable-delivery seam ahead of the first
+triggering consumer. It is **additive**: producers that need cross-restart durable
+delivery enqueue in-transaction and a relay republishes post-commit onto this same
+bus. The jobs runner's direct-publish path is deliberately **unchanged** — the
+defer reasoning above stands for that producer (its durability is its store +
+`Recover`, and its state is re-fetchable), so it was not migrated. ADR-0017
+governs the outbox from here; this amendment is preserved for the reasoning.

--- a/docs/architecture/decisions/0017-transactional-outbox-relay.md
+++ b/docs/architecture/decisions/0017-transactional-outbox-relay.md
@@ -1,0 +1,115 @@
+# ADR-0017: Transactional outbox relay
+
+**Status:** Accepted — 2026-06-07 · Closes the Phase-5 persistence track
+
+## Context
+
+ADR-0004 (in-process domain event bus) mandated a **transactional outbox** so an
+event is only ever delivered after the database write that produced it commits — a
+rolled-back operation must never fire an "it happened" fact. ADR-0004's
+2026-06-03 amendment then **deferred** the outbox on YAGNI grounds: the only
+producer was the jobs runner, the only subscriber was the ephemeral SSE bridge,
+and clients re-fetch durable job state on reconnect, so the dual-write gap had no
+observable victim. The amendment recorded three explicit triggers for building it
+(a cross-process consumer, a durable subscriber that must not miss events across a
+restart, or an event carrying information not reconstructable from durable state).
+
+The decision now is to **build the outbox** to close out the Phase-5 persistence
+track and complete the re-architecture — providing the durable-delivery seam
+*ahead of* the first triggering consumer rather than scrambling to retrofit it
+when one lands. Two constraints shape the design:
+
+1. **No regression to the live path.** The jobs runner already survives restart
+   (durable store + `Recover`, ADR-0005) and re-derives state on reconnect. The
+   amendment correctly warned that rewriting the runner to publish *through* the
+   outbox would add a relay, poll cadence, and ordering concerns "for no present
+   benefit." So the outbox must be **additive**, not a rewrite of the direct
+   `bus.Publish` path the runner uses today.
+
+2. **The bus stays the single delivery seam.** Subscribers already register by
+   topic against `platform/events`. A relayed event must arrive on the same bus,
+   on its original topic, so a future durable subscriber is an ordinary
+   `bus.Subscribe` — it does not learn about the outbox.
+
+## Decision
+
+A **transactional outbox with a post-commit relay**, layered under
+`internal/platform/outbox`, additive to the existing bus.
+
+**Write side (atomic with the domain change).** A producer that needs durable
+delivery enqueues the event *in the same transaction* as its domain write:
+
+```go
+err := db.WithTx(ctx, func(tx *sql.Tx) error {
+    if err := domainWrite(tx, …); err != nil {
+        return err            // rolls back; no outbox row, no event — ever
+    }
+    return db.Outbox().Enqueue(ctx, tx, topic, payload)
+})
+```
+
+The `outbox` table row and the domain row commit or roll back **together** — that
+is the entire correctness guarantee. `Enqueue` takes the caller's `*sql.Tx`; it
+never opens its own transaction.
+
+**Read side (the relay).** `outbox.Relay` polls the store for unpublished rows,
+republishes each onto the bus as an `outbox.Message` (which implements
+`events.Event`, `Topic()` returning the row's stored topic), and marks the batch
+published — **publish first, mark second**. A crash between the two leaves the row
+unpublished, so it replays on the next drain. The relay drains once on `Start`
+(this is the across-restart republish), then on a short ticker.
+
+**Delivery semantics: at-least-once.** Each enqueued row is published to the bus
+at least once across restarts. Because publish-then-mark can double-publish (and
+because the bus is fire-and-forget to async subscribers), **consumers must be
+idempotent**, keyed on `Message.ID` — the outbox row's stable id. `outbox.Dedupe`
+wraps a handler with a bounded most-recently-seen set to make the common case a
+one-liner.
+
+**Retention.** Published rows are pruned by `DeletePublishedBefore` on the
+existing hourly maintenance loop (the same place jobs retention runs), so the
+table does not grow without bound.
+
+**Ordering.** Rows are fetched and published in insert order (`id` is a
+monotonic, gap-tolerant key); per-topic order is preserved by the bus. The relay
+does not promise cross-topic global order — events are independent facts.
+
+## Consequences
+
+- The durability seam ADR-0004 mandated now exists. The three deferral triggers
+  are satisfied in advance: a cross-process consumer, a durable subscriber, or a
+  non-reconstructable event can be added as a plain `bus.Subscribe` whose producer
+  enqueues in-tx — no further infrastructure work.
+- **The jobs runner is unchanged.** It keeps publishing `job.*` facts directly to
+  the bus; its durability is its store + `Recover`, not the outbox. Migrating it
+  to publish through the outbox would be a rewrite with no behavioural gain and is
+  explicitly out of scope (the ADR-0004 amendment's reasoning stands for that
+  path). The outbox is for *new* producers that need cross-restart durable
+  delivery.
+- At-least-once + idempotent consumers is a weaker contract than exactly-once, but
+  exactly-once is unavailable to an in-process async bus without a transactional
+  consumer; at-least-once with `Message.ID` dedup is the honest, standard choice.
+- A relay goroutine polls the table on a short cadence. With no producers the cost
+  is one indexed `WHERE published_at IS NULL` query per interval over an empty
+  table — negligible, and the price of having the seam ready.
+- This ADR **supersedes the "defer" disposition** of the ADR-0004 amendment (its
+  reasoning is preserved there for the record); ADR-0005's "events emit
+  post-commit via outbox" line is now satisfied by this relay for producers that
+  opt in.
+
+## Implementation status (2026-06-07)
+
+- **Migration `00005_outbox.sql`** — `outbox` table (STRICT): `id` INTEGER PK
+  AUTOINCREMENT (monotonic order key), `topic` TEXT, `payload` BLOB, `created_at`
+  TEXT, `published_at` TEXT NULL. Partial index on unpublished rows; index on
+  `published_at` for retention.
+- **`database.OutboxRepository`** (`repository_outbox.go`) — `Enqueue(ctx, tx,
+  topic, payload)` (runs on the caller's `*sql.Tx`), `FetchUnpublished(ctx,
+  limit)`, `MarkPublished(ctx, ids)`, `DeletePublishedBefore(ctx, cutoff)`.
+- **`internal/platform/outbox`** — `Store` port, `Record`, `Message`
+  (`events.Event`), `Relay` (`Drain`/`Start`/`Stop`/`Cleanup`), `Dedupe` +
+  `Deduper`. Pure; no `database/sql` import.
+- **`dbOutboxStore`** (`internal/api/outbox_store.go`) — composition-root adapter
+  bridging `outbox.Store` to `database.OutboxRepository`.
+- **Wiring** — `BackgroundComponents.Outbox` (drains on Start, short ticker);
+  retention on the maintenance loop. Dormant until a producer enqueues.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -11,7 +11,7 @@ See the [Re-Architecture Blueprint](../RE_ARCHITECTURE_BLUEPRINT.md) for the ful
 | [0001](0001-modulith-hexagon.md) | Modulith hexagon structure | Accepted |
 | [0002](0002-capability-registry.md) | Capability registry for route policy | Accepted |
 | [0003](0003-contract-first-boundary.md) | Contract boundary — code-first; OpenAPI deferred | Amended |
-| [0004](0004-event-bus.md) | In-process domain event bus | Accepted |
+| [0004](0004-event-bus.md) | In-process domain event bus | Amended |
 | [0005](0005-unified-jobs.md) | Unified async job runner | Accepted |
 | [0006](0006-migrations-sql-goose-strict.md) | Schema as embedded `.sql` files, goose, STRICT tables | Accepted |
 | [0007](0007-discovery-orchestrator-convergence.md) | Discovery orchestrator convergence — engine vs pipeline, deferred to Phase 7 | Accepted |
@@ -24,3 +24,4 @@ See the [Re-Architecture Blueprint](../RE_ARCHITECTURE_BLUEPRINT.md) for the ful
 | [0014](0014-config-validation-schema-is-a-constraints-validator.md) | config validation schema is a curated constraints validator, not a duplicate | Accepted |
 | [0015](0015-credential-encryption-key-separation.md) | Separate the credential data-encryption key from `Auth.JWTSecret` | Proposed |
 | [0016](0016-strangle-internal-api-into-use-cases.md) | Strangle `internal/api` into per-domain use-case services | Accepted |
+| [0017](0017-transactional-outbox-relay.md) | Transactional outbox relay — durable post-commit event delivery | Accepted |

--- a/internal/api/background.go
+++ b/internal/api/background.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 
+	"github.com/MustardSeedNetworks/seed/internal/platform/outbox"
 	"github.com/MustardSeedNetworks/seed/internal/reporting"
 	wificapture "github.com/MustardSeedNetworks/seed/internal/wifi/capture"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/visibility"
@@ -13,12 +14,18 @@ import (
 // and the api service groupings, built directly from the feature packages; only
 // components that own background work belong here: the report scheduler
 // (internal/reporting), the Wi-Fi airspace visibility loop
-// (internal/wifi/visibility), and the monitor-mode capture producer that feeds it
-// (internal/wifi/capture).
+// (internal/wifi/visibility), the monitor-mode capture producer that feeds it
+// (internal/wifi/capture), and the transactional-outbox relay that drains durable
+// events to the bus (internal/platform/outbox, ADR-0017).
+//
+// The outbox relay is created during server init (it needs the event bus, which
+// is built there) rather than in the cmd-layer constructor, so it is wired onto
+// this struct after construction.
 type BackgroundComponents struct {
 	Reporting      *reporting.Service
 	WiFiVisibility *visibility.Service
 	WiFiCapture    *wificapture.Capture
+	Outbox         *outbox.Relay
 }
 
 // Start initializes and starts all background components. The visibility loop
@@ -39,12 +46,20 @@ func (b *BackgroundComponents) Start(ctx context.Context) error {
 			return err
 		}
 	}
+	if b.Outbox != nil {
+		// The relay owns its own lifecycle context (it polls until Stop), so it
+		// is detached from the start ctx; Stop tears it down on shutdown.
+		b.Outbox.Start(context.WithoutCancel(ctx))
+	}
 	return nil
 }
 
 // Stop gracefully shuts down all background components. Capture stops before the
 // visibility loop it feeds (stop producing, then consuming).
 func (b *BackgroundComponents) Stop() error {
+	if b.Outbox != nil {
+		b.Outbox.Stop()
+	}
 	if b.WiFiCapture != nil {
 		_ = b.WiFiCapture.Stop()
 	}

--- a/internal/api/jobs_retention.go
+++ b/internal/api/jobs_retention.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/platform/jobs"
 )
 
@@ -34,5 +35,22 @@ func sweepJobs(
 		} else if n > 0 {
 			logger.InfoContext(ctx, "jobs retention cleanup completed", "jobs_deleted", n)
 		}
+	}
+}
+
+// sweepOutbox prunes delivered outbox rows past the retention window (ADR-0017).
+// It is a no-op unless the relay is wired (db-backed); pending rows are never
+// touched. Driven by the maintenance loop alongside sweepJobs.
+func (s *Server) sweepOutbox(ctx context.Context) {
+	if s.background == nil || s.background.Outbox == nil {
+		return
+	}
+	n, err := s.background.Outbox.Cleanup(ctx, outboxRetention)
+	if err != nil {
+		logging.GetLogger().ErrorContext(ctx, "outbox retention cleanup failed", "error", err)
+		return
+	}
+	if n > 0 {
+		logging.GetLogger().InfoContext(ctx, "outbox retention cleanup completed", "rows_deleted", n)
 	}
 }

--- a/internal/api/outbox_store.go
+++ b/internal/api/outbox_store.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/platform/outbox"
+)
+
+// outboxRetention is how long a delivered (published) outbox row is kept before
+// the maintenance loop prunes it. Delivered rows have no further use; the window
+// is a short grace period for debugging, mirroring jobs retention.
+const outboxRetention = time.Hour
+
+// dbOutboxStore adapts the durable database.OutboxRepository to the outbox.Store
+// seam the relay drains through (ADR-0017). It is the composition-root bridge
+// between internal/platform/outbox (which must not know about persistence) and
+// the outbox table. The repository keys rows by the int64 autoincrement id; the
+// relay's dedup token is an opaque string, so the adapter is the one place that
+// translates between the two.
+type dbOutboxStore struct {
+	repo *database.OutboxRepository
+}
+
+// newDBOutboxStore builds the adapter over db's outbox repository.
+func newDBOutboxStore(db *database.DB) *dbOutboxStore {
+	return &dbOutboxStore{repo: db.Outbox()}
+}
+
+// FetchUnpublished returns pending rows as relay records, stringifying the id.
+func (s *dbOutboxStore) FetchUnpublished(ctx context.Context, limit int) ([]outbox.Record, error) {
+	recs, err := s.repo.FetchUnpublished(ctx, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]outbox.Record, len(recs))
+	for i, r := range recs {
+		out[i] = outbox.Record{
+			ID:      strconv.FormatInt(r.ID, 10),
+			Topic:   r.Topic,
+			Payload: r.Payload,
+		}
+	}
+	return out, nil
+}
+
+// MarkPublished parses the relay's string ids back to the repository's int64 keys.
+func (s *dbOutboxStore) MarkPublished(ctx context.Context, ids []string) error {
+	intIDs := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		n, parseErr := strconv.ParseInt(id, 10, 64)
+		if parseErr != nil {
+			return fmt.Errorf("outbox store: invalid id %q: %w", id, parseErr)
+		}
+		intIDs = append(intIDs, n)
+	}
+	return s.repo.MarkPublished(ctx, intIDs)
+}
+
+// DeletePublishedBefore prunes delivered rows older than cutoff.
+func (s *dbOutboxStore) DeletePublishedBefore(ctx context.Context, cutoff time.Time) (int, error) {
+	n, err := s.repo.DeletePublishedBefore(ctx, cutoff)
+	return int(n), err
+}

--- a/internal/api/outbox_store_internal_test.go
+++ b/internal/api/outbox_store_internal_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/platform/events"
+	"github.com/MustardSeedNetworks/seed/internal/platform/outbox"
+)
+
+func newOutboxStoreTestDB(t *testing.T) *database.DB {
+	t.Helper()
+	db, err := database.Open(filepath.Join(t.TempDir(), "outbox-store.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestOutboxRelayEndToEnd is the wiring proof for ADR-0017: an event enqueued in
+// a domain transaction is drained by the relay through the real database adapter
+// and delivered on its original topic, exactly once to an idempotent consumer.
+func TestOutboxRelayEndToEnd(t *testing.T) {
+	t.Parallel()
+	db := newOutboxStoreTestDB(t)
+	ctx := context.Background()
+
+	// Producer: enqueue an event in the same transaction as a domain write.
+	if err := db.WithTx(ctx, func(tx *sql.Tx) error {
+		return db.Outbox().Enqueue(ctx, tx, "device.discovered", []byte(`{"id":"d1"}`))
+	}); err != nil {
+		t.Fatalf("enqueue in tx: %v", err)
+	}
+
+	bus := events.New(slog.New(slog.DiscardHandler))
+	var got []string
+	dedup := outbox.NewDeduper(64)
+	bus.Subscribe("device.discovered", outbox.Dedupe(dedup, func(_ context.Context, ev events.Event) {
+		if m, ok := ev.(outbox.Message); ok {
+			got = append(got, string(m.Payload))
+		}
+	}))
+
+	relay := outbox.NewRelay(newDBOutboxStore(db), bus, slog.New(slog.DiscardHandler))
+
+	// First drain delivers it.
+	if n, err := relay.Drain(ctx); err != nil || n != 1 {
+		t.Fatalf("drain = (%d,%v), want (1,nil)", n, err)
+	}
+	// A second drain finds nothing (the row was marked published).
+	if n, err := relay.Drain(ctx); err != nil || n != 0 {
+		t.Fatalf("second drain = (%d,%v), want (0,nil)", n, err)
+	}
+
+	closeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := bus.Close(closeCtx); err != nil {
+		t.Fatalf("bus close: %v", err)
+	}
+
+	if len(got) != 1 || got[0] != `{"id":"d1"}` {
+		t.Fatalf("consumer got %v, want one delivery of the payload", got)
+	}
+
+	// Retention respects age: a freshly delivered row (younger than the window)
+	// is retained. (Deletion past the window is covered at the repository layer
+	// by TestOutboxDeletePublishedBeforeRetainsUnpublished.)
+	if n, err := relay.Cleanup(ctx, time.Hour); err != nil || n != 0 {
+		t.Fatalf("cleanup of a fresh row = (%d,%v), want (0,nil)", n, err)
+	}
+}

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -18,6 +18,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/mibdb"
 	"github.com/MustardSeedNetworks/seed/internal/platform/events"
 	"github.com/MustardSeedNetworks/seed/internal/platform/jobs"
+	"github.com/MustardSeedNetworks/seed/internal/platform/outbox"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/survey"
 )
 
@@ -184,6 +185,19 @@ func (s *Server) initSSEAndLogging(db *database.DB) {
 		} else if n > 0 {
 			logging.GetLogger().Info("recovered interrupted jobs from a prior run", "count", n)
 		}
+	}
+
+	// Transactional-outbox relay (ADR-0017): drains durable events written in a
+	// domain transaction and republishes them post-commit onto the same bus. It
+	// needs both the bus (built just above) and a durable store, so it is created
+	// here and attached to the background components — started/stopped with them.
+	// Dormant until a producer enqueues (no producer is rewired today; the jobs
+	// runner keeps publishing directly). Subscribers register before Start, so a
+	// future durable consumer never misses the startup replay.
+	if db != nil && s.background != nil {
+		s.background.Outbox = outbox.NewRelay(
+			newDBOutboxStore(db), s.eventBus(), logging.GetLogger(),
+		)
 	}
 
 	// Wire up database persistence for logs if database is available

--- a/internal/api/server_shutdown.go
+++ b/internal/api/server_shutdown.go
@@ -186,6 +186,10 @@ func (s *Server) startMaintenance(retentionDays int) {
 			sweepJobs(context.Background(), s.jobsRunner(), jobsRepo,
 				time.Now().UTC().Add(-jobsRetention), logging.GetLogger())
 
+			// Outbox retention (ADR-0017): prune delivered event rows so the
+			// table does not grow without bound. Pending rows are never touched.
+			s.sweepOutbox(context.Background())
+
 			// Data-retention policy (metrics/alerts/etc.) is only applied when
 			// enabled; a zero window must never be interpreted as "delete all".
 			if retentionDays <= 0 || s.db() == nil {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -77,6 +77,7 @@ type DB struct {
 	probes            *ProbeRepository
 	pollingTargets    *PollingTargetRepository
 	jobs              *JobRepository
+	outbox            *OutboxRepository
 	snmpObservations  *SNMPObservationsRepository
 	listenerEvents    *ListenerEventsRepository
 	topology          *TopologyRepository

--- a/internal/database/migrations/00005_outbox.sql
+++ b/internal/database/migrations/00005_outbox.sql
@@ -1,0 +1,33 @@
+-- 00005_outbox.sql — transactional outbox (ADR-0017, closes Phase 5).
+-- A producer that needs durable, cross-restart event delivery writes one row
+-- here in the SAME transaction as its domain change (database.OutboxRepository
+-- .Enqueue runs on the caller's *sql.Tx). The row and the domain row commit or
+-- roll back together — that atomicity is the entire correctness guarantee. A
+-- post-commit relay (internal/platform/outbox.Relay) drains unpublished rows,
+-- republishes them onto the in-process bus, and stamps published_at; published
+-- rows are pruned on the maintenance loop's retention tick. At-least-once
+-- delivery — consumers dedupe on the row id (see outbox.Dedupe). Additive: no
+-- existing producer is rewired; the jobs runner keeps publishing directly.
+-- STRICT + explicit CHECKs, consistent with the 0001 baseline. Regenerate the
+-- gate golden after edits:
+--   UPDATE_SCHEMA_GOLDEN=1 go test ./internal/database/ -run TestSchemaSnapshot
+
+-- +goose Up
+CREATE TABLE outbox (
+	-- AUTOINCREMENT so ids are monotonic and never reused after retention
+	-- deletes — the dedup key (Message.ID) must stay stable and collision-free.
+	id           INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+	topic        TEXT NOT NULL CHECK (topic <> ''),
+	payload      BLOB NOT NULL,
+	created_at   TEXT NOT NULL,
+	published_at TEXT
+) STRICT;
+
+-- The relay's hot path: fetch unpublished rows in insert order. Partial index
+-- keeps it tiny — it only spans the backlog, not the published history.
+CREATE INDEX idx_outbox_unpublished ON outbox(id) WHERE published_at IS NULL;
+-- Retention sweep: delete published rows older than the cutoff.
+CREATE INDEX idx_outbox_published ON outbox(published_at);
+
+-- +goose Down
+DROP TABLE IF EXISTS outbox;

--- a/internal/database/repository_outbox.go
+++ b/internal/database/repository_outbox.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// OutboxRecord is one row of the transactional outbox (ADR-0017): a domain event
+// awaiting delivery. ID is the monotonic autoincrement key the relay uses as the
+// stable dedup token; Payload is the opaque serialized event. PublishedAt is the
+// zero time while the row is pending and the relay's publish timestamp once
+// drained.
+type OutboxRecord struct {
+	ID          int64
+	Topic       string
+	Payload     []byte
+	CreatedAt   time.Time
+	PublishedAt time.Time
+}
+
+// OutboxRepository owns the outbox table (ADR-0017). Enqueue is called inside a
+// caller-supplied transaction so the event row commits atomically with the
+// domain change; the relay (internal/platform/outbox) drains via FetchUnpublished
+// / MarkPublished and the maintenance loop prunes with DeletePublishedBefore.
+type OutboxRepository struct {
+	db *DB
+}
+
+// Outbox returns the transactional-outbox repository (ADR-0017). Producers that
+// need durable, cross-restart delivery enqueue in-transaction; a relay
+// republishes post-commit onto the in-process bus.
+func (db *DB) Outbox() *OutboxRepository {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.outbox == nil {
+		db.outbox = &OutboxRepository{db: db}
+	}
+	return db.outbox
+}
+
+// Enqueue writes one pending event on the caller's transaction. It deliberately
+// runs on tx (not db) so the row is committed or rolled back together with the
+// domain write that produced the event — the outbox's entire correctness
+// guarantee. The row is left unpublished (published_at NULL) for the relay.
+func (r *OutboxRepository) Enqueue(ctx context.Context, tx *sql.Tx, topic string, payload []byte) error {
+	if tx == nil {
+		return errors.New("outbox: Enqueue requires a transaction")
+	}
+	if topic == "" {
+		return errors.New("outbox: empty topic")
+	}
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO outbox (topic, payload, created_at)
+		VALUES (?, ?, ?)
+	`, topic, payload, time.Now().UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("enqueue outbox row: %w", err)
+	}
+	return nil
+}
+
+// FetchUnpublished returns up to limit pending rows in insert order (the partial
+// index keeps this scan bounded to the backlog). The relay publishes them, then
+// MarkPublished the ones it delivered.
+func (r *OutboxRepository) FetchUnpublished(ctx context.Context, limit int) ([]OutboxRecord, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	rows, err := r.db.Query(ctx, `
+		SELECT id, topic, payload, created_at
+		FROM outbox
+		WHERE published_at IS NULL
+		ORDER BY id
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("fetch unpublished outbox rows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []OutboxRecord
+	for rows.Next() {
+		var (
+			rec          OutboxRecord
+			createdAtStr string
+		)
+		if scanErr := rows.Scan(&rec.ID, &rec.Topic, &rec.Payload, &createdAtStr); scanErr != nil {
+			return nil, fmt.Errorf("scan outbox row: %w", scanErr)
+		}
+		rec.CreatedAt = parseTime(createdAtStr)
+		out = append(out, rec)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("iterate outbox rows: %w", rowsErr)
+	}
+	return out, nil
+}
+
+// MarkPublished stamps published_at on the given rows. It is called after the
+// relay has published them to the bus; a crash between publish and mark leaves
+// the rows pending, so they replay (at-least-once). An empty slice is a no-op.
+func (r *OutboxRepository) MarkPublished(ctx context.Context, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	return r.db.WithTx(ctx, func(tx *sql.Tx) error {
+		stmt, err := tx.PrepareContext(ctx,
+			`UPDATE outbox SET published_at = ? WHERE id = ? AND published_at IS NULL`)
+		if err != nil {
+			return fmt.Errorf("prepare mark published: %w", err)
+		}
+		defer func() { _ = stmt.Close() }()
+		for _, id := range ids {
+			if _, execErr := stmt.ExecContext(ctx, now, id); execErr != nil {
+				return fmt.Errorf("mark outbox row %d published: %w", id, execErr)
+			}
+		}
+		return nil
+	})
+}
+
+// DeletePublishedBefore removes published rows whose published_at is before
+// cutoff and returns the count removed. Pending rows (NULL published_at) are
+// never touched — the durable analogue of jobs retention.
+func (r *OutboxRepository) DeletePublishedBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := r.db.Exec(ctx, `
+		DELETE FROM outbox
+		WHERE published_at IS NOT NULL AND published_at < ?
+	`, cutoff.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return 0, fmt.Errorf("delete published outbox rows: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}

--- a/internal/database/repository_outbox_test.go
+++ b/internal/database/repository_outbox_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package database_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+func setupOutboxTest(t *testing.T) (*database.DB, context.Context) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp(t.TempDir(), "seed-outbox-*.db")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	tmpPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() { _ = os.Remove(tmpPath) })
+
+	db, openErr := database.Open(tmpPath)
+	if openErr != nil {
+		t.Fatalf("open db: %v", openErr)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db, context.Background()
+}
+
+// TestOutboxEnqueueCommitsWithDomainWrite is the load-bearing atomicity test: an
+// outbox row enqueued inside WithTx is durable only if the surrounding
+// transaction — domain write included — commits.
+func TestOutboxEnqueueCommitsWithDomainWrite(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupOutboxTest(t)
+
+	// A stand-in domain table so the test exercises a real co-committed write.
+	if _, err := db.Exec(ctx, `CREATE TABLE scratch_domain (id TEXT NOT NULL PRIMARY KEY)`); err != nil {
+		t.Fatalf("create scratch table: %v", err)
+	}
+
+	err := db.WithTx(ctx, func(tx *sql.Tx) error {
+		if _, execErr := tx.ExecContext(ctx, `INSERT INTO scratch_domain (id) VALUES (?)`, "d1"); execErr != nil {
+			return execErr
+		}
+		return db.Outbox().Enqueue(ctx, tx, "device.discovered", []byte(`{"id":"d1"}`))
+	})
+	if err != nil {
+		t.Fatalf("WithTx: %v", err)
+	}
+
+	recs, err := db.Outbox().FetchUnpublished(ctx, 10)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("got %d unpublished rows, want 1", len(recs))
+	}
+	if recs[0].Topic != "device.discovered" || string(recs[0].Payload) != `{"id":"d1"}` {
+		t.Errorf("row = topic %q payload %q, want device.discovered / {\"id\":\"d1\"}",
+			recs[0].Topic, string(recs[0].Payload))
+	}
+	if recs[0].ID == 0 {
+		t.Error("row ID should be a nonzero autoincrement key")
+	}
+}
+
+// TestOutboxEnqueueRollbackDropsRow proves the row participates in the caller's
+// transaction: if the domain write fails and the tx rolls back, no event is left
+// behind — a rolled-back operation never fires an "it happened" fact.
+func TestOutboxEnqueueRollbackDropsRow(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupOutboxTest(t)
+
+	sentinel := errors.New("domain write failed")
+	err := db.WithTx(ctx, func(tx *sql.Tx) error {
+		if enqErr := db.Outbox().Enqueue(ctx, tx, "device.discovered", []byte(`{"id":"x"}`)); enqErr != nil {
+			return enqErr
+		}
+		return sentinel // forces rollback after the enqueue
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("WithTx error = %v, want sentinel", err)
+	}
+
+	recs, err := db.Outbox().FetchUnpublished(ctx, 10)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("rollback left %d outbox rows, want 0", len(recs))
+	}
+}
+
+func TestOutboxFetchUnpublishedOrdersByInsertionAndLimits(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupOutboxTest(t)
+
+	for _, topic := range []string{"a", "b", "c"} {
+		if err := db.WithTx(ctx, func(tx *sql.Tx) error {
+			return db.Outbox().Enqueue(ctx, tx, topic, []byte(topic))
+		}); err != nil {
+			t.Fatalf("enqueue %s: %v", topic, err)
+		}
+	}
+
+	recs, err := db.Outbox().FetchUnpublished(ctx, 2)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("limit not honored: got %d, want 2", len(recs))
+	}
+	if recs[0].Topic != "a" || recs[1].Topic != "b" {
+		t.Errorf("order = %q,%q, want a,b (insert order)", recs[0].Topic, recs[1].Topic)
+	}
+}
+
+func TestOutboxMarkPublishedExcludesFromFetch(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupOutboxTest(t)
+
+	for _, topic := range []string{"a", "b"} {
+		if err := db.WithTx(ctx, func(tx *sql.Tx) error {
+			return db.Outbox().Enqueue(ctx, tx, topic, []byte(topic))
+		}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+	recs, err := db.Outbox().FetchUnpublished(ctx, 10)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if markErr := db.Outbox().MarkPublished(ctx, []int64{recs[0].ID}); markErr != nil {
+		t.Fatalf("mark published: %v", markErr)
+	}
+
+	left, err := db.Outbox().FetchUnpublished(ctx, 10)
+	if err != nil {
+		t.Fatalf("fetch after mark: %v", err)
+	}
+	if len(left) != 1 || left[0].Topic != "b" {
+		t.Fatalf("after marking 'a' published, unpublished = %v, want only b", left)
+	}
+}
+
+func TestOutboxDeletePublishedBeforeRetainsUnpublished(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupOutboxTest(t)
+
+	for _, topic := range []string{"old", "keep"} {
+		if err := db.WithTx(ctx, func(tx *sql.Tx) error {
+			return db.Outbox().Enqueue(ctx, tx, topic, []byte(topic))
+		}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+	recs, err := db.Outbox().FetchUnpublished(ctx, 10)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	// Publish only "old".
+	if markErr := db.Outbox().MarkPublished(ctx, []int64{recs[0].ID}); markErr != nil {
+		t.Fatalf("mark: %v", markErr)
+	}
+
+	// Retention sweep with a cutoff in the future removes the published row only.
+	n, err := db.Outbox().DeletePublishedBefore(ctx, time.Now().UTC().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("deleted %d rows, want 1 (only the published one)", n)
+	}
+	left, err := db.Outbox().FetchUnpublished(ctx, 10)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(left) != 1 || left[0].Topic != "keep" {
+		t.Fatalf("retention removed an unpublished row: left = %v", left)
+	}
+}

--- a/internal/database/testdata/schema.sql
+++ b/internal/database/testdata/schema.sql
@@ -388,6 +388,12 @@ CREATE INDEX idx_oui_category ON oui_vendors(device_category);
 -- index: idx_oui_vendor_name
 CREATE INDEX idx_oui_vendor_name ON oui_vendors(vendor_name);
 
+-- index: idx_outbox_published
+CREATE INDEX idx_outbox_published ON outbox(published_at);
+
+-- index: idx_outbox_unpublished
+CREATE INDEX idx_outbox_unpublished ON outbox(id) WHERE published_at IS NULL;
+
 -- index: idx_pipeline_runs_started
 CREATE INDEX idx_pipeline_runs_started ON pipeline_runs(started_at);
 
@@ -1184,6 +1190,17 @@ CREATE TABLE oui_vendors (
 				device_category TEXT,
 				updated_at TEXT DEFAULT CURRENT_TIMESTAMP
 			) STRICT;
+
+-- table: outbox
+CREATE TABLE outbox (
+	-- AUTOINCREMENT so ids are monotonic and never reused after retention
+	-- deletes — the dedup key (Message.ID) must stay stable and collision-free.
+	id           INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+	topic        TEXT NOT NULL CHECK (topic <> ''),
+	payload      BLOB NOT NULL,
+	created_at   TEXT NOT NULL,
+	published_at TEXT
+) STRICT;
 
 -- table: pipeline_runs
 CREATE TABLE pipeline_runs (

--- a/internal/platform/outbox/outbox.go
+++ b/internal/platform/outbox/outbox.go
@@ -1,0 +1,267 @@
+// Package outbox is seed's transactional-outbox relay (ADR-0017): the durability
+// layer for the in-process event bus (platform/events).
+//
+// A producer that needs cross-restart durable delivery writes an outbox row in
+// the SAME database transaction as its domain change (database.OutboxRepository
+// .Enqueue runs on the caller's *sql.Tx). The row and the domain row commit or
+// roll back together — a rolled-back operation never leaves an event behind. A
+// Relay then drains pending rows post-commit, republishes each onto the bus as a
+// Message on its original topic, and marks the batch published.
+//
+// Delivery is at-least-once: the relay publishes first and marks second, so a
+// crash between the two replays the row on the next drain, and rows enqueued by a
+// prior process are redelivered on Start. Consumers must therefore be idempotent,
+// keyed on Message.ID (the stable outbox row id) — Dedupe wraps a handler with a
+// bounded most-recently-seen window to make that a one-liner.
+//
+// This package is pure: it knows the Store port and the bus, never database/sql.
+// The composition root supplies the Store adapter over the real repository.
+package outbox
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/platform/events"
+)
+
+const (
+	// defaultBatchSize bounds how many pending rows one Drain publishes — a
+	// large backlog drains across several ticks rather than one long stall.
+	defaultBatchSize = 100
+	// defaultInterval is the relay's poll cadence. Short enough that durable
+	// events feel live, long enough that an empty table costs almost nothing.
+	defaultInterval = 2 * time.Second
+)
+
+// Record is one pending outbox row handed to the relay by the Store. ID is the
+// stable, monotonic dedup token; Payload is the opaque serialized event.
+type Record struct {
+	ID      string
+	Topic   string
+	Payload []byte
+}
+
+// Store is the relay's persistence seam (satisfied in the composition root over
+// database.OutboxRepository). It exposes only what the relay needs: read the
+// backlog, mark a batch delivered, and prune delivered rows. Enqueue is
+// deliberately absent — it must run on the producer's transaction, so it lives on
+// the repository, not here.
+type Store interface {
+	// FetchUnpublished returns up to limit pending rows in insert order.
+	FetchUnpublished(ctx context.Context, limit int) ([]Record, error)
+	// MarkPublished stamps the given rows delivered (idempotent per id).
+	MarkPublished(ctx context.Context, ids []string) error
+	// DeletePublishedBefore prunes delivered rows older than cutoff.
+	DeletePublishedBefore(ctx context.Context, cutoff time.Time) (int, error)
+}
+
+// Message is the bus event the relay republishes for an outbox row. It carries
+// the stable ID (the dedup key) and the raw Payload; its Topic is the row's
+// original topic, so an ordinary bus subscriber receives it transparently.
+type Message struct {
+	ID         string
+	EventTopic string
+	Payload    []byte
+}
+
+// Topic implements events.Event, routing the message on its original topic.
+func (m Message) Topic() string { return m.EventTopic }
+
+// Relay drains the outbox to the bus. The zero value is not usable; call
+// NewRelay. A Relay is safe for concurrent use.
+type Relay struct {
+	store    Store
+	bus      *events.Bus
+	logger   *slog.Logger
+	batch    int
+	interval time.Duration
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	done    chan struct{}
+	started bool
+}
+
+// Option tunes a Relay.
+type Option func(*Relay)
+
+// WithBatchSize sets the maximum rows published per drain (<= 0 keeps the default).
+func WithBatchSize(n int) Option {
+	return func(r *Relay) {
+		if n > 0 {
+			r.batch = n
+		}
+	}
+}
+
+// WithInterval sets the poll cadence (<= 0 keeps the default).
+func WithInterval(d time.Duration) Option {
+	return func(r *Relay) {
+		if d > 0 {
+			r.interval = d
+		}
+	}
+}
+
+// NewRelay builds a relay over store publishing to bus. store, bus and logger
+// must be non-nil.
+func NewRelay(store Store, bus *events.Bus, logger *slog.Logger, opts ...Option) *Relay {
+	r := &Relay{
+		store:    store,
+		bus:      bus,
+		logger:   logger,
+		batch:    defaultBatchSize,
+		interval: defaultInterval,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// Drain publishes one batch of pending rows to the bus and marks them published,
+// returning how many it published. It publishes before marking: a failure to
+// mark (or a crash in between) leaves the rows pending so the next Drain replays
+// them — at-least-once. A fetch or mark error is returned to the caller after the
+// publishes already happened.
+func (r *Relay) Drain(ctx context.Context) (int, error) {
+	recs, err := r.store.FetchUnpublished(ctx, r.batch)
+	if err != nil {
+		return 0, fmt.Errorf("outbox: fetch unpublished: %w", err)
+	}
+	if len(recs) == 0 {
+		return 0, nil
+	}
+
+	ids := make([]string, 0, len(recs))
+	for _, rec := range recs {
+		r.bus.Publish(Message{ID: rec.ID, EventTopic: rec.Topic, Payload: rec.Payload})
+		ids = append(ids, rec.ID)
+	}
+	if markErr := r.store.MarkPublished(ctx, ids); markErr != nil {
+		return len(recs), fmt.Errorf("outbox: mark published: %w", markErr)
+	}
+	return len(recs), nil
+}
+
+// Cleanup prunes delivered rows older than retention, returning the count
+// removed. Driven by the maintenance loop, like jobs retention.
+func (r *Relay) Cleanup(ctx context.Context, retention time.Duration) (int, error) {
+	n, err := r.store.DeletePublishedBefore(ctx, time.Now().UTC().Add(-retention))
+	if err != nil {
+		return 0, fmt.Errorf("outbox: cleanup: %w", err)
+	}
+	return n, nil
+}
+
+// Start drains the backlog once (the across-restart replay) and then polls on the
+// configured interval until Stop. It is idempotent: a second Start while running
+// is a no-op.
+func (r *Relay) Start(ctx context.Context) {
+	r.mu.Lock()
+	if r.started {
+		r.mu.Unlock()
+		return
+	}
+	r.started = true
+	runCtx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	r.done = make(chan struct{})
+	r.mu.Unlock()
+
+	if _, err := r.Drain(runCtx); err != nil {
+		r.logger.ErrorContext(runCtx, "outbox initial drain failed", "err", err)
+	}
+	go r.loop(runCtx)
+}
+
+// Stop halts the poll loop and waits for it to exit. Idempotent.
+func (r *Relay) Stop() {
+	r.mu.Lock()
+	if !r.started {
+		r.mu.Unlock()
+		return
+	}
+	r.started = false
+	cancel := r.cancel
+	done := r.done
+	r.cancel = nil
+	r.mu.Unlock()
+
+	cancel()
+	<-done
+}
+
+// loop polls the store until ctx is cancelled.
+func (r *Relay) loop(ctx context.Context) {
+	defer close(r.done)
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := r.Drain(ctx); err != nil {
+				r.logger.ErrorContext(ctx, "outbox drain failed", "err", err)
+			}
+		}
+	}
+}
+
+// Deduper is a bounded most-recently-seen set of Message IDs for idempotent
+// consumers. It is safe for concurrent use. Size it above the relay's redelivery
+// horizon: an id evicted once capacity is exceeded is forgotten and would be
+// reprocessed.
+type Deduper struct {
+	mu       sync.Mutex
+	capacity int
+	seen     map[string]struct{}
+	order    []string
+}
+
+// NewDeduper returns a Deduper retaining the most recent capacity ids (a
+// capacity <= 0 is treated as 1).
+func NewDeduper(capacity int) *Deduper {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &Deduper{
+		capacity: capacity,
+		seen:     make(map[string]struct{}, capacity),
+	}
+}
+
+// Seen records id and reports whether it was already in the window. The first
+// call for an id returns false (process it); a repeat within the window returns
+// true (skip it). Evicts the oldest id once capacity is exceeded.
+func (d *Deduper) Seen(id string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.seen[id]; ok {
+		return true
+	}
+	if len(d.order) >= d.capacity {
+		oldest := d.order[0]
+		d.order = d.order[1:]
+		delete(d.seen, oldest)
+	}
+	d.seen[id] = struct{}{}
+	d.order = append(d.order, id)
+	return false
+}
+
+// Dedupe wraps h so a redelivered Message (same ID, within d's window) is
+// skipped. Non-Message events pass through untouched.
+func Dedupe(d *Deduper, h events.Handler) events.Handler {
+	return func(ctx context.Context, ev events.Event) {
+		if m, ok := ev.(Message); ok && d.Seen(m.ID) {
+			return
+		}
+		h(ctx, ev)
+	}
+}

--- a/internal/platform/outbox/outbox_test.go
+++ b/internal/platform/outbox/outbox_test.go
@@ -1,0 +1,269 @@
+package outbox_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/platform/events"
+	"github.com/MustardSeedNetworks/seed/internal/platform/outbox"
+)
+
+// fakeStore is an in-memory outbox.Store for the relay tests. It is safe for
+// concurrent use since the relay's ticker may drain from its own goroutine.
+type fakeStore struct {
+	mu        sync.Mutex
+	records   []outbox.Record
+	published map[string]bool
+	failMark  bool // when true, MarkPublished returns an error (at-least-once probe)
+	markCalls [][]string
+}
+
+func newFakeStore(recs ...outbox.Record) *fakeStore {
+	return &fakeStore{records: recs, published: map[string]bool{}}
+}
+
+func (s *fakeStore) FetchUnpublished(_ context.Context, limit int) ([]outbox.Record, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []outbox.Record
+	for _, r := range s.records {
+		if s.published[r.ID] {
+			continue
+		}
+		out = append(out, r)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (s *fakeStore) MarkPublished(_ context.Context, ids []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failMark {
+		return errors.New("mark failed")
+	}
+	s.markCalls = append(s.markCalls, ids)
+	for _, id := range ids {
+		s.published[id] = true
+	}
+	return nil
+}
+
+func (s *fakeStore) DeletePublishedBefore(_ context.Context, _ time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	kept := s.records[:0]
+	for _, r := range s.records {
+		if s.published[r.ID] {
+			n++
+			continue
+		}
+		kept = append(kept, r)
+	}
+	s.records = kept
+	return n, nil
+}
+
+// recorder collects Message IDs a subscriber receives, guarded for the race
+// detector (delivery is on the bus's own goroutines).
+type recorder struct {
+	mu  sync.Mutex
+	got []string
+}
+
+func (r *recorder) handle(_ context.Context, ev events.Event) {
+	m, ok := ev.(outbox.Message)
+	if !ok {
+		return
+	}
+	r.mu.Lock()
+	r.got = append(r.got, m.ID)
+	r.mu.Unlock()
+}
+
+func (r *recorder) ids() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.got))
+	copy(out, r.got)
+	return out
+}
+
+func quiet() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+func drainBus(t *testing.T, bus *events.Bus) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := bus.Close(ctx); err != nil {
+		t.Fatalf("bus close: %v", err)
+	}
+}
+
+func TestRelayDrainPublishesOnTopicAndMarks(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore(
+		outbox.Record{ID: "1", Topic: "device.discovered", Payload: []byte(`{"id":"a"}`)},
+		outbox.Record{ID: "2", Topic: "device.discovered", Payload: []byte(`{"id":"b"}`)},
+	)
+	bus := events.New(quiet())
+	var rec recorder
+	bus.Subscribe("device.discovered", rec.handle)
+
+	relay := outbox.NewRelay(store, bus, quiet())
+	n, err := relay.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("drained %d, want 2", n)
+	}
+	drainBus(t, bus)
+
+	if got := rec.ids(); len(got) != 2 || got[0] != "1" || got[1] != "2" {
+		t.Fatalf("subscriber got %v, want [1 2] on the original topic", got)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if !store.published["1"] || !store.published["2"] {
+		t.Fatalf("rows not marked published: %v", store.published)
+	}
+}
+
+// TestRelayRepublishesAfterRestart models a process restart: rows enqueued by a
+// prior process are still unpublished (its ephemeral subscriber is gone). A fresh
+// relay + subscriber must redeliver them — durability across restart.
+func TestRelayRepublishesAfterRestart(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore(
+		outbox.Record{ID: "7", Topic: "survey.completed", Payload: []byte(`{}`)},
+	)
+	bus := events.New(quiet())
+	var rec recorder
+	bus.Subscribe("survey.completed", rec.handle)
+
+	relay := outbox.NewRelay(store, bus, quiet())
+	relay.Start(context.Background()) // initial drain == the across-restart replay
+	t.Cleanup(relay.Stop)
+	drainBus(t, bus)
+
+	if got := rec.ids(); len(got) != 1 || got[0] != "7" {
+		t.Fatalf("after restart got %v, want [7]", got)
+	}
+}
+
+// TestRelayAtLeastOnceOnMarkFailure: if MarkPublished fails after the publish,
+// the rows stay pending and a later drain republishes them — at-least-once.
+func TestRelayAtLeastOnceOnMarkFailure(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore(
+		outbox.Record{ID: "1", Topic: "t", Payload: []byte(`x`)},
+	)
+	store.failMark = true
+	bus := events.New(quiet())
+	var rec recorder
+	bus.Subscribe("t", rec.handle)
+
+	relay := outbox.NewRelay(store, bus, quiet())
+	if _, err := relay.Drain(context.Background()); err == nil {
+		t.Fatal("drain should surface the mark failure")
+	}
+	// Recover the store and drain again — the row must still be deliverable.
+	store.mu.Lock()
+	store.failMark = false
+	store.mu.Unlock()
+	if _, err := relay.Drain(context.Background()); err != nil {
+		t.Fatalf("second drain: %v", err)
+	}
+	drainBus(t, bus)
+
+	// The subscriber saw the event at least once (here twice — that is why
+	// consumers must dedupe).
+	if got := rec.ids(); len(got) < 1 {
+		t.Fatalf("at-least-once violated: got %v", got)
+	}
+}
+
+func TestRelayCleanupDeletesPublished(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore(
+		outbox.Record{ID: "1", Topic: "t", Payload: []byte(`x`)},
+	)
+	bus := events.New(quiet())
+	bus.Subscribe("t", func(context.Context, events.Event) {})
+	relay := outbox.NewRelay(store, bus, quiet())
+	if _, err := relay.Drain(context.Background()); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	drainBus(t, bus)
+
+	n, err := relay.Cleanup(context.Background(), time.Hour)
+	if err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("cleanup removed %d, want 1", n)
+	}
+}
+
+func TestRelayStartStopIdempotent(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	bus := events.New(quiet())
+	relay := outbox.NewRelay(store, bus, quiet())
+	relay.Start(context.Background())
+	relay.Start(context.Background()) // second start is a no-op
+	relay.Stop()
+	relay.Stop() // second stop is a no-op
+	drainBus(t, bus)
+}
+
+func TestDedupeSkipsRepeatedID(t *testing.T) {
+	t.Parallel()
+	bus := events.New(quiet())
+	var rec recorder
+	d := outbox.NewDeduper(16)
+	bus.Subscribe("t", outbox.Dedupe(d, rec.handle))
+
+	bus.Publish(outbox.Message{ID: "dup", EventTopic: "t", Payload: []byte(`x`)})
+	bus.Publish(outbox.Message{ID: "dup", EventTopic: "t", Payload: []byte(`x`)})
+	bus.Publish(outbox.Message{ID: "other", EventTopic: "t", Payload: []byte(`y`)})
+	drainBus(t, bus)
+
+	if got := rec.ids(); len(got) != 2 || got[0] != "dup" || got[1] != "other" {
+		t.Fatalf("dedupe got %v, want [dup other] (second dup skipped)", got)
+	}
+}
+
+// TestDeduperForgetsBeyondCapacity documents the bounded contract: Seen reports
+// true for a duplicate it still remembers, but an id evicted once capacity is
+// exceeded is forgotten (and would be reprocessed). The window must be sized
+// above the relay's redelivery horizon.
+func TestDeduperForgetsBeyondCapacity(t *testing.T) {
+	t.Parallel()
+	d := outbox.NewDeduper(2)
+
+	if d.Seen("a") {
+		t.Fatal("first sight of a should be new")
+	}
+	if d.Seen("b") {
+		t.Fatal("first sight of b should be new")
+	}
+	if !d.Seen("b") {
+		t.Fatal("b is still in the window, should be a duplicate")
+	}
+	// "c" evicts the oldest tracked id ("a").
+	if d.Seen("c") {
+		t.Fatal("first sight of c should be new")
+	}
+	if d.Seen("a") {
+		t.Fatal("a was evicted, should read as new again")
+	}
+}


### PR DESCRIPTION
## Summary
Closes the Phase-5 persistence track by **building the transactional outbox** that ADR-0004 mandated and its 2026-06-03 amendment deferred (YAGNI). Per owner directive, the durable-delivery seam is built ahead of the first triggering consumer to complete the re-architecture.

The seam is **additive**: a producer that needs cross-restart durable delivery enqueues an event row in the **same transaction** as its domain write; a post-commit **relay** republishes pending rows onto the in-process bus on their original topic.

```go
db.WithTx(ctx, func(tx *sql.Tx) error {
    if err := domainWrite(tx, …); err != nil { return err } // rollback → no event
    return db.Outbox().Enqueue(ctx, tx, topic, payload)
})
```

## What landed
- **migration `00005_outbox.sql`** — STRICT `outbox` table; autoincrement id is the stable dedup key; partial index on the unpublished backlog; retention index.
- **`database.OutboxRepository`** — `Enqueue` (on caller's `*sql.Tx`), `FetchUnpublished`, `MarkPublished`, `DeletePublishedBefore`.
- **`internal/platform/outbox`** — `Store` port, `Message` (`events.Event`), `Relay` (`Drain`/`Start`/`Stop`/`Cleanup`; publish-then-mark = at-least-once), `Deduper` + `Dedupe` for idempotent consumers. Pure (no `database/sql`).
- **`dbOutboxStore`** adapter (composition root) + wiring as a `BackgroundComponents` lifecycle component; retention on the maintenance loop.

## Deliberately out of scope
The **jobs runner is unchanged** — it keeps publishing `job.*` directly; its durability is its store + `Recover`, so migrating it to the outbox would be a rewrite with no behavioural gain (the ADR-0004 amendment reasoning stands for that path). The relay is **dormant** until a producer opts in.

## Delivery contract
At-least-once across restarts; consumers dedupe on `Message.ID`. Honest choice for an in-process async bus.

## Tests (test-first, all layers)
- in-tx atomicity (rollback drops the row; commit keeps it)
- across-restart replay; at-least-once on mark failure; ordering/limit; retention
- `Dedupe` skip + bounded eviction; relay Start/Stop idempotency
- end-to-end wiring: enqueue-in-tx → adapter → relay → bus → idempotent consumer

## Docs
ADR-0017 (new, Accepted), ADR-0004 (marked built), blueprint §6/§7 updated to **Phase 5 COMPLETE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)