### PR TITLE
fix(ui): rename customer-facing 'wi-fi planning mode' to 'wi-fi survey mode' (l3)

### DIFF
--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -317,7 +317,7 @@
     "recommended": "Recommended",
     "switchTo": "Switch to {{name}}",
     "wifi": "Wi-Fi",
-    "wifiPlanning": "Wi-Fi planning"
+    "wifiSurvey": "Wi-Fi Survey Mode"
   },
   "pathDiscovery": {
     "completed": "Completed",

--- a/internal/i18n/locales/es/common.json
+++ b/internal/i18n/locales/es/common.json
@@ -317,7 +317,7 @@
     "recommended": "Recomendado",
     "switchTo": "Cambiar a {{name}}",
     "wifi": "Wi-Fi",
-    "wifiPlanning": "Planificación Wi-Fi"
+    "wifiSurvey": "Modo de encuesta Wi-Fi"
   },
   "pathDiscovery": {
     "completed": "Completado",

--- a/ui/src/components/app/HeaderBar.tsx
+++ b/ui/src/components/app/HeaderBar.tsx
@@ -538,7 +538,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = memo(function headerBar({
             ) : null}
           </div>
 
-          {/* WiFi interface selector - always visible for survey/planning */}
+          {/* Wi-Fi interface selector - always visible for survey mode */}
           <div className="relative">
             <button
               type="button"
@@ -547,15 +547,16 @@ export const HeaderBar: React.FC<HeaderBarProps> = memo(function headerBar({
                 isWifi && 'ring-2 ring-brand-primary ring-offset-1 ring-offset-surface-raised',
               )}
               onClick={(): void => {
-                // Always use switchToInterfaceType to properly set WiFi mode
-                // This handles both real WiFi interfaces and planning mode
+                // Always use switchToInterfaceType to properly set Wi-Fi mode.
+                // This handles both real Wi-Fi interfaces and survey mode
+                // (no-hardware): Canopy is troubleshooting/survey, not planning.
                 switchToInterfaceType('wifi');
               }}
               aria-label={t('accessibility.selectWifi', 'Select Wi-Fi / Survey Mode')}
               title={
                 hasWifiInterface
                   ? t('interface.wifi', 'Wi-Fi')
-                  : t('interface.wifiPlanning', 'Wi-Fi Planning Mode')
+                  : t('interface.wifiSurvey', 'Wi-Fi Survey Mode')
               }
             >
               {/* WiFi signal icon */}
@@ -577,7 +578,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = memo(function headerBar({
               {!hasWifiInterface && (
                 <span
                   className="absolute -bottom-0.5 -right-0.5 w-2 h-2 bg-status-warning rounded-full"
-                  title={t('interface.noWifiHardware', 'No WiFi hardware - Planning mode')}
+                  title={t('interface.noWifiHardware', 'No Wi-Fi hardware — Survey mode')}
                 />
               )}
             </button>


### PR DESCRIPTION
## Summary
Strategy-compliance copy fix (finding **L3**). The locked strategy (hard rule #4) positions **Canopy as Wi-Fi visibility & troubleshooting / survey — NOT planning** (coverage modelling and AP-placement optimisation were removed). The HeaderBar still showed operators **"Wi-Fi Planning Mode"** for the no-Wi-Fi-hardware case — off-message.

- Rename i18n key `interface.wifiPlanning` → `interface.wifiSurvey`; copy → **"Wi-Fi Survey Mode"** (en) / **"Modo de encuesta Wi-Fi"** (es, matching the locale's existing `encuesta` term for survey).
- Update the HeaderBar tooltips + surrounding comments.

## Safety
- Only `HeaderBar.tsx` referenced the key; i18n **key parity preserved** (en + es); ratchet validator green; tsc + biome clean.

## Follow-up flagged (not in this PR)
`SurveyAnalysisPanel`'s doc comment advertises *"AP placement optimization suggestions"* + *"capacity planning analysis"* — phrasing that maps to **removed** features (#4). Needs owner review of whether the underlying analysis is diagnostic (allowed) or crosses into predictive planning/optimisation (banned). Left untouched here — out of scope for a copy fix.

Part of Phase 7 / UI coherence (SEED_UI_ARCH_PLAN.md, L3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)