### PR TITLE
refactor(discovery): relocate the vuln assessment stage into a subpackage (adr-0018)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -291,6 +291,23 @@ linters:
           deny:
             - pkg: github.com/gopacket/gopacket/pcap
               desc: "live capture must go through the capture port (internal/capture); only internal/capture/pcap may import gopacket/pcap"
+        # ADR-0018 (Phase 6): the discovery KERNEL (internal/discovery) holds the
+        # shared device + result types and the stage PORTS (stages.go); each
+        # pipeline stage lives in a subpackage that depends INWARD on the kernel.
+        # The kernel must never import a stage subpackage — that would invert the
+        # direction and create an import cycle. The Engine holds each stage as a
+        # port interface (e.g. Assessor) and the composition root (internal/api)
+        # injects the concrete stage. Applies to production AND tests. As further
+        # stages are relocated (fingerprint/resolve/enumerate) they are added to
+        # the exclusions + deny list. The vuln subpackage is exempt — it is the
+        # stage and legitimately imports the kernel.
+        "discovery-stage-direction":
+          files:
+            - "**/internal/discovery/**"
+            - "!**/internal/discovery/vuln/**"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/discovery/vuln
+              desc: "inward-only — a discovery stage (internal/discovery/vuln) imports the kernel, never the reverse; the Engine holds the Assessor port and the composition root injects the stage"
 
     embeddedstructfieldcheck:
       # Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.

--- a/docs/architecture/decisions/0018-discovery-pipeline-stage-split.md
+++ b/docs/architecture/decisions/0018-discovery-pipeline-stage-split.md
@@ -187,7 +187,13 @@ orchestrates the ports. Per-stage subpackage relocation + depguard follow.
 
 - [x] 0. stage ports + stage types in-package; Engine orchestrates ports
       (`stages.go`); behaviour-preserving, golden byte-identical
-- [ ] 1. `vuln` stage → `discovery/vuln` subpackage + depguard
+- [x] 1. `vuln` stage → `discovery/vuln` subpackage + depguard. `VulnerabilityScanner`
+      + CVE providers (NVD/local/KEV) + the assess `Stage` moved; result types
+      (`Vulnerability`/`DeviceVulnerabilities`) stay in the kernel (DiscoveredDevice
+      fields) and are aliased in the stage. Engine holds the injected `Assessor`
+      port; `internal/api` wires `vuln.NewStage(scanner, engine.Registry(),
+      engine.EventBus())`. depguard rule `discovery-stage-direction` bans the kernel
+      from importing the stage. Golden byte-identical, schema unchanged.
 - [ ] 2. `fingerprint`/enrich stage → `discovery/fingerprint` + depguard
 - [ ] 3. `resolve` stage → `discovery/resolve` + depguard
 - [ ] 4. `enumerate` stage → `discovery/enumerate` + depguard

--- a/internal/api/handlers_vuln.go
+++ b/internal/api/handlers_vuln.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/validation"
@@ -281,7 +282,7 @@ func (s *Server) handleVulnerabilitySettings(w http.ResponseWriter, r *http.Requ
 		sendJSONResponse(w, logger, http.StatusOK, s.config.Security.VulnerabilityScanning)
 
 	case http.MethodPut:
-		var settings discovery.VulnerabilityScannerConfig
+		var settings vuln.VulnerabilityScannerConfig
 		if !decodeJSONStrictLocalized(w, r, &settings, MaxBodySizeJSON,
 			logger, localizer) {
 			return
@@ -382,7 +383,7 @@ func (s *Server) handleNVDAPIKeyValidate(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Validate the API key by making a test request to NVD
-	valid, err := discovery.ValidateNVDAPIKey(r.Context(), req.APIKey)
+	valid, err := vuln.ValidateNVDAPIKey(r.Context(), req.APIKey)
 	if err != nil {
 		logger.WarnContext(r.Context(), "NVD API key validation failed", "error", err)
 		response.Valid = false

--- a/internal/api/jobs_vuln.go
+++ b/internal/api/jobs_vuln.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/platform/jobs"
 )
@@ -103,7 +104,7 @@ func decodeVulnScanParams(params any) (VulnScanParams, error) {
 // serverVulnScanService adapts the Server's scanner + device registry to the
 // vulnScanService seam.
 type serverVulnScanService struct {
-	scanner *discovery.VulnerabilityScanner
+	scanner *vuln.VulnerabilityScanner
 	devices *discovery.DeviceDiscovery
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/speedtest"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/vlan"
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/health"
 	"github.com/MustardSeedNetworks/seed/internal/license"
 	listenersink "github.com/MustardSeedNetworks/seed/internal/listener/sink"
@@ -650,7 +651,7 @@ func (s *Server) DiscoveryService() *discovery.Service { return s.services.Disco
 // Pipeline returns the discovery pipeline.
 
 // VulnScanner returns the vulnerability scanner.
-func (s *Server) VulnScanner() *discovery.VulnerabilityScanner {
+func (s *Server) VulnScanner() *vuln.VulnerabilityScanner {
 	return s.services.Discovery.Vulnerability
 }
 
@@ -724,7 +725,7 @@ func (s *Server) netManager() *netif.Manager                  { return s.service
 func (s *Server) linkMonitor() *netif.LinkMonitor             { return s.services.Network.LinkMonitor }
 func (s *Server) deviceDiscovery() *discovery.DeviceDiscovery { return s.services.Discovery.Device }
 func (s *Server) discoveryService() *discovery.Service        { return s.services.Discovery.Service }
-func (s *Server) vulnScanner() *discovery.VulnerabilityScanner {
+func (s *Server) vulnScanner() *vuln.VulnerabilityScanner {
 	return s.services.Discovery.Vulnerability
 }
 func (s *Server) dnsTester() *dns.Tester                   { return s.services.Diagnostics.DNS }

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/dns"
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/mibdb"
 	"github.com/MustardSeedNetworks/seed/internal/platform/events"
@@ -252,7 +253,7 @@ func (s *Server) initVulnerabilityScanner(cfg *config.Config) {
 		return
 	}
 
-	scannerCfg := &discovery.VulnerabilityScannerConfig{
+	scannerCfg := &vuln.VulnerabilityScannerConfig{
 		Enabled:           cfg.Security.VulnerabilityScanning.Enabled,
 		CVEDatabase:       cfg.Security.VulnerabilityScanning.CVEDatabase,
 		NVDAPIKey:         cfg.Security.VulnerabilityScanning.NVDAPIKey,
@@ -261,7 +262,7 @@ func (s *Server) initVulnerabilityScanner(cfg *config.Config) {
 		MaxConcurrent:     cfg.Security.VulnerabilityScanning.MaxConcurrent,
 	}
 
-	vulnScanner, err := discovery.NewVulnerabilityScanner(scannerCfg)
+	vulnScanner, err := vuln.NewVulnerabilityScanner(scannerCfg)
 	if err != nil {
 		logging.GetLogger().Warn("Failed to initialize vulnerability scanner", "error", err)
 		return
@@ -316,7 +317,13 @@ func (s *Server) initVulnerabilityScanner(cfg *config.Config) {
 		s.services.Discovery.Engine.SetPortScanner(s.services.Discovery.PortScanner)
 	}
 	if s.services.Discovery.Vulnerability != nil {
-		s.services.Discovery.Engine.SetVulnScanner(s.services.Discovery.Vulnerability)
+		// ADR-0018: the vuln assessment stage is a subpackage adapter injected
+		// as the engine's Assessor port, built over the engine's registry + bus.
+		s.services.Discovery.Engine.SetAssessor(vuln.NewStage(
+			s.services.Discovery.Vulnerability,
+			s.services.Discovery.Engine.Registry(),
+			s.services.Discovery.Engine.EventBus(),
+		))
 	}
 
 	// Start the engine

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/speedtest"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/vlan"
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
 	"github.com/MustardSeedNetworks/seed/internal/health"
 	"github.com/MustardSeedNetworks/seed/internal/license"
@@ -121,7 +122,7 @@ type NetworkServices struct {
 type DiscoveryServices struct {
 	Device           *discovery.DeviceDiscovery
 	Service          *discovery.Service
-	Vulnerability    *discovery.VulnerabilityScanner
+	Vulnerability    *vuln.VulnerabilityScanner
 	ProblemDetector  *discovery.ProblemDetector
 	BluetoothScanner *discovery.BluetoothScanner
 	WiFiBridge       *discovery.WiFiBridge

--- a/internal/discovery/engine.go
+++ b/internal/discovery/engine.go
@@ -57,8 +57,9 @@ type Engine struct {
 	portScanner   *PortScanner
 	profiler      *DeviceProfiler
 
-	// Assessment components
-	vulnScanner *VulnerabilityScanner
+	// Assessment stage (ADR-0018): the vuln Assessor port, injected by the
+	// composition root (the concrete stage lives in internal/discovery/vuln).
+	assessor Assessor
 
 	// Configuration
 	config *EngineConfig
@@ -289,11 +290,13 @@ func (e *Engine) SetProfiler(profiler *DeviceProfiler) {
 	e.profiler = profiler
 }
 
-// SetVulnScanner sets the vulnerability scanner.
-func (e *Engine) SetVulnScanner(scanner *VulnerabilityScanner) {
+// SetAssessor sets the vulnerability-assessment stage (ADR-0018). The composition
+// root builds the concrete stage (internal/discovery/vuln) over the engine's
+// registry + event bus and injects it here as the Assessor port.
+func (e *Engine) SetAssessor(assessor Assessor) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.vulnScanner = scanner
+	e.assessor = assessor
 }
 
 // Start starts the discovery engine.
@@ -494,15 +497,10 @@ func (e *Engine) runScanPhases(ctx context.Context, logger *slog.Logger, opts *S
 	}
 
 	// Phase 5: Assessment (vuln stage)
-	if opts.IncludeVulnScan && e.vulnScanner != nil {
+	if opts.IncludeVulnScan && e.assessor != nil {
 		logger.InfoContext(ctx, "Starting assessment phase")
 		result.Phases = append(result.Phases, "assessment")
-		var assess Assessor = &assessStage{
-			registry:    e.registry,
-			eventBus:    e.eventBus,
-			vulnScanner: e.vulnScanner,
-		}
-		assess.Assess(ctx, result.Stats)
+		e.assessor.Assess(ctx, result.Stats)
 		complete("assessment")
 	}
 }
@@ -518,7 +516,7 @@ func (e *Engine) countScanPhases(opts *ScanOptions) int {
 	if opts.IncludeSNMP || opts.IncludePortScan || opts.IncludeProfiling {
 		total++
 	}
-	if opts.IncludeVulnScan && e.vulnScanner != nil {
+	if opts.IncludeVulnScan && e.assessor != nil {
 		total++
 	}
 	return total
@@ -635,7 +633,7 @@ func (e *Engine) GetCapabilities() map[string]bool {
 		"snmp":        e.snmpCollector != nil && e.config.EnableSNMP,
 		"portScan":    e.portScanner != nil && e.config.EnablePortScan,
 		"profiling":   e.profiler != nil && e.config.EnableProfiling,
-		"vulnScan":    e.vulnScanner != nil && e.config.EnableVulnScan,
+		"vulnScan":    e.assessor != nil && e.config.EnableVulnScan,
 		"nameRes":     e.wiredCollector != nil,
 		"correlation": true, // Always available
 	}

--- a/internal/discovery/engine_test.go
+++ b/internal/discovery/engine_test.go
@@ -58,7 +58,7 @@ func TestEngineSetCollectors(_ *testing.T) {
 	engine.SetSNMPCollector(nil)
 	engine.SetPortScanner(nil)
 	engine.SetProfiler(nil)
-	engine.SetVulnScanner(nil)
+	engine.SetAssessor(nil)
 }
 
 func TestEngineGetCapabilities(t *testing.T) {

--- a/internal/discovery/export_test.go
+++ b/internal/discovery/export_test.go
@@ -3,10 +3,7 @@ package discovery
 // This file is only compiled during testing (due to _test.go suffix)
 // and provides access to internal implementation details.
 
-import (
-	"net"
-	"sync"
-)
+import "net"
 
 // ExportIncrementIP exposes incrementIP for testing.
 func ExportIncrementIP(ip net.IP, n int) net.IP {
@@ -27,12 +24,6 @@ func ExportGuessOSFromTTL(ttl int) string {
 func ExportSplitSubnetIntoChunks(subnet *net.IPNet, maxChunks int) []*net.IPNet {
 	return splitSubnetIntoChunks(subnet, maxChunks)
 }
-
-// Export NVD rate limit constants for testing.
-const (
-	NVDRateLimitNoKey   = nvdRateLimitNoKey
-	NVDRateLimitWithKey = nvdRateLimitWithKey
-)
 
 // ARPScannerTestAccessor provides access to ARPScanner's private fields for testing.
 type ARPScannerTestAccessor struct {
@@ -109,53 +100,6 @@ func (t *TracerTestAccessor) GetMaxHops() int {
 	return t.Tracer.maxHops
 }
 
-// VulnerabilityScannerTestAccessor provides access to VulnerabilityScanner's private fields for testing.
-type VulnerabilityScannerTestAccessor struct {
-	Scanner *VulnerabilityScanner
-}
-
-// GetMu returns the scanner's mutex for testing.
-func (v *VulnerabilityScannerTestAccessor) GetMu() *sync.RWMutex {
-	return &v.Scanner.mu
-}
-
-// GetDeviceResults returns the scanner's deviceResults map.
-func (v *VulnerabilityScannerTestAccessor) GetDeviceResults() map[string]*DeviceVulnerabilities {
-	return v.Scanner.deviceResults
-}
-
-// SetDeviceResults sets the scanner's deviceResults map.
-func (v *VulnerabilityScannerTestAccessor) SetDeviceResults(
-	results map[string]*DeviceVulnerabilities,
-) {
-	v.Scanner.deviceResults = results
-}
-
-// GetConfig returns the scanner's config.
-func (v *VulnerabilityScannerTestAccessor) GetConfig() *VulnerabilityScannerConfig {
-	return v.Scanner.config
-}
-
-// FilterBySeverity exposes the private filterBySeverity method.
-func (v *VulnerabilityScannerTestAccessor) FilterBySeverity(vulns []Vulnerability) []Vulnerability {
-	return v.Scanner.filterBySeverity(vulns)
-}
-
-// NVDProviderTestAccessor provides access to NVDProvider's private fields for testing.
-type NVDProviderTestAccessor struct {
-	Provider *NVDProvider
-}
-
-// GetAPIKey returns the provider's API key.
-func (n *NVDProviderTestAccessor) GetAPIKey() string {
-	return n.Provider.apiKey
-}
-
-// GetRateLimit returns the provider's rate limit.
-func (n *NVDProviderTestAccessor) GetRateLimit() int {
-	return n.Provider.rateLimit
-}
-
 // DeviceDiscoveryTestAccessor provides access to DeviceDiscovery's private fields for testing.
 type DeviceDiscoveryTestAccessor struct {
 	Discovery *DeviceDiscovery
@@ -195,11 +139,6 @@ func NewEnumerateStageForTest(reg *DeviceRegistry, cfg *EngineConfig) Enumerator
 // NewEnrichStageForTest builds the enrich stage (no components) as its port.
 func NewEnrichStageForTest(reg *DeviceRegistry, cfg *EngineConfig) Enricher {
 	return &enrichStage{registry: reg, config: cfg}
-}
-
-// NewAssessStageForTest builds the assess stage (no scanner) as its port.
-func NewAssessStageForTest(reg *DeviceRegistry, bus *EventBus) Assessor {
-	return &assessStage{registry: reg, eventBus: bus}
 }
 
 // EngineTestAccessor provides access to Engine's private fields for testing.

--- a/internal/discovery/stages.go
+++ b/internal/discovery/stages.go
@@ -234,46 +234,11 @@ func (s *enrichStage) profileDevice(device *DiscoveredDevice) {
 }
 
 // --- Stage 4: vuln (assess) --------------------------------------------------
-
-// assessStage scans each registry device for vulnerabilities and emits an event
-// per finding.
-type assessStage struct {
-	registry    *DeviceRegistry
-	eventBus    *EventBus
-	vulnScanner *VulnerabilityScanner
-}
-
-func (s *assessStage) Assess(ctx context.Context, stats *ScanStats) {
-	for _, device := range s.registry.GetDevices() {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
-		vulns := s.assess(ctx, device)
-		if vulns != nil && len(vulns.Vulnerabilities) > 0 {
-			device.Vulnerabilities = vulns
-			stats.VulnerableDevices++
-			s.registry.AddOrUpdate(device)
-
-			for _, v := range vulns.Vulnerabilities {
-				s.eventBus.Publish(NewVulnDiscoveredEvent(device, v.CVEID, v.Severity))
-			}
-		}
-	}
-}
-
-func (s *assessStage) assess(ctx context.Context, device *DiscoveredDevice) *DeviceVulnerabilities {
-	if s.vulnScanner == nil {
-		return nil
-	}
-	vulns, err := s.vulnScanner.ScanDevice(ctx, device)
-	if err != nil {
-		return nil
-	}
-	return vulns
-}
+//
+// The assess stage's implementation lives in the internal/discovery/vuln
+// subpackage (it owns the scanner + CVE providers); it satisfies the Assessor
+// port above and is injected into the Engine by the composition root. The kernel
+// keeps only the port, not the concrete stage (ADR-0018, Phase 6).
 
 // --- shared converters (pure transforms; package-level so any stage can use) --
 

--- a/internal/discovery/stages_test.go
+++ b/internal/discovery/stages_test.go
@@ -94,19 +94,5 @@ func TestEnrichStageNilComponentsIsNoop(t *testing.T) {
 	}
 }
 
-func TestAssessStageNilScannerIsNoop(t *testing.T) {
-	t.Parallel()
-	reg := newTestRegistry()
-	reg.AddOrUpdate(&discovery.DiscoveredDevice{MAC: "de:ad:be:ef:00:02", IP: "10.0.0.2"})
-	stage := discovery.NewAssessStageForTest(reg, discovery.NewEventBus(&discovery.EventBusConfig{}))
-	stats := &discovery.ScanStats{}
-
-	stage.Assess(context.Background(), stats) // nil vulnScanner
-
-	if stats.VulnerableDevices != 0 {
-		t.Fatalf("VulnerableDevices = %d, want 0 with nil scanner", stats.VulnerableDevices)
-	}
-	if d := reg.GetDevice("de:ad:be:ef:00:02"); d == nil || d.Vulnerabilities != nil {
-		t.Fatalf("device unexpectedly assessed: %+v", d)
-	}
-}
+// The assess stage's nil-safety test moved to internal/discovery/vuln with the
+// stage (TestStageNilScannerIsNoop).

--- a/internal/discovery/utils_test.go
+++ b/internal/discovery/utils_test.go
@@ -136,15 +136,5 @@ func TestExportSplitSubnetIntoChunks(t *testing.T) {
 	}
 }
 
-func TestNVDRateLimitConstants(t *testing.T) {
-	// Test that NVD rate limit constants are accessible
-	if discovery.NVDRateLimitNoKey <= 0 {
-		t.Error("Expected NVDRateLimitNoKey to be positive")
-	}
-	if discovery.NVDRateLimitWithKey <= 0 {
-		t.Error("Expected NVDRateLimitWithKey to be positive")
-	}
-	if discovery.NVDRateLimitWithKey <= discovery.NVDRateLimitNoKey {
-		t.Error("Expected NVDRateLimitWithKey to be greater than NVDRateLimitNoKey")
-	}
-}
+// TestNVDRateLimitConstants moved to internal/discovery/vuln with the NVD
+// provider (ADR-0018).

--- a/internal/discovery/vuln/aliases.go
+++ b/internal/discovery/vuln/aliases.go
@@ -1,0 +1,21 @@
+// Package vuln is the discovery pipeline's assessment stage (ADR-0018, Phase 6):
+// the vulnerability scanner, its CVE data providers (NVD / local / CISA KEV), and
+// the Assessor adapter the Engine drives. It depends inward on the discovery
+// kernel for the shared device + result types; the kernel never imports this
+// package (depguard-enforced one-way direction).
+package vuln
+
+import "github.com/MustardSeedNetworks/seed/internal/discovery"
+
+// Kernel type aliases. The scanner and providers operate on the device aggregate
+// and the vulnerability result types, which live in the kernel (they are fields
+// of DiscoveredDevice). Aliasing them here lets the stage code reference them
+// unqualified without duplicating the definitions or inverting the dependency.
+type (
+	// DiscoveredDevice is the kernel device aggregate the scanner inspects.
+	DiscoveredDevice = discovery.DiscoveredDevice
+	// Vulnerability is a single CVE finding (kernel result type).
+	Vulnerability = discovery.Vulnerability
+	// DeviceVulnerabilities is a device's assessment result (kernel result type).
+	DeviceVulnerabilities = discovery.DeviceVulnerabilities
+)

--- a/internal/discovery/vuln/cve_kev.go
+++ b/internal/discovery/vuln/cve_kev.go
@@ -1,4 +1,4 @@
-package discovery
+package vuln
 
 //
 // This file integrates with the CISA KEV (Known Exploited Vulnerabilities) catalog

--- a/internal/discovery/vuln/cve_local.go
+++ b/internal/discovery/vuln/cve_local.go
@@ -1,4 +1,4 @@
-package discovery
+package vuln
 
 //
 // The LocalProvider loads CVE data from a JSON file, enabling vulnerability scanning

--- a/internal/discovery/vuln/cve_nvd.go
+++ b/internal/discovery/vuln/cve_nvd.go
@@ -1,4 +1,4 @@
-package discovery
+package vuln
 
 //
 // This file integrates with the National Vulnerability Database (NVD) to identify known

--- a/internal/discovery/vuln/export_test.go
+++ b/internal/discovery/vuln/export_test.go
@@ -1,0 +1,59 @@
+package vuln
+
+// export_test.go exposes vuln-package internals for the external vuln_test
+// package (moved from internal/discovery/export_test.go with the stage, ADR-0018).
+
+import "sync"
+
+// Export NVD rate limit constants for testing.
+const (
+	NVDRateLimitNoKey   = nvdRateLimitNoKey
+	NVDRateLimitWithKey = nvdRateLimitWithKey
+)
+
+// VulnerabilityScannerTestAccessor provides access to VulnerabilityScanner's private fields for testing.
+type VulnerabilityScannerTestAccessor struct {
+	Scanner *VulnerabilityScanner
+}
+
+// GetMu returns the scanner's mutex for testing.
+func (v *VulnerabilityScannerTestAccessor) GetMu() *sync.RWMutex {
+	return &v.Scanner.mu
+}
+
+// GetDeviceResults returns the scanner's deviceResults map.
+func (v *VulnerabilityScannerTestAccessor) GetDeviceResults() map[string]*DeviceVulnerabilities {
+	return v.Scanner.deviceResults
+}
+
+// SetDeviceResults sets the scanner's deviceResults map.
+func (v *VulnerabilityScannerTestAccessor) SetDeviceResults(
+	results map[string]*DeviceVulnerabilities,
+) {
+	v.Scanner.deviceResults = results
+}
+
+// GetConfig returns the scanner's config.
+func (v *VulnerabilityScannerTestAccessor) GetConfig() *VulnerabilityScannerConfig {
+	return v.Scanner.config
+}
+
+// FilterBySeverity exposes the private filterBySeverity method.
+func (v *VulnerabilityScannerTestAccessor) FilterBySeverity(vulns []Vulnerability) []Vulnerability {
+	return v.Scanner.filterBySeverity(vulns)
+}
+
+// NVDProviderTestAccessor provides access to NVDProvider's private fields for testing.
+type NVDProviderTestAccessor struct {
+	Provider *NVDProvider
+}
+
+// GetAPIKey returns the provider's API key.
+func (n *NVDProviderTestAccessor) GetAPIKey() string {
+	return n.Provider.apiKey
+}
+
+// GetRateLimit returns the provider's rate limit.
+func (n *NVDProviderTestAccessor) GetRateLimit() int {
+	return n.Provider.rateLimit
+}

--- a/internal/discovery/vuln/nvd_test.go
+++ b/internal/discovery/vuln/nvd_test.go
@@ -1,0 +1,22 @@
+package vuln_test
+
+import (
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
+)
+
+// TestNVDRateLimitConstants verifies the NVD provider's rate-limit constants
+// (moved here with the provider, ADR-0018).
+func TestNVDRateLimitConstants(t *testing.T) {
+	t.Parallel()
+	if vuln.NVDRateLimitNoKey <= 0 {
+		t.Error("Expected NVDRateLimitNoKey to be positive")
+	}
+	if vuln.NVDRateLimitWithKey <= 0 {
+		t.Error("Expected NVDRateLimitWithKey to be positive")
+	}
+	if vuln.NVDRateLimitWithKey <= vuln.NVDRateLimitNoKey {
+		t.Error("Expected NVDRateLimitWithKey to be greater than NVDRateLimitNoKey")
+	}
+}

--- a/internal/discovery/vuln/scanner.go
+++ b/internal/discovery/vuln/scanner.go
@@ -1,4 +1,4 @@
-package discovery
+package vuln
 
 // Vulnerability scanning integrates with the NVD (National Vulnerability Database) to identify
 // CVEs (Common Vulnerabilities and Exposures) affecting detected devices. Maps software versions
@@ -39,37 +39,9 @@ const (
 	severityRankCritical = 4 // Critical severity rank
 )
 
-// Vulnerability represents a CVE vulnerability for a device.
-type Vulnerability struct {
-	CVEID       string    `json:"cveId"`       // CVE-2023-12345
-	Description string    `json:"description"` // Brief description
-	Severity    string    `json:"severity"`    // CRITICAL, HIGH, MEDIUM, LOW
-	Score       float64   `json:"score"`       // CVSS score (0-10)
-	Published   time.Time `json:"published"`
-	Modified    time.Time `json:"modified"`
-	References  []string  `json:"references"`  // URLs to advisories
-	AffectedCPE string    `json:"affectedCpe"` // CPE string that matched
-
-	// CISA KEV (Known Exploited Vulnerabilities) enrichment fields
-	ActivelyExploited bool   `json:"activelyExploited,omitempty"` // In CISA KEV catalog
-	RansomwareRelated bool   `json:"ransomwareRelated,omitempty"` // Known ransomware use
-	RequiredAction    string `json:"requiredAction,omitempty"`    // CISA remediation guidance
-	DueDate           string `json:"dueDate,omitempty"`           // CISA remediation deadline
-	OriginalSeverity  string `json:"originalSeverity,omitempty"`  // Pre-KEV severity (if escalated)
-}
-
-// DeviceVulnerabilities holds vulnerability scan results for a device.
-type DeviceVulnerabilities struct {
-	DeviceIP        string          `json:"deviceIp"`
-	MAC             string          `json:"mac"`
-	Hostname        string          `json:"hostname"`
-	Vendor          string          `json:"vendor"`
-	Product         string          `json:"product"`
-	Version         string          `json:"version"`
-	Vulnerabilities []Vulnerability `json:"vulnerabilities"`
-	ScanTime        time.Time       `json:"scanTime"`
-	Error           string          `json:"error,omitempty"`
-}
+// Vulnerability and DeviceVulnerabilities are the kernel result types (see
+// aliases.go); they are defined in package discovery because DiscoveredDevice
+// embeds them.
 
 // VulnerabilityScannerConfig holds configuration for vulnerability scanning.
 type VulnerabilityScannerConfig struct {

--- a/internal/discovery/vuln/scanner_test.go
+++ b/internal/discovery/vuln/scanner_test.go
@@ -1,22 +1,22 @@
-package discovery_test
+package vuln_test
 
 import (
 	"context"
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 )
 
 func TestNewVulnerabilityScanner(t *testing.T) {
 	// Test with nil config (should use defaults)
-	config := &discovery.VulnerabilityScannerConfig{
+	config := &vuln.VulnerabilityScannerConfig{
 		Enabled:           true,
 		CVEDatabase:       "nvd",
 		SeverityThreshold: "medium",
 	}
 
-	scanner, err := discovery.NewVulnerabilityScanner(config)
+	scanner, err := vuln.NewVulnerabilityScanner(config)
 	if err != nil {
 		t.Fatalf("NewVulnerabilityScanner failed: %v", err)
 	}
@@ -26,14 +26,14 @@ func TestNewVulnerabilityScanner(t *testing.T) {
 }
 
 func TestVulnerabilityScanner_StartStop(t *testing.T) {
-	config := &discovery.VulnerabilityScannerConfig{
+	config := &vuln.VulnerabilityScannerConfig{
 		Enabled:           true,
 		CVEDatabase:       "nvd",
 		SeverityThreshold: "medium",
 		UpdateInterval:    3600,
 	}
 
-	scanner, scannerErr := discovery.NewVulnerabilityScanner(config)
+	scanner, scannerErr := vuln.NewVulnerabilityScanner(config)
 	if scannerErr != nil {
 		t.Fatalf("NewVulnerabilityScanner failed: %v", scannerErr)
 	}
@@ -77,19 +77,19 @@ func TestVulnerabilityScanner_StartStop(t *testing.T) {
 }
 
 func TestVulnerabilityScanner_FilterBySeverity(t *testing.T) {
-	config := &discovery.VulnerabilityScannerConfig{
+	config := &vuln.VulnerabilityScannerConfig{
 		Enabled:           true,
 		CVEDatabase:       "nvd",
 		SeverityThreshold: "high",
 	}
 
-	scanner, err := discovery.NewVulnerabilityScanner(config)
+	scanner, err := vuln.NewVulnerabilityScanner(config)
 	if err != nil {
 		t.Fatalf("NewVulnerabilityScanner failed: %v", err)
 	}
 
 	// Create test vulnerabilities with different severities
-	vulns := []discovery.Vulnerability{
+	vulns := []vuln.Vulnerability{
 		{CVEID: "CVE-2023-0001", Severity: "LOW", Score: 3.5},
 		{CVEID: "CVE-2023-0002", Severity: "MEDIUM", Score: 5.5},
 		{CVEID: "CVE-2023-0003", Severity: "HIGH", Score: 7.5},
@@ -97,7 +97,7 @@ func TestVulnerabilityScanner_FilterBySeverity(t *testing.T) {
 	}
 
 	// Filter with "high" threshold should only return HIGH and CRITICAL
-	accessor := &discovery.VulnerabilityScannerTestAccessor{Scanner: scanner}
+	accessor := &vuln.VulnerabilityScannerTestAccessor{Scanner: scanner}
 	filtered := accessor.FilterBySeverity(vulns)
 	if len(filtered) != 2 {
 		t.Errorf("expected 2 vulnerabilities, got %d", len(filtered))
@@ -112,18 +112,18 @@ func TestVulnerabilityScanner_FilterBySeverity(t *testing.T) {
 }
 
 func TestVulnerabilityScanner_FilterBySeverityLow(t *testing.T) {
-	config := &discovery.VulnerabilityScannerConfig{
+	config := &vuln.VulnerabilityScannerConfig{
 		Enabled:           true,
 		CVEDatabase:       "nvd",
 		SeverityThreshold: "low",
 	}
 
-	scanner, err := discovery.NewVulnerabilityScanner(config)
+	scanner, err := vuln.NewVulnerabilityScanner(config)
 	if err != nil {
 		t.Fatalf("NewVulnerabilityScanner failed: %v", err)
 	}
 
-	vulns := []discovery.Vulnerability{
+	vulns := []vuln.Vulnerability{
 		{CVEID: "CVE-2023-0001", Severity: "LOW", Score: 3.5},
 		{CVEID: "CVE-2023-0002", Severity: "MEDIUM", Score: 5.5},
 		{CVEID: "CVE-2023-0003", Severity: "HIGH", Score: 7.5},
@@ -131,7 +131,7 @@ func TestVulnerabilityScanner_FilterBySeverityLow(t *testing.T) {
 	}
 
 	// Filter with "low" threshold should return all
-	accessor := &discovery.VulnerabilityScannerTestAccessor{Scanner: scanner}
+	accessor := &vuln.VulnerabilityScannerTestAccessor{Scanner: scanner}
 	filtered := accessor.FilterBySeverity(vulns)
 	if len(filtered) != len(vulns) {
 		t.Errorf("expected %d vulnerabilities, got %d", len(vulns), len(filtered))
@@ -139,31 +139,31 @@ func TestVulnerabilityScanner_FilterBySeverityLow(t *testing.T) {
 }
 
 func TestVulnerabilityScanner_GetStats(t *testing.T) {
-	config := &discovery.VulnerabilityScannerConfig{
+	config := &vuln.VulnerabilityScannerConfig{
 		Enabled:           true,
 		CVEDatabase:       "nvd",
 		SeverityThreshold: "low",
 	}
 
-	scanner, err := discovery.NewVulnerabilityScanner(config)
+	scanner, err := vuln.NewVulnerabilityScanner(config)
 	if err != nil {
 		t.Fatalf("NewVulnerabilityScanner failed: %v", err)
 	}
 
 	// Add some mock results
-	accessor := &discovery.VulnerabilityScannerTestAccessor{Scanner: scanner}
+	accessor := &vuln.VulnerabilityScannerTestAccessor{Scanner: scanner}
 	accessor.GetMu().Lock()
-	accessor.SetDeviceResults(map[string]*discovery.DeviceVulnerabilities{
+	accessor.SetDeviceResults(map[string]*vuln.DeviceVulnerabilities{
 		"192.168.1.100": {
 			DeviceIP: "192.168.1.100",
-			Vulnerabilities: []discovery.Vulnerability{
+			Vulnerabilities: []vuln.Vulnerability{
 				{CVEID: "CVE-2023-0001", Severity: "CRITICAL", Score: 9.5},
 				{CVEID: "CVE-2023-0002", Severity: "HIGH", Score: 7.5},
 			},
 		},
 		"192.168.1.101": {
 			DeviceIP: "192.168.1.101",
-			Vulnerabilities: []discovery.Vulnerability{
+			Vulnerabilities: []vuln.Vulnerability{
 				{CVEID: "CVE-2023-0003", Severity: "MEDIUM", Score: 5.5},
 			},
 		},
@@ -199,22 +199,22 @@ func TestVulnerabilityScanner_GetStats(t *testing.T) {
 }
 
 func TestVulnerabilityScanner_ClearResults(t *testing.T) {
-	config := &discovery.VulnerabilityScannerConfig{
+	config := &vuln.VulnerabilityScannerConfig{
 		Enabled:           true,
 		CVEDatabase:       "nvd",
 		SeverityThreshold: "low",
 	}
 
-	scanner, err := discovery.NewVulnerabilityScanner(config)
+	scanner, err := vuln.NewVulnerabilityScanner(config)
 	if err != nil {
 		t.Fatalf("NewVulnerabilityScanner failed: %v", err)
 	}
 
 	// Add some mock results
-	accessor := &discovery.VulnerabilityScannerTestAccessor{Scanner: scanner}
+	accessor := &vuln.VulnerabilityScannerTestAccessor{Scanner: scanner}
 	accessor.GetMu().Lock()
 	results := accessor.GetDeviceResults()
-	results["192.168.1.100"] = &discovery.DeviceVulnerabilities{
+	results["192.168.1.100"] = &vuln.DeviceVulnerabilities{
 		DeviceIP: "192.168.1.100",
 	}
 	accessor.GetMu().Unlock()
@@ -234,20 +234,20 @@ func TestVulnerabilityScanner_ClearResults(t *testing.T) {
 }
 
 func TestVulnerabilityScanner_GetConfig(t *testing.T) {
-	config := &discovery.VulnerabilityScannerConfig{
+	config := &vuln.VulnerabilityScannerConfig{
 		Enabled:           true,
 		CVEDatabase:       "nvd",
 		SeverityThreshold: "high",
 		UpdateInterval:    7200,
 	}
 
-	scanner, err := discovery.NewVulnerabilityScanner(config)
+	scanner, err := vuln.NewVulnerabilityScanner(config)
 	if err != nil {
 		t.Fatalf("NewVulnerabilityScanner failed: %v", err)
 	}
 
 	retrievedConfig := scanner.GetConfig()
-	accessor := &discovery.VulnerabilityScannerTestAccessor{Scanner: scanner}
+	accessor := &vuln.VulnerabilityScannerTestAccessor{Scanner: scanner}
 
 	// Verify it's a copy, not the original
 	if retrievedConfig == accessor.GetConfig() {
@@ -271,7 +271,7 @@ func TestVulnerabilityScanner_GetConfig(t *testing.T) {
 
 func TestNVDProvider_NewNVDProvider(t *testing.T) {
 	// Test without API key
-	provider, err := discovery.NewNVDProvider("")
+	provider, err := vuln.NewNVDProvider("")
 	if err != nil {
 		t.Fatalf("NewNVDProvider failed: %v", err)
 	}
@@ -279,36 +279,36 @@ func TestNVDProvider_NewNVDProvider(t *testing.T) {
 		t.Fatal("provider should not be nil")
 	}
 
-	accessor := &discovery.NVDProviderTestAccessor{Provider: provider}
-	if accessor.GetRateLimit() != discovery.NVDRateLimitNoKey {
+	accessor := &vuln.NVDProviderTestAccessor{Provider: provider}
+	if accessor.GetRateLimit() != vuln.NVDRateLimitNoKey {
 		t.Errorf(
 			"expected rate limit %d, got %d",
-			discovery.NVDRateLimitNoKey,
+			vuln.NVDRateLimitNoKey,
 			accessor.GetRateLimit(),
 		)
 	}
 
 	// Test with API key
-	provider, err = discovery.NewNVDProvider("test-api-key")
+	provider, err = vuln.NewNVDProvider("test-api-key")
 	if err != nil {
 		t.Fatalf("NewNVDProvider with key failed: %v", err)
 	}
 
-	accessor = &discovery.NVDProviderTestAccessor{Provider: provider}
+	accessor = &vuln.NVDProviderTestAccessor{Provider: provider}
 	if accessor.GetAPIKey() != "test-api-key" {
 		t.Error("API key not set correctly")
 	}
-	if accessor.GetRateLimit() != discovery.NVDRateLimitWithKey {
+	if accessor.GetRateLimit() != vuln.NVDRateLimitWithKey {
 		t.Errorf(
 			"expected rate limit %d, got %d",
-			discovery.NVDRateLimitWithKey,
+			vuln.NVDRateLimitWithKey,
 			accessor.GetRateLimit(),
 		)
 	}
 }
 
 func TestNVDProvider_UpdateDatabase(t *testing.T) {
-	provider, providerErr := discovery.NewNVDProvider("")
+	provider, providerErr := vuln.NewNVDProvider("")
 	if providerErr != nil {
 		t.Fatalf("NewNVDProvider failed: %v", providerErr)
 	}

--- a/internal/discovery/vuln/stage.go
+++ b/internal/discovery/vuln/stage.go
@@ -1,0 +1,62 @@
+package vuln
+
+import (
+	"context"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
+)
+
+// Stage is the assessment stage adapter (ADR-0018): it satisfies
+// discovery.Assessor, scanning every registry device for vulnerabilities and
+// emitting a discovery event per finding. It holds the kernel collaborators
+// (registry + event bus) the Engine exposes, so the orchestrator depends only on
+// the Assessor port while the concrete scanner lives here.
+type Stage struct {
+	registry *discovery.DeviceRegistry
+	eventBus *discovery.EventBus
+	scanner  *VulnerabilityScanner
+}
+
+// NewStage builds the assessment stage over scanner, writing results into reg
+// and publishing findings on bus. Returned as the discovery.Assessor port the
+// Engine consumes.
+func NewStage(
+	scanner *VulnerabilityScanner,
+	reg *discovery.DeviceRegistry,
+	bus *discovery.EventBus,
+) discovery.Assessor {
+	return &Stage{registry: reg, eventBus: bus, scanner: scanner}
+}
+
+// Assess scans each registry device and records any vulnerabilities found.
+func (s *Stage) Assess(ctx context.Context, stats *discovery.ScanStats) {
+	for _, device := range s.registry.GetDevices() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		vulns := s.assess(ctx, device)
+		if vulns != nil && len(vulns.Vulnerabilities) > 0 {
+			device.Vulnerabilities = vulns
+			stats.VulnerableDevices++
+			s.registry.AddOrUpdate(device)
+
+			for _, v := range vulns.Vulnerabilities {
+				s.eventBus.Publish(discovery.NewVulnDiscoveredEvent(device, v.CVEID, v.Severity))
+			}
+		}
+	}
+}
+
+func (s *Stage) assess(ctx context.Context, device *DiscoveredDevice) *DeviceVulnerabilities {
+	if s.scanner == nil {
+		return nil
+	}
+	vulns, err := s.scanner.ScanDevice(ctx, device)
+	if err != nil {
+		return nil
+	}
+	return vulns
+}

--- a/internal/discovery/vuln/stage_test.go
+++ b/internal/discovery/vuln/stage_test.go
@@ -1,0 +1,35 @@
+package vuln_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
+)
+
+func newTestRegistry() *discovery.DeviceRegistry {
+	return discovery.NewDeviceRegistry(
+		discovery.NewEventBus(&discovery.EventBusConfig{}),
+		&discovery.RegistryConfig{EmitEvents: false},
+	)
+}
+
+// TestStageNilScannerIsNoop verifies the assess stage with a nil scanner is a
+// safe no-op (ADR-0018): no panic, no vulnerabilities recorded.
+func TestStageNilScannerIsNoop(t *testing.T) {
+	t.Parallel()
+	reg := newTestRegistry()
+	reg.AddOrUpdate(&discovery.DiscoveredDevice{MAC: "de:ad:be:ef:00:02", IP: "10.0.0.2"})
+	stage := vuln.NewStage(nil, reg, discovery.NewEventBus(&discovery.EventBusConfig{}))
+	stats := &discovery.ScanStats{}
+
+	stage.Assess(context.Background(), stats)
+
+	if stats.VulnerableDevices != 0 {
+		t.Fatalf("VulnerableDevices = %d, want 0 with nil scanner", stats.VulnerableDevices)
+	}
+	if d := reg.GetDevice("de:ad:be:ef:00:02"); d == nil || d.Vulnerabilities != nil {
+		t.Fatalf("device unexpectedly assessed: %+v", d)
+	}
+}

--- a/internal/discovery/vulnerability_types.go
+++ b/internal/discovery/vulnerability_types.go
@@ -1,0 +1,43 @@
+package discovery
+
+// vulnerability_types.go holds the vulnerability RESULT types that are part of
+// the device aggregate. They stay in the kernel because DiscoveredDevice embeds
+// *DeviceVulnerabilities (devices_types.go) and the registry/device-copy code
+// reads them — moving them would force the kernel to import the vuln stage and
+// create an import cycle. The vuln stage (internal/discovery/vuln) — the scanner,
+// CVE providers, and the Assessor adapter — lives in its own package and aliases
+// these types (ADR-0018, Phase 6).
+
+import "time"
+
+// Vulnerability represents a CVE vulnerability for a device.
+type Vulnerability struct {
+	CVEID       string    `json:"cveId"`       // CVE-2023-12345
+	Description string    `json:"description"` // Brief description
+	Severity    string    `json:"severity"`    // CRITICAL, HIGH, MEDIUM, LOW
+	Score       float64   `json:"score"`       // CVSS score (0-10)
+	Published   time.Time `json:"published"`
+	Modified    time.Time `json:"modified"`
+	References  []string  `json:"references"`  // URLs to advisories
+	AffectedCPE string    `json:"affectedCpe"` // CPE string that matched
+
+	// CISA KEV (Known Exploited Vulnerabilities) enrichment fields
+	ActivelyExploited bool   `json:"activelyExploited,omitempty"` // In CISA KEV catalog
+	RansomwareRelated bool   `json:"ransomwareRelated,omitempty"` // Known ransomware use
+	RequiredAction    string `json:"requiredAction,omitempty"`    // CISA remediation guidance
+	DueDate           string `json:"dueDate,omitempty"`           // CISA remediation deadline
+	OriginalSeverity  string `json:"originalSeverity,omitempty"`  // Pre-KEV severity (if escalated)
+}
+
+// DeviceVulnerabilities holds vulnerability scan results for a device.
+type DeviceVulnerabilities struct {
+	DeviceIP        string          `json:"deviceIp"`
+	MAC             string          `json:"mac"`
+	Hostname        string          `json:"hostname"`
+	Vendor          string          `json:"vendor"`
+	Product         string          `json:"product"`
+	Version         string          `json:"version"`
+	Vulnerabilities []Vulnerability `json:"vulnerabilities"`
+	ScanTime        time.Time       `json:"scanTime"`
+	Error           string          `json:"error,omitempty"`
+}

--- a/scripts/json-casing-baseline.txt
+++ b/scripts/json-casing-baseline.txt
@@ -108,8 +108,6 @@ internal/discovery/bluetooth.go	total_devices
 internal/discovery/bluetooth.go	tx_power
 internal/discovery/bluetooth.go	unauthorized_count
 internal/discovery/bluetooth.go	vendor_breakdown
-internal/discovery/cve_local.go	cvss_score
-internal/discovery/cve_local.go	last_updated
 internal/discovery/problems.go	actual_vendor
 internal/discovery/problems.go	adjacent_channel_aps
 internal/discovery/problems.go	affected_macs
@@ -184,6 +182,8 @@ internal/discovery/problems.go	total_active
 internal/discovery/problems.go	utilization_percent
 internal/discovery/problems.go	vendor_mismatch
 internal/discovery/problems.go	wifi_problems
+internal/discovery/vuln/cve_local.go	cvss_score
+internal/discovery/vuln/cve_local.go	last_updated
 internal/discovery/wifi_bridge.go	authorized_bssids
 internal/discovery/wifi_bridge.go	authorized_ssids
 internal/discovery/wifi_bridge.go	min_signal_dbm


### PR DESCRIPTION
## Summary
First **stage relocation** of Phase 6 (ADR-0018, after the in-package port seam #1564): move the vulnerability scanner, its CVE data providers (NVD / local / CISA KEV), and the assess `Stage` into `internal/discovery/vuln`, with **depguard** enforcing the inward dependency direction.

## How the cycle is avoided
`DiscoveredDevice` embeds `*DeviceVulnerabilities`, so the **result types `Vulnerability` + `DeviceVulnerabilities` stay in the kernel**; the `vuln` package **aliases** them (`type Vulnerability = discovery.Vulnerability`), so the moved scanner/provider code is otherwise unchanged and there is no import cycle.

## Mechanics
- `Engine` drops its concrete `*VulnerabilityScanner` field for an injected **`Assessor` port** (`SetAssessor`); the composition root builds `vuln.NewStage(scanner, engine.Registry(), engine.EventBus())`.
- **depguard** rule `discovery-stage-direction` bans the kernel from importing the stage subpackage (stages depend on the kernel, never the reverse).
- `internal/api` re-points the ~8 scanner-**type** references to `vuln.*`; the result types and all `/api/v1` wire shapes are unchanged. Vuln tests + `export_test` accessors moved with the package.

## Validation (behaviour-preserving)
- Golden HTTP **byte-identical**; **schema unchanged** (no vuln type was reflected).
- Full `internal/api` + `internal/discovery` + `internal/discovery/vuln` suites green.
- Lint clean including the new depguard rule.

## Next (ADR-0018)
fingerprint → resolve → enumerate, same pattern, then the direction-lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)