### PR TITLE
refactor(discovery): drive Engine collectors through ports (adr-0018)

### DIFF
--- a/internal/discovery/engine.go
+++ b/internal/discovery/engine.go
@@ -47,10 +47,12 @@ type Engine struct {
 	registry *DeviceRegistry
 	eventBus *EventBus
 
-	// Discovery sources (collectors)
-	wiredCollector     *DeviceDiscovery
-	wifiCollector      *WiFiBridge
-	bluetoothCollector *BluetoothScanner
+	// Discovery sources (collectors). Held behind the enumerate stage's collector
+	// ports (ADR-0018, Phase 6) so the concrete collectors can relocate to
+	// internal/discovery/enumerate; the composition root injects them.
+	wiredCollector     WiredCollectorPort
+	wifiCollector      WiFiCollectorPort
+	bluetoothCollector BluetoothCollectorPort
 
 	// Enrichment components. portScanner is the fingerprint stage's PortScannerPort
 	// (ADR-0018, Phase 6): the concrete scanner lives in internal/discovery/fingerprint
@@ -251,22 +253,22 @@ func NewEngine(config *EngineConfig) *Engine {
 	}
 }
 
-// SetWiredCollector sets the wired discovery collector.
-func (e *Engine) SetWiredCollector(collector *DeviceDiscovery) {
+// SetWiredCollector sets the wired discovery collector (WiredCollectorPort).
+func (e *Engine) SetWiredCollector(collector WiredCollectorPort) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.wiredCollector = collector
 }
 
-// SetWiFiCollector sets the WiFi discovery collector.
-func (e *Engine) SetWiFiCollector(collector *WiFiBridge) {
+// SetWiFiCollector sets the WiFi discovery collector (WiFiCollectorPort).
+func (e *Engine) SetWiFiCollector(collector WiFiCollectorPort) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.wifiCollector = collector
 }
 
-// SetBluetoothCollector sets the Bluetooth discovery collector.
-func (e *Engine) SetBluetoothCollector(collector *BluetoothScanner) {
+// SetBluetoothCollector sets the Bluetooth discovery collector (BluetoothCollectorPort).
+func (e *Engine) SetBluetoothCollector(collector BluetoothCollectorPort) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.bluetoothCollector = collector

--- a/internal/discovery/stages.go
+++ b/internal/discovery/stages.go
@@ -55,6 +55,38 @@ type PortScannerPort interface {
 	QuickScan(ctx context.Context, target string) *PortScanResult
 }
 
+// The collector ports are the enumerate stage's input seams (ADR-0018, Phase 6):
+// the Engine drives the wired / Wi-Fi / Bluetooth collectors through these narrow
+// interfaces rather than holding their concrete types, so the collectors can be
+// relocated to internal/discovery/enumerate without the kernel depending on the
+// stage subpackage. The composition root injects the concrete collectors. The
+// result types in these signatures (DiscoveredDevice, WiFiScanResult,
+// WiFiAccessPoint, BluetoothScanResult) stay kernel-side.
+
+// WiredCollectorPort is the wired/active host-discovery collector (ARP/ICMP/NDP/
+// passive protocols) plus its name-resolution pass, consumed by the enumerate and
+// resolve stages.
+type WiredCollectorPort interface {
+	Scan(ctx context.Context) error
+	GetDevices() []*DiscoveredDevice
+	ResolveNetBIOSNames(ctx context.Context)
+	ResolveMDNSNames(ctx context.Context)
+}
+
+// WiFiCollectorPort is the Wi-Fi access-point collector consumed by the enumerate
+// stage.
+type WiFiCollectorPort interface {
+	Scan(ctx context.Context) (*WiFiScanResult, error)
+	GetAccessPoints() []WiFiAccessPoint
+}
+
+// BluetoothCollectorPort is the Bluetooth device collector consumed by the
+// enumerate stage.
+type BluetoothCollectorPort interface {
+	Scan(ctx context.Context) (*BluetoothScanResult, error)
+	GetLastScan() *BluetoothScanResult
+}
+
 // --- Stage 1: enumerate ------------------------------------------------------
 
 // enumerateStage runs the discovery sources concurrently and writes results to
@@ -63,9 +95,9 @@ type PortScannerPort interface {
 type enumerateStage struct {
 	registry           *DeviceRegistry
 	config             *EngineConfig
-	wiredCollector     *DeviceDiscovery
-	wifiCollector      *WiFiBridge
-	bluetoothCollector *BluetoothScanner
+	wiredCollector     WiredCollectorPort
+	wifiCollector      WiFiCollectorPort
+	bluetoothCollector BluetoothCollectorPort
 }
 
 func (s *enumerateStage) Enumerate(ctx context.Context, opts *ScanOptions) error {
@@ -152,7 +184,7 @@ func (s *enumerateStage) enumerateBluetooth(ctx context.Context, opts *ScanOptio
 
 // resolveStage attaches names via the wired collector's resolvers.
 type resolveStage struct {
-	wiredCollector *DeviceDiscovery
+	wiredCollector WiredCollectorPort
 }
 
 func (s *resolveStage) Resolve(ctx context.Context) {


### PR DESCRIPTION
## What
Enabling step for the `enumerate` stage relocation (Phase 6, the last stage). The Engine + its enumerate/resolve stages held the **concrete** collector types (`*DeviceDiscovery`/`*WiFiBridge`/`*BluetoothScanner`). Introduce three narrow kernel ports and have the Engine drive collectors through them:

- `WiredCollectorPort{Scan,GetDevices,ResolveNetBIOSNames,ResolveMDNSNames}`
- `WiFiCollectorPort{Scan,GetAccessPoints}`
- `BluetoothCollectorPort{Scan,GetLastScan}`

## Why
The Engine is the kernel orchestrator. While it holds concrete collector types, the collectors can't relocate to `internal/discovery/enumerate` without the kernel depending on the stage subpackage (a cycle). Port-ifying the seam now (the concretes already satisfy the interfaces) lets the collectors move in a follow-up **without touching the Engine** — the same de-risking pattern proven by #1564 (stage ports) and #1587 (PortScannerPort).

## Notes
- Composition root **untouched** — it injects the same concrete collectors (which satisfy the ports); api already guards nil before injecting.
- `GetCapabilities` keeps its per-collector nil-checks on the interface fields.
- Result types in the signatures (`DiscoveredDevice`, `WiFiScanResult`, `WiFiAccessPoint`, `BluetoothScanResult`) stay kernel-side.
- Interfacebloat-safe (≤4 methods each).

## Validation
- `go build ./...` ✓
- `go test ./internal/discovery/...` ✓
- `go test ./internal/api -run TestGolden` ✓ **byte-identical**
- `golangci-lint` → 0 issues