### PR TITLE
refactor(discovery): extract name/identity resolution to resolve leaf (adr-0018)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -582,8 +582,9 @@ linters:
         linters: [ goconst ]
       # oui.go is a MAC OUI -> vendor name lookup table. Apple/Dell appear
       # 16-24 times because the IEEE assigns them many prefixes; extracting
-      # `const VendorApple` adds noise without improving safety.
-      - path: 'internal/discovery/oui\.go'
+      # `const VendorApple` adds noise without improving safety. (Relocated to
+      # the resolve leaf package in Phase 6, ADR-0018.)
+      - path: 'internal/discovery/resolve/oui\.go'
         linters: [ goconst ]
       # Shared JSON response field-name conventions across all api handlers
       # (status/message/error/interface/available/good). Project uses literal

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -15,6 +15,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/dns"
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/fingerprint"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/mibdb"
@@ -278,7 +279,7 @@ func (s *Server) initVulnerabilityScanner(cfg *config.Config) {
 
 	// Initialize Bluetooth scanner
 	btConfig := discovery.DefaultBluetoothScanConfig()
-	var ouiDB *discovery.OUIDatabase
+	var ouiDB *resolve.OUIDatabase
 	if s.services.Discovery.Device != nil {
 		ouiDB = s.services.Discovery.Device.GetOUIDatabase()
 	}

--- a/internal/discovery/arp.go
+++ b/internal/discovery/arp.go
@@ -55,6 +55,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
@@ -115,7 +116,7 @@ const (
 // ARPScanner performs active network discovery via ARP.
 type ARPScanner struct {
 	interfaceName     string
-	oui               *OUIDatabase
+	oui               *resolve.OUIDatabase
 	mu                sync.RWMutex
 	entries           map[string]*ARPEntry // Key by IP
 	subnet            *net.IPNet
@@ -130,7 +131,7 @@ type ARPScanner struct {
 }
 
 // NewARPScanner creates a new ARP scanner for the given interface.
-func NewARPScanner(interfaceName string, oui *OUIDatabase) *ARPScanner {
+func NewARPScanner(interfaceName string, oui *resolve.OUIDatabase) *ARPScanner {
 	return &ARPScanner{
 		interfaceName:     interfaceName,
 		oui:               oui,

--- a/internal/discovery/arp_test.go
+++ b/internal/discovery/arp_test.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
 )
 
 func TestNewARPScanner(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("lo", oui)
 
 	if scanner == nil {
@@ -30,7 +31,7 @@ func TestNewARPScanner(t *testing.T) {
 }
 
 func TestARPScanner_SetInterface(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("lo", oui)
 
 	scanner.SetInterface("eth0")
@@ -49,7 +50,7 @@ func TestARPScanner_SetInterface(t *testing.T) {
 }
 
 func TestARPScanner_SetAdditionalSubnets(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("lo", oui)
 
 	// Valid CIDRs
@@ -71,7 +72,7 @@ func TestARPScanner_SetAdditionalSubnets(t *testing.T) {
 }
 
 func TestARPScanner_GetAdditionalSubnets(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("lo", oui)
 
 	// Empty initially
@@ -196,7 +197,7 @@ func TestGuessOSFromTTL(t *testing.T) {
 }
 
 func TestARPScanner_IsScanning(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("lo", oui)
 
 	// Initially not scanning
@@ -206,7 +207,7 @@ func TestARPScanner_IsScanning(t *testing.T) {
 }
 
 func TestARPScanner_LastScan(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("lo", oui)
 
 	// Initially zero
@@ -216,7 +217,7 @@ func TestARPScanner_LastScan(t *testing.T) {
 }
 
 func TestARPScanner_Count(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("lo", oui)
 
 	// Initially zero
@@ -226,7 +227,7 @@ func TestARPScanner_Count(t *testing.T) {
 }
 
 func TestARPScanner_GetEntries(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("lo", oui)
 
 	// Initially empty
@@ -237,7 +238,7 @@ func TestARPScanner_GetEntries(t *testing.T) {
 }
 
 func TestARPScanner_GetEntry(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("lo", oui)
 
 	// Non-existent entry
@@ -248,7 +249,7 @@ func TestARPScanner_GetEntry(t *testing.T) {
 }
 
 func TestARPScanner_ScanAlreadyInProgress(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("lo", oui)
 
 	// Set scanning to true manually
@@ -268,7 +269,7 @@ func TestARPScanner_ScanAlreadyInProgress(t *testing.T) {
 }
 
 func TestARPScanner_ScanInvalidInterface(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("nonexistent_interface_xyz", oui)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -331,7 +332,7 @@ func TestARPEntry_Fields(t *testing.T) {
 }
 
 func TestARPScanner_isInSubnet(t *testing.T) {
-	oui := discovery.NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	scanner := discovery.NewARPScanner("lo", oui)
 
 	// Set up a subnet on the scanner

--- a/internal/discovery/bluetooth.go
+++ b/internal/discovery/bluetooth.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
@@ -180,14 +181,14 @@ type BluetoothScanner struct {
 	mu                sync.RWMutex
 	adapterName       string
 	config            *BluetoothScanConfig
-	oui               *OUIDatabase
+	oui               *resolve.OUIDatabase
 	lastScan          *BluetoothScanResult
 	lastScanTime      time.Time
 	authorizedDevices map[string]bool // Authorized MAC addresses
 }
 
 // NewBluetoothScanner creates a new Bluetooth scanner.
-func NewBluetoothScanner(adapterName string, config *BluetoothScanConfig, oui *OUIDatabase) *BluetoothScanner {
+func NewBluetoothScanner(adapterName string, config *BluetoothScanConfig, oui *resolve.OUIDatabase) *BluetoothScanner {
 	if config == nil {
 		config = DefaultBluetoothScanConfig()
 	}

--- a/internal/discovery/devices.go
+++ b/internal/discovery/devices.go
@@ -22,19 +22,20 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
 // DeviceDiscovery aggregates device discovery from all sources.
 type DeviceDiscovery struct {
 	interfaceName   string
-	oui             *OUIDatabase
+	oui             *resolve.OUIDatabase
 	arpScanner      *ARPScanner
 	ndpScanner      *NDPScanner
 	protoManager    *Manager
-	netbiosResolver *NetBIOSResolver
-	mdnsResolver    *MDNSResolver // Active mDNS resolution
-	mdnsListener    *MDNSListener // Passive mDNS capture
+	netbiosResolver *resolve.NetBIOSResolver
+	mdnsResolver    *resolve.MDNSResolver // Active mDNS resolution
+	mdnsListener    *resolve.MDNSListener // Passive mDNS capture
 	mu              sync.RWMutex
 	devices         map[string]*DiscoveredDevice // Key by MAC
 	lastScan        time.Time
@@ -47,7 +48,7 @@ type DeviceDiscovery struct {
 
 // loadOUIDatabase loads the OUI database based on configuration.
 // Uses early returns to minimize nesting complexity.
-func loadOUIDatabase(oui *OUIDatabase, ouiPath string, ouiMaxAge time.Duration) {
+func loadOUIDatabase(oui *resolve.OUIDatabase, ouiPath string, ouiMaxAge time.Duration) {
 	// No path provided: try standard locations silently
 	if ouiPath == "" {
 		_ = oui.TryLoadIEEEFile()
@@ -65,7 +66,7 @@ func loadOUIDatabase(oui *OUIDatabase, ouiPath string, ouiMaxAge time.Duration) 
 }
 
 // loadOUIFromFile loads OUI from a specific file path with fallback.
-func loadOUIFromFile(oui *OUIDatabase, ouiPath string) {
+func loadOUIFromFile(oui *resolve.OUIDatabase, ouiPath string) {
 	if err := oui.LoadFromIEEEFormat(ouiPath); err != nil {
 		logging.GetLogger().Warn("Failed to load OUI from file", "path", ouiPath, "error", err)
 		if loadErr := oui.TryLoadIEEEFile(); loadErr != nil {
@@ -87,7 +88,7 @@ func loadOUIFromFile(oui *OUIDatabase, ouiPath string) {
 //
 // Production binaries get a fresh OUI baked in at build time, so the
 // in-process refresh is a quality-of-life feature, not load-bearing.
-func loadOUIWithAutoUpdate(oui *OUIDatabase, ouiPath string, ouiMaxAge time.Duration) {
+func loadOUIWithAutoUpdate(oui *resolve.OUIDatabase, ouiPath string, ouiMaxAge time.Duration) {
 	if os.Getenv("SKIP_NETWORK_TESTS") != "" {
 		if err := oui.TryLoadIEEEFile(); err != nil {
 			logging.GetLogger().Warn("SKIP_NETWORK_TESTS set; bundled OUI file not loadable", "error", err)
@@ -127,7 +128,7 @@ func NewDeviceDiscoveryWithOUI(
 	ouiMaxAge time.Duration,
 	opts ...Option,
 ) *DeviceDiscovery {
-	oui := NewOUIDatabase()
+	oui := resolve.NewOUIDatabase()
 	loadOUIDatabase(oui, ouiPath, ouiMaxAge)
 
 	return &DeviceDiscovery{
@@ -136,9 +137,9 @@ func NewDeviceDiscoveryWithOUI(
 		arpScanner:      NewARPScanner(interfaceName, oui),
 		ndpScanner:      NewNDPScanner(interfaceName),
 		protoManager:    NewManager(interfaceName, opts...),
-		netbiosResolver: NewNetBIOSResolver(),
-		mdnsResolver:    NewMDNSResolver(interfaceName),
-		mdnsListener:    NewMDNSListener(interfaceName),
+		netbiosResolver: resolve.NewNetBIOSResolver(),
+		mdnsResolver:    resolve.NewMDNSResolver(interfaceName),
+		mdnsListener:    resolve.NewMDNSListener(interfaceName),
 		devices:         make(map[string]*DiscoveredDevice),
 		nameResolution:  true,                       // Enabled by default
 		deviceTTL:       deviceTTLHours * time.Hour, // Default: expire stale devices after 24h (fixes #829)
@@ -213,7 +214,7 @@ func (d *DeviceDiscovery) SetInterface(name string) error {
 	// Update all sub-components that can accept interface changes (fixes #840)
 	d.arpScanner.SetInterface(name)
 
-	// Note: NDPScanner, MDNSResolver, MDNSListener, and NetBIOSResolver
+	// Note: NDPScanner, resolve.MDNSResolver, resolve.MDNSListener, and resolve.NetBIOSResolver
 	// don't have SetInterface methods - they're bound to the original interface.
 	// For a complete interface change, Stop() and recreate the DeviceDiscovery.
 
@@ -328,7 +329,7 @@ func (d *DeviceDiscovery) SetNameResolution(enabled bool) {
 
 // GetOUIDatabase returns the OUI database for vendor lookups.
 // This allows other discovery components (Bluetooth, WiFi) to share the same OUI data.
-func (d *DeviceDiscovery) GetOUIDatabase() *OUIDatabase {
+func (d *DeviceDiscovery) GetOUIDatabase() *resolve.OUIDatabase {
 	return d.oui
 }
 

--- a/internal/discovery/export_test.go
+++ b/internal/discovery/export_test.go
@@ -3,7 +3,11 @@ package discovery
 // This file is only compiled during testing (due to _test.go suffix)
 // and provides access to internal implementation details.
 
-import "net"
+import (
+	"net"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
+)
 
 // ExportIncrementIP exposes incrementIP for testing.
 func ExportIncrementIP(ip net.IP, n int) net.IP {
@@ -36,7 +40,7 @@ func (a *ARPScannerTestAccessor) GetInterfaceName() string {
 }
 
 // GetOUI returns the scanner's OUI database.
-func (a *ARPScannerTestAccessor) GetOUI() *OUIDatabase {
+func (a *ARPScannerTestAccessor) GetOUI() *resolve.OUIDatabase {
 	return a.Scanner.oui
 }
 

--- a/internal/discovery/profiler.go
+++ b/internal/discovery/profiler.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
@@ -26,9 +27,9 @@ import (
 type DeviceProfiler struct {
 	config          *ProfilerConfig
 	snmpConfig      *config.SNMPConfig
-	snmpCollector   *SNMPCollector   // For full MIB collection
-	netbiosResolver *NetBIOSResolver // For NetBIOS name queries
-	mdnsResolver    *MDNSResolver    // For mDNS name queries
+	snmpCollector   *SNMPCollector           // For full MIB collection
+	netbiosResolver *resolve.NetBIOSResolver // For NetBIOS name queries
+	mdnsResolver    *resolve.MDNSResolver    // For mDNS name queries
 	httpClient      *http.Client
 	transport       *http.Transport // Store transport for cleanup (fixes #825)
 	mu              sync.RWMutex
@@ -95,10 +96,10 @@ func NewDeviceProfiler(cfg *ProfilerConfig, snmpCfg *config.SNMPConfig) *DeviceP
 	// Initialize name resolvers if enabled
 	if cfg.EnableNameResolution {
 		if cfg.ResolveNetBIOS {
-			p.netbiosResolver = NewNetBIOSResolver()
+			p.netbiosResolver = resolve.NewNetBIOSResolver()
 		}
 		if cfg.ResolveMDNS {
-			p.mdnsResolver = NewMDNSResolver("") // Interface set later via SetInterface
+			p.mdnsResolver = resolve.NewMDNSResolver("") // Interface set later via SetInterface
 		}
 		logging.GetLogger().Info("Name resolution initialized",
 			"dns", cfg.ResolveDNS,

--- a/internal/discovery/profiler_resolve.go
+++ b/internal/discovery/profiler_resolve.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
@@ -131,7 +132,7 @@ func (p *DeviceProfiler) SetInterface(interfaceName string) {
 	defer p.mu.Unlock()
 	p.interfaceName = interfaceName
 	if p.mdnsResolver != nil {
-		p.mdnsResolver = NewMDNSResolver(interfaceName)
+		p.mdnsResolver = resolve.NewMDNSResolver(interfaceName)
 	}
 }
 

--- a/internal/discovery/resolve/mdns.go
+++ b/internal/discovery/resolve/mdns.go
@@ -1,4 +1,4 @@
-package discovery
+package resolve
 
 // This file implements mDNS/Bonjour name resolution for Apple/Linux device discovery.
 //

--- a/internal/discovery/resolve/netbios.go
+++ b/internal/discovery/resolve/netbios.go
@@ -1,4 +1,4 @@
-package discovery
+package resolve
 
 // This file implements NetBIOS name resolution (NBNS) for Windows device discovery.
 //

--- a/internal/discovery/resolve/oui.go
+++ b/internal/discovery/resolve/oui.go
@@ -1,4 +1,4 @@
-package discovery
+package resolve
 
 //
 // This file implements a MAC address vendor lookup system using IEEE OUI assignments.

--- a/internal/discovery/resolve/oui_test.go
+++ b/internal/discovery/resolve/oui_test.go
@@ -1,4 +1,4 @@
-package discovery_test
+package resolve_test
 
 import (
 	"context"
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
 )
 
 func TestNewOUIDatabase(t *testing.T) {
-	db := discovery.NewOUIDatabase()
+	db := resolve.NewOUIDatabase()
 
 	if db == nil {
 		t.Fatal("NewOUIDatabase returned nil")
@@ -25,7 +25,7 @@ func TestNewOUIDatabase(t *testing.T) {
 }
 
 func TestOUILookup(t *testing.T) {
-	db := discovery.NewOUIDatabase()
+	db := resolve.NewOUIDatabase()
 
 	tests := []struct {
 		mac      string
@@ -53,7 +53,7 @@ func TestOUILookup(t *testing.T) {
 }
 
 func TestOUILookupWithDefault(t *testing.T) {
-	db := discovery.NewOUIDatabase()
+	db := resolve.NewOUIDatabase()
 
 	// Known vendor
 	result := db.LookupWithDefault("00:00:0C:12:34:56", "Unknown")
@@ -78,7 +78,7 @@ func TestOUILoadFromFile(t *testing.T) {
 		t.Fatalf("Failed to write temp OUI file: %v", err)
 	}
 
-	db := discovery.NewOUIDatabase()
+	db := resolve.NewOUIDatabase()
 	initialCount := db.Count()
 
 	if err := db.LoadFromFile(ouiFile); err != nil {
@@ -125,7 +125,7 @@ DDEEFF     (base 16)		Another Corp
 		t.Fatalf("Failed to write temp IEEE OUI file: %v", err)
 	}
 
-	db := discovery.NewOUIDatabase()
+	db := resolve.NewOUIDatabase()
 	initialCount := db.Count()
 
 	if err := db.LoadFromIEEEFormat(ouiFile); err != nil {
@@ -151,7 +151,7 @@ func TestOUINeedsUpdate(t *testing.T) {
 	tmpDir := t.TempDir()
 	ouiFile := filepath.Join(tmpDir, "oui.txt")
 
-	db := discovery.NewOUIDatabase()
+	db := resolve.NewOUIDatabase()
 
 	// Non-existent file should need update
 	if !db.NeedsUpdate(ouiFile, 24*time.Hour) {
@@ -190,7 +190,7 @@ func TestOUIDownloadDatabase(t *testing.T) {
 	tmpDir := t.TempDir()
 	ouiFile := filepath.Join(tmpDir, "oui.txt")
 
-	db := discovery.NewOUIDatabase()
+	db := resolve.NewOUIDatabase()
 	initialCount := db.Count()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -232,7 +232,7 @@ func TestOUIUpdateIfNeeded(t *testing.T) {
 	tmpDir := t.TempDir()
 	ouiFile := filepath.Join(tmpDir, "oui.txt")
 
-	db := discovery.NewOUIDatabase()
+	db := resolve.NewOUIDatabase()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()

--- a/internal/discovery/wifi_bridge.go
+++ b/internal/discovery/wifi_bridge.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/wifi"
 )
@@ -28,7 +29,7 @@ type WiFiBridge struct {
 	mu              sync.RWMutex
 	scanner         *wifi.Scanner
 	manager         *wifi.Manager
-	oui             *OUIDatabase
+	oui             *resolve.OUIDatabase
 	config          *WiFiBridgeConfig
 	lastScan        *WiFiScanResult
 	lastScanTime    time.Time
@@ -67,7 +68,7 @@ func DefaultWiFiBridgeConfig() *WiFiBridgeConfig {
 func NewWiFiBridge(
 	scanner *wifi.Scanner,
 	manager *wifi.Manager,
-	oui *OUIDatabase,
+	oui *resolve.OUIDatabase,
 	config *WiFiBridgeConfig,
 ) *WiFiBridge {
 	if config == nil {


### PR DESCRIPTION
## What
Phase 6 resolve stage: move OUI vendor lookup + active NetBIOS/mDNS name resolution → `internal/discovery/resolve` as a **pure leaf** package.

## Why a leaf (not a port-injected stage)
These utilities have **zero discovery-kernel type deps** and are shared by *both* the kernel-resident `DeviceProfiler` and the enumerate-bound collectors (`DeviceDiscovery`/ARP/Bluetooth/WiFiBridge). They sit *below* the kernel, so the kernel imports `resolve` directly — which makes any back-import an instant compile-time cycle. The one-way boundary is therefore **compiler-enforced**; no depguard rule needed (resolve is shared infra, not a stage the Engine injects).

## Changes
- `oui.go`, `netbios.go`, `mdns.go` (+ `oui_test.go`) → `internal/discovery/resolve` (repackaged).
- Consumers (`profiler`, `profiler_resolve`, `devices`, `arp`, `bluetooth`, `wifi_bridge`, `export_test`, `arp_test`, api `server_init`) re-qualified to `resolve.*`.
- goconst lookup-table exclusion follows `oui.go` to its new path.

## Validation
- `go build ./...` ✓ · whole-repo test-compile ✓
- `go test ./internal/discovery/...` (incl. `resolve`) ✓
- `go test ./internal/api -run TestGolden` ✓ **byte-identical**
- `golangci-lint` → **0 issues**

## Follow-up (separate PR)
`oui.go` still carries ~135 hardcoded vendor prefixes + two dead 6MB committed `oui.txt` copies. A follow-up makes the IEEE `oui.txt` the single source and removes the hardcoded maps + dead copies.