### PR TITLE
test(e2e): fix rotating post-login dashboard flake in auth-complete

### DIFF
--- a/ui/e2e/auth-complete.spec.ts
+++ b/ui/e2e/auth-complete.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
-import { AUTH_STORAGE_STATE, disableAnimations, TEST_CREDENTIALS } from './helpers/auth';
+import {
+  AUTH_STORAGE_STATE,
+  disableAnimations,
+  loginAndAwaitDashboard,
+  TEST_CREDENTIALS,
+} from './helpers/auth';
 
 /**
  * Complete Authentication Lifecycle E2E Tests
@@ -23,6 +28,13 @@ import { AUTH_STORAGE_STATE, disableAnimations, TEST_CREDENTIALS } from './helpe
 test.use({ storageState: { cookies: [], origins: [] } });
 
 test.describe('Complete Authentication Lifecycle', () => {
+  // This is the heaviest auth file and Playwright assigns it to a
+  // single shard; under workers=4 the post-login dashboard mount can
+  // run long (see loginAndAwaitDashboard's 20s settle). Give the file
+  // 45s per test so the multi-login tests (re-login after expiry) keep
+  // headroom above the default 30s budget.
+  test.describe.configure({ timeout: 45_000 });
+
   // No outer-level beforeEach: each test already starts in a fresh
   // browser context with cookies/origins cleared by the file-wide
   // `test.use` above, so the legacy `localStorage.clear()` +
@@ -63,15 +75,8 @@ test.describe('Complete Authentication Lifecycle', () => {
     test('should login successfully with valid credentials', async ({ page }) => {
       await page.goto('/');
 
-      // Login with valid credentials
-      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
-      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
-      await page.getByTestId('login-submit').click();
-
-      // Verify redirect to dashboard
-      await expect(page.getByTestId('page-header-title')).toBeVisible({
-        timeout: 10000,
-      });
+      // Login with valid credentials and wait for the dashboard.
+      await loginAndAwaitDashboard(page);
 
       // Verify URL changed from root
       expect(page.url()).not.toBe('http://localhost:5173/');
@@ -232,12 +237,7 @@ test.describe('Complete Authentication Lifecycle', () => {
     test('should handle 401 unauthorized response gracefully', async ({ page }) => {
       // Login first
       await page.goto('/');
-      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
-      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
-      await page.getByTestId('login-submit').click();
-      await expect(page.getByTestId('page-header-title')).toBeVisible({
-        timeout: 10000,
-      });
+      await loginAndAwaitDashboard(page);
 
       // Mock expired session by intercepting API calls to return 401
       await page.route('**/api/**', (route) => {
@@ -271,12 +271,7 @@ test.describe('Complete Authentication Lifecycle', () => {
     test('should allow re-login after session expiry', async ({ page }) => {
       // Login first
       await page.goto('/');
-      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
-      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
-      await page.getByTestId('login-submit').click();
-      await expect(page.getByTestId('page-header-title')).toBeVisible({
-        timeout: 10000,
-      });
+      await loginAndAwaitDashboard(page);
 
       // Logout to simulate session expiry
       // Open the profile dropdown — header-logout lives inside the
@@ -296,15 +291,8 @@ test.describe('Complete Authentication Lifecycle', () => {
         timeout: 5000,
       });
 
-      // Login again
-      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
-      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
-      await page.getByTestId('login-submit').click();
-
-      // Should successfully login again
-      await expect(page.getByTestId('page-header-title')).toBeVisible({
-        timeout: 10000,
-      });
+      // Login again and confirm the dashboard mounts.
+      await loginAndAwaitDashboard(page);
     });
   });
 
@@ -323,16 +311,9 @@ test.describe('Complete Authentication Lifecycle', () => {
     });
 
     test('should allow access to protected routes when authenticated', async ({ page }) => {
-      // Login
+      // Login and land on the dashboard.
       await page.goto('/');
-      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
-      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
-      await page.getByTestId('login-submit').click();
-
-      // Should access dashboard
-      await expect(page.getByTestId('page-header-title')).toBeVisible({
-        timeout: 10000,
-      });
+      await loginAndAwaitDashboard(page);
 
       // Verify dashboard cards are loading
       const linkCard = page
@@ -343,14 +324,9 @@ test.describe('Complete Authentication Lifecycle', () => {
     });
 
     test('should persist authentication on page reload', async ({ page }) => {
-      // Login
+      // Login and land on the dashboard.
       await page.goto('/');
-      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
-      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
-      await page.getByTestId('login-submit').click();
-      await expect(page.getByTestId('page-header-title')).toBeVisible({
-        timeout: 10000,
-      });
+      await loginAndAwaitDashboard(page);
 
       // Reload page
       await page.reload();
@@ -371,14 +347,9 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Set mobile viewport
       await page.setViewportSize({ width: 375, height: 667 });
 
-      // Login
+      // Login and land on the dashboard.
       await page.goto('/');
-      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
-      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
-      await page.getByTestId('login-submit').click();
-      await expect(page.getByTestId('page-header-title')).toBeVisible({
-        timeout: 10000,
-      });
+      await loginAndAwaitDashboard(page);
 
       // Profile dropdown trigger lives in the icon toolbar, which is
       // visible on mobile too — no separate hamburger step needed.
@@ -409,14 +380,9 @@ test.describe('Complete Authentication Lifecycle', () => {
         }
       });
 
-      // Login
+      // Login and land on the dashboard.
       await page.goto('/');
-      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
-      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
-      await page.getByTestId('login-submit').click();
-      await expect(page.getByTestId('page-header-title')).toBeVisible({
-        timeout: 10000,
-      });
+      await loginAndAwaitDashboard(page);
 
       // Wait to see if any automatic refresh happens
       // (In a real scenario, we'd mock a near-expiry token)
@@ -446,13 +412,8 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Check remember me
       await rememberMe.check();
 
-      // Login
-      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
-      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
-      await page.getByTestId('login-submit').click();
-      await expect(page.getByTestId('page-header-title')).toBeVisible({
-        timeout: 10000,
-      });
+      // Login and land on the dashboard.
+      await loginAndAwaitDashboard(page);
 
       // Close and reopen (simulate browser restart)
       const _cookies = await page.context().cookies();
@@ -475,13 +436,8 @@ test.describe('Complete Authentication Lifecycle', () => {
       // Ensure remember me is unchecked
       await rememberMe.uncheck();
 
-      // Login
-      await page.getByLabel(/username/i).fill(TEST_CREDENTIALS.username);
-      await page.getByLabel(/password/i).fill(TEST_CREDENTIALS.password);
-      await page.getByTestId('login-submit').click();
-      await expect(page.getByTestId('page-header-title')).toBeVisible({
-        timeout: 10000,
-      });
+      // Login and land on the dashboard.
+      await loginAndAwaitDashboard(page);
 
       // Close and reopen (simulate browser restart)
       await page.context().clearCookies();

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 
 /**
  * Shared E2E auth helpers.
@@ -87,6 +87,36 @@ export async function loginViaUI(
   await page.getByLabel(/username/i).fill(creds.username);
   await page.getByLabel(/password/i).fill(creds.password);
   await page.getByTestId('login-submit').click();
+}
+
+/**
+ * Fill the login form, submit, and wait for the authenticated
+ * dashboard to mount (page-header-title). The caller is responsible
+ * for navigating to the login surface (`await page.goto('/')`) and any
+ * pre-login setup (viewport, request listeners, route mocks) first —
+ * this helper owns only the credential entry, submit, and the
+ * post-login settle.
+ *
+ * The 20s settle (vs. the per-test default 10s) is deliberate: the
+ * post-login chain — login POST → SPA route swap → dashboard's first
+ * data fetch → header paint — occasionally exceeds 10s on the heaviest
+ * shard (auth-complete.spec.ts lands on shard-1) when the single CI
+ * backend is serving four Playwright workers at once. That contention
+ * produced a rotating one-test-per-run flake on main (#1170): whichever
+ * login-then-dashboard test happened to land the slowest mount failed
+ * the 10s assertion, then passed on retry. 20s sits comfortably inside
+ * the 30s per-test budget (45s for the multi-login describes) and
+ * removes the race without weakening the assertion — the login still
+ * has to succeed and the real dashboard still has to render.
+ */
+export async function loginAndAwaitDashboard(
+  page: Page,
+  creds: { username: string; password: string } = TEST_CREDENTIALS,
+): Promise<void> {
+  await page.getByLabel(/username/i).fill(creds.username);
+  await page.getByLabel(/password/i).fill(creds.password);
+  await page.getByTestId('login-submit').click();
+  await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 20000 });
 }
 
 /**


### PR DESCRIPTION
The login-then-dashboard assertions in auth-complete.spec.ts flaked
one-test-per-run on shard-1 (#1170): after a real form login,
page-header-title occasionally took >10s to mount under workers=4
backend contention, failing the 10s assertion then passing on retry.
Three full main runs showed 0 hard failures but a rotating flaky test,
always one of the form-login-then-dashboard cases.

Centralize the copy-pasted "fill -> submit -> await dashboard" block
into a loginAndAwaitDashboard() helper with a 20s settle (inside the
30s per-test budget; the multi-login describes get 45s headroom via
describe.configure). Removes the race without weakening the assertion
— login still has to succeed and the real dashboard still has to
render. Net -44 lines in the spec.
