### PR TITLE
refactor(discovery): relocate port-scan leaf to fingerprint stage (adr-0018)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -305,9 +305,12 @@ linters:
           files:
             - "**/internal/discovery/**"
             - "!**/internal/discovery/vuln/**"
+            - "!**/internal/discovery/fingerprint/**"
           deny:
             - pkg: github.com/MustardSeedNetworks/seed/internal/discovery/vuln
               desc: "inward-only — a discovery stage (internal/discovery/vuln) imports the kernel, never the reverse; the Engine holds the Assessor port and the composition root injects the stage"
+            - pkg: github.com/MustardSeedNetworks/seed/internal/discovery/fingerprint
+              desc: "inward-only — a discovery stage (internal/discovery/fingerprint) imports the kernel, never the reverse; the Engine holds the PortScannerPort and the composition root injects the scanner"
 
     embeddedstructfieldcheck:
       # Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.

--- a/docs/architecture/decisions/0018-discovery-pipeline-stage-split.md
+++ b/docs/architecture/decisions/0018-discovery-pipeline-stage-split.md
@@ -194,27 +194,46 @@ orchestrates the ports. Per-stage subpackage relocation + depguard follow.
       port; `internal/api` wires `vuln.NewStage(scanner, engine.Registry(),
       engine.EventBus())`. depguard rule `discovery-stage-direction` bans the kernel
       from importing the stage. Golden byte-identical, schema unchanged.
-- [ ] 2. `fingerprint`/enrich stage → `discovery/fingerprint` + depguard.
-      **DESIGN (scoped 2026-06-07): this is an ATOMIC ~9-file move, not per-component.**
-      `DeviceProfiler` embeds `*SNMPCollector` + `*PortScanner` (profiler.go), so the
-      three enrich components are mutually coupled and relocate together: `snmp_collector`,
-      `portscan`, `tcpprobe(_windows)`, `profiler{,_config,_scan,_resolve,_infer,_accessors}`.
-      **Component-port approach (keeps GetCapabilities byte-identical):** define three
-      seams in the kernel — `SNMPCollectorPort{Collect}`, `PortScannerPort{QuickScan}`,
-      `ProfilerPort{QueueProfile,GetProfile}` — change the kernel `enrichStage` + `Engine`
-      fields (and the `Set*` injectors) to those interface types; the concrete producers
-      move to `fingerprint` and implement them. `Engine.GetCapabilities` keeps its
-      per-component nil-checks on the interface fields → identical wire. **Result/config
-      types STAY in the kernel (split out, then alias in fingerprint):** `SNMPFullData`
-      + nested (snmp_collector.go), `DeviceProfile`/`OpenPort`/`OSFingerprint`/
-      `ServiceVersion`/`TLSInfo`/`ResolvedNames` (profiler_types.go — already mostly a
-      types file), `PortScanResult`/`PortInfo`/`ServiceInfo` (portscan.go),
-      `PortScanIntensity`/`ScanTimingProfile` (scan_config.go — used by kernel
-      `ScanOptions`). `Fingerprinter` + `Tracer` are NOT in the enrich path — leave them
-      in the kernel for a later slice. api re-points `New{DeviceProfiler,PortScanner,
-      TCPProber}`/`DefaultProfilerConfig`/`DeviceProfiler`/`PortScanner` → `fingerprint.*`;
-      keeps `discovery.{DeviceProfile,PortInfo,PortScanResult,PortScanIntensity,
-      ScanTimingProfile}` (result types). SNMP is currently dormant (never wired in api).
+- [x] 2. `fingerprint` stage → `discovery/fingerprint` + depguard. **DONE — scoped to
+      the port-scan leaf cluster (PortScanner + TCPProber), NOT the whole enrich cluster.**
+
+      **Why the original "atomic ~9-file move" plan was wrong (discovered during
+      implementation, 2026-06-08):** the plan rested on *"`DeviceProfiler` embeds
+      `*SNMPCollector` + `*PortScanner`, so the three enrich components are mutually
+      coupled."* The first half is false in the code: `DeviceProfiler` embeds only
+      `*SNMPCollector` and does its own `net.Dial` port scanning — it holds **no**
+      `PortScanner`. So the enrich code is two *independent* clusters:
+      (A) `SNMPCollector` ← `DeviceProfiler`, and (B) `TCPProber` ← `PortScanner`.
+
+      **Why cluster A (profiler/SNMP) STAYS kernel-resident, by design:** the kernel
+      orchestrator `discovery.Service` co-owns the `DeviceProfiler` lifecycle — it
+      constructs it and drives ~11 methods (`Start/Stop/QueueProfile/GetProfile/
+      IsProfiling/GetSNMPData/GetResolvedNames/GetProfilingStatus/Clear{Profiles,
+      SNMPData,ResolvedNames}`), and the Engine adds `ScanConfigSnapshot/UpdateScanConfig`.
+      `Service` cannot move to a stage subpackage (it reaches into `DeviceDiscovery`'s
+      unexported `protoManager`). Moving `DeviceProfiler` out while `Service` stays
+      would force a ~13-method union "ProfilerPort" that trips `interfacebloat` and is a
+      1:1 mirror of the struct — a header-interface anti-pattern that hides nothing and
+      adds only indirection. The profiler is genuinely orchestrator-coupled, not a leaf;
+      forcing it behind a port fights that reality. It stays in the kernel until/unless
+      a deliberate redesign gives `Service` a narrow profiler contract.
+
+      **What moved (cluster B — a clean leaf with a narrow seam):** `portscan.go`,
+      `tcpprobe.go`, `tcpprobe_windows.go` (+ their tests) → `internal/discovery/fingerprint`.
+      The kernel gains one narrow port `PortScannerPort{QuickScan}` (stages.go); the
+      `enrichStage`/`Engine` `portScanner` field + `SetPortScanner` take that interface;
+      the composition root injects the concrete `fingerprint.PortScanner`.
+      `Engine.GetCapabilities` keeps its nil-check on the interface field → identical wire.
+      **Result types STAY in the kernel (`portscan_types.go`), aliased in fingerprint:**
+      `PortState` (+ `PortOpen/PortClosed/PortFiltered`), `ServiceInfo`, `PortScanResult`
+      (they sit in the `QuickScan` signature). `TCPProbeResult` moved to fingerprint (no
+      kernel port uses it). Two unexported strings (`serviceUnknown`, `errNoIPv4ForTarget`)
+      stay in the kernel for staying callers (the classifier / traceroute) with private
+      copies in fingerprint. api re-points `New{PortScanner,TCPProber}` → `fingerprint.*`
+      and keeps `discovery.PortScanResult` (kernel result type). depguard
+      `discovery-stage-direction` extended to ban the kernel from importing fingerprint.
+      Golden byte-identical, schema unchanged. `Fingerprinter` + `Tracer` were never in
+      the enrich path and remain kernel-resident.
 - [ ] 3. `resolve` stage → `discovery/resolve` + depguard
 - [ ] 4. `enumerate` stage → `discovery/enumerate` + depguard
 - [ ] 5. direction-lock depguard + cleanup + §16 doc

--- a/internal/api/handlers_tools.go
+++ b/internal/api/handlers_tools.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/fingerprint"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/validation"
@@ -62,7 +63,7 @@ type TCPProbeResponse struct {
 }
 
 // TCPProbeResult is the flat transport view of a single TCP probe outcome. It
-// mirrors discovery.TCPProbeResult's wire shape so the published schema stays
+// mirrors fingerprint.TCPProbeResult's wire shape so the published schema stays
 // self-contained instead of reaching into the discovery domain package. State
 // is a plain string (the domain's PortState is a string enum); Error carries
 // the error message (the domain's error field serialized as an opaque "{}").
@@ -77,7 +78,7 @@ type TCPProbeResult struct {
 }
 
 // toTCPProbeResults maps discovery probe results onto their flat transport view.
-func toTCPProbeResults(results []discovery.TCPProbeResult) []TCPProbeResult {
+func toTCPProbeResults(results []fingerprint.TCPProbeResult) []TCPProbeResult {
 	out := make([]TCPProbeResult, len(results))
 	for i, r := range results {
 		out[i] = TCPProbeResult{
@@ -194,7 +195,7 @@ func (s *Server) handleTCPProbe(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create prober
-	prober, err := discovery.NewTCPProber(timeout)
+	prober, err := fingerprint.NewTCPProber(timeout)
 	if err != nil {
 		logger.ErrorContext(r.Context(), "Failed to create TCP prober", "error", err)
 		sendErrorResponseWithDetails(
@@ -387,7 +388,7 @@ func (s *Server) handlePortScan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create scanner
-	scanner, err := discovery.NewPortScanner(portScanTimeoutSec * time.Second)
+	scanner, err := fingerprint.NewPortScanner(portScanTimeoutSec * time.Second)
 	if err != nil {
 		logger.ErrorContext(r.Context(), "Failed to create port scanner", "error", err)
 		sendErrorResponseWithDetails(

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/dns"
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/fingerprint"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/mibdb"
@@ -231,7 +232,7 @@ func (s *Server) initDiscovery(cfg *config.Config) {
 	s.services.Discovery.Profiler = sharedProfiler
 
 	// Create PortScanner for Engine
-	portScanner, err := discovery.NewPortScanner(portScannerTimeout)
+	portScanner, err := fingerprint.NewPortScanner(portScannerTimeout)
 	if err != nil {
 		logging.GetLogger().Warn("Failed to create port scanner", "error", err)
 	} else {

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/speedtest"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/vlan"
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/fingerprint"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
 	"github.com/MustardSeedNetworks/seed/internal/health"
@@ -127,7 +128,7 @@ type DiscoveryServices struct {
 	BluetoothScanner *discovery.BluetoothScanner
 	WiFiBridge       *discovery.WiFiBridge
 	Profiler         *discovery.DeviceProfiler // Shared profiler for SNMP/ports/fingerprinting
-	PortScanner      *discovery.PortScanner    // TCP port scanner
+	PortScanner      *fingerprint.PortScanner  // TCP port scanner (fingerprint stage)
 	Engine           *discovery.Engine         // Unified discovery engine (primary)
 }
 

--- a/internal/discovery/engine.go
+++ b/internal/discovery/engine.go
@@ -52,9 +52,12 @@ type Engine struct {
 	wifiCollector      *WiFiBridge
 	bluetoothCollector *BluetoothScanner
 
-	// Enrichment components
+	// Enrichment components. portScanner is the fingerprint stage's PortScannerPort
+	// (ADR-0018, Phase 6): the concrete scanner lives in internal/discovery/fingerprint
+	// and is injected by the composition root. snmpCollector + profiler stay concrete
+	// kernel types — the kernel orchestrator (Service) co-owns the profiler lifecycle.
 	snmpCollector *SNMPCollector
-	portScanner   *PortScanner
+	portScanner   PortScannerPort
 	profiler      *DeviceProfiler
 
 	// Assessment stage (ADR-0018): the vuln Assessor port, injected by the
@@ -276,8 +279,8 @@ func (e *Engine) SetSNMPCollector(collector *SNMPCollector) {
 	e.snmpCollector = collector
 }
 
-// SetPortScanner sets the port scanner.
-func (e *Engine) SetPortScanner(scanner *PortScanner) {
+// SetPortScanner sets the port scanner (the fingerprint stage's PortScannerPort).
+func (e *Engine) SetPortScanner(scanner PortScannerPort) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.portScanner = scanner

--- a/internal/discovery/fingerprint/aliases.go
+++ b/internal/discovery/fingerprint/aliases.go
@@ -1,0 +1,37 @@
+// Package fingerprint is the discovery pipeline's active port-scan stage
+// (ADR-0018, Phase 6): the TCP prober and the banner-grabbing port scanner the
+// Engine drives via the discovery.PortScannerPort seam. It depends inward on
+// the discovery kernel for the shared port-scan result types; the kernel never
+// imports this package (depguard-enforced one-way direction).
+//
+// Scope note: only the PortScanner/TCPProber leaf cluster lives here. The
+// SNMPCollector + DeviceProfiler cluster stays in the kernel because the kernel
+// orchestrator discovery.Service co-owns the profiler lifecycle (Start/Stop/
+// Clear/queue/get) and cannot move without an import cycle — see ADR-0018 §2.
+package fingerprint
+
+import "github.com/MustardSeedNetworks/seed/internal/discovery"
+
+// Kernel type aliases. The scanner returns the kernel's port-scan result types
+// (they sit in the PortScannerPort.QuickScan signature, so they must live in the
+// kernel). Aliasing them here lets the stage code reference them unqualified
+// without duplicating the definitions or inverting the dependency.
+type (
+	// PortState is the kernel TCP port-state enum.
+	PortState = discovery.PortState
+	// ServiceInfo is a single detected service (kernel result type).
+	ServiceInfo = discovery.ServiceInfo
+	// PortScanResult is a host's complete scan result (kernel result type).
+	PortScanResult = discovery.PortScanResult
+)
+
+// Kernel port-state constant aliases, re-exported so the prober/scanner logic
+// references them unqualified.
+const (
+	// PortOpen indicates a SYN/ACK was received.
+	PortOpen = discovery.PortOpen
+	// PortClosed indicates an RST was received.
+	PortClosed = discovery.PortClosed
+	// PortFiltered indicates no response (timeout).
+	PortFiltered = discovery.PortFiltered
+)

--- a/internal/discovery/fingerprint/portscan.go
+++ b/internal/discovery/fingerprint/portscan.go
@@ -1,8 +1,12 @@
-package discovery
+package fingerprint
 
 // Port scanning support enables detection of open services and their versions on discovered devices.
 // Performs banner grabbing to identify service types and versions, mapping active services
 // and potential vulnerabilities based on detected ports and versions.
+//
+// The PortScanResult / ServiceInfo / PortState result types live in the discovery
+// kernel (aliased in aliases.go) so they sit in the PortScannerPort seam without
+// inverting the stage→kernel dependency.
 
 import (
 	"bufio"
@@ -14,7 +18,10 @@ import (
 	"time"
 )
 
-// Error messages and common values for port scanning.
+// Error messages and common values for port scanning. errNoIPv4ForTarget and
+// serviceUnknown are private copies of the kernel constants of the same name
+// (the kernel keeps its own for traceroute / the device classifier); they are
+// unexported and so cannot be aliased across the package boundary.
 const (
 	errNoIPv4ForTarget = "no IPv4 address found for target"
 	serviceUnknown     = "unknown"
@@ -31,25 +38,6 @@ const (
 	bannerTimeoutS       = 2    // Banner timeout in seconds
 	maxBannerBytes       = 512  // Maximum bytes to read from banner
 )
-
-// ServiceInfo contains information about a detected service.
-type ServiceInfo struct {
-	Port     int       `json:"port"`
-	State    PortState `json:"state"`
-	Service  string    `json:"service"`            // Service name (http, ssh, etc.)
-	Banner   string    `json:"banner,omitempty"`   // Raw banner text
-	Version  string    `json:"version,omitempty"`  // Parsed version if available
-	Protocol string    `json:"protocol,omitempty"` // tcp or udp
-}
-
-// PortScanResult contains the complete result of a port scan.
-type PortScanResult struct {
-	IP       string        `json:"ip"`
-	Hostname string        `json:"hostname,omitempty"`
-	Services []ServiceInfo `json:"services"`
-	ScanTime time.Duration `json:"scanTime"`
-	Error    string        `json:"error,omitempty"`
-}
 
 // PortScanner provides port scanning with service detection.
 type PortScanner struct {

--- a/internal/discovery/fingerprint/portscan_test.go
+++ b/internal/discovery/fingerprint/portscan_test.go
@@ -1,4 +1,4 @@
-package discovery_test
+package fingerprint_test
 
 import (
 	"context"
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/fingerprint"
 )
 
 func TestNewPortScanner(t *testing.T) {
-	scanner, err := discovery.NewPortScanner(100 * time.Millisecond)
+	scanner, err := fingerprint.NewPortScanner(100 * time.Millisecond)
 	if err != nil {
 		t.Fatalf("NewPortScanner failed: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestNewPortScanner(t *testing.T) {
 }
 
 func TestPortScanner_Close(t *testing.T) {
-	scanner, err := discovery.NewPortScanner(100 * time.Millisecond)
+	scanner, err := fingerprint.NewPortScanner(100 * time.Millisecond)
 	if err != nil {
 		t.Fatalf("NewPortScanner failed: %v", err)
 	}
@@ -43,9 +43,9 @@ func TestPortScanner_Close(t *testing.T) {
 }
 
 func TestServiceInfo_Fields(t *testing.T) {
-	info := discovery.ServiceInfo{
+	info := fingerprint.ServiceInfo{
 		Port:     22,
-		State:    discovery.PortOpen,
+		State:    fingerprint.PortOpen,
 		Service:  "ssh",
 		Banner:   "SSH-2.0-OpenSSH_8.4p1",
 		Version:  "8.4p1",
@@ -55,7 +55,7 @@ func TestServiceInfo_Fields(t *testing.T) {
 	if info.Port != 22 {
 		t.Errorf("Port should be 22, got %d", info.Port)
 	}
-	if info.State != discovery.PortOpen {
+	if info.State != fingerprint.PortOpen {
 		t.Errorf("State should be PortOpen, got %v", info.State)
 	}
 	if info.Service != "ssh" {
@@ -73,10 +73,10 @@ func TestServiceInfo_Fields(t *testing.T) {
 }
 
 func TestPortScanResult_Fields(t *testing.T) {
-	result := discovery.PortScanResult{
+	result := fingerprint.PortScanResult{
 		IP:       "192.168.1.10",
 		Hostname: "test-host",
-		Services: []discovery.ServiceInfo{
+		Services: []fingerprint.ServiceInfo{
 			{Port: 22, Service: "ssh"},
 			{Port: 80, Service: "http"},
 		},
@@ -102,7 +102,7 @@ func TestPortScanResult_Fields(t *testing.T) {
 }
 
 func TestPortScanResult_WithError(t *testing.T) {
-	result := discovery.PortScanResult{
+	result := fingerprint.PortScanResult{
 		IP:    "192.168.1.10",
 		Error: "connection refused",
 	}
@@ -116,7 +116,7 @@ func TestPortScanResult_WithError(t *testing.T) {
 }
 
 func TestPortScanner_ScanWithBanners_NonRoutable(t *testing.T) {
-	scanner, err := discovery.NewPortScanner(100 * time.Millisecond)
+	scanner, err := fingerprint.NewPortScanner(100 * time.Millisecond)
 	if err != nil {
 		t.Fatalf("NewPortScanner failed: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestPortScanner_ScanWithBanners_NonRoutable(t *testing.T) {
 }
 
 func TestPortScanner_ScanWithBanners_ContextCancelled(t *testing.T) {
-	scanner, err := discovery.NewPortScanner(1 * time.Second)
+	scanner, err := fingerprint.NewPortScanner(1 * time.Second)
 	if err != nil {
 		t.Fatalf("NewPortScanner failed: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestPortScanner_ScanWithBanners_ContextCancelled(t *testing.T) {
 }
 
 func TestPortScanner_QuickScan(t *testing.T) {
-	scanner, err := discovery.NewPortScanner(50 * time.Millisecond)
+	scanner, err := fingerprint.NewPortScanner(50 * time.Millisecond)
 	if err != nil {
 		t.Fatalf("NewPortScanner failed: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestPortScanner_QuickScan(t *testing.T) {
 }
 
 func TestPortScanner_WebScan(t *testing.T) {
-	scanner, err := discovery.NewPortScanner(50 * time.Millisecond)
+	scanner, err := fingerprint.NewPortScanner(50 * time.Millisecond)
 	if err != nil {
 		t.Fatalf("NewPortScanner failed: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestPortScanner_FullScan(t *testing.T) {
 		t.Skip("Skipping full scan in short mode")
 	}
 
-	scanner, err := discovery.NewPortScanner(10 * time.Millisecond)
+	scanner, err := fingerprint.NewPortScanner(10 * time.Millisecond)
 	if err != nil {
 		t.Fatalf("NewPortScanner failed: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestPortScanner_FullScan(t *testing.T) {
 }
 
 func TestPortScanner_ScanWithBanners_Hostname(t *testing.T) {
-	scanner, err := discovery.NewPortScanner(100 * time.Millisecond)
+	scanner, err := fingerprint.NewPortScanner(100 * time.Millisecond)
 	if err != nil {
 		t.Fatalf("NewPortScanner failed: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestPortScanner_ScanWithBanners_Hostname(t *testing.T) {
 }
 
 func TestPortScanner_ScanWithBanners_InvalidHostname(t *testing.T) {
-	scanner, err := discovery.NewPortScanner(100 * time.Millisecond)
+	scanner, err := fingerprint.NewPortScanner(100 * time.Millisecond)
 	if err != nil {
 		t.Fatalf("NewPortScanner failed: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestPortScanner_ScanWithBanners_InvalidHostname(t *testing.T) {
 }
 
 func TestGetWebPorts(t *testing.T) {
-	ports := discovery.GetWebPorts()
+	ports := fingerprint.GetWebPorts()
 
 	if len(ports) == 0 {
 		t.Fatal("GetWebPorts should return ports")
@@ -282,13 +282,13 @@ func TestGetWebPorts(t *testing.T) {
 
 func TestPortState_Constants(t *testing.T) {
 	// Verify port state constants exist and are distinct
-	if discovery.PortOpen == discovery.PortClosed {
+	if fingerprint.PortOpen == fingerprint.PortClosed {
 		t.Error("PortOpen and PortClosed should be different")
 	}
-	if discovery.PortOpen == discovery.PortFiltered {
+	if fingerprint.PortOpen == fingerprint.PortFiltered {
 		t.Error("PortOpen and PortFiltered should be different")
 	}
-	if discovery.PortClosed == discovery.PortFiltered {
+	if fingerprint.PortClosed == fingerprint.PortFiltered {
 		t.Error("PortClosed and PortFiltered should be different")
 	}
 }

--- a/internal/discovery/fingerprint/tcpprobe.go
+++ b/internal/discovery/fingerprint/tcpprobe.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package discovery
+package fingerprint
 
 import (
 	"context"
@@ -15,17 +15,9 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
-// PortState represents the state of a TCP port.
-type PortState string
-
-// TCP port state constants indicating probe results.
-const (
-	PortOpen     PortState = "open"     // SYN/ACK received
-	PortClosed   PortState = "closed"   // RST received
-	PortFiltered PortState = "filtered" // No response (timeout)
-)
-
-// TCPProbeResult contains the result of a TCP probe.
+// TCPProbeResult contains the result of a TCP probe. PortState (and its
+// PortOpen/PortClosed/PortFiltered constants) live in the discovery kernel and
+// are aliased in aliases.go.
 type TCPProbeResult struct {
 	IP    string        `json:"ip"`
 	Port  int           `json:"port"`
@@ -44,7 +36,10 @@ const (
 )
 
 // TCP probe constants.
-const tcpProbeDialTimeoutS = 5 // Default timeout in seconds for local IP detection dial
+const (
+	tcpProbeDialTimeoutS = 5               // Default timeout in seconds for local IP detection dial
+	defaultProbeTimeout  = 1 * time.Second // Default prober timeout
+)
 
 // TCPProber provides TCP connect probing functionality.
 type TCPProber struct {
@@ -59,7 +54,7 @@ type TCPProber struct {
 // Requires root privileges or CAP_NET_RAW capability.
 func NewTCPProber(timeout time.Duration) (*TCPProber, error) {
 	if timeout == 0 {
-		timeout = defaultTimeout
+		timeout = defaultProbeTimeout
 	}
 
 	// Get local IP for source address

--- a/internal/discovery/fingerprint/tcpprobe_test.go
+++ b/internal/discovery/fingerprint/tcpprobe_test.go
@@ -1,15 +1,15 @@
-package discovery_test
+package fingerprint_test
 
 import (
 	"context"
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/fingerprint"
 )
 
 func TestTCPProber_ProbeTCP(t *testing.T) {
-	prober, err := discovery.NewTCPProber(2 * time.Second)
+	prober, err := fingerprint.NewTCPProber(2 * time.Second)
 	if err != nil {
 		t.Fatalf("failed to create prober: %v", err)
 	}
@@ -29,7 +29,7 @@ func TestTCPProber_ProbeTCP(t *testing.T) {
 }
 
 func TestTCPProber_ProbeClosedPort(t *testing.T) {
-	prober, err := discovery.NewTCPProber(1 * time.Second)
+	prober, err := fingerprint.NewTCPProber(1 * time.Second)
 	if err != nil {
 		t.Fatalf("failed to create prober: %v", err)
 	}
@@ -40,13 +40,13 @@ func TestTCPProber_ProbeClosedPort(t *testing.T) {
 	result := prober.ProbeTCP(ctx, "127.0.0.1", 59999)
 
 	// Should be closed on localhost
-	if result.State != discovery.PortClosed {
+	if result.State != fingerprint.PortClosed {
 		t.Logf("expected closed state, got %s (may vary by system config)", result.State)
 	}
 }
 
 func TestTCPProber_ScanPorts(t *testing.T) {
-	prober, err := discovery.NewTCPProber(1 * time.Second)
+	prober, err := fingerprint.NewTCPProber(1 * time.Second)
 	if err != nil {
 		t.Fatalf("failed to create prober: %v", err)
 	}
@@ -72,12 +72,12 @@ func TestTCPProber_ScanPorts(t *testing.T) {
 
 func TestPortState_String(t *testing.T) {
 	tests := []struct {
-		state    discovery.PortState
+		state    fingerprint.PortState
 		expected string
 	}{
-		{discovery.PortOpen, "open"},
-		{discovery.PortClosed, "closed"},
-		{discovery.PortFiltered, "filtered"},
+		{fingerprint.PortOpen, "open"},
+		{fingerprint.PortClosed, "closed"},
+		{fingerprint.PortFiltered, "filtered"},
 	}
 
 	for _, tt := range tests {
@@ -89,7 +89,7 @@ func TestPortState_String(t *testing.T) {
 
 func TestGetCommonPorts(t *testing.T) {
 	// Verify common ports slice is populated
-	commonPorts := discovery.GetCommonPorts()
+	commonPorts := fingerprint.GetCommonPorts()
 	if len(commonPorts) == 0 {
 		t.Error("GetCommonPorts() should not return empty slice")
 	}

--- a/internal/discovery/fingerprint/tcpprobe_windows.go
+++ b/internal/discovery/fingerprint/tcpprobe_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package discovery
+package fingerprint
 
 import (
 	"context"
@@ -12,17 +12,9 @@ import (
 	"time"
 )
 
-// PortState represents the state of a TCP port.
-type PortState string
-
-// TCP port state constants indicating probe results.
-const (
-	PortOpen     PortState = "open"     // SYN/ACK received
-	PortClosed   PortState = "closed"   // RST received
-	PortFiltered PortState = "filtered" // No response (timeout)
-)
-
-// TCPProbeResult contains the result of a TCP probe.
+// TCPProbeResult contains the result of a TCP probe. PortState (and its
+// PortOpen/PortClosed/PortFiltered constants) live in the discovery kernel and
+// are aliased in aliases.go.
 type TCPProbeResult struct {
 	IP    string        `json:"ip"`
 	Port  int           `json:"port"`
@@ -41,7 +33,10 @@ const (
 )
 
 // TCP probe constants.
-const tcpProbeDialTimeoutS = 5 // Default timeout for local IP detection dial
+const (
+	tcpProbeDialTimeoutS = 5               // Default timeout for local IP detection dial
+	defaultProbeTimeout  = 1 * time.Second // Default prober timeout
+)
 
 // TCPProber provides TCP connect probing functionality.
 type TCPProber struct {
@@ -56,7 +51,7 @@ type TCPProber struct {
 // On Windows, this uses standard Go net.Dial which works without elevated privileges.
 func NewTCPProber(timeout time.Duration) (*TCPProber, error) {
 	if timeout == 0 {
-		timeout = defaultTimeout
+		timeout = defaultProbeTimeout
 	}
 
 	// Get local IP for source address

--- a/internal/discovery/portscan_types.go
+++ b/internal/discovery/portscan_types.go
@@ -1,0 +1,56 @@
+package discovery
+
+// portscan_types.go holds the port-scan RESULT vocabulary that stays in the
+// discovery kernel after the fingerprint stage relocation (ADR-0018, Phase 6):
+// PortState + its constants, ServiceInfo, and PortScanResult. These are kept
+// kernel-side because they appear in the PortScannerPort.QuickScan signature
+// (stages.go) — the Engine and enrich stage consume them without importing the
+// fingerprint subpackage, and the fingerprint scanner aliases them. PortState
+// also previously lived (duplicated) in the build-tagged tcpprobe files; it is
+// platform-independent, so consolidating it here removes that duplication.
+//
+// Two unexported strings also stay here because staying kernel code references
+// them (they originated in the relocated portscan.go): serviceUnknown (used by
+// the device-type classifier in profiler_infer.go) and errNoIPv4ForTarget (used
+// by traceroute.go). The fingerprint scanner keeps its own private copies.
+
+import "time"
+
+// Shared port-scan string constants retained in the kernel for staying callers.
+const (
+	// errNoIPv4ForTarget is reported when a hostname resolves to no IPv4 address.
+	// Referenced by traceroute.go.
+	errNoIPv4ForTarget = "no IPv4 address found for target"
+	// serviceUnknown is the placeholder service name. Referenced by the device
+	// classifier in profiler_infer.go.
+	serviceUnknown = "unknown"
+)
+
+// PortState represents the state of a TCP port.
+type PortState string
+
+// TCP port state constants indicating probe results.
+const (
+	PortOpen     PortState = "open"     // SYN/ACK received
+	PortClosed   PortState = "closed"   // RST received
+	PortFiltered PortState = "filtered" // No response (timeout)
+)
+
+// ServiceInfo contains information about a detected service.
+type ServiceInfo struct {
+	Port     int       `json:"port"`
+	State    PortState `json:"state"`
+	Service  string    `json:"service"`            // Service name (http, ssh, etc.)
+	Banner   string    `json:"banner,omitempty"`   // Raw banner text
+	Version  string    `json:"version,omitempty"`  // Parsed version if available
+	Protocol string    `json:"protocol,omitempty"` // tcp or udp
+}
+
+// PortScanResult contains the complete result of a port scan.
+type PortScanResult struct {
+	IP       string        `json:"ip"`
+	Hostname string        `json:"hostname,omitempty"`
+	Services []ServiceInfo `json:"services"`
+	ScanTime time.Duration `json:"scanTime"`
+	Error    string        `json:"error,omitempty"`
+}

--- a/internal/discovery/stages.go
+++ b/internal/discovery/stages.go
@@ -45,6 +45,16 @@ type Assessor interface {
 	Assess(ctx context.Context, stats *ScanStats)
 }
 
+// PortScannerPort is the fingerprint stage's port-scan seam (ADR-0018, Phase 6):
+// a quick scan of a host's common ports, returning the open services. The
+// concrete scanner lives in internal/discovery/fingerprint; the composition root
+// injects it so the enrich stage depends only on this narrow port, never on the
+// stage subpackage. PortScanResult stays kernel-side (portscan_types.go) so it
+// sits in this signature without inverting the dependency.
+type PortScannerPort interface {
+	QuickScan(ctx context.Context, target string) *PortScanResult
+}
+
 // --- Stage 1: enumerate ------------------------------------------------------
 
 // enumerateStage runs the discovery sources concurrently and writes results to
@@ -158,7 +168,7 @@ type enrichStage struct {
 	registry      *DeviceRegistry
 	config        *EngineConfig
 	snmpCollector *SNMPCollector
-	portScanner   *PortScanner
+	portScanner   PortScannerPort
 	profiler      *DeviceProfiler
 }
 


### PR DESCRIPTION
## What

Phase 6 fingerprint relocation (ADR-0018), **scoped to the port-scan leaf cluster** (`PortScanner` + `TCPProber`) → `internal/discovery/fingerprint`.

## Why this scope (the ADR step-2 plan was wrong)

The original "atomic ~9-file move of the whole enrich cluster" plan rested on two false premises, found during implementation:

1. **`DeviceProfiler` does not embed `*PortScanner`.** It embeds only `*SNMPCollector` and does its own `net.Dial` scanning. So enrich is two *independent* clusters: **(A)** `SNMPCollector`←`DeviceProfiler` and **(B)** `TCPProber`←`PortScanner`.
2. **The kernel orchestrator `Service` co-owns the `DeviceProfiler` lifecycle** (~11 methods) and can't leave the kernel (it reaches into `DeviceDiscovery.protoManager`). Moving cluster A would force a ~13-method union `ProfilerPort` — a mirror-interface that trips `interfacebloat` and hides nothing. **Cluster A stays kernel-resident by design.**

So this PR moves **cluster B**, a clean leaf with a narrow seam. Cluster A is documented as deferred-by-design in ADR-0018.

## Changes

- `portscan.go`, `tcpprobe.go`, `tcpprobe_windows.go` (+ tests) → `internal/discovery/fingerprint`.
- New narrow port `PortScannerPort{QuickScan}` in the kernel (`stages.go`); `enrichStage`/`Engine` field + `SetPortScanner` take it; composition root injects `fingerprint.PortScanner`.
- Result types stay kernel-side (`portscan_types.go`): `PortState` (+ `PortOpen/Closed/Filtered`), `ServiceInfo`, `PortScanResult` — they sit in the `QuickScan` signature; aliased in fingerprint. `TCPProbeResult` moved (no kernel port uses it). `serviceUnknown` / `errNoIPv4ForTarget` kept kernel-side for staying callers.
- api re-points `New{PortScanner,TCPProber}` → `fingerprint.*`; keeps `discovery.PortScanResult`.
- depguard `discovery-stage-direction` extended to ban kernel→fingerprint.
- ADR-0018 step 2 amended (corrected premise + cluster-A scope decision).

## Validation

- `go build ./...` ✓
- `go test ./internal/discovery/...` (incl. fingerprint, CGO-free) ✓
- `go test ./internal/api -run TestGolden` ✓ **byte-identical wire** (schema unchanged)
- `golangci-lint run ./internal/discovery/... ./internal/api/...` → **0 issues** (`interfacebloat` + depguard pass)
- whole-repo test-compile ✓ · JSON casing gate ✓
- Direction is compiler-enforced: a kernel→fingerprint import is an import cycle (RED-checked); depguard is documented belt-and-suspenders.