### PR TITLE
fix(ui): stop the FAB presenting a partial run as complete (c2)

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -499,9 +499,9 @@ function App(): JSX.Element {
         cardTestsToWait.push('healthchecks');
       }
 
-      // If no card-managed tests, signal completion immediately
+      // If no card-managed tests, the run is fully complete now.
       if (cardTestsToWait.length === 0) {
-        window.dispatchEvent(new CustomEvent('testsComplete'));
+        window.dispatchEvent(new CustomEvent('testsComplete', { detail: { partial: false } }));
         return;
       }
 
@@ -514,7 +514,8 @@ function App(): JSX.Element {
           // Check if all expected tests are done
           if (completed.size === cardTestsToWait.length) {
             window.removeEventListener('cardTestComplete', handleCardComplete as EventListener);
-            window.dispatchEvent(new CustomEvent('testsComplete'));
+            // Every expected card reported: a genuine, complete run.
+            window.dispatchEvent(new CustomEvent('testsComplete', { detail: { partial: false } }));
           }
         }
       };
@@ -522,15 +523,18 @@ function App(): JSX.Element {
       // Listen for card test completions
       window.addEventListener('cardTestComplete', handleCardComplete as EventListener);
 
-      // Failsafe timeout (90s) in case a card doesn't report completion
+      // Failsafe timeout (90s) in case a card never reports completion. The run
+      // is then PARTIAL — some checks did not finish — and must be surfaced as
+      // such (partial: true), never as a clean completion. Presenting partial
+      // results as final was the C2 correctness defect.
       setTimeout(() => {
         window.removeEventListener('cardTestComplete', handleCardComplete as EventListener);
         if (completed.size < cardTestsToWait.length) {
-          logger.warn(
-            LogComponents.UI,
-            'FAB timeout: Not all card tests completed, signaling done anyway',
-          );
-          window.dispatchEvent(new CustomEvent('testsComplete'));
+          logger.warn(LogComponents.UI, 'FAB timeout: not all card tests completed', {
+            completed: completed.size,
+            expected: cardTestsToWait.length,
+          });
+          window.dispatchEvent(new CustomEvent('testsComplete', { detail: { partial: true } }));
         }
       }, 90000);
     };

--- a/ui/src/components/ui/fab.test.tsx
+++ b/ui/src/components/ui/fab.test.tsx
@@ -96,6 +96,60 @@ describe('Fab', () => {
     expect(button).not.toBeDisabled();
   });
 
+  it('marks the run partial when the backstop timeout fires (no completion)', () => {
+    render(<Fab />);
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('data-run-status', 'running');
+
+    act(() => {
+      vi.advanceTimersByTime(60000);
+    });
+
+    // Timed out without a completion signal: partial, never a clean done.
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute('data-run-status', 'partial');
+    expect(button).toHaveAttribute(
+      'aria-label',
+      'Some checks did not finish — tap to run all tests again',
+    );
+  });
+
+  it('marks the run partial when testsComplete reports partial: true (C2)', () => {
+    render(<Fab />);
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    act(() => {
+      window.dispatchEvent(new CustomEvent('testsComplete', { detail: { partial: true } }));
+    });
+
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute('data-run-status', 'partial');
+  });
+
+  it('settles to idle on a complete (partial: false) run and clears a prior warning', () => {
+    render(<Fab />);
+
+    const button = screen.getByRole('button');
+
+    // First run times out -> partial.
+    fireEvent.click(button);
+    act(() => {
+      vi.advanceTimersByTime(60000);
+    });
+    expect(button).toHaveAttribute('data-run-status', 'partial');
+
+    // A fresh run that completes cleanly clears the partial warning.
+    fireEvent.click(button);
+    act(() => {
+      window.dispatchEvent(new CustomEvent('testsComplete', { detail: { partial: false } }));
+    });
+    expect(button).toHaveAttribute('data-run-status', 'idle');
+    expect(button).toHaveAttribute('aria-label', 'Run All Tests');
+  });
+
   it('does not dispatch multiple events while running', () => {
     const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
 

--- a/ui/src/components/ui/fab.tsx
+++ b/ui/src/components/ui/fab.tsx
@@ -44,12 +44,19 @@ interface FabProps {
  */
 export function Fab({ className = '' }: FabProps): React.JSX.Element {
   const [isRunning, setIsRunning] = useState(false);
+  // partial = the previous run finished without every check reporting (a timeout
+  // or a card that never completed). Surfaced distinctly so partial results are
+  // never presented as a clean completion (the C2 correctness fix).
+  const [partial, setPartial] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Stop spinner when testsComplete fires
+  // Settle the run when testsComplete fires: success clears any partial flag;
+  // a partial completion records it so the button can warn the operator.
   useEffect(() => {
-    const handleTestsComplete = (): void => {
+    const handleTestsComplete = (event: Event): void => {
+      const detail = (event as CustomEvent<{ partial?: boolean }>).detail;
       setIsRunning(false);
+      setPartial(Boolean(detail?.partial));
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
         timeoutRef.current = null;
@@ -70,14 +77,22 @@ export function Fab({ className = '' }: FabProps): React.JSX.Element {
       return;
     }
     setIsRunning(true);
+    setPartial(false); // a fresh run clears the prior partial warning
 
     window.dispatchEvent(new CustomEvent('runAllTests'));
 
-    // Fallback timeout in case testsComplete never fires
+    // Backstop: if no testsComplete arrives (e.g. the orchestrator never ran),
+    // stop the spinner and mark the run partial — never silently "done".
     timeoutRef.current = setTimeout(() => {
       setIsRunning(false);
+      setPartial(true);
     }, 60000);
   }, [isRunning]);
+
+  const runStatus = isRunning ? 'running' : partial ? 'partial' : 'idle';
+  const label = partial
+    ? 'Some checks did not finish — tap to run all tests again'
+    : 'Run All Tests';
 
   return (
     <button
@@ -91,14 +106,16 @@ export function Fab({ className = '' }: FabProps): React.JSX.Element {
         isRunning && 'opacity-75 cursor-not-allowed',
         className,
       )}
-      title="Run All Tests"
-      aria-label="Run All Tests"
+      title={label}
+      aria-label={label}
       // aria-busy + data-testid let E2E specs synchronise on the
       // "running" → "idle" transition without racing the animate-spin
-      // class on the SVG. See seed#1168 / E2E_CONVENTIONS.
+      // class on the SVG. See seed#1168 / E2E_CONVENTIONS. data-run-status
+      // additionally exposes the partial outcome (idle | running | partial).
       aria-busy={isRunning}
       data-testid="fab-run-all-tests"
       data-running={isRunning ? 'true' : 'false'}
+      data-run-status={runStatus}
     >
       {isRunning ? (
         <svg
@@ -120,6 +137,24 @@ export function Fab({ className = '' }: FabProps): React.JSX.Element {
             fill="currentColor"
             d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
           />
+        </svg>
+      ) : partial ? (
+        // Partial run: a warning triangle distinguishes "some checks did not
+        // finish" from a clean completion, so partial results are never read as
+        // final (C2). A re-click clears it and starts a fresh run.
+        <svg
+          className={iconTokens.size.lg}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+          <path d="M12 9v4" />
+          <path d="M12 17h.01" />
         </svg>
       ) : (
         <svg


### PR DESCRIPTION
## Summary
Fixes finding **C2** (Critical correctness defect): the "Run All Tests" FAB could present **partial results as a finished run**.

- `app.tsx`'s 90s failsafe dispatched `testsComplete` even when card-managed checks (speedtest/iperf/health) never reported.
- The FAB's own 60s backstop stopped the spinner with no completion signal at all.

Both made an incomplete run look done.

## Fix
Completion now carries intent:
- `app.tsx` tags the genuine all-reported path `{ partial: false }` and the failsafe-timeout path `{ partial: true }`.
- The FAB's backstop timeout also marks the run partial.
- The FAB surfaces a **distinct partial state** — a warning-triangle icon, an explanatory `aria-label`, and `data-run-status` (`idle | running | partial`) — so a timed-out/incomplete run can never read as a clean "done". A fresh click clears the warning and starts a new run.

## Scope
This is the bounded fix of the **C2 correctness bug**. The broader **H2** architectural work — replacing the fragile `window` `CustomEvent` bus with a Zustand `testRunStore` and aligning the 60s/90s timeouts — remains a documented follow-up (it touches fab/app/2 cards/2 hooks).

## Tests
- New FAB tests: partial-by-timeout, partial-by-`testsComplete` signal, and complete-clears-partial.
- Existing FAB (8) + app (13) tests unchanged and green; tsc + biome clean; token-clean (no raw palette).

Part of Phase 7 / UI coherence (SEED_UI_ARCH_PLAN.md, C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)