### PR TITLE
refactor(ui): replace window event test-orchestration bus with a zustand store

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -67,6 +67,7 @@ import { useTheme } from './hooks/useTheme';
 import { LogComponents, logger } from './lib/logger';
 import { navGroups } from './navGroups';
 import { pages } from './pageRegistry';
+import { useTestRunSignal, useTestRunStore } from './stores/testRunStore';
 import { cn, section } from './styles/theme';
 import { PageLoader } from './ui/PageLoader';
 import { SidebarLayout } from './ui/Sidebar';
@@ -446,8 +447,12 @@ function App(): JSX.Element {
     [cardSettings],
   );
 
-  // Listen for FAB "run all tests" event with per-card autoRunOnLink settings
-  useEffect(() => {
+  // React to a run start (FAB click or link-up auto-run) via the testRunStore.
+  // This replaces the former `window` runAllTests/cardTestComplete/testsComplete
+  // event bus (seed#1568, SEED_UI_ARCH_PLAN.md A2/H2). The handler closure reads
+  // the latest render scope each time (useTestRunSignal captures it by ref), so
+  // no dependency array is needed.
+  useTestRunSignal((runId: number): void => {
     const handleRunAllTests = async (): Promise<void> => {
       // Use per-card autoRunOnLink settings to determine which tests to run
 
@@ -483,8 +488,8 @@ function App(): JSX.Element {
       }
 
       // Wait for all fetches to complete
-      // Note: runSpeedtest/runIperf and runHealthChecks are handled by
-      // their respective card components listening for the 'runAllTests' event
+      // Note: runSpeedtest/runIperf and runHealthChecks are handled by their
+      // respective card components reacting to the same testRunStore start signal.
       await Promise.all(fetchPromises);
 
       // Determine how many card-managed tests we need to wait for
@@ -499,61 +504,34 @@ function App(): JSX.Element {
         cardTestsToWait.push('healthchecks');
       }
 
-      // If no card-managed tests, the run is fully complete now.
+      // Declare the card-managed tests this run must await. Completion
+      // accounting lives in the store: each card calls reportComplete() and the
+      // last one settles the run to idle — no listener-lifecycle race. An empty
+      // set settles the run immediately.
+      useTestRunStore.getState().awaitTests(cardTestsToWait);
       if (cardTestsToWait.length === 0) {
-        window.dispatchEvent(new CustomEvent('testsComplete', { detail: { partial: false } }));
         return;
       }
 
-      // Wait for all card-managed tests to complete
-      const completed = new Set<string>();
-      const handleCardComplete = (event: CustomEvent): void => {
-        const testName = event.detail?.test;
-        if (testName && cardTestsToWait.includes(testName)) {
-          completed.add(testName);
-          // Check if all expected tests are done
-          if (completed.size === cardTestsToWait.length) {
-            window.removeEventListener('cardTestComplete', handleCardComplete as EventListener);
-            // Every expected card reported: a genuine, complete run.
-            window.dispatchEvent(new CustomEvent('testsComplete', { detail: { partial: false } }));
-          }
-        }
-      };
-
-      // Listen for card test completions
-      window.addEventListener('cardTestComplete', handleCardComplete as EventListener);
-
-      // Failsafe timeout (90s) in case a card never reports completion. The run
-      // is then PARTIAL — some checks did not finish — and must be surfaced as
-      // such (partial: true), never as a clean completion. Presenting partial
-      // results as final was the C2 correctness defect.
+      // Failsafe (90s) in case a card never reports completion. The run is then
+      // PARTIAL — some checks did not finish — surfaced as such, never as a clean
+      // completion. Presenting partial results as final was the C2 defect.
+      // Scoped to this run id so a stale timeout cannot clobber a later run.
       setTimeout(() => {
-        window.removeEventListener('cardTestComplete', handleCardComplete as EventListener);
-        if (completed.size < cardTestsToWait.length) {
-          logger.warn(LogComponents.UI, 'FAB timeout: not all card tests completed', {
-            completed: completed.size,
-            expected: cardTestsToWait.length,
+        const { pending, expected } = useTestRunStore.getState();
+        if (pending.length > 0) {
+          logger.warn(LogComponents.UI, 'run timeout: not all card tests completed', {
+            completed: expected.length - pending.length,
+            expected: expected.length,
           });
-          window.dispatchEvent(new CustomEvent('testsComplete', { detail: { partial: true } }));
+          useTestRunStore.getState().settlePartial(runId);
         }
       }, 90000);
     };
-    window.addEventListener('runAllTests', handleRunAllTests);
-    return () => {
-      window.removeEventListener('runAllTests', handleRunAllTests);
-    };
-  }, [
-    fetchLinkData,
-    fetchIpConfig,
-    fetchDiscoveryData,
-    fetchDnsData,
-    fetchGatewayData,
-    fetchVlanData,
-    fetchWifiData,
-    fetchCableData,
-    triggerDeviceScan,
-    runOpts,
-  ]);
+    handleRunAllTests().catch((err: unknown) => {
+      logger.error(LogComponents.UI, 'run-all-tests orchestration failed', { error: err });
+    });
+  });
 
   // SSE connection for real-time updates (simpler than WebSocket)
   const { status: sseStatus, reconnect } = useSse({

--- a/ui/src/components/cards/HealthCheckCard.tsx
+++ b/ui/src/components/cards/HealthCheckCard.tsx
@@ -29,6 +29,7 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSettings } from '../../contexts/useSettings';
+import { useTestRunSignal, useTestRunStore } from '../../stores/testRunStore';
 import {
   cn,
   icon as iconTokens,
@@ -101,34 +102,27 @@ export const HealthCheckCard: React.MemoExoticComponent<
     };
   }, [fetchTests]);
 
-  // Listen for FAB "run all tests" event
-  useEffect((): (() => void) => {
+  // React to a run start via the testRunStore (was the `window` runAllTests
+  // event). Reports completion to the run orchestrator when the fetch settles.
+  useTestRunSignal((): void => {
     const handleRunAllTests = async (): Promise<void> => {
-      // Check per-card autoRunOnLink setting - skip if health checks disabled
+      // Check per-card autoRunOnLink setting - skip if health checks disabled.
+      // (The orchestrator only awaits 'healthchecks' under the same setting, so
+      // an early return here keeps the run accounting consistent.)
       if (!cardSettings.healthChecks.autoRunOnLink) {
         return;
       }
 
       if (!isRunning) {
         await fetchTests();
-        // Signal FAB that healthchecks are complete
-        window.dispatchEvent(
-          new CustomEvent('cardTestComplete', {
-            detail: { test: 'healthchecks' },
-          }),
-        );
+        // Signal the run orchestrator that healthchecks are complete.
+        useTestRunStore.getState().reportComplete('healthchecks');
       }
     };
-    const wrappedHandler = (): void => {
-      handleRunAllTests().catch((): void => {
-        /* Error handled in fetchTests */
-      });
-    };
-    window.addEventListener('runAllTests', wrappedHandler);
-    return (): void => {
-      window.removeEventListener('runAllTests', wrappedHandler);
-    };
-  }, [fetchTests, isRunning, cardSettings.healthChecks.autoRunOnLink]);
+    handleRunAllTests().catch((): void => {
+      /* Error handled in fetchTests */
+    });
+  });
 
   // Don't render card if no tests are configured
   if (!(data?.hasTests || loading || isRunning)) {

--- a/ui/src/components/cards/PerformanceCard.tsx
+++ b/ui/src/components/cards/PerformanceCard.tsx
@@ -35,6 +35,7 @@ import { useTranslation } from 'react-i18next';
 import { api } from '../../api';
 import { useSettings } from '../../contexts/useSettings';
 import { LogComponents, logger } from '../../lib/logger';
+import { useTestRunSignal, useTestRunStore } from '../../stores/testRunStore';
 import {
   cn,
   icon as iconTokens,
@@ -333,12 +334,8 @@ export const PerformanceCard: React.NamedExoticComponent<PerformanceCardProps> =
                 if (data.last) {
                   setSpeedtestResult(data.last);
                 }
-                // Signal FAB that speedtest is complete
-                window.dispatchEvent(
-                  new CustomEvent('cardTestComplete', {
-                    detail: { test: 'speedtest' },
-                  }),
-                );
+                // Signal the run orchestrator that speedtest is complete.
+                useTestRunStore.getState().reportComplete('speedtest');
               }
             }
           } catch (err) {
@@ -372,12 +369,8 @@ export const PerformanceCard: React.NamedExoticComponent<PerformanceCardProps> =
                 if (data.last) {
                   setIperfResult(data.last);
                 }
-                // Signal FAB that iperf is complete
-                window.dispatchEvent(
-                  new CustomEvent('cardTestComplete', {
-                    detail: { test: 'iperf' },
-                  }),
-                );
+                // Signal the run orchestrator that iperf is complete.
+                useTestRunStore.getState().reportComplete('iperf');
               }
             }
           } catch (err) {
@@ -454,45 +447,25 @@ export const PerformanceCard: React.NamedExoticComponent<PerformanceCardProps> =
       }
     }, [iperfSettings, runIperfEnabled, t]);
 
-    // Listen for FAB "run all tests" event
-    useEffect(() => {
-      const handleRunAllTests = (): void => {
-        // Run speedtest if enabled
-        if (runSpeedtestEnabled && !speedtestRunning) {
-          runSpeedtest().catch(() => {
-            // Error handled in runSpeedtest
+    // React to a run start via the testRunStore (was the `window` runAllTests
+    // event). Completion is reported from the poll effects above.
+    useTestRunSignal((): void => {
+      // Run speedtest if enabled
+      if (runSpeedtestEnabled && !speedtestRunning) {
+        runSpeedtest().catch(() => {
+          // Error handled in runSpeedtest
+        });
+      }
+      // Run iperf client test if enabled and configured
+      if (runIperfEnabled && !iperfClientRunning && iperfSettings.server && iperfInfo?.installed) {
+        // Delay slightly so tests don't all hammer at once
+        setTimeout((): void => {
+          runIperfClient().catch(() => {
+            // Error handled in runIperfClient
           });
-        }
-        // Run iperf client test if enabled and configured
-        if (
-          runIperfEnabled &&
-          !iperfClientRunning &&
-          iperfSettings.server &&
-          iperfInfo?.installed
-        ) {
-          // Delay slightly so tests don't all hammer at once
-          setTimeout((): void => {
-            runIperfClient().catch(() => {
-              // Error handled in runIperfClient
-            });
-          }, 500);
-        }
-      };
-
-      window.addEventListener('runAllTests', handleRunAllTests);
-      return (): void => {
-        window.removeEventListener('runAllTests', handleRunAllTests);
-      };
-    }, [
-      runSpeedtest,
-      runIperfClient,
-      speedtestRunning,
-      iperfClientRunning,
-      iperfSettings.server,
-      iperfInfo?.installed,
-      runSpeedtestEnabled,
-      runIperfEnabled,
-    ]);
+        }, 500);
+      }
+    });
 
     const formatSpeed = (mbps: number): string => {
       if (mbps >= 1000) {

--- a/ui/src/components/ui/fab.stories.tsx
+++ b/ui/src/components/ui/fab.stories.tsx
@@ -1,5 +1,5 @@
 import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
-import { useEffect } from 'react';
+import { useTestRunSignal, useTestRunStore } from '../../stores/testRunStore';
 import { cn, spacing } from '../../styles/theme';
 import { Fab } from './fab';
 
@@ -35,17 +35,13 @@ export const Default: Story = {};
 
 export const WithSimulatedTest: Story = {
   render: () => {
-    // Simulate test completion after 3 seconds
-    useEffect(() => {
-      const handleRunTests = () => {
-        setTimeout(() => {
-          window.dispatchEvent(new CustomEvent('testsComplete'));
-        }, 3000);
-      };
-
-      window.addEventListener('runAllTests', handleRunTests);
-      return () => window.removeEventListener('runAllTests', handleRunTests);
-    }, []);
+    // Simulate a card-managed run that completes after 3 seconds via the store.
+    useTestRunSignal((): void => {
+      useTestRunStore.getState().awaitTests(['speedtest']);
+      setTimeout(() => {
+        useTestRunStore.getState().reportComplete('speedtest');
+      }, 3000);
+    });
 
     return <Fab />;
   },

--- a/ui/src/components/ui/fab.test.tsx
+++ b/ui/src/components/ui/fab.test.tsx
@@ -1,35 +1,23 @@
 /**
- * FAB.test.tsx - Floating Action Button Tests
+ * fab.test.tsx - Floating Action Button Tests
  *
- * Purpose: Test suite for the FAB (Floating Action Button) component testing
- * button rendering, event dispatching, loading state, and timeout handling.
+ * The FAB triggers a run via the testRunStore and reflects the store's run
+ * status (idle / running / partial). These tests pin: clicking starts a run,
+ * the button disables while running, a re-click is ignored, the 60s backstop
+ * surfaces a partial outcome, and a clean completion settles back to idle.
  *
- * Key Test Areas:
- * - Rendering: FAB button displays with correct aria-label
- * - Event dispatch: clicking button dispatches runAllTests event
- * - Custom event: verifies CustomEvent structure and detail
- * - Loading state: shows spinner while tests are running
- * - Test completion: listens for testsComplete event
- * - Timeout handling: 60-second timeout clears loading state
- * - Visual feedback: spinner visible during test execution
- *
- * Test Framework: Vitest with React Testing Library and fake timers
- *
- * Usage:
- * ```bash
- * npm test -- FAB.test.tsx
- * ```
- *
- * Dependencies: vitest, @testing-library/react
+ * Test Framework: Vitest with React Testing Library and fake timers.
  */
 
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTestRunStore } from '../../stores/testRunStore';
 import { Fab } from './fab';
 
 describe('Fab', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    useTestRunStore.getState().reset();
   });
 
   afterEach(() => {
@@ -44,56 +32,27 @@ describe('Fab', () => {
     expect(button).toHaveAttribute('aria-label', 'Run All Tests');
   });
 
-  it('dispatches runAllTests event when clicked', () => {
-    const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
-
+  it('starts a run when clicked', () => {
+    const before = useTestRunStore.getState().startSignal;
     render(<Fab />);
 
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
+    fireEvent.click(screen.getByRole('button'));
 
-    expect(dispatchEventSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'runAllTests',
-      }),
-    );
-
-    dispatchEventSpy.mockRestore();
+    expect(useTestRunStore.getState().startSignal).toBe(before + 1);
+    expect(useTestRunStore.getState().status).toBe('running');
   });
 
-  it('shows spinner when running', () => {
+  it('shows spinner and disables while running', () => {
     render(<Fab />);
 
     const button = screen.getByRole('button');
-
-    // Initially not running
     expect(button).not.toBeDisabled();
 
-    // Click to start running
-    fireEvent.click(button);
-
-    // Should be disabled while running
-    expect(button).toBeDisabled();
-
-    // Should show spinner (has animate-spin class)
-    const spinner = button.querySelector('.animate-spin');
-    expect(spinner).toBeInTheDocument();
-  });
-
-  it('resets after timeout', () => {
-    render(<Fab />);
-
-    const button = screen.getByRole('button');
     fireEvent.click(button);
 
     expect(button).toBeDisabled();
-
-    // Fast forward fallback timeout (60s)
-    act(() => {
-      vi.advanceTimersByTime(60000);
-    });
-
-    expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute('data-run-status', 'running');
+    expect(button.querySelector('.animate-spin')).toBeInTheDocument();
   });
 
   it('marks the run partial when the backstop timeout fires (no completion)', () => {
@@ -116,20 +75,22 @@ describe('Fab', () => {
     );
   });
 
-  it('marks the run partial when testsComplete reports partial: true (C2)', () => {
+  it('reflects a partial outcome settled on the store (C2)', () => {
     render(<Fab />);
 
     const button = screen.getByRole('button');
     fireEvent.click(button);
+    const { runId } = useTestRunStore.getState();
+
     act(() => {
-      window.dispatchEvent(new CustomEvent('testsComplete', { detail: { partial: true } }));
+      useTestRunStore.getState().settlePartial(runId);
     });
 
     expect(button).not.toBeDisabled();
     expect(button).toHaveAttribute('data-run-status', 'partial');
   });
 
-  it('settles to idle on a complete (partial: false) run and clears a prior warning', () => {
+  it('settles to idle on a complete run and clears a prior warning', () => {
     render(<Fab />);
 
     const button = screen.getByRole('button');
@@ -141,31 +102,26 @@ describe('Fab', () => {
     });
     expect(button).toHaveAttribute('data-run-status', 'partial');
 
-    // A fresh run that completes cleanly clears the partial warning.
+    // A fresh run with no card tests completes cleanly and clears the warning.
     fireEvent.click(button);
     act(() => {
-      window.dispatchEvent(new CustomEvent('testsComplete', { detail: { partial: false } }));
+      useTestRunStore.getState().awaitTests([]);
     });
     expect(button).toHaveAttribute('data-run-status', 'idle');
     expect(button).toHaveAttribute('aria-label', 'Run All Tests');
   });
 
-  it('does not dispatch multiple events while running', () => {
-    const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
-
+  it('does not start a second run while one is running', () => {
     render(<Fab />);
 
     const button = screen.getByRole('button');
 
-    // First click
     fireEvent.click(button);
-    expect(dispatchEventSpy).toHaveBeenCalledTimes(1);
+    const afterFirst = useTestRunStore.getState().startSignal;
 
-    // Second click while running - should not dispatch
+    // Second click while running - should not start again.
     fireEvent.click(button);
-    expect(dispatchEventSpy).toHaveBeenCalledTimes(1);
-
-    dispatchEventSpy.mockRestore();
+    expect(useTestRunStore.getState().startSignal).toBe(afterFirst);
   });
 
   it('has correct accessibility attributes', () => {

--- a/ui/src/components/ui/fab.tsx
+++ b/ui/src/components/ui/fab.tsx
@@ -6,29 +6,23 @@
  * Features:
  * - Fixed positioning (bottom-right corner)
  * - Loading spinner animation while tests are running
- * - Dispatches 'runAllTests' custom event
- * - Fallback 60-second timeout if event never completes
+ * - Starts a run via the testRunStore (`start()`)
+ * - Fallback 60-second backstop if the run never settles
  * - Disabled state during test execution
  * - Keyboard accessible with focus ring
  * - Touch-friendly sizing (56x56 pixels)
  *
- * Usage:
- * ```tsx
- * // In app layout:
- * <Fab />
- *
- * // Listen for test completion:
- * window.addEventListener('testsComplete', () => {
- *   // Handle completion
- * });
- * ```
+ * Run state (idle / running / partial) is owned by the testRunStore, not by
+ * local component state or a `window` event bus — see seed#1568 (C2) and the
+ * store's module doc. The FAB reads `status` and triggers `start()`.
  *
  * The FAB is rendered at the root App level and provides quick access
  * to running all network diagnostics without opening settings.
  */
 
 import type React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { useTestRunStore } from '../../stores/testRunStore';
 import { cn, icon as iconTokens, layout, radius } from '../../styles/theme';
 
 /**
@@ -43,51 +37,42 @@ interface FabProps {
  * Floating Action Button - triggers all diagnostic tests
  */
 export function Fab({ className = '' }: FabProps): React.JSX.Element {
-  const [isRunning, setIsRunning] = useState(false);
-  // partial = the previous run finished without every check reporting (a timeout
-  // or a card that never completed). Surfaced distinctly so partial results are
-  // never presented as a clean completion (the C2 correctness fix).
-  const [partial, setPartial] = useState(false);
+  // Run state is owned by the store. `running` disables the button and shows the
+  // spinner; `partial` warns that the previous run finished without every check
+  // reporting — surfaced distinctly so partial results are never presented as a
+  // clean completion (the C2 correctness fix, seed#1568).
+  const status = useTestRunStore((s) => s.status);
+  const start = useTestRunStore((s) => s.start);
+  const isRunning = status === 'running';
+  const partial = status === 'partial';
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Settle the run when testsComplete fires: success clears any partial flag;
-  // a partial completion records it so the button can warn the operator.
-  useEffect(() => {
-    const handleTestsComplete = (event: Event): void => {
-      const detail = (event as CustomEvent<{ partial?: boolean }>).detail;
-      setIsRunning(false);
-      setPartial(Boolean(detail?.partial));
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-        timeoutRef.current = null;
-      }
-    };
-
-    window.addEventListener('testsComplete', handleTestsComplete);
-    return (): void => {
-      window.removeEventListener('testsComplete', handleTestsComplete);
+  // Clear a pending backstop on unmount.
+  useEffect(
+    () => (): void => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
-    };
-  }, []);
+    },
+    [],
+  );
 
   const handleClick = useCallback((): void => {
     if (isRunning) {
       return;
     }
-    setIsRunning(true);
-    setPartial(false); // a fresh run clears the prior partial warning
+    const runId = start();
 
-    window.dispatchEvent(new CustomEvent('runAllTests'));
-
-    // Backstop: if no testsComplete arrives (e.g. the orchestrator never ran),
-    // stop the spinner and mark the run partial — never silently "done".
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    // Backstop: if the run never settles (e.g. the orchestrator never ran),
+    // mark it partial — never silently "done". Scoped to this run id so a
+    // stale timeout cannot clobber a later run.
     timeoutRef.current = setTimeout(() => {
-      setIsRunning(false);
-      setPartial(true);
+      useTestRunStore.getState().settlePartial(runId);
     }, 60000);
-  }, [isRunning]);
+  }, [isRunning, start]);
 
   const runStatus = isRunning ? 'running' : partial ? 'partial' : 'idle';
   const label = partial

--- a/ui/src/hooks/useCardState.ts
+++ b/ui/src/hooks/useCardState.ts
@@ -24,6 +24,7 @@ import type { PublicIpData } from '../components/cards/PublicIpCard';
 import type { SwitchData, VlanData } from '../components/cards/SwitchCard';
 import type { WiFiData } from '../components/cards/WiFiCard';
 import { LogComponents, logger } from '../lib/logger';
+import { useTestRunStore } from '../stores/testRunStore';
 import type { SseCardUpdate as CardUpdate, SseMessage as Message } from './useSse';
 
 /**
@@ -190,7 +191,7 @@ export function useCardState({
                     // Track timeout for cleanup on unmount (fixes #851)
                     const timeoutId = setTimeout(() => {
                       timeoutIdsRef.current.delete(timeoutId);
-                      window.dispatchEvent(new CustomEvent('runAllTests'));
+                      useTestRunStore.getState().start();
                     }, 2000);
                     timeoutIdsRef.current.add(timeoutId);
                   }
@@ -273,7 +274,7 @@ export function useCardState({
         // Track timeout for cleanup on unmount (fixes #851)
         const timeoutId = setTimeout(() => {
           timeoutIdsRef.current.delete(timeoutId);
-          window.dispatchEvent(new CustomEvent('runAllTests'));
+          useTestRunStore.getState().start();
         }, 1500);
         timeoutIdsRef.current.add(timeoutId);
       }

--- a/ui/src/hooks/useNetworkFetchers.ts
+++ b/ui/src/hooks/useNetworkFetchers.ts
@@ -33,6 +33,7 @@ import type { PublicIpData } from '../components/cards/PublicIpCard';
 import type { SwitchData, VlanData } from '../components/cards/SwitchCard';
 import type { WiFiData } from '../components/cards/WiFiCard';
 import { LogComponents, logger } from '../lib/logger';
+import { useTestRunStore } from '../stores/testRunStore';
 
 const API_BASE: string = import.meta.env.VITE_API_BASE || '';
 
@@ -148,7 +149,7 @@ export function useNetworkFetchers({
         if (newLinkUp && wasDown) {
           logger.info(LogComponents.NETWORK, 'Link up detected (poll), triggering auto-run tests');
           setTimeout(() => {
-            window.dispatchEvent(new CustomEvent('runAllTests'));
+            useTestRunStore.getState().start();
           }, 1500);
         }
 

--- a/ui/src/stores/testRunStore.test.ts
+++ b/ui/src/stores/testRunStore.test.ts
@@ -1,0 +1,130 @@
+/**
+ * testRunStore.test.ts — unit tests for the run-all-tests orchestration store.
+ *
+ * The store replaces the former `window` CustomEvent bus (`runAllTests` /
+ * `cardTestComplete` / `testsComplete`). These tests pin the state machine:
+ * a run starts, declares the card-managed tests it must await, settles to
+ * `idle` only when every awaited test reports, and settles to `partial`
+ * (never a silent `idle`) when a backstop fires — the C2 correctness invariant.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useTestRunStore } from './testRunStore';
+
+const store = (): ReturnType<typeof useTestRunStore.getState> => useTestRunStore.getState();
+
+describe('testRunStore', () => {
+  beforeEach(() => {
+    store().reset();
+  });
+
+  it('starts idle with no pending tests', () => {
+    expect(store().status).toBe('idle');
+    expect(store().pending).toEqual([]);
+  });
+
+  it('start() moves to running and bumps the start signal and run id', () => {
+    const beforeSignal = store().startSignal;
+    const beforeRun = store().runId;
+
+    store().start();
+
+    expect(store().status).toBe('running');
+    expect(store().startSignal).toBe(beforeSignal + 1);
+    expect(store().runId).toBe(beforeRun + 1);
+  });
+
+  it('awaitTests([]) settles a card-free run straight to idle', () => {
+    store().start();
+    store().awaitTests([]);
+
+    expect(store().status).toBe('idle');
+    expect(store().pending).toEqual([]);
+  });
+
+  it('awaitTests(tests) records the pending set while running', () => {
+    store().start();
+    store().awaitTests(['speedtest', 'iperf']);
+
+    expect(store().status).toBe('running');
+    expect(store().pending).toEqual(['speedtest', 'iperf']);
+    expect(store().expected).toEqual(['speedtest', 'iperf']);
+  });
+
+  it('reportComplete() decrements pending and settles idle on the last one', () => {
+    store().start();
+    store().awaitTests(['speedtest', 'iperf']);
+
+    store().reportComplete('speedtest');
+    expect(store().status).toBe('running');
+    expect(store().pending).toEqual(['iperf']);
+
+    store().reportComplete('iperf');
+    expect(store().status).toBe('idle');
+    expect(store().pending).toEqual([]);
+  });
+
+  it('ignores reportComplete for a test that is not awaited', () => {
+    store().start();
+    store().awaitTests(['speedtest']);
+
+    store().reportComplete('healthchecks');
+    expect(store().pending).toEqual(['speedtest']);
+    expect(store().status).toBe('running');
+  });
+
+  it('ignores reportComplete arriving before awaitTests (race with no listener)', () => {
+    store().start();
+    // A card finishes before the orchestrator declares what to await — mirrors
+    // the prior behaviour where the cardTestComplete listener was attached only
+    // after the fetch phase. The early report is dropped, not double-counted.
+    store().reportComplete('speedtest');
+    store().awaitTests(['speedtest']);
+
+    expect(store().status).toBe('running');
+    expect(store().pending).toEqual(['speedtest']);
+  });
+
+  it('settlePartial() flips a running run to partial for the matching run id', () => {
+    store().start();
+    const { runId } = store();
+    store().awaitTests(['healthchecks']);
+
+    store().settlePartial(runId);
+
+    expect(store().status).toBe('partial');
+    expect(store().pending).toEqual(['healthchecks']);
+  });
+
+  it('settlePartial() with a stale run id is a no-op (does not clobber a new run)', () => {
+    store().start();
+    const staleRunId = store().runId;
+    // A fresh run supersedes the first; the first run's backstop must not fire.
+    store().start();
+    store().awaitTests(['speedtest']);
+
+    store().settlePartial(staleRunId);
+
+    expect(store().status).toBe('running');
+  });
+
+  it('settlePartial() does not override an already-completed run', () => {
+    store().start();
+    const { runId } = store();
+    store().awaitTests([]); // completes → idle
+
+    store().settlePartial(runId);
+
+    expect(store().status).toBe('idle');
+  });
+
+  it('a fresh start() clears a prior partial outcome', () => {
+    store().start();
+    const { runId } = store();
+    store().settlePartial(runId);
+    expect(store().status).toBe('partial');
+
+    store().start();
+    expect(store().status).toBe('running');
+  });
+});

--- a/ui/src/stores/testRunStore.ts
+++ b/ui/src/stores/testRunStore.ts
@@ -27,7 +27,6 @@
  */
 
 import { useEffect, useRef } from 'react';
-import type { StoreApi, UseBoundStore } from 'zustand';
 import { create } from 'zustand';
 import { devtools, subscribeWithSelector } from 'zustand/middleware';
 
@@ -70,9 +69,11 @@ const initialState: TestRunState = {
   awaiting: false,
 };
 
-export const useTestRunStore: UseBoundStore<StoreApi<TestRunState & TestRunActions>> = create<
-  TestRunState & TestRunActions
->()(
+// NB: the store type is inferred (not annotated) so the `subscribeWithSelector`
+// augmentation to `.subscribe(selector, listener)` survives — an explicit
+// `UseBoundStore<StoreApi<…>>` annotation would erase that overload, which
+// `useTestRunSignal` below depends on.
+export const useTestRunStore = create<TestRunState & TestRunActions>()(
   devtools(
     subscribeWithSelector((set, get) => ({
       ...initialState,

--- a/ui/src/stores/testRunStore.ts
+++ b/ui/src/stores/testRunStore.ts
@@ -1,0 +1,169 @@
+/**
+ * Test-run orchestration store (Zustand).
+ *
+ * Replaces the former `window` CustomEvent bus that coordinated the
+ * "Run All Tests" flow (`runAllTests` → `cardTestComplete` → `testsComplete`).
+ * The event bus was global, untyped, and untestable, and its completion
+ * accounting raced the listener lifecycle — the root cause behind the C2
+ * false-`testsComplete` defect (seed#1568). This store makes the run a small,
+ * typed, unit-testable state machine.
+ *
+ * Flow:
+ *   1. A trigger (FAB click, link-up auto-run) calls `start()`. This bumps
+ *      `startSignal` (subscribers react and kick off their work) and `runId`
+ *      (scopes async backstops to a single run).
+ *   2. The orchestrator (app shell) declares which card-managed tests the run
+ *      must await via `awaitTests(...)`. An empty set completes the run at once.
+ *   3. Each card calls `reportComplete(test)` when its poll-driven test settles.
+ *      The last expected report flips the run back to `idle`.
+ *   4. A backstop timeout calls `settlePartial(runId)`; a run that did not see
+ *      every report is surfaced as `partial`, never as a silent `idle` (the C2
+ *      correctness invariant).
+ *
+ * Subscribe to the start signal with {@link useTestRunSignal}; read `status`
+ * for UI (e.g. the FAB) via the hook directly.
+ *
+ * Related: seed#1568 (C2), SEED_UI_ARCH_PLAN.md A2/H2.
+ */
+
+import { useEffect, useRef } from 'react';
+import type { StoreApi, UseBoundStore } from 'zustand';
+import { create } from 'zustand';
+import { devtools, subscribeWithSelector } from 'zustand/middleware';
+
+export type TestRunStatus = 'idle' | 'running' | 'partial';
+
+interface TestRunState {
+  /** Current run lifecycle state. `partial` persists until the next `start()`. */
+  status: TestRunStatus;
+  /** Monotonic counter bumped on every `start()`; subscribers react to changes. */
+  startSignal: number;
+  /** Monotonic run identifier; backstops capture it to ignore stale timeouts. */
+  runId: number;
+  /** Card-managed tests still awaited for the active run. */
+  pending: string[];
+  /** Full set of card-managed tests for the active run (for "X of Y" messaging). */
+  expected: string[];
+  /** True once `awaitTests` has declared the set — guards early `reportComplete`. */
+  awaiting: boolean;
+}
+
+interface TestRunActions {
+  /** Begin a run: clear prior outcome, bump the start signal and run id. Returns the new run id. */
+  start: () => number;
+  /** Declare the card-managed tests to await; an empty set completes at once. */
+  awaitTests: (tests: string[]) => void;
+  /** Record a card-managed test as finished; the last one settles the run. */
+  reportComplete: (test: string) => void;
+  /** Backstop: mark the still-running run (matched by id) as partial. */
+  settlePartial: (runId: number) => void;
+  /** Reset to the initial idle state (used by tests and on teardown). */
+  reset: () => void;
+}
+
+const initialState: TestRunState = {
+  status: 'idle',
+  startSignal: 0,
+  runId: 0,
+  pending: [],
+  expected: [],
+  awaiting: false,
+};
+
+export const useTestRunStore: UseBoundStore<StoreApi<TestRunState & TestRunActions>> = create<
+  TestRunState & TestRunActions
+>()(
+  devtools(
+    subscribeWithSelector((set, get) => ({
+      ...initialState,
+
+      start: (): number => {
+        set(
+          (s) => ({
+            status: 'running',
+            startSignal: s.startSignal + 1,
+            runId: s.runId + 1,
+            pending: [],
+            expected: [],
+            awaiting: false,
+          }),
+          false,
+          'testRun/start',
+        );
+        return get().runId;
+      },
+
+      awaitTests: (tests: string[]) =>
+        set(
+          (s) => {
+            if (s.status !== 'running') {
+              return {};
+            }
+            if (tests.length === 0) {
+              // Nothing to wait for — a genuine, complete run.
+              return { status: 'idle', pending: [], expected: [], awaiting: false };
+            }
+            return { expected: tests, pending: tests, awaiting: true };
+          },
+          false,
+          'testRun/awaitTests',
+        ),
+
+      reportComplete: (test: string) =>
+        set(
+          (s) => {
+            if (s.status !== 'running' || !s.awaiting || !s.pending.includes(test)) {
+              return {};
+            }
+            const pending = s.pending.filter((t) => t !== test);
+            if (pending.length === 0) {
+              // Every awaited card reported — a genuine, complete run.
+              return { status: 'idle', pending: [], awaiting: false };
+            }
+            return { pending };
+          },
+          false,
+          'testRun/reportComplete',
+        ),
+
+      settlePartial: (runId: number) =>
+        set(
+          (s) => {
+            if (s.status !== 'running' || s.runId !== runId) {
+              return {};
+            }
+            return { status: 'partial', awaiting: false };
+          },
+          false,
+          'testRun/settlePartial',
+        ),
+
+      reset: () => set({ ...initialState }, false, 'testRun/reset'),
+    })),
+    { name: 'testRunStore' },
+  ),
+);
+
+/**
+ * Subscribe to run starts. `handler` is invoked once per `start()` with the
+ * run's id, using the latest closure each render — replicating the
+ * fire-once-per-event semantics of the former `window` `runAllTests` listener
+ * without re-firing when unrelated dependencies change.
+ */
+export function useTestRunSignal(handler: (runId: number) => void): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(
+    () =>
+      useTestRunStore.subscribe(
+        (s) => s.startSignal,
+        (signal, previous) => {
+          if (signal !== previous) {
+            handlerRef.current(useTestRunStore.getState().runId);
+          }
+        },
+      ),
+    [],
+  );
+}


### PR DESCRIPTION
## What

Replaces the `window` CustomEvent bus that coordinated the **Run All Tests** flow (`runAllTests` → `cardTestComplete` → `testsComplete`) with a small, typed, unit-tested Zustand store (`stores/testRunStore.ts`).

This is **H2** from `SEED_UI_ARCH_PLAN.md` (item A2) — the architectural root behind the C2 false-`testsComplete` defect. C2 (#1568) fixed the symptom (the FAB no longer reports a clean done on a timeout); this PR removes the fragile, untestable global bus that caused it.

## Why

The old bus was global, untyped, and untestable, and its completion accounting raced the listener lifecycle: the orchestrator attached its `cardTestComplete` listener only *after* the fetch phase, and a card finishing early was simply missed. The store makes the run a real state machine with a decrementing counter — completion can't be lost to listener timing.

## Design

`testRunStore` — `status: idle | running | partial`:
- `start()` → bumps a `startSignal` (subscribers react) and `runId` (scopes async backstops); returns the new run id.
- `awaitTests(tests)` → orchestrator declares the card-managed tests to await; empty set completes at once.
- `reportComplete(test)` → cards report from their poll effects; the last awaited report settles the run to `idle`.
- `settlePartial(runId)` → backstop; only flips a *still-running* run with the *matching* id, so partial results are surfaced distinctly and never as a clean done (the C2 invariant).
- `useTestRunSignal(handler)` → subscribes to start, invoking the latest closure once per run (replicates the former `addEventListener` semantics without re-firing on unrelated dep changes).

## Consumers migrated

| File | Before | After |
|---|---|---|
| `fab.tsx` | local `useState` + dispatch/listen `runAllTests`/`testsComplete` | reads `status`, calls `start()`, run-id-scoped 60s backstop |
| `app.tsx` | `window` orchestrator effect | `useTestRunSignal` + `awaitTests` + 90s failsafe |
| `PerformanceCard.tsx` | listen `runAllTests`, dispatch `cardTestComplete` | `useTestRunSignal`, `reportComplete('speedtest'\|'iperf')` |
| `HealthCheckCard.tsx` | listen `runAllTests`, dispatch `cardTestComplete` | `useTestRunSignal`, `reportComplete('healthchecks')` |
| `useCardState.ts`, `useNetworkFetchers.ts` | dispatch `runAllTests` on link-up | `start()` |
| `fab.stories.tsx` | window-event simulation | store simulation |

No behavioural change to run semantics. Zero `window` add/remove/dispatch for test events remain (verified by grep).

## Tests

- New `testRunStore.test.ts` — 11 cases pinning the state machine (start, await, report, last-settles-idle, early-report-dropped, stale/duplicate `settlePartial` no-ops, partial-then-fresh-start).
- Rewrote `fab.test.tsx` against the store — 10 cases (start, running/disabled, backstop→partial, store-driven partial, complete→idle clears warning, no double-start, a11y).
- `tsc --noEmit` clean; Biome clean; token-discipline gate clean; production `vite build` clean.
- FAB E2E (`e2e/fab.spec.ts`) unchanged — exercised in CI on this UI PR.

> Note: `app.test.tsx` and `Button.a11y.test.tsx` flake under full-suite parallel load on `main` as well (verified) — pre-existing environmental flake, unrelated to this change.