### PR TITLE
fix(ui): unblock frontend gate (@storybook/react devDep) + repair reports-page e2e

### DIFF
--- a/ui/e2e/reports-page.spec.ts
+++ b/ui/e2e/reports-page.spec.ts
@@ -4,8 +4,11 @@ import { skipSetupWizard } from './helpers/auth';
 /**
  * Reports Page (/reports) E2E
  *
- * Covers the harvest module's reporting surface:
- * - SLADashboardCard renders
+ * Covers the harvest module's reporting surface. Reports are gated behind the
+ * `export_csv_json` feature (Starter tier or higher) via RequireFeature; the
+ * E2E suite runs unlicensed (Free), so the page renders the license-gate
+ * fallback, not the SLADashboardCard. The card-rendering path needs a licensed
+ * fixture and is out of scope here.
  */
 
 test.describe('Reports Page', () => {
@@ -26,9 +29,13 @@ test.describe('Reports Page', () => {
     await expect(page).toHaveURL(/\/reports$/);
   });
 
-  test('should render the SLA Dashboard card', async ({ page }) => {
-    await expect(page.locator('text=/sla|dashboard|service.*level|target/i').first()).toBeVisible({
-      timeout: 5000,
-    });
+  test('should gate reports behind a Starter+ license on the free tier', async ({ page }) => {
+    // Unlicensed (Free) suite: RequireFeature renders the upsell fallback rather
+    // than the SLADashboardCard. Scope to <main> so the assertion can never be
+    // hijacked by sidebar nav labels (e.g. "Polling Targets" matches a loose
+    // /target/i regex) — the prior text-regex `.first()` was brittle this way.
+    await expect(page.getByRole('main').getByText(/reports require the starter tier/i)).toBeVisible(
+      { timeout: 5000 },
+    );
   });
 });

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -37,6 +37,7 @@
         "@storybook/addon-docs": "10.4.2",
         "@storybook/addon-onboarding": "10.4.2",
         "@storybook/addon-vitest": "10.4.2",
+        "@storybook/react": "10.4.1",
         "@storybook/react-vite": "10.4.2",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.9.1",
@@ -3360,6 +3361,68 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.1.tgz",
+      "integrity": "sha512-WuYz4NaUk4gmFAMliSpCbV8w6jP5OY9juBfw1huwzu2S/k5FhnVXwmrUaL0fmf3Bq/7NgkzmBBbZr6I6LuHayQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "10.4.1",
+        "react-docgen": "^8.0.2",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.1",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.1.tgz",
+      "integrity": "sha512-6QFqfDNH4DMrt7yHKRfpqRopsVUc/Az+sXIdJ39IetYnHUxL3nW4NVaPc6uy/8Qi8urzUyEXL/nn7cpSIP2aPQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@storybook/react-vite": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -54,6 +54,7 @@
     "@storybook/addon-docs": "10.4.2",
     "@storybook/addon-onboarding": "10.4.2",
     "@storybook/addon-vitest": "10.4.2",
+    "@storybook/react": "10.4.1",
     "@storybook/react-vite": "10.4.2",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",


### PR DESCRIPTION
## Summary
Restores a **fully green Frontend + E2E pipeline**, which had two stacked pre-existing failures hidden behind each other.

### 1. Frontend `tsc` gate (the visible red)
87 story files import `@storybook/react`, but it was only a **transitive** dep (via `@storybook/react-vite`). A clean `npm ci` left it un-hoisted, so `tsc` from `src/` hit `TS2307` → the unit-test and build steps were skipped too. **Fix:** declare `@storybook/react` as an explicit `devDependency` at `10.4.1` (react-vite's exact pin); lockfile diff is purely additive, no other versions change.

### 2. Reports-page E2E (surfaced once tsc was fixed)
With the gate green, the **E2E suite ran for the first time in a while** (it's path-gated: backend PRs skip it, UI PRs run it — but every recent UI PR was blocked at tsc first). It surfaced a real failure in `reports-page.spec.ts`:
- Reports is gated behind `export_csv_json` (Starter+); the E2E suite runs **unlicensed (Free)**, so the page renders the **license-gate fallback**, not the `SLADashboardCard`. The old test asserted the card and only ever passed by accidentally matching the page *description*.
- The loose `text=/…|target/i`.first()` locator started matching the hidden sidebar span **"Polling Targets"** (added to `navGroups` in #1565 — "Targets" matches `/target/i`), so `.first()` resolved to a hidden element.

**Fix:** rewrite the test to assert the actual Free-tier behaviour (the Starter-tier license gate), via a stable `getByRole('main').getByText(...)` immune to sidebar labels.

## Validation
- `tsc --noEmit` clean, `vite build` clean, vitest green locally.
- The Frontend job already went **green in CI (49s)** on the first commit; this push adds the E2E repair so the previously-failing `reports-page` shard passes too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)