### PR TITLE
refactor(ui): single canonical SeedLogo brand mark (M3)

### DIFF
--- a/ui/src/components/app/HeaderBar.tsx
+++ b/ui/src/components/app/HeaderBar.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../styles/theme';
 import type { Profile } from '../../types/profile';
 import type { NetworkInterface } from '../ui/InterfaceSelector';
+import { SeedLogo } from './SeedLogo';
 
 type WsStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
 
@@ -219,20 +220,15 @@ export const HeaderBar: React.FC<HeaderBarProps> = memo(function headerBar({
               : getStatusTooltip()
           }
         >
-          {/* Seed icon - color indicates connection status */}
-          <svg
+          {/* Seed brand mark — color indicates connection status */}
+          <SeedLogo
             className={cn(
               'w-7 h-7 shrink-0 transition-colors',
               getSeedColor(),
               wsStatus === 'connecting' && 'animate-pulse',
               wsStatus !== 'connected' && 'group-hover:opacity-80',
             )}
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            aria-hidden="true"
-          >
-            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.94-.49-7-3.85-7-7.93s3.05-7.44 7-7.93v15.86zm2-15.86c1.03.13 2 .45 2.87.93H13v-.93zM13 7h5.24c.25.31.48.65.68 1H13V7zm0 3h6.74c.08.33.15.66.19 1H13v-1zm0 9.93V19h2.87c-.87.48-1.84.8-2.87.93zM18.24 17H13v-1h5.92c-.2.35-.43.69-.68 1zm1.5-3H13v-1h6.93c-.04.34-.11.67-.19 1z" />
-          </svg>
+          />
           <h1 className="heading-4 hidden xs:block sm:block truncate text-text-primary">
             {t('app.title')}
           </h1>

--- a/ui/src/components/app/SeedLogo.tsx
+++ b/ui/src/components/app/SeedLogo.tsx
@@ -1,0 +1,62 @@
+/**
+ * SeedLogo — the single canonical Seed brand mark (M3).
+ *
+ * Replaces the two previously-divergent marks (the topbar's inline seed-glyph
+ * SVG and the sidebar's generic `Activity`-in-gradient icon) with one component.
+ * The seed glyph is the canonical product mark.
+ *
+ * - Default (plain): a bare glyph; pass `className` for size + color. The topbar
+ *   uses this and tints it by connection status.
+ * - `badge`: the glyph inside the brand gradient box (the sidebar mark).
+ */
+
+import type { JSX } from 'react';
+import { cn } from '../../styles/theme';
+
+// Seed/leaf-in-circle glyph — the canonical brand mark.
+const SEED_GLYPH_PATH =
+  'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.94-.49-7-3.85-7-7.93s3.05-7.44 7-7.93v15.86zm2-15.86c1.03.13 2 .45 2.87.93H13v-.93zM13 7h5.24c.25.31.48.65.68 1H13V7zm0 3h6.74c.08.33.15.66.19 1H13v-1zm0 9.93V19h2.87c-.87.48-1.84.8-2.87.93zM18.24 17H13v-1h5.92c-.2.35-.43.69-.68 1zm1.5-3H13v-1h6.93c-.04.34-.11.67-.19 1z';
+
+interface SeedLogoProps {
+  /** Plain glyph: classes applied directly to the `<svg>` (size + color). */
+  className?: string;
+  /** Render inside the brand gradient badge (the sidebar mark). */
+  badge?: boolean;
+  /** Badge box classes (size + shadow). Only used when `badge`. */
+  badgeClassName?: string;
+  /** Glyph classes inside the badge (size). Only used when `badge`. */
+  glyphClassName?: string;
+}
+
+export function SeedLogo({
+  className,
+  badge = false,
+  badgeClassName,
+  glyphClassName,
+}: SeedLogoProps): JSX.Element {
+  if (badge) {
+    return (
+      <div
+        className={cn(
+          'rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center',
+          badgeClassName,
+        )}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+          className={cn('text-text-inverse', glyphClassName)}
+        >
+          <path d={SEED_GLYPH_PATH} />
+        </svg>
+      </div>
+    );
+  }
+
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className={className}>
+      <path d={SEED_GLYPH_PATH} />
+    </svg>
+  );
+}

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -11,7 +11,6 @@
  * AppShell level alongside the existing test/state plumbing.
  */
 import {
-  Activity,
   ChevronLeft,
   ChevronRight,
   HelpCircle,
@@ -25,6 +24,7 @@ import {
 import { createElement, type FC, type ReactNode, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { SeedLogo } from '../components/app/SeedLogo';
 import { iconSizes } from '../constants/sizes';
 import { prefetchRoute } from '../utils/prefetch';
 import { safeGetItem, safeSetItem } from '../utils/storage';
@@ -147,9 +147,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ collapsed, onCollapse }) => {
     >
       <div className={`flex items-center gap-compact ${collapsed ? 'justify-center' : ''}`}>
         <div className="relative flex-shrink-0">
-          <div className="h-9 w-9 rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center shadow-lg">
-            <Activity className={`${iconSizes.lg} text-text-inverse`} />
-          </div>
+          <SeedLogo badge badgeClassName="h-9 w-9 shadow-lg" glyphClassName={iconSizes.lg} />
           <div className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-status-success border-2 border-surface-raised" />
         </div>
         {!collapsed ? (
@@ -354,9 +352,7 @@ const MobileTopBar: FC<MobileTopBarProps> = ({ mobileOpen, toggleMobile }) => {
   return (
     <header className="lg:hidden fixed top-0 left-0 right-0 z-50 flex-between px-4 py-row-lg bg-surface-raised/95 backdrop-blur-xl border-b border-surface-border">
       <div className="flex items-center gap-compact">
-        <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center">
-          <Activity className={`${iconSizes.md} text-text-inverse`} />
-        </div>
+        <SeedLogo badge badgeClassName="h-8 w-8" glyphClassName={iconSizes.md} />
         <span className="font-display font-bold text-text-primary">{t('app.title')}</span>
       </div>
       <button


### PR DESCRIPTION
## What (M3)
Consolidates the two divergent brand marks into one `<SeedLogo>`:
- **Topbar** used an inline seed-glyph SVG (status-tinted).
- **Sidebar** used a generic lucide `Activity` icon in a gradient box.

The **seed glyph is canonical** (owner-confirmed). New `components/app/SeedLogo.tsx`:
- default = plain glyph (`className` for size/color) — topbar keeps its connection-status tint + pulse;
- `badge` = glyph inside the brand gradient box — sidebar (expanded + collapsed mobile header) now shows the real seed mark instead of `Activity`.

`Activity` import dropped from Sidebar. Pure visual consolidation, no behaviour change.

## Verify
tsc + Biome + production build green. E2E on CI. Storybook unaffected (no SeedLogo story yet).

## Follow-up
**M2** — HeaderBar's remaining 12 functional inline SVGs → lucide via `icons.tsx` (needs new exports: LogOut, EthernetPort, Star, Moon, Sun) — separate PR.