### PR TITLE
fix(auth): stop a late mount /status probe from clobbering a completed login

### DIFF
--- a/ui/src/hooks/useAuth.test.ts
+++ b/ui/src/hooks/useAuth.test.ts
@@ -158,6 +158,36 @@ describe('useAuth', () => {
     );
   });
 
+  it('a late mount /status probe does not clobber a completed login (seed#1593)', async () => {
+    // The mount-time /status probe is fired while unauthenticated. Hold it
+    // pending, log in successfully, THEN let the stale 401 resolve — it must
+    // not flip isAuthenticated back to false (the rotating E2E flake's cause).
+    let resolveProbe!: (value: { ok: boolean; status: number }) => void;
+    const pendingProbe = new Promise<{ ok: boolean; status: number }>((res) => {
+      resolveProbe = res;
+    });
+    mockFetch.mockReturnValueOnce(pendingProbe); // mount /status — stays in flight
+
+    const { result } = renderHook(() => useAuth());
+
+    // Log in successfully while the mount probe is still pending.
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ token: 'access-token', expires: 3600 }),
+    });
+    await act(async () => {
+      await result.current.login('admin', 'password');
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+
+    // Now the stale mount probe resolves 401 — the guard must hold.
+    await act(async () => {
+      resolveProbe({ ok: false, status: 401 });
+      await pendingProbe;
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
   it('login sets error on failure', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false }); // Initial status check
 

--- a/ui/src/hooks/useAuth.ts
+++ b/ui/src/hooks/useAuth.ts
@@ -114,6 +114,14 @@ export function useAuth(): UseAuthReturn {
   const [error, setError] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
   const pollingIntervalRef = useRef<number | null>(null);
+  // Guards the mount-time /api/v1/status probe from clobbering an explicit
+  // login. The probe is fired once on mount while unauthenticated; under
+  // backend contention its (401) response can resolve AFTER the user has
+  // logged in, and its setState({isAuthenticated:false}) would bounce the SPA
+  // back to the login page. login() flips this so a late probe result is
+  // ignored. Fixes the rotating E2E flake (seed#1593) and the real
+  // load-then-login-fast bounce it mirrors.
+  const loginSupersededProbeRef = useRef(false);
 
   // Expire session handler - clears state and shows error message
   const expireSession = useCallback((message = 'Session expired. Please sign in again.') => {
@@ -158,6 +166,11 @@ export function useAuth(): UseAuthReturn {
       credentials: 'include', // Send cookies
     })
       .then((response) => {
+        // A login that started after this probe is authoritative — never let a
+        // late/stale probe result override it (seed#1593).
+        if (loginSupersededProbeRef.current) {
+          return;
+        }
         if (response.ok) {
           // Authenticated - we don't have username from /api/v1/status, will be set on login
           setState({
@@ -177,6 +190,10 @@ export function useAuth(): UseAuthReturn {
         }
       })
       .catch((err) => {
+        // A login that started after this probe is authoritative (seed#1593).
+        if (loginSupersededProbeRef.current) {
+          return;
+        }
         // Error checking auth, assume not authenticated
         // fixes #678 - added logging for auth check errors
         logger.error(LogComponents.AUTH, 'Failed to check authentication status', err, {
@@ -195,6 +212,9 @@ export function useAuth(): UseAuthReturn {
   }, []);
 
   const login = useCallback(async (username: string, password: string): Promise<boolean> => {
+    // From here on, the mount-time /status probe must not override our result:
+    // an explicit login is authoritative even if the probe resolves later.
+    loginSupersededProbeRef.current = true;
     setIsLoading(true);
     setError(null);
 


### PR DESCRIPTION
The AuthProvider fires a one-shot /api/v1/status probe on mount while
unauthenticated. Under backend contention that 401 response can resolve
*after* the user has logged in, and its setState({isAuthenticated:false})
bounced the SPA back to the login page — a real "load page, log in fast,
get kicked back to login" bug, and the cause of the rotating E2E flake in
auth-complete.spec.ts (seed#1593: page-header-title never appears, passes
on retry).

Guard it: login() flips loginSupersededProbeRef, and the mount probe's
then/catch ignore their result once a login has begun. An explicit login
is authoritative.

Adds a regression test that holds the mount probe pending, logs in, then
resolves the stale 401 and asserts isAuthenticated stays true (verified to
fail without the guard).
