### PR TITLE
refactor(discovery): express scan as stage ports (adr-0018, phase 6)

### DIFF
--- a/docs/architecture/decisions/0018-discovery-pipeline-stage-split.md
+++ b/docs/architecture/decisions/0018-discovery-pipeline-stage-split.md
@@ -161,11 +161,34 @@ them at the subpackages directly once the dust settles.
   error when the depguard rule lands — which is exactly the coupling this surfaces
   and fixes, not a regression.
 
+## Implementation note (2026-06-07): ports-first, root-as-kernel
+
+During implementation a lower-risk refinement of the foundation step emerged. The
+hub type `DiscoveredDevice` aggregates a field of every stage's result type
+(`*DeviceProfile`, `*SNMPFullData`, `*DeviceVulnerabilities`, the protocol-info
+structs). Moving those result types into a `model` leaf is therefore impossible
+without either moving the whole cluster or creating an import cycle. So instead of
+a `model` leaf + facade aliases, the **root `discovery` package is the kernel**:
+it keeps `DiscoveredDevice` + all result types + the stage **port interfaces**;
+each stage *subpackage* will import the kernel for those types and implement its
+port; the kernel does **not** import the stages (the orchestrator holds the ports
+as interfaces, and the composition root injects the concrete stages). `depguard`
+enforces `stages → kernel`, never the reverse, and no sibling-to-sibling imports.
+This keeps shared types put (zero `internal/api` churn, golden/schema unchanged)
+and avoids the large, risky type move the `model`-leaf plan implied.
+
+The first increment ("define stage seams as ports") was therefore done
+**in-package**: the four ports (`Enumerator`, `Resolver`, `Enricher`, `Assessor`
+— `Enricher` rather than `Fingerprinter`, which is an existing capability type)
+and their stage structs live in `stages.go`, and `Engine.runScanPhases` now
+orchestrates the ports. Per-stage subpackage relocation + depguard follow.
+
 ## Implementation status
 
-- [ ] 1. `model` foundation + facade aliases
-- [ ] 2. `vuln` stage + `Assessor` port + depguard
-- [ ] 3. `fingerprint` stage + `Fingerprinter` port + depguard
-- [ ] 4. `resolve` stage + `Resolver` port + depguard
-- [ ] 5. `enumerate` stage + `Enumerator` port + depguard
-- [ ] 6. direction-lock depguard + cleanup + §16 doc
+- [x] 0. stage ports + stage types in-package; Engine orchestrates ports
+      (`stages.go`); behaviour-preserving, golden byte-identical
+- [ ] 1. `vuln` stage → `discovery/vuln` subpackage + depguard
+- [ ] 2. `fingerprint`/enrich stage → `discovery/fingerprint` + depguard
+- [ ] 3. `resolve` stage → `discovery/resolve` + depguard
+- [ ] 4. `enumerate` stage → `discovery/enumerate` + depguard
+- [ ] 5. direction-lock depguard + cleanup + §16 doc

--- a/internal/discovery/engine.go
+++ b/internal/discovery/engine.go
@@ -15,7 +15,6 @@ package discovery
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"slices"
 	"sync"
@@ -448,10 +447,17 @@ func (e *Engine) runScanPhases(ctx context.Context, logger *slog.Logger, opts *S
 		e.reportScanProgress(opts, phase, float64(done)/float64(total))
 	}
 
-	// Phase 1: Discovery
+	// Phase 1: Discovery (enumerate stage)
 	logger.InfoContext(ctx, "Starting discovery phase")
 	result.Phases = append(result.Phases, "discovery")
-	if err := e.runDiscoveryPhase(ctx, opts, result.Stats); err != nil {
+	var enumerate Enumerator = &enumerateStage{
+		registry:           e.registry,
+		config:             e.config,
+		wiredCollector:     e.wiredCollector,
+		wifiCollector:      e.wifiCollector,
+		bluetoothCollector: e.bluetoothCollector,
+	}
+	if err := enumerate.Enumerate(ctx, opts); err != nil {
 		result.Error = err.Error()
 		logger.ErrorContext(ctx, "Discovery phase failed", "error", err)
 	}
@@ -463,28 +469,40 @@ func (e *Engine) runScanPhases(ctx context.Context, logger *slog.Logger, opts *S
 	e.correlateDevices(ctx)
 	complete("correlation")
 
-	// Phase 3: Name Resolution
+	// Phase 3: Name Resolution (resolve stage)
 	if opts.IncludeNameRes && e.wiredCollector != nil {
 		logger.InfoContext(ctx, "Starting name resolution phase")
 		result.Phases = append(result.Phases, "name_resolution")
-		e.wiredCollector.ResolveNetBIOSNames(ctx)
-		e.wiredCollector.ResolveMDNSNames(ctx)
+		var resolve Resolver = &resolveStage{wiredCollector: e.wiredCollector}
+		resolve.Resolve(ctx)
 		complete("name_resolution")
 	}
 
-	// Phase 4: Enrichment
+	// Phase 4: Enrichment (fingerprint stage)
 	if opts.IncludeSNMP || opts.IncludePortScan || opts.IncludeProfiling {
 		logger.InfoContext(ctx, "Starting enrichment phase")
 		result.Phases = append(result.Phases, "enrichment")
-		e.runEnrichmentPhase(ctx, opts, result.Stats)
+		var enrich Enricher = &enrichStage{
+			registry:      e.registry,
+			config:        e.config,
+			snmpCollector: e.snmpCollector,
+			portScanner:   e.portScanner,
+			profiler:      e.profiler,
+		}
+		enrich.Enrich(ctx, opts, result.Stats)
 		complete("enrichment")
 	}
 
-	// Phase 5: Assessment
+	// Phase 5: Assessment (vuln stage)
 	if opts.IncludeVulnScan && e.vulnScanner != nil {
 		logger.InfoContext(ctx, "Starting assessment phase")
 		result.Phases = append(result.Phases, "assessment")
-		e.runAssessmentPhase(ctx, result.Stats)
+		var assess Assessor = &assessStage{
+			registry:    e.registry,
+			eventBus:    e.eventBus,
+			vulnScanner: e.vulnScanner,
+		}
+		assess.Assess(ctx, result.Stats)
 		complete("assessment")
 	}
 }
@@ -528,99 +546,6 @@ func (e *Engine) FullScan(ctx context.Context) (*ScanResult, error) {
 	return e.Scan(ctx, DefaultFullScanOpts())
 }
 
-// runWiredDiscovery performs wired device discovery.
-func (e *Engine) runWiredDiscovery(ctx context.Context, opts *ScanOptions) error {
-	if opts.FreshWiredScan {
-		if err := e.wiredCollector.Scan(ctx); err != nil {
-			return fmt.Errorf("wired scan: %w", err)
-		}
-	}
-	for _, device := range e.wiredCollector.GetDevices() {
-		device.ConnectionTypes = ensureConnectionType(device.ConnectionTypes, ConnectionWired)
-		e.registry.AddOrUpdate(device)
-	}
-	return nil
-}
-
-// runWiFiDiscovery performs WiFi device discovery.
-func (e *Engine) runWiFiDiscovery(ctx context.Context, opts *ScanOptions) error {
-	if opts.FreshWiFiScan {
-		if _, err := e.wifiCollector.Scan(ctx); err != nil {
-			return fmt.Errorf("wifi scan: %w", err)
-		}
-	}
-	aps := e.wifiCollector.GetAccessPoints()
-	for i := range aps {
-		device := e.wifiAPToDevice(&aps[i])
-		e.registry.AddOrUpdate(device)
-	}
-	return nil
-}
-
-// runBluetoothDiscovery performs Bluetooth device discovery.
-func (e *Engine) runBluetoothDiscovery(ctx context.Context, opts *ScanOptions) error {
-	if opts.FreshBluetoothScan {
-		if _, err := e.bluetoothCollector.Scan(ctx); err != nil {
-			return fmt.Errorf("bluetooth scan: %w", err)
-		}
-	}
-	scanResult := e.bluetoothCollector.GetLastScan()
-	if scanResult != nil {
-		for i := range scanResult.Devices {
-			device := e.bluetoothDeviceToDevice(&scanResult.Devices[i])
-			e.registry.AddOrUpdate(device)
-		}
-	}
-	return nil
-}
-
-// runDiscoveryPhase collects devices from all enabled sources.
-func (e *Engine) runDiscoveryPhase(ctx context.Context, opts *ScanOptions, _ *ScanStats) error {
-	var wg sync.WaitGroup
-	errCh := make(chan error, discoveryPhaseChannelBuffer)
-
-	// Wired discovery
-	if opts.IncludeWired && e.wiredCollector != nil && e.config.EnableWired {
-		wg.Go(func() {
-			if err := e.runWiredDiscovery(ctx, opts); err != nil {
-				errCh <- err
-			}
-		})
-	}
-
-	// WiFi discovery
-	if opts.IncludeWiFi && e.wifiCollector != nil && e.config.EnableWiFi {
-		wg.Go(func() {
-			if err := e.runWiFiDiscovery(ctx, opts); err != nil {
-				errCh <- err
-			}
-		})
-	}
-
-	// Bluetooth discovery
-	if opts.IncludeBluetooth && e.bluetoothCollector != nil && e.config.EnableBluetooth {
-		wg.Go(func() {
-			if err := e.runBluetoothDiscovery(ctx, opts); err != nil {
-				errCh <- err
-			}
-		})
-	}
-
-	wg.Wait()
-	close(errCh)
-
-	var errs []error
-	for err := range errCh {
-		errs = append(errs, err)
-	}
-
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
-}
-
 // correlateDevices merges devices seen on multiple networks.
 // Since we use MAC as the primary key, correlation happens automatically
 // in AddOrUpdate. This method handles any additional correlation logic.
@@ -628,187 +553,6 @@ func (e *Engine) correlateDevices(_ context.Context) {
 	// The registry already correlates by MAC on AddOrUpdate.
 	// This method can be extended for additional correlation strategies
 	// (e.g., IP-based correlation, hostname matching, etc.)
-}
-
-// runEnrichmentPhase performs SNMP, port scanning, and profiling.
-func (e *Engine) runEnrichmentPhase(ctx context.Context, opts *ScanOptions, stats *ScanStats) {
-	devices := e.registry.GetDevices()
-
-	for _, device := range devices {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
-		// SNMP enrichment
-		if opts.IncludeSNMP && e.snmpCollector != nil && e.config.EnableSNMP {
-			if snmpData := e.collectSNMPData(ctx, device); snmpData != nil {
-				device.SNMPData = snmpData
-				stats.EnrichedDevices++
-			}
-		}
-
-		// Port scanning
-		if opts.IncludePortScan && e.portScanner != nil && e.config.EnablePortScan {
-			if profile := e.scanPorts(ctx, device); profile != nil {
-				device.Profile = profile
-			}
-		}
-
-		// Profiling
-		if opts.IncludeProfiling && e.profiler != nil && e.config.EnableProfiling {
-			e.profileDevice(ctx, device)
-		}
-
-		// Update device in registry
-		e.registry.AddOrUpdate(device)
-	}
-}
-
-// runAssessmentPhase performs vulnerability scanning.
-func (e *Engine) runAssessmentPhase(ctx context.Context, stats *ScanStats) {
-	devices := e.registry.GetDevices()
-
-	for _, device := range devices {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
-		vulns := e.assessVulnerabilities(ctx, device)
-		if vulns != nil && len(vulns.Vulnerabilities) > 0 {
-			device.Vulnerabilities = vulns
-			stats.VulnerableDevices++
-			e.registry.AddOrUpdate(device)
-
-			// Emit vulnerability event for each finding
-			for _, v := range vulns.Vulnerabilities {
-				e.eventBus.Publish(NewVulnDiscoveredEvent(device, v.CVEID, v.Severity))
-			}
-		}
-	}
-}
-
-// collectSNMPData collects SNMP data for a device.
-func (e *Engine) collectSNMPData(ctx context.Context, device *DiscoveredDevice) *SNMPFullData {
-	if device.IP == "" || e.snmpCollector == nil {
-		return nil
-	}
-
-	// Try SNMP collection (collector handles v2c and v3)
-	data, err := e.snmpCollector.Collect(ctx, device.IP)
-	if err != nil {
-		return nil
-	}
-	return data
-}
-
-// scanPorts scans ports on a device.
-func (e *Engine) scanPorts(ctx context.Context, device *DiscoveredDevice) *DeviceProfile {
-	if device.IP == "" || e.portScanner == nil {
-		return nil
-	}
-
-	result := e.portScanner.QuickScan(ctx, device.IP)
-	if result == nil || result.Error != "" {
-		return nil
-	}
-
-	// Convert ServiceInfo to OpenPort
-	openPorts := make([]OpenPort, 0, len(result.Services))
-	for _, svc := range result.Services {
-		openPorts = append(openPorts, OpenPort{
-			Port:     svc.Port,
-			Protocol: svc.Protocol,
-			Service:  svc.Service,
-			Banner:   svc.Banner,
-			IsOpen:   svc.State == "open",
-		})
-	}
-
-	profile := &DeviceProfile{
-		OpenPorts: openPorts,
-	}
-	return profile
-}
-
-// profileDevice performs device profiling.
-func (e *Engine) profileDevice(_ context.Context, device *DiscoveredDevice) {
-	if e.profiler == nil || device.IP == "" {
-		return
-	}
-
-	// Queue the device for profiling (async)
-	if err := e.profiler.QueueProfile(device.IP); err != nil {
-		return
-	}
-
-	// Check if profile is already available (from previous profiling)
-	if profile := e.profiler.GetProfile(device.IP); profile != nil {
-		device.Profile = profile
-	}
-}
-
-// assessVulnerabilities checks a device for vulnerabilities.
-func (e *Engine) assessVulnerabilities(ctx context.Context, device *DiscoveredDevice) *DeviceVulnerabilities {
-	if e.vulnScanner == nil {
-		return nil
-	}
-
-	vulns, err := e.vulnScanner.ScanDevice(ctx, device)
-	if err != nil {
-		return nil
-	}
-	return vulns
-}
-
-// wifiAPToDevice converts a WiFi access point to a DiscoveredDevice.
-func (e *Engine) wifiAPToDevice(ap *WiFiAccessPoint) *DiscoveredDevice {
-	device := &DiscoveredDevice{
-		MAC:             ap.BSSID,
-		Vendor:          ap.Vendor,
-		DiscoveryMethod: []Method{},
-		ConnectionTypes: []ConnectionType{ConnectionWiFi},
-		WiFiPresence: &WiFiPresence{
-			SSID:          ap.SSIDName,
-			Channel:       ap.Channel,
-			ChannelWidth:  ap.ChannelWidth,
-			FrequencyMHz:  ap.FrequencyMHz,
-			SignalDBm:     ap.SignalDBm,
-			IsAccessPoint: true,
-			IsAuthorized:  ap.IsAuthorized,
-			Band:          string(ap.Band),
-			LastSeen:      ap.LastSeen,
-		},
-		LastSeen: ap.LastSeen,
-	}
-	return device
-}
-
-// bluetoothDeviceToDevice converts a Bluetooth device to a DiscoveredDevice.
-func (e *Engine) bluetoothDeviceToDevice(bt *BluetoothDevice) *DiscoveredDevice {
-	device := &DiscoveredDevice{
-		MAC:             bt.Address,
-		Vendor:          bt.Vendor,
-		DiscoveryMethod: []Method{},
-		ConnectionTypes: []ConnectionType{ConnectionBluetooth},
-		BluetoothPresence: &BluetoothPresence{
-			Name:         bt.Name,
-			Type:         bt.Type,
-			DeviceClass:  bt.DeviceClass,
-			RSSI:         bt.RSSI,
-			TxPower:      bt.TxPower,
-			IsPaired:     bt.IsPaired,
-			IsConnected:  bt.IsConnected,
-			IsAuthorized: bt.IsAuthorized,
-			Services:     bt.ServiceUUIDs,
-			LastSeen:     bt.LastSeen,
-		},
-		LastSeen: bt.LastSeen,
-	}
-	return device
 }
 
 // autoScanLoop runs periodic scans. stopCh is passed as a parameter rather

--- a/internal/discovery/export_test.go
+++ b/internal/discovery/export_test.go
@@ -176,6 +176,32 @@ func ExportEnsureConnectionType(types []ConnectionType, add ConnectionType) []Co
 	return ensureConnectionType(types, add)
 }
 
+// ExportWiFiAPToDevice exposes wifiAPToDevice (ADR-0018 enumerate stage) for testing.
+func ExportWiFiAPToDevice(ap *WiFiAccessPoint) *DiscoveredDevice {
+	return wifiAPToDevice(ap)
+}
+
+// ExportBluetoothDeviceToDevice exposes bluetoothDeviceToDevice for testing.
+func ExportBluetoothDeviceToDevice(bt *BluetoothDevice) *DiscoveredDevice {
+	return bluetoothDeviceToDevice(bt)
+}
+
+// NewEnumerateStageForTest builds the enumerate stage (no collectors) as its
+// port, for nil-safety testing (ADR-0018).
+func NewEnumerateStageForTest(reg *DeviceRegistry, cfg *EngineConfig) Enumerator {
+	return &enumerateStage{registry: reg, config: cfg}
+}
+
+// NewEnrichStageForTest builds the enrich stage (no components) as its port.
+func NewEnrichStageForTest(reg *DeviceRegistry, cfg *EngineConfig) Enricher {
+	return &enrichStage{registry: reg, config: cfg}
+}
+
+// NewAssessStageForTest builds the assess stage (no scanner) as its port.
+func NewAssessStageForTest(reg *DeviceRegistry, bus *EventBus) Assessor {
+	return &assessStage{registry: reg, eventBus: bus}
+}
+
 // EngineTestAccessor provides access to Engine's private fields for testing.
 type EngineTestAccessor struct {
 	Engine *Engine

--- a/internal/discovery/stages.go
+++ b/internal/discovery/stages.go
@@ -1,0 +1,323 @@
+package discovery
+
+// stages.go expresses the discovery scan as four explicit pipeline stages behind
+// ports (ADR-0018, Phase 6): enumerate -> resolve -> fingerprint -> vuln. These
+// are the existing Engine.runScanPhases boundaries, lifted into stage types so
+// the Engine orchestrates ports rather than inlining each phase. The stage types
+// and the Engine still live in this package; subsequent PRs relocate each stage
+// into its own subpackage (with depguard enforcing the one-way direction) — at
+// which point these ports are the stable seam the orchestrator depends on.
+//
+// Behaviour is unchanged: each stage holds the same components the Engine held
+// and runs the same logic, reading from / writing to the shared DeviceRegistry.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Enumerator is stage 1: discover hosts and links from the enabled sources
+// (wired/Wi-Fi/Bluetooth), writing each device into the registry.
+type Enumerator interface {
+	Enumerate(ctx context.Context, opts *ScanOptions) error
+}
+
+// Resolver is stage 2: attach identity/naming (NetBIOS, mDNS) to discovered
+// devices already in the registry.
+type Resolver interface {
+	Resolve(ctx context.Context)
+}
+
+// Enricher is stage 3 (the engine's "enrichment" phase, a.k.a. fingerprint):
+// actively probe registry devices for services, OS, and SNMP detail, recording
+// the results back on each device. Named Enricher rather than Fingerprinter
+// because the latter is already an advanced-probing capability used within this
+// stage.
+type Enricher interface {
+	Enrich(ctx context.Context, opts *ScanOptions, stats *ScanStats)
+}
+
+// Assessor is stage 4: evaluate registry devices for vulnerabilities, recording
+// findings and emitting a discovery event per finding.
+type Assessor interface {
+	Assess(ctx context.Context, stats *ScanStats)
+}
+
+// --- Stage 1: enumerate ------------------------------------------------------
+
+// enumerateStage runs the discovery sources concurrently and writes results to
+// the registry. Per-source gating (opts + collector presence + config enable)
+// matches the Engine's prior behaviour exactly.
+type enumerateStage struct {
+	registry           *DeviceRegistry
+	config             *EngineConfig
+	wiredCollector     *DeviceDiscovery
+	wifiCollector      *WiFiBridge
+	bluetoothCollector *BluetoothScanner
+}
+
+func (s *enumerateStage) Enumerate(ctx context.Context, opts *ScanOptions) error {
+	var wg sync.WaitGroup
+	errCh := make(chan error, discoveryPhaseChannelBuffer)
+
+	if opts.IncludeWired && s.wiredCollector != nil && s.config.EnableWired {
+		wg.Go(func() {
+			if err := s.enumerateWired(ctx, opts); err != nil {
+				errCh <- err
+			}
+		})
+	}
+	if opts.IncludeWiFi && s.wifiCollector != nil && s.config.EnableWiFi {
+		wg.Go(func() {
+			if err := s.enumerateWiFi(ctx, opts); err != nil {
+				errCh <- err
+			}
+		})
+	}
+	if opts.IncludeBluetooth && s.bluetoothCollector != nil && s.config.EnableBluetooth {
+		wg.Go(func() {
+			if err := s.enumerateBluetooth(ctx, opts); err != nil {
+				errCh <- err
+			}
+		})
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func (s *enumerateStage) enumerateWired(ctx context.Context, opts *ScanOptions) error {
+	if opts.FreshWiredScan {
+		if err := s.wiredCollector.Scan(ctx); err != nil {
+			return fmt.Errorf("wired scan: %w", err)
+		}
+	}
+	for _, device := range s.wiredCollector.GetDevices() {
+		device.ConnectionTypes = ensureConnectionType(device.ConnectionTypes, ConnectionWired)
+		s.registry.AddOrUpdate(device)
+	}
+	return nil
+}
+
+func (s *enumerateStage) enumerateWiFi(ctx context.Context, opts *ScanOptions) error {
+	if opts.FreshWiFiScan {
+		if _, err := s.wifiCollector.Scan(ctx); err != nil {
+			return fmt.Errorf("wifi scan: %w", err)
+		}
+	}
+	aps := s.wifiCollector.GetAccessPoints()
+	for i := range aps {
+		s.registry.AddOrUpdate(wifiAPToDevice(&aps[i]))
+	}
+	return nil
+}
+
+func (s *enumerateStage) enumerateBluetooth(ctx context.Context, opts *ScanOptions) error {
+	if opts.FreshBluetoothScan {
+		if _, err := s.bluetoothCollector.Scan(ctx); err != nil {
+			return fmt.Errorf("bluetooth scan: %w", err)
+		}
+	}
+	scanResult := s.bluetoothCollector.GetLastScan()
+	if scanResult != nil {
+		for i := range scanResult.Devices {
+			s.registry.AddOrUpdate(bluetoothDeviceToDevice(&scanResult.Devices[i]))
+		}
+	}
+	return nil
+}
+
+// --- Stage 2: resolve --------------------------------------------------------
+
+// resolveStage attaches names via the wired collector's resolvers.
+type resolveStage struct {
+	wiredCollector *DeviceDiscovery
+}
+
+func (s *resolveStage) Resolve(ctx context.Context) {
+	s.wiredCollector.ResolveNetBIOSNames(ctx)
+	s.wiredCollector.ResolveMDNSNames(ctx)
+}
+
+// --- Stage 3: fingerprint (enrichment) ---------------------------------------
+
+// enrichStage enriches each registry device with SNMP, port-scan, and profiler
+// results.
+type enrichStage struct {
+	registry      *DeviceRegistry
+	config        *EngineConfig
+	snmpCollector *SNMPCollector
+	portScanner   *PortScanner
+	profiler      *DeviceProfiler
+}
+
+func (s *enrichStage) Enrich(ctx context.Context, opts *ScanOptions, stats *ScanStats) {
+	for _, device := range s.registry.GetDevices() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		if opts.IncludeSNMP && s.snmpCollector != nil && s.config.EnableSNMP {
+			if snmpData := s.collectSNMP(ctx, device); snmpData != nil {
+				device.SNMPData = snmpData
+				stats.EnrichedDevices++
+			}
+		}
+		if opts.IncludePortScan && s.portScanner != nil && s.config.EnablePortScan {
+			if profile := s.scanPorts(ctx, device); profile != nil {
+				device.Profile = profile
+			}
+		}
+		if opts.IncludeProfiling && s.profiler != nil && s.config.EnableProfiling {
+			s.profileDevice(device)
+		}
+
+		s.registry.AddOrUpdate(device)
+	}
+}
+
+func (s *enrichStage) collectSNMP(ctx context.Context, device *DiscoveredDevice) *SNMPFullData {
+	if device.IP == "" || s.snmpCollector == nil {
+		return nil
+	}
+	data, err := s.snmpCollector.Collect(ctx, device.IP)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+func (s *enrichStage) scanPorts(ctx context.Context, device *DiscoveredDevice) *DeviceProfile {
+	if device.IP == "" || s.portScanner == nil {
+		return nil
+	}
+	result := s.portScanner.QuickScan(ctx, device.IP)
+	if result == nil || result.Error != "" {
+		return nil
+	}
+	openPorts := make([]OpenPort, 0, len(result.Services))
+	for _, svc := range result.Services {
+		openPorts = append(openPorts, OpenPort{
+			Port:     svc.Port,
+			Protocol: svc.Protocol,
+			Service:  svc.Service,
+			Banner:   svc.Banner,
+			IsOpen:   svc.State == "open",
+		})
+	}
+	return &DeviceProfile{OpenPorts: openPorts}
+}
+
+func (s *enrichStage) profileDevice(device *DiscoveredDevice) {
+	if s.profiler == nil || device.IP == "" {
+		return
+	}
+	if err := s.profiler.QueueProfile(device.IP); err != nil {
+		return
+	}
+	if profile := s.profiler.GetProfile(device.IP); profile != nil {
+		device.Profile = profile
+	}
+}
+
+// --- Stage 4: vuln (assess) --------------------------------------------------
+
+// assessStage scans each registry device for vulnerabilities and emits an event
+// per finding.
+type assessStage struct {
+	registry    *DeviceRegistry
+	eventBus    *EventBus
+	vulnScanner *VulnerabilityScanner
+}
+
+func (s *assessStage) Assess(ctx context.Context, stats *ScanStats) {
+	for _, device := range s.registry.GetDevices() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		vulns := s.assess(ctx, device)
+		if vulns != nil && len(vulns.Vulnerabilities) > 0 {
+			device.Vulnerabilities = vulns
+			stats.VulnerableDevices++
+			s.registry.AddOrUpdate(device)
+
+			for _, v := range vulns.Vulnerabilities {
+				s.eventBus.Publish(NewVulnDiscoveredEvent(device, v.CVEID, v.Severity))
+			}
+		}
+	}
+}
+
+func (s *assessStage) assess(ctx context.Context, device *DiscoveredDevice) *DeviceVulnerabilities {
+	if s.vulnScanner == nil {
+		return nil
+	}
+	vulns, err := s.vulnScanner.ScanDevice(ctx, device)
+	if err != nil {
+		return nil
+	}
+	return vulns
+}
+
+// --- shared converters (pure transforms; package-level so any stage can use) --
+
+// wifiAPToDevice converts a Wi-Fi access point to a DiscoveredDevice.
+func wifiAPToDevice(ap *WiFiAccessPoint) *DiscoveredDevice {
+	return &DiscoveredDevice{
+		MAC:             ap.BSSID,
+		Vendor:          ap.Vendor,
+		DiscoveryMethod: []Method{},
+		ConnectionTypes: []ConnectionType{ConnectionWiFi},
+		WiFiPresence: &WiFiPresence{
+			SSID:          ap.SSIDName,
+			Channel:       ap.Channel,
+			ChannelWidth:  ap.ChannelWidth,
+			FrequencyMHz:  ap.FrequencyMHz,
+			SignalDBm:     ap.SignalDBm,
+			IsAccessPoint: true,
+			IsAuthorized:  ap.IsAuthorized,
+			Band:          string(ap.Band),
+			LastSeen:      ap.LastSeen,
+		},
+		LastSeen: ap.LastSeen,
+	}
+}
+
+// bluetoothDeviceToDevice converts a Bluetooth device to a DiscoveredDevice.
+func bluetoothDeviceToDevice(bt *BluetoothDevice) *DiscoveredDevice {
+	return &DiscoveredDevice{
+		MAC:             bt.Address,
+		Vendor:          bt.Vendor,
+		DiscoveryMethod: []Method{},
+		ConnectionTypes: []ConnectionType{ConnectionBluetooth},
+		BluetoothPresence: &BluetoothPresence{
+			Name:         bt.Name,
+			Type:         bt.Type,
+			DeviceClass:  bt.DeviceClass,
+			RSSI:         bt.RSSI,
+			TxPower:      bt.TxPower,
+			IsPaired:     bt.IsPaired,
+			IsConnected:  bt.IsConnected,
+			IsAuthorized: bt.IsAuthorized,
+			Services:     bt.ServiceUUIDs,
+			LastSeen:     bt.LastSeen,
+		},
+		LastSeen: bt.LastSeen,
+	}
+}

--- a/internal/discovery/stages_test.go
+++ b/internal/discovery/stages_test.go
@@ -1,0 +1,112 @@
+package discovery_test
+
+// stages_test.go covers the stage seam introduced in ADR-0018 (Phase 6): the
+// pure device converters and each stage's nil-component safety. Behavioural
+// equivalence with the prior inline phases is additionally guarded by the
+// engine scan tests (engine_test.go) and the golden HTTP harness.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
+)
+
+func newTestRegistry() *discovery.DeviceRegistry {
+	return discovery.NewDeviceRegistry(
+		discovery.NewEventBus(&discovery.EventBusConfig{}),
+		&discovery.RegistryConfig{EmitEvents: false},
+	)
+}
+
+func TestWiFiAPToDeviceMapsFields(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	ap := &discovery.WiFiAccessPoint{
+		BSSID: "aa:bb:cc:dd:ee:ff", Vendor: "Acme", SSIDName: "net",
+		Channel: 6, ChannelWidth: 40, FrequencyMHz: 2437, SignalDBm: -50,
+		IsAuthorized: true, Band: discovery.WiFiBand("2.4GHz"), LastSeen: now,
+	}
+	d := discovery.ExportWiFiAPToDevice(ap)
+	if d.MAC != ap.BSSID || d.Vendor != "Acme" {
+		t.Fatalf("identity not mapped: mac=%q vendor=%q", d.MAC, d.Vendor)
+	}
+	if len(d.ConnectionTypes) != 1 || d.ConnectionTypes[0] != discovery.ConnectionWiFi {
+		t.Fatalf("connection type = %v, want [wifi]", d.ConnectionTypes)
+	}
+	if d.WiFiPresence == nil || !d.WiFiPresence.IsAccessPoint || d.WiFiPresence.SSID != "net" ||
+		d.WiFiPresence.Channel != 6 || d.WiFiPresence.Band != "2.4GHz" {
+		t.Fatalf("wifi presence not mapped: %+v", d.WiFiPresence)
+	}
+}
+
+func TestBluetoothDeviceToDeviceMapsFields(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	bt := &discovery.BluetoothDevice{
+		Address: "11:22:33:44:55:66", Vendor: "BT Inc", Name: "phone",
+		RSSI: -60, TxPower: 4, IsPaired: true, IsConnected: true, IsAuthorized: true,
+		ServiceUUIDs: []string{"180f"}, LastSeen: now,
+	}
+	d := discovery.ExportBluetoothDeviceToDevice(bt)
+	if d.MAC != bt.Address || d.Vendor != "BT Inc" {
+		t.Fatalf("identity not mapped: mac=%q vendor=%q", d.MAC, d.Vendor)
+	}
+	if len(d.ConnectionTypes) != 1 || d.ConnectionTypes[0] != discovery.ConnectionBluetooth {
+		t.Fatalf("connection type = %v, want [bluetooth]", d.ConnectionTypes)
+	}
+	if d.BluetoothPresence == nil || d.BluetoothPresence.Name != "phone" ||
+		!d.BluetoothPresence.IsPaired || len(d.BluetoothPresence.Services) != 1 {
+		t.Fatalf("bluetooth presence not mapped: %+v", d.BluetoothPresence)
+	}
+}
+
+func TestEnumerateStageNilCollectorsIsNoop(t *testing.T) {
+	t.Parallel()
+	reg := newTestRegistry()
+	stage := discovery.NewEnumerateStageForTest(reg, discovery.DefaultEngineConfig())
+	// All collectors nil; opts ask for everything. Gating must skip each source.
+	if err := stage.Enumerate(context.Background(), discovery.DefaultFullScanOpts()); err != nil {
+		t.Fatalf("nil-collector enumerate returned error: %v", err)
+	}
+	if got := len(reg.GetDevices()); got != 0 {
+		t.Fatalf("expected no devices, got %d", got)
+	}
+}
+
+func TestEnrichStageNilComponentsIsNoop(t *testing.T) {
+	t.Parallel()
+	reg := newTestRegistry()
+	reg.AddOrUpdate(&discovery.DiscoveredDevice{MAC: "de:ad:be:ef:00:01", IP: "10.0.0.1"})
+	stage := discovery.NewEnrichStageForTest(reg, discovery.DefaultEngineConfig())
+	stats := &discovery.ScanStats{}
+
+	// No SNMP/port/profiler components: must not panic and must enrich nothing.
+	stage.Enrich(context.Background(), discovery.DefaultFullScanOpts(), stats)
+
+	if stats.EnrichedDevices != 0 {
+		t.Fatalf("EnrichedDevices = %d, want 0 with nil components", stats.EnrichedDevices)
+	}
+	d := reg.GetDevice("de:ad:be:ef:00:01")
+	if d == nil || d.SNMPData != nil || d.Profile != nil {
+		t.Fatalf("device unexpectedly enriched: %+v", d)
+	}
+}
+
+func TestAssessStageNilScannerIsNoop(t *testing.T) {
+	t.Parallel()
+	reg := newTestRegistry()
+	reg.AddOrUpdate(&discovery.DiscoveredDevice{MAC: "de:ad:be:ef:00:02", IP: "10.0.0.2"})
+	stage := discovery.NewAssessStageForTest(reg, discovery.NewEventBus(&discovery.EventBusConfig{}))
+	stats := &discovery.ScanStats{}
+
+	stage.Assess(context.Background(), stats) // nil vulnScanner
+
+	if stats.VulnerableDevices != 0 {
+		t.Fatalf("VulnerableDevices = %d, want 0 with nil scanner", stats.VulnerableDevices)
+	}
+	if d := reg.GetDevice("de:ad:be:ef:00:02"); d == nil || d.Vulnerabilities != nil {
+		t.Fatalf("device unexpectedly assessed: %+v", d)
+	}
+}


### PR DESCRIPTION
## Summary
First implementation increment of **Phase 6** (ADR-0018): lift `Engine.runScanPhases`'s inline phases into four explicit **stage ports** — `Enumerator → Resolver → Enricher → Assessor` — implemented by stage types in `stages.go`. The Engine now orchestrates the ports instead of inlining each phase.

These are the **existing** phase boundaries (discovery / name-resolution / enrichment / assessment), so this is **behaviour-preserving** and the **golden HTTP harness is byte-identical** (TestGolden* pass without UPDATE_GOLDEN).

## Refinement of ADR-0018's foundation
`DiscoveredDevice` aggregates a field of every stage's result type (`*DeviceProfile`, `*SNMPFullData`, `*DeviceVulnerabilities`, …), so a `model` leaf can't hold them without moving the whole cluster or cycling. Instead the **root `discovery` package is the kernel** (shared types + ports); subsequent PRs relocate each stage's *logic* into its own subpackage importing the kernel, with **depguard enforcing `stages → kernel`** (never the reverse). This keeps shared types put → **zero `internal/api` churn, schema unchanged**. (`Enricher`, not `Fingerprinter`, because the latter is an existing capability type.) ADR-0018 implementation status updated.

## Tests
- The two device converters (`wifiAPToDevice`, `bluetoothDeviceToDevice`) become package funcs with new external unit tests (exposed via `export_test.go`).
- New nil-component safety tests for each stage.
- Existing engine scan tests + golden harness guard behaviour equivalence.

## Next (per ADR-0018)
Relocate each stage into its own subpackage + depguard, leaf-first: vuln → fingerprint → resolve → enumerate, then the direction-lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)