### PR TITLE
test(auth): pin the CSRF exempt-list with a coverage gate (#1223)

### DIFF
--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -171,6 +171,28 @@ func (m *CSRFManager) Stop() {
 	m.cancel()
 }
 
+// isCSRFExemptPath reports whether path is on the curated CSRF exempt-list:
+// pre-session auth/setup endpoints, the client-log sink, and the SSO handshake.
+// Every entry MUST be safe to serve on a state-changing method without a CSRF
+// token — i.e. pre-session or non-security-state-changing — NEVER a data-mutating
+// route. csrf_coverage_test.go pins this set (#1223): a change here must be
+// reflected and justified there. Kept as a switch (no package globals) per the
+// repo's gochecknoglobals convention; the switch is also allocation-free on the
+// per-request hot path.
+func isCSRFExemptPath(path string) bool {
+	switch path {
+	case "/api/v1/auth/login", // pre-session: no CSRF token issued yet
+		"/api/v1/auth/refresh",          // access token may be expired → no valid token yet
+		"/api/v1/auth/logout",           // safe/idempotent session teardown
+		"/api/v1/setup/status",          // first-run, pre-auth
+		"/api/v1/setup/complete",        // first-run, pre-auth
+		"/api/v1/reporting/logs/client": // logger runs before CSRF tokens exist
+		return true
+	}
+	// SSO handshake endpoints are pre-session.
+	return strings.HasPrefix(path, "/api/v1/sso/")
+}
+
 // CSRFMiddleware returns HTTP middleware that validates CSRF tokens on state-changing requests.
 // It exempts GET, HEAD, OPTIONS, and TRACE methods as they should be safe/idempotent.
 func (m *CSRFManager) CSRFMiddleware(next http.Handler) http.Handler {
@@ -190,19 +212,11 @@ func (m *CSRFManager) CSRFMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// Skip CSRF for auth endpoints that don't have a session yet, token refresh,
-		// logout (safe operation), SSO, and client logging. Refresh needs exemption because
-		// the user may not have a valid CSRF token when their access token expires.
-		// Client logs endpoint is exempted because the logger runs before CSRF tokens are
-		// available and logging doesn't change security-sensitive state.
-		// Note: API routes use /api/v1/ prefix
-		if r.URL.Path == "/api/v1/auth/login" ||
-			r.URL.Path == "/api/v1/auth/refresh" ||
-			r.URL.Path == "/api/v1/auth/logout" ||
-			r.URL.Path == "/api/v1/setup/status" ||
-			r.URL.Path == "/api/v1/setup/complete" ||
-			r.URL.Path == "/api/v1/reporting/logs/client" ||
-			strings.HasPrefix(r.URL.Path, "/api/v1/sso/") {
+		// Skip CSRF for the curated exempt-list (pre-session auth/setup + client
+		// logging + SSO handshake). See isCSRFExemptPath for the per-entry
+		// justification; the set is pinned by csrf_coverage_test.go (#1223) so a
+		// new exemption can't slip in unreviewed.
+		if isCSRFExemptPath(r.URL.Path) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/auth/csrf_coverage_test.go
+++ b/internal/auth/csrf_coverage_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/auth"
+)
+
+// TestCSRFExemptList_Golden pins the CSRF exempt-list (#1223). It is the
+// regression gate: every currently-exempt path must stay exempt, and a
+// representative set of data-mutating routes must stay PROTECTED. Changing
+// isCSRFExemptPath without updating this table fails CI — forcing a reviewer to
+// confirm a new exemption is a pre-session/non-state-changing endpoint, never a
+// data-mutating route. Do NOT "fix" a failure by pasting the new behaviour in
+// blind; confirm the exemption is safe first.
+func TestCSRFExemptList_Golden(t *testing.T) {
+	t.Parallel()
+	exempt := []string{
+		"/api/v1/auth/login",
+		"/api/v1/auth/refresh",
+		"/api/v1/auth/logout",
+		"/api/v1/setup/status",
+		"/api/v1/setup/complete",
+		"/api/v1/reporting/logs/client",
+		"/api/v1/sso/callback", // prefix match
+		"/api/v1/sso/",
+	}
+	for _, p := range exempt {
+		if !auth.ExportIsCSRFExemptPath(p) {
+			t.Errorf("expected %q to be CSRF-exempt, but it is NOT — did the exempt-list shrink?", p)
+		}
+	}
+
+	// These mutating routes MUST require a CSRF token. If any becomes exempt,
+	// that is a security regression — fix the route, not this test.
+	protected := []string{
+		"/api/v1/profiles",
+		"/api/v1/config/import",
+		"/api/v1/devices",
+		"/api/v1/users",
+		"/api/v1/auth/loginX",             // not an exact match
+		"/api/v1/reporting/logs/client/x", // exact entry, not a prefix
+		"/api/v1/sso",                     // prefix needs the trailing slash
+	}
+	for _, p := range protected {
+		if auth.ExportIsCSRFExemptPath(p) {
+			t.Errorf("SECURITY: %q is CSRF-exempt but must be protected (#1223)", p)
+		}
+	}
+}
+
+// TestCSRFMiddleware_BlocksProtectedMutation is the integration test (#1223): a
+// state-changing request to a non-exempt /api route without a valid CSRF token
+// is blocked (the wrapped handler never runs), while an exempt path and safe
+// methods pass through. Without a session the middleware returns 401; with a
+// session but a bad/absent token it returns 403 — both are "blocked", the
+// property pinned here.
+func TestCSRFMiddleware_BlocksProtectedMutation(t *testing.T) {
+	t.Parallel()
+	m := auth.NewCSRFManager()
+	defer m.Stop()
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	h := m.CSRFMiddleware(next)
+
+	serve := func(method, path string) *httptest.ResponseRecorder {
+		called = false
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(method, path, nil))
+		return rec
+	}
+
+	// Protected mutating route, no session, no token → blocked.
+	rec := serve(http.MethodPost, "/api/v1/profiles")
+	if called {
+		t.Error("CSRF middleware let an unprotected POST /api/v1/profiles reach the handler")
+	}
+	if rec.Code == http.StatusOK {
+		t.Errorf("POST /api/v1/profiles without CSRF token: status = %d, want a block (401/403)", rec.Code)
+	}
+
+	// Exempt route passes through.
+	if serve(http.MethodPost, "/api/v1/auth/login"); !called {
+		t.Error("CSRF middleware blocked an exempt POST /api/v1/auth/login")
+	}
+
+	// Safe method on a protected route passes through (RFC 7231).
+	if serve(http.MethodGet, "/api/v1/profiles"); !called {
+		t.Error("CSRF middleware blocked a safe GET /api/v1/profiles")
+	}
+}

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -48,6 +48,12 @@ func (m *Manager) ManagerUsername() string {
 	return m.username
 }
 
+// ExportIsCSRFExemptPath exports isCSRFExemptPath so the CSRF exempt-list
+// coverage gate (#1223) can pin the policy from the external test package.
+func ExportIsCSRFExemptPath(path string) bool {
+	return isCSRFExemptPath(path)
+}
+
 // ManagerSessionTimeout returns the sessionTimeout from a Manager for testing.
 func (m *Manager) ManagerSessionTimeout() any {
 	return m.sessionTimeout


### PR DESCRIPTION
Closes the regression-gate ask in #1223. CSRF middleware already wraps the whole mux; this adds a gate so a mutating route can't silently join the exempt-list. Extracts the inline exempt checks into `isCSRFExemptPath` (switch, no globals), and adds `csrf_coverage_test.go` pinning the exempt set (every exemption stays exempt + data-mutating routes stay protected) plus an integration test (POST /api/v1/profiles w/o token → blocked). Behaviour-identical. golangci 0, tests green.