### PR TITLE
ci(e2e): promote full E2E suite to a blocking gate via CI Complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -849,18 +849,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, backend, frontend]
     timeout-minutes: 15
-    # Advisory tier — "CI Complete" does NOT gate on this job. PR-2.5 added a
-    # second matrix axis (shard 1–4) on top of the browser axis so the full
-    # 186-test suite is split into 8 parallel jobs (4 shards × 2 browsers).
-    # Combined with playwright.config.ts workers=4, each shard sees ~46 tests
-    # at 4-way parallelism, dropping per-shard wall-clock from ~17 min to
-    # ~5 min today and ~2 min once PRs 1–5 land. timeout-minutes was 30 for
-    # the single-shard runs; now 15 is comfortable headroom. continue-on-error
-    # keeps a slow or failing leg from flipping the overall workflow run to a
-    # non-success conclusion (which would skip release-please's workflow_run
-    # success gate). The required, blocking E2E gate is the separate E2E
-    # Smoke job.
-    continue-on-error: true
+    # Blocking tier — "CI Complete" gates on this job (see ci-complete.needs).
+    # PR-2.5 added a second matrix axis (shard 1–4) on top of the browser axis
+    # so the full 186-test suite is split into 8 parallel jobs (4 shards × 2
+    # browsers). Combined with playwright.config.ts workers=4, each shard sees
+    # ~46 tests at 4-way parallelism, dropping per-shard wall-clock to ~3–5 min.
+    # timeout-minutes was 30 for the single-shard runs; 15 is comfortable
+    # headroom.
+    #
+    # continue-on-error was REMOVED once the suite went flake-free (the rotating
+    # post-login dashboard flake was fixed in #1588; full-suite main runs are 0
+    # hard failures / 0 flaky). The flag had masked real failures from the
+    # ci-complete aggregator, so the full E2E suite could not gate merge.
+    # Tradeoff now made explicit: a genuine E2E failure flips the CI workflow_run
+    # conclusion to failure, which defers release-please's workflow_run success
+    # gate (release-please.yml) to the next green CI run. That is the intended
+    # behavior — main being E2E-red should NOT cut a release — and release-please
+    # re-triggers on the next push. If a flake recurs, fix or quarantine it (do
+    # NOT re-add continue-on-error); retries:1 in playwright.config.ts already
+    # absorbs single transient failures.
     strategy:
       fail-fast: false
       matrix:
@@ -1146,12 +1153,19 @@ jobs:
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
-    # NOTE: e2e and lighthouse are deliberately excluded from this aggregator.
-    # They were dropped from required-status-checks on main because they're
-    # advisory (flaky / surface real issues that are tracked separately).
-    # Including them here would re-block merge via the dispatcher on the
-    # same flakes. They still run on every PR and surface their own status;
-    # they just don't gate merge.
+    # The full E2E browser suite (e2e) and E2E Smoke now gate merge through
+    # this aggregator — the suite went flake-free after #1588, so it can be
+    # trusted to block. Branch protection should require ONLY "CI Complete"
+    # (plus the cross-workflow CodeQL + license checks), NOT the individual
+    # E2E shard names: enumerating "E2E Browser Tests (webkit 3/4)" ×8 in
+    # branch protection is brittle (a reshard silently breaks every required
+    # entry) and was also toothless while e2e carried continue-on-error. The
+    # aggregator's success-or-skipped check below handles the path-filter case
+    # (a docs/backend-only PR skips e2e and still passes) without the
+    # skipped-required-check deadlock.
+    #
+    # lighthouse stays excluded — it's a genuine perf-advisory signal, not a
+    # correctness gate.
     needs:
       - changes
       - backend
@@ -1163,6 +1177,8 @@ jobs:
       - i18n
       - docs
       - build
+      - e2e
+      - e2e-smoke
     if: always()
     steps:
       - name: Verify upstream results


### PR DESCRIPTION
## What

Make the full E2E browser suite a **real merge-blocking gate**, routed through the existing `CI Complete` aggregator instead of 8 brittle pinned shard names.

- Remove `continue-on-error: true` from the `e2e` job so its real (matrix-combined) result propagates to dependents.
- Add `e2e` + `e2e-smoke` to `ci-complete.needs`. The aggregator's existing `success-or-skipped` check handles path-filtered PRs (docs/backend-only skip E2E and still pass) without the skipped-required-check deadlock.
- `lighthouse` stays excluded (perf-advisory, not correctness).

## Why now

E2E was advisory because the suite was flaky. It is now flake-free: the rotating post-login dashboard flake in `auth-complete.spec.ts` was fixed in #1588, and full-suite main runs show **0 hard failures / 0 flaky** (3 consecutive runs pre-fix already had 0 hard failures; #1588 removes the last flake). `continue-on-error` had two bad effects — it masked real failures from `ci-complete`, and it pushed branch protection to pin the individual shard names (`E2E Browser Tests (webkit 3/4)` ×8), which is brittle (a reshard silently breaks every required entry) and was toothless anyway.

## Tradeoff (explicit)

Removing `continue-on-error` means a **genuine** E2E failure flips the CI `workflow_run` conclusion, which defers `release-please.yml`'s `workflow_run.conclusion == 'success'` gate to the next green CI run. This is intended — an E2E-red `main` should not cut a release — and release-please re-triggers on the next push. `retries: 1` in `playwright.config.ts` absorbs single transient failures. **If a flake recurs, fix or quarantine it — do not re-add `continue-on-error`.**

## ⚠️ DO NOT MERGE YET — soak first

Merge only after E2E **soaks flake-free for ~3–5 `main` runs** post-#1588 (watch the full-suite runs that exercise UI changes). This PR is a draft until then.

## Paired branch-protection change (owner-admin, apply at merge)

Branch protection currently requires `CI Complete` **and** the 8 E2E shard contexts **and** `E2E Smoke` (all now covered transitively by `CI Complete`). At merge, drop the redundant individual contexts so only the aggregator + cross-workflow security checks remain:

```sh
gh api -X PATCH repos/MustardSeedNetworks/seed/branches/main/protection/required_status_checks \
  --input - <<'JSON'
{
  "strict": false,
  "contexts": ["CI Complete", "License Compliance Check", "Analyze (go)", "Analyze (javascript-typescript)"]
}
JSON
```

(Current `strict` is `false`; preserved above.) Order: merge this PR first so `CI Complete` starts gating E2E, then run the PATCH — avoids a window where neither the shards nor the aggregator gate E2E.

## Validation

- `yaml.safe_load` parses; `ci-complete.needs` includes `e2e` + `e2e-smoke`; `e2e` no longer has `continue-on-error`.
- This PR's own CI exercises the new wiring (E2E now contributes its real result to `CI Complete`).