### PR TITLE
fix(ui): surface NMS pages in sidebar + guard nav/route parity (h3)

### DIFF
--- a/ui/src/navGroups.test.ts
+++ b/ui/src/navGroups.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { navGroups } from './navGroups';
+import { pages } from './pageRegistry';
+
+// Guards finding H3 (nav/route drift): a page reachable by URL but absent from
+// the sidebar is a discoverability bug. These assertions fail the build if the
+// route table and the sidebar ever diverge again.
+describe('navGroups <-> pageRegistry parity', () => {
+  const navPaths = new Set(navGroups.flatMap((group) => group.items.map((item) => item.path)));
+  const routePaths = new Set(pages.map((page) => page.path));
+
+  it('exposes every routable page in the sidebar', () => {
+    const missing = pages.map((page) => page.path).filter((path) => !navPaths.has(path));
+    expect(missing, `pages missing from navGroups: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('has no sidebar entries pointing at a non-existent route', () => {
+    const orphaned = [...navPaths].filter((path) => !routePaths.has(path));
+    expect(orphaned, `navGroups entries without a page: ${orphaned.join(', ')}`).toEqual([]);
+  });
+});

--- a/ui/src/navGroups.ts
+++ b/ui/src/navGroups.ts
@@ -2,17 +2,27 @@
  * Sidebar navigation groups for The Seed.
  *
  * Groups follow the existing module taxonomy (Roots / Canopy / Shell /
- * Sap / Harvest). The sibling projects (niac, stem) ship the same
- * shape via their own navGroups files.
+ * Sap / Harvest). The botanical group *labels* are intentional brand (the
+ * code-vs-brand split, R4b) — do not "fix" them to literal module names.
+ * Non-module functional groups (Performance, Monitoring) are allowed where
+ * pages do not map to a botanical module.
+ *
+ * Every routable page in pageRegistry must appear here so it is reachable
+ * from the sidebar; navGroups.test.ts asserts that parity (guards H3 drift).
+ * The sibling projects (niac, stem) ship the same shape via their own
+ * navGroups files.
  */
 import {
   Activity,
   BarChart3,
+  Bell,
   Network,
   Route,
   ScrollText,
   Server,
+  Share2,
   Shield,
+  Target,
   Wifi,
 } from 'lucide-react';
 import type { SidebarNavGroup } from './ui/Sidebar';
@@ -40,6 +50,17 @@ export const navGroups: SidebarNavGroup[] = [
   {
     label: 'Performance',
     items: [{ path: '/performance', label: 'Performance', icon: Activity }],
+  },
+  {
+    // NMS pages (SNMP/LLDP/CDP topology, alerting, polling). Minimal
+    // discoverable placement in a functional group; the broader nav IA
+    // redesign is deferred (#1452).
+    label: 'Monitoring',
+    items: [
+      { path: '/topology', label: 'Topology', icon: Share2 },
+      { path: '/alerts', label: 'Alerts', icon: Bell },
+      { path: '/polling-targets', label: 'Polling Targets', icon: Target },
+    ],
   },
   {
     label: 'Harvest',


### PR DESCRIPTION
## Summary
Fixes finding **H3** from the UI architecture plan: `Topology`, `Alerts`, and `PollingTargets` were reachable by typing the URL but **absent from the sidebar** — a discoverability bug.

- Adds a functional **`Monitoring`** sidebar group for the NMS trio (SNMP/LLDP/CDP topology, alerting, polling). Minimal, discoverable placement — the broader **nav IA redesign stays deferred (#1452)**; this just makes existing pages reachable.
- Adds `navGroups.test.ts` — a **parity guard** asserting every `pageRegistry` route appears in `navGroups` and every nav entry points at a real route. Future drift now **fails the build** instead of silently shipping unreachable pages.
- Documents the intentional code-vs-brand label split (R4b) in `navGroups.ts`.

## Safety / scope
- **Token-clean** (no raw palette — just icon imports + paths/labels), so it doesn't add to the token-gate debt.
- Not the deferred IA redesign (#1452); botanical group labels untouched.
- Biome + tsc clean; `navGroups.test.ts` (2) + `app.test.tsx` (13) green; no E2E nav-count assertions affected.

Part of Phase 7 / UI coherence (SEED_UI_ARCH_PLAN.md, finding H3 / Phase B2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)