### PR TITLE
refactor(discovery): relocate wired+service collector to enumerate stage (adr-0018)

### DIFF
--- a/cmd/seed/cmd_serve.go
+++ b/cmd/seed/cmd_serve.go
@@ -17,7 +17,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/auth"
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/netif"
 	"github.com/MustardSeedNetworks/seed/internal/paths"
@@ -144,7 +144,7 @@ func initializeBackgroundComponents(cfg *config.Config, db *database.DB) *api.Ba
 // checkICMPCapabilities checks for ICMP privileges and returns availability status.
 // Note: Called before logging is initialized, so uses [fmt.Fprintf].
 func checkICMPCapabilities() bool {
-	if err := discovery.CheckICMPPrivilegesWithMessage(); err != nil {
+	if err := enumerate.CheckICMPPrivilegesWithMessage(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: ICMP features disabled - %v\n", err)
 		fmt.Fprintln(
 			os.Stderr,

--- a/internal/api/broadcast.go
+++ b/internal/api/broadcast.go
@@ -32,7 +32,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
@@ -339,7 +339,7 @@ func (s *Server) collectDiscoveryData() map[string]any {
 
 	// Also get discovered devices count and status from pipeline/service
 	var deviceCount int
-	var serviceStatus *discovery.ServiceStatus
+	var serviceStatus *enumerate.ServiceStatus
 	if s.discoveryService() != nil {
 		deviceCount = len(s.discoveryService().GetDevices())
 		serviceStatus = s.discoveryService().GetStatus()
@@ -371,7 +371,7 @@ func (s *Server) collectDiscoveryData() map[string]any {
 }
 
 // addServiceStatusToResult adds discovery service status fields to the result map.
-func addServiceStatusToResult(result map[string]any, status *discovery.ServiceStatus) {
+func addServiceStatusToResult(result map[string]any, status *enumerate.ServiceStatus) {
 	if status == nil {
 		return
 	}

--- a/internal/api/jobs_devices.go
+++ b/internal/api/jobs_devices.go
@@ -26,7 +26,7 @@ type DeviceScanJobResult struct {
 	Count   int                           `json:"count"`
 }
 
-// deviceScanService is the slice of *discovery.DeviceDiscovery behaviour the
+// deviceScanService is the slice of *enumerate.DeviceDiscovery behaviour the
 // kind needs.
 type deviceScanService interface {
 	Scan(ctx context.Context) error

--- a/internal/api/jobs_vuln.go
+++ b/internal/api/jobs_vuln.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/platform/jobs"
@@ -105,7 +106,7 @@ func decodeVulnScanParams(params any) (VulnScanParams, error) {
 // vulnScanService seam.
 type serverVulnScanService struct {
 	scanner *vuln.VulnerabilityScanner
-	devices *discovery.DeviceDiscovery
+	devices *enumerate.DeviceDiscovery
 }
 
 func (a serverVulnScanService) Devices(targetIP string) []*discovery.DiscoveredDevice {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -25,7 +25,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/iperf"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/speedtest"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/vlan"
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/health"
 	"github.com/MustardSeedNetworks/seed/internal/license"
@@ -287,11 +287,11 @@ func initCaptureServices(services *ServiceContainer, cfg *config.Config) {
 	captureOpener := defaultCaptureOpener()
 
 	// services.Discovery.Service is initialized later, after the shared profiler.
-	services.Discovery.Device = discovery.NewDeviceDiscoveryWithOUI(
+	services.Discovery.Device = enumerate.NewDeviceDiscoveryWithOUI(
 		cfg.Interface.Default,
 		cfg.NetworkDiscovery.OUIFilePath,
 		cfg.NetworkDiscovery.OUIMaxAge,
-		discovery.WithCapture(captureOpener),
+		enumerate.WithCapture(captureOpener),
 	)
 	services.Diagnostics.DHCP = dhcp.NewMonitor(cfg.Interface.Default, dhcp.WithCapture(captureOpener))
 	services.Diagnostics.RogueDetector = dhcp.NewRogueDetector(&dhcp.RogueDetectorConfig{
@@ -643,10 +643,10 @@ func (s *Server) NetManager() *netif.Manager { return s.services.Network.Manager
 func (s *Server) LinkMonitor() *netif.LinkMonitor { return s.services.Network.LinkMonitor }
 
 // DeviceDiscovery returns the device discovery service.
-func (s *Server) DeviceDiscovery() *discovery.DeviceDiscovery { return s.services.Discovery.Device }
+func (s *Server) DeviceDiscovery() *enumerate.DeviceDiscovery { return s.services.Discovery.Device }
 
 // DiscoveryService returns the unified discovery service.
-func (s *Server) DiscoveryService() *discovery.Service { return s.services.Discovery.Service }
+func (s *Server) DiscoveryService() *enumerate.Service { return s.services.Discovery.Service }
 
 // Pipeline returns the discovery pipeline.
 
@@ -723,8 +723,8 @@ func (s *Server) loginRateLimiter() *RateLimiter              { return s.service
 func (s *Server) endpointRateLimiter() *EndpointRateLimiter   { return s.services.RateLimit.Endpoint }
 func (s *Server) netManager() *netif.Manager                  { return s.services.Network.Manager }
 func (s *Server) linkMonitor() *netif.LinkMonitor             { return s.services.Network.LinkMonitor }
-func (s *Server) deviceDiscovery() *discovery.DeviceDiscovery { return s.services.Discovery.Device }
-func (s *Server) discoveryService() *discovery.Service        { return s.services.Discovery.Service }
+func (s *Server) deviceDiscovery() *enumerate.DeviceDiscovery { return s.services.Discovery.Device }
+func (s *Server) discoveryService() *enumerate.Service        { return s.services.Discovery.Service }
 func (s *Server) vulnScanner() *vuln.VulnerabilityScanner {
 	return s.services.Discovery.Vulnerability
 }

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -244,8 +244,8 @@ func (s *Server) initDiscovery(cfg *config.Config) {
 	// Initialize discovery service with the shared profiler. WithCapture injects
 	// the build-tagged capture adapter so the Service's internal device discovery
 	// uses real libpcap capture in production (CGO-free no-op under CGO_ENABLED=0).
-	s.services.Discovery.Service = discovery.NewService(
-		cfg, cfg.Interface.Default, sharedProfiler, discovery.WithCapture(defaultCaptureOpener()),
+	s.services.Discovery.Service = enumerate.NewService(
+		cfg, cfg.Interface.Default, sharedProfiler, enumerate.WithCapture(defaultCaptureOpener()),
 	)
 	logging.GetLogger().Info("Discovery service initialized with shared profiler")
 }

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -122,8 +122,8 @@ type NetworkServices struct {
 
 // DiscoveryServices groups device and network discovery services.
 type DiscoveryServices struct {
-	Device           *discovery.DeviceDiscovery
-	Service          *discovery.Service
+	Device           *enumerate.DeviceDiscovery
+	Service          *enumerate.Service
 	Vulnerability    *vuln.VulnerabilityScanner
 	ProblemDetector  *discovery.ProblemDetector
 	BluetoothScanner *enumerate.BluetoothScanner

--- a/internal/diagnostics/gateway/export_test.go
+++ b/internal/diagnostics/gateway/export_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 )
 
 // TesterPingCount returns the ping count for testing.
@@ -61,14 +61,14 @@ func (t *Tester) DetermineStatus(stats *PingStats) Status {
 }
 
 // TesterSetPinger sets the pinger for testing.
-func (t *Tester) TesterSetPinger(p *discovery.ICMPPinger) {
+func (t *Tester) TesterSetPinger(p *enumerate.ICMPPinger) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.pinger = p
 }
 
 // TesterGetPinger gets the pinger for testing.
-func (t *Tester) TesterGetPinger() *discovery.ICMPPinger {
+func (t *Tester) TesterGetPinger() *enumerate.ICMPPinger {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.pinger

--- a/internal/diagnostics/gateway/gateway.go
+++ b/internal/diagnostics/gateway/gateway.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 )
 
 // Status represents the status of a gateway ping operation.
@@ -111,7 +111,7 @@ type Tester struct {
 	stopCh      chan struct{}
 	running     bool
 	stopOnce    sync.Once             // Prevents double-close panic on stopCh (fixes #854)
-	pinger      *discovery.ICMPPinger // Raw ICMP pinger (nil if unavailable)
+	pinger      *enumerate.ICMPPinger // Raw ICMP pinger (nil if unavailable)
 }
 
 // NewTester creates a new gateway tester.
@@ -125,7 +125,7 @@ func NewTester(thresholds Thresholds) *Tester {
 	}
 
 	// Try to create ICMP pinger (requires CAP_NET_RAW or root)
-	pinger, err := discovery.NewICMPPinger(t.pingTimeout)
+	pinger, err := enumerate.NewICMPPinger(t.pingTimeout)
 	if err == nil {
 		t.pinger = pinger
 	}

--- a/internal/discovery/devices_types.go
+++ b/internal/discovery/devices_types.go
@@ -65,25 +65,6 @@ type BluetoothPresence struct {
 	LastSeen     time.Time            `json:"lastSeen"`
 }
 
-// Time constants for device discovery operations.
-const (
-	ouiUpdateTimeoutMinutes = 2  // Timeout for OUI database updates
-	nameResGoroutineCount   = 2  // Number of name resolution goroutines
-	dbPersistTimeoutSeconds = 30 // Timeout for database persistence operations
-)
-
-// MAC address parsing constants.
-const (
-	macOctetMinLen  = 2    // Minimum length to parse a MAC octet
-	hexLetterOffset = 10   // Offset to add when parsing A-F hex digits (after subtracting 'A' or 'a')
-	localAdminBit   = 0x02 // Bit mask for locally administered MAC address check
-	deviceTTLHours  = 24   // Default device TTL in hours before expiration
-)
-
-// maxIPv6AddressesPerDevice limits IPv6 address accumulation to prevent
-// unbounded memory growth from devices with many addresses (fixes #884).
-const maxIPv6AddressesPerDevice = 16
-
 // DiscoveredDevice represents a network device with aggregated discovery info.
 type DiscoveredDevice struct {
 	IP              string    `json:"ip"`                      // Primary IPv4 address

--- a/internal/discovery/enumerate/arp.go
+++ b/internal/discovery/enumerate/arp.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 //
 // This file provides active Layer 2 and Layer 3 network scanning to discover
@@ -55,6 +55,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
@@ -296,7 +297,7 @@ func (s *ARPScanner) Scan(ctx context.Context) error {
 
 	// Perform ping sweep on primary subnet with retry logic
 	// Note: ping sweep may fail without CAP_NET_RAW - continue with ARP table
-	result := RetryWithBackoff(ctx, NetworkRetryConfig(), func() error {
+	result := discovery.RetryWithBackoff(ctx, discovery.NetworkRetryConfig(), func() error {
 		return s.pingSweep(ctx, subnet)
 	})
 	if !result.Successful {
@@ -315,7 +316,7 @@ func (s *ARPScanner) Scan(ctx context.Context) error {
 		default:
 			// Retry logic for additional subnets - continue even if some fail
 			subnetCopy := additionalSubnet // Capture for closure
-			subnetResult := RetryWithBackoff(ctx, NetworkRetryConfig(), func() error {
+			subnetResult := discovery.RetryWithBackoff(ctx, discovery.NetworkRetryConfig(), func() error {
 				return s.pingSweep(ctx, subnetCopy)
 			})
 			if !subnetResult.Successful {

--- a/internal/discovery/enumerate/arp_darwin.go
+++ b/internal/discovery/enumerate/arp_darwin.go
@@ -15,7 +15,7 @@
 
 //go:build darwin
 
-package discovery
+package enumerate
 
 import (
 	"encoding/binary"

--- a/internal/discovery/enumerate/arp_linux.go
+++ b/internal/discovery/enumerate/arp_linux.go
@@ -15,7 +15,7 @@
 
 //go:build linux
 
-package discovery
+package enumerate
 
 import (
 	"time"

--- a/internal/discovery/enumerate/arp_test.go
+++ b/internal/discovery/enumerate/arp_test.go
@@ -1,4 +1,4 @@
-package discovery_test
+package enumerate_test
 
 import (
 	"context"
@@ -6,19 +6,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
 )
 
 func TestNewARPScanner(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("lo", oui)
+	scanner := enumerate.NewARPScanner("lo", oui)
 
 	if scanner == nil {
 		t.Fatal("NewARPScanner returned nil")
 	}
 
-	accessor := &discovery.ARPScannerTestAccessor{Scanner: scanner}
+	accessor := &enumerate.ARPScannerTestAccessor{Scanner: scanner}
 	if accessor.GetInterfaceName() != "lo" {
 		t.Errorf("Expected interface 'lo', got %q", accessor.GetInterfaceName())
 	}
@@ -32,11 +32,11 @@ func TestNewARPScanner(t *testing.T) {
 
 func TestARPScanner_SetInterface(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("lo", oui)
+	scanner := enumerate.NewARPScanner("lo", oui)
 
 	scanner.SetInterface("eth0")
 
-	accessor := &discovery.ARPScannerTestAccessor{Scanner: scanner}
+	accessor := &enumerate.ARPScannerTestAccessor{Scanner: scanner}
 	if accessor.GetInterfaceName() != "eth0" {
 		t.Errorf("Expected interface 'eth0', got %q", accessor.GetInterfaceName())
 	}
@@ -51,7 +51,7 @@ func TestARPScanner_SetInterface(t *testing.T) {
 
 func TestARPScanner_SetAdditionalSubnets(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("lo", oui)
+	scanner := enumerate.NewARPScanner("lo", oui)
 
 	// Valid CIDRs
 	err := scanner.SetAdditionalSubnets([]string{"192.168.1.0/24", "10.0.0.0/8"})
@@ -73,7 +73,7 @@ func TestARPScanner_SetAdditionalSubnets(t *testing.T) {
 
 func TestARPScanner_GetAdditionalSubnets(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("lo", oui)
+	scanner := enumerate.NewARPScanner("lo", oui)
 
 	// Empty initially
 	subnets := scanner.GetAdditionalSubnets()
@@ -111,7 +111,7 @@ func TestIncrementIP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ip := net.ParseIP(tt.ip).To4()
-			result := discovery.ExportIncrementIP(ip, tt.n)
+			result := enumerate.ExportIncrementIP(ip, tt.n)
 			if result.String() != tt.expected {
 				t.Errorf(
 					"incrementIP(%s, %d) = %s, want %s",
@@ -128,13 +128,13 @@ func TestIncrementIP(t *testing.T) {
 func TestIncrementIP_Nil(t *testing.T) {
 	// IPv6 address should return nil (only IPv4 supported)
 	ip := net.ParseIP("::1")
-	result := discovery.ExportIncrementIP(ip, 1)
+	result := enumerate.ExportIncrementIP(ip, 1)
 	if result != nil {
 		t.Errorf("Expected nil for IPv6, got %v", result)
 	}
 
 	// nil input
-	result = discovery.ExportIncrementIP(nil, 1)
+	result = enumerate.ExportIncrementIP(nil, 1)
 	if result != nil {
 		t.Errorf("Expected nil for nil input, got %v", result)
 	}
@@ -156,7 +156,7 @@ func TestNormalizeMac(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			result := discovery.ExportNormalizeMac(tt.input)
+			result := enumerate.ExportNormalizeMac(tt.input)
 			if result != tt.expected {
 				t.Errorf("normalizeMac(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
@@ -188,7 +188,7 @@ func TestGuessOSFromTTL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.expected, func(t *testing.T) {
-			result := discovery.ExportGuessOSFromTTL(tt.ttl)
+			result := enumerate.ExportGuessOSFromTTL(tt.ttl)
 			if result != tt.expected {
 				t.Errorf("guessOSFromTTL(%d) = %q, want %q", tt.ttl, result, tt.expected)
 			}
@@ -198,7 +198,7 @@ func TestGuessOSFromTTL(t *testing.T) {
 
 func TestARPScanner_IsScanning(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("lo", oui)
+	scanner := enumerate.NewARPScanner("lo", oui)
 
 	// Initially not scanning
 	if scanner.IsScanning() {
@@ -208,7 +208,7 @@ func TestARPScanner_IsScanning(t *testing.T) {
 
 func TestARPScanner_LastScan(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("lo", oui)
+	scanner := enumerate.NewARPScanner("lo", oui)
 
 	// Initially zero
 	if !scanner.LastScan().IsZero() {
@@ -218,7 +218,7 @@ func TestARPScanner_LastScan(t *testing.T) {
 
 func TestARPScanner_Count(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("lo", oui)
+	scanner := enumerate.NewARPScanner("lo", oui)
 
 	// Initially zero
 	if scanner.Count() != 0 {
@@ -228,7 +228,7 @@ func TestARPScanner_Count(t *testing.T) {
 
 func TestARPScanner_GetEntries(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("lo", oui)
+	scanner := enumerate.NewARPScanner("lo", oui)
 
 	// Initially empty
 	entries := scanner.GetEntries()
@@ -239,7 +239,7 @@ func TestARPScanner_GetEntries(t *testing.T) {
 
 func TestARPScanner_GetEntry(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("lo", oui)
+	scanner := enumerate.NewARPScanner("lo", oui)
 
 	// Non-existent entry
 	entry := scanner.GetEntry("192.168.1.1")
@@ -250,10 +250,10 @@ func TestARPScanner_GetEntry(t *testing.T) {
 
 func TestARPScanner_ScanAlreadyInProgress(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("lo", oui)
+	scanner := enumerate.NewARPScanner("lo", oui)
 
 	// Set scanning to true manually
-	accessor := &discovery.ARPScannerTestAccessor{Scanner: scanner}
+	accessor := &enumerate.ARPScannerTestAccessor{Scanner: scanner}
 	accessor.Lock()
 	accessor.SetScanning(true)
 	accessor.Unlock()
@@ -270,7 +270,7 @@ func TestARPScanner_ScanAlreadyInProgress(t *testing.T) {
 
 func TestARPScanner_ScanInvalidInterface(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("nonexistent_interface_xyz", oui)
+	scanner := enumerate.NewARPScanner("nonexistent_interface_xyz", oui)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -282,7 +282,7 @@ func TestARPScanner_ScanInvalidInterface(t *testing.T) {
 }
 
 func TestARPEntry_Fields(t *testing.T) {
-	entry := discovery.ARPEntry{
+	entry := enumerate.ARPEntry{
 		IP:           "192.168.1.1",
 		MAC:          "AA:BB:CC:DD:EE:FF",
 		Vendor:       "Test Vendor",
@@ -333,11 +333,11 @@ func TestARPEntry_Fields(t *testing.T) {
 
 func TestARPScanner_isInSubnet(t *testing.T) {
 	oui := resolve.NewOUIDatabase()
-	scanner := discovery.NewARPScanner("lo", oui)
+	scanner := enumerate.NewARPScanner("lo", oui)
 
 	// Set up a subnet on the scanner
 	_, subnet, _ := net.ParseCIDR("192.168.1.0/24")
-	accessor := &discovery.ARPScannerTestAccessor{Scanner: scanner}
+	accessor := &enumerate.ARPScannerTestAccessor{Scanner: scanner}
 	accessor.Lock()
 	accessor.SetSubnet(subnet)
 	accessor.Unlock()
@@ -475,7 +475,7 @@ func getSubnetChunkTestCases() []subnetChunkTestCase {
 		{
 			name:           "/16 - 256 chunks (capped by default)",
 			cidr:           "10.0.0.0/16",
-			expectedChunks: discovery.MaxChunksDefault, // 256 - capped by default
+			expectedChunks: enumerate.MaxChunksDefault, // 256 - capped by default
 			firstChunk:     "10.0.0.0/24",
 			lastChunk:      "10.0.255.0/24",
 		},
@@ -491,7 +491,7 @@ func runSubnetChunkTest(t *testing.T, tc subnetChunkTestCase) {
 		t.Fatalf("Invalid CIDR %s: %v", tc.cidr, err)
 	}
 
-	chunks := discovery.ExportSplitSubnetIntoChunks(subnet, tc.maxChunks)
+	chunks := enumerate.ExportSplitSubnetIntoChunks(subnet, tc.maxChunks)
 
 	assertChunkCount(t, len(chunks), tc.expectedChunks)
 	assertFirstChunk(t, chunks, tc.firstChunk)
@@ -516,7 +516,7 @@ func TestSplitSubnetIntoChunks_MaxChunksCap(t *testing.T) {
 	_, subnet, _ := net.ParseCIDR("10.0.0.0/8")
 
 	// With cap of 16, should only get 16 chunks
-	chunks := discovery.ExportSplitSubnetIntoChunks(subnet, 16)
+	chunks := enumerate.ExportSplitSubnetIntoChunks(subnet, 16)
 	if len(chunks) != 16 {
 		t.Errorf("/8 with maxChunks=16: expected 16 chunks, got %d", len(chunks))
 	}
@@ -537,11 +537,11 @@ func TestSplitSubnetIntoChunks_DefaultCap(t *testing.T) {
 	_, subnet, _ := net.ParseCIDR("10.0.0.0/8")
 
 	// With default cap, should get MaxChunksDefault chunks
-	chunks := discovery.ExportSplitSubnetIntoChunks(subnet, 0)
-	if len(chunks) != discovery.MaxChunksDefault {
+	chunks := enumerate.ExportSplitSubnetIntoChunks(subnet, 0)
+	if len(chunks) != enumerate.MaxChunksDefault {
 		t.Errorf(
 			"/8 with default cap: expected %d chunks, got %d",
-			discovery.MaxChunksDefault,
+			enumerate.MaxChunksDefault,
 			len(chunks),
 		)
 	}

--- a/internal/discovery/enumerate/arp_windows.go
+++ b/internal/discovery/enumerate/arp_windows.go
@@ -2,7 +2,7 @@
 
 // Windows-specific ARP table implementation using Windows IP Helper API.
 // Uses GetIpNetTable to read the ARP cache entries.
-package discovery
+package enumerate
 
 import (
 	"fmt"

--- a/internal/discovery/enumerate/cdp.go
+++ b/internal/discovery/enumerate/cdp.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 // CDP (Cisco Discovery Protocol) support enables discovery of Cisco networking equipment
 // and compatible devices that advertise their capabilities, platform, and management information

--- a/internal/discovery/enumerate/devices.go
+++ b/internal/discovery/enumerate/devices.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 // Package discovery aggregates device information discovered through various
 // protocols (ARP, NDP, LLDP, CDP, EDP, mDNS, and ICMP ping) and maintains a

--- a/internal/discovery/enumerate/devices_comprehensive_test.go
+++ b/internal/discovery/enumerate/devices_comprehensive_test.go
@@ -1,10 +1,11 @@
-package discovery_test
+package enumerate_test
 
 import (
 	"testing"
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 )
 
 func TestDiscoveredDevice_AllFields(t *testing.T) {
@@ -610,9 +611,9 @@ func TestStatus_Comprehensive(t *testing.T) {
 
 func TestDeviceDiscovery_Basic(t *testing.T) {
 	// Test creation with loopback interface
-	dd := discovery.NewDeviceDiscovery("lo0")
+	dd := enumerate.NewDeviceDiscovery("lo0")
 	if dd == nil {
-		dd = discovery.NewDeviceDiscovery("lo")
+		dd = enumerate.NewDeviceDiscovery("lo")
 	}
 
 	if dd == nil {
@@ -682,52 +683,5 @@ func TestErrScanInProgress_Comprehensive(t *testing.T) {
 	}
 	if err.Error() != "scan already in progress" {
 		t.Errorf("Error message mismatch: got %q", err.Error())
-	}
-}
-
-func TestIsLocallyAdministeredMAC_Comprehensive(t *testing.T) {
-	tests := []struct {
-		name     string
-		mac      string
-		expected bool
-	}{
-		// LAA MACs (second bit of first octet set)
-		{"laa_02", "02:00:00:00:00:00", true},
-		{"laa_06", "06:00:00:00:00:00", true},
-		{"laa_0A", "0A:11:22:33:44:55", true},
-		{"laa_0E", "0E:00:00:00:00:00", true},
-		{"laa_vmware", "02:50:56:00:00:01", true},
-		{"laa_hyperv", "02:15:5D:00:00:01", true},
-		{"laa_docker", "02:42:AC:11:00:02", true},
-		{"laa_xen", "02:00:00:00:00:01", true},
-
-		// UAA MACs (second bit NOT set)
-		{"uaa_00", "00:11:22:33:44:55", false},
-		{"uaa_04", "04:00:00:00:00:00", false},
-		{"uaa_08", "08:00:00:00:00:00", false},
-		{"uaa_apple", "A4:83:E7:12:34:56", false},
-		{"uaa_dell", "D0:67:E5:12:34:56", false},
-		{"uaa_cisco", "00:1A:2B:3C:4D:5E", false},
-
-		// Edge cases
-		{"empty", "", false},
-		{"too_short", "0", false},
-		{"single_char", "A", false},
-		{"lowercase_laa", "0a:11:22:33:44:55", true},
-		{"lowercase_uaa", "00:11:22:33:44:55", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := discovery.ExportIsLocallyAdministeredMAC(tt.mac)
-			if result != tt.expected {
-				t.Errorf(
-					"isLocallyAdministeredMAC(%q) = %v, expected %v",
-					tt.mac,
-					result,
-					tt.expected,
-				)
-			}
-		})
 	}
 }

--- a/internal/discovery/enumerate/devices_copy.go
+++ b/internal/discovery/enumerate/devices_copy.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 // devices_copy.go contains the deep-copy helpers that GetDevices / GetDevice /
 // GetDeviceByIP use to return immutable snapshots to callers, plus the per-

--- a/internal/discovery/enumerate/devices_helper_test.go
+++ b/internal/discovery/enumerate/devices_helper_test.go
@@ -1,10 +1,11 @@
-package discovery_test
+package enumerate_test
 
 import (
 	"testing"
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 )
 
 func TestMethod_Constants(t *testing.T) {
@@ -390,7 +391,7 @@ func TestDiscoveredDevice_DuplicateIP(t *testing.T) {
 }
 
 func TestDeviceDiscovery_GetInterfaceName(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	interfaceName := dd.GetInterfaceName()
 	if interfaceName != "lo" {
@@ -401,7 +402,7 @@ func TestDeviceDiscovery_GetInterfaceName(t *testing.T) {
 func TestDeviceDiscovery_SetNameResolution(t *testing.T) {
 	t.Parallel()
 
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	// Enable name resolution
 	dd.SetNameResolution(true)
@@ -417,30 +418,5 @@ func TestErrScanInProgress(t *testing.T) {
 
 	if err.Error() != "scan already in progress" {
 		t.Errorf("Expected error message 'scan already in progress', got %s", err.Error())
-	}
-}
-
-func TestIsLocallyAdministeredMAC(t *testing.T) {
-	tests := []struct {
-		name     string
-		mac      string
-		expected bool
-	}{
-		{"LAA_second_bit_set", "02:00:00:00:00:00", true},
-		{"LAA_second_bit_set_upper", "0A:11:22:33:44:55", true},
-		{"UAA_no_bit_set", "00:11:22:33:44:55", false},
-		{"UAA_common_vendor", "00:1A:2B:3C:4D:5E", false},
-		{"LAA_vmware_style", "02:50:56:00:00:01", true},
-		{"empty_string", "", false},
-		{"too_short", "0", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := discovery.ExportIsLocallyAdministeredMAC(tt.mac)
-			if result != tt.expected {
-				t.Errorf("isLocallyAdministeredMAC(%q) = %v, expected %v", tt.mac, result, tt.expected)
-			}
-		})
 	}
 }

--- a/internal/discovery/enumerate/devices_scan.go
+++ b/internal/discovery/enumerate/devices_scan.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 // devices_scan.go contains DeviceDiscovery.Scan plus the per-protocol merge
 // helpers (ARP/LLDP/CDP/EDP/NDP), the duplicate-IP detector, the vendor /

--- a/internal/discovery/enumerate/discovery_test.go
+++ b/internal/discovery/enumerate/discovery_test.go
@@ -1,4 +1,4 @@
-package discovery_test
+package enumerate_test
 
 import (
 	"context"
@@ -6,11 +6,12 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 	"github.com/MustardSeedNetworks/seed/internal/testutil"
 )
 
 func TestDeviceDiscovery(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 	if dd == nil {
 		t.Fatal("NewDeviceDiscovery returned nil")
 	}
@@ -32,7 +33,7 @@ func TestDeviceDiscovery(t *testing.T) {
 }
 
 func TestGetDevice(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	// Test GetDevice for non-existent device
 	device := dd.GetDevice("00:11:22:33:44:55")
@@ -42,7 +43,7 @@ func TestGetDevice(t *testing.T) {
 }
 
 func TestGetDeviceByIP(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	// Test GetDeviceByIP for non-existent device
 	device := dd.GetDeviceByIP("192.168.1.10")
@@ -52,7 +53,7 @@ func TestGetDeviceByIP(t *testing.T) {
 }
 
 func TestClearDevices(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	// Clear should work even with no devices
 	dd.ClearDevices()
@@ -64,7 +65,7 @@ func TestClearDevices(t *testing.T) {
 }
 
 func TestSetInterface(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	err := dd.SetInterface("eth0")
 	if err != nil {
@@ -120,7 +121,7 @@ func TestProfilerConfig(t *testing.T) {
 }
 
 func TestNeighborInfo(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	// Start protocol manager
 	if err := dd.Start(); err != nil {
@@ -133,7 +134,7 @@ func TestNeighborInfo(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Test GetNeighbors (likely empty on test system)
-	accessor := &discovery.DeviceDiscoveryTestAccessor{Discovery: dd}
+	accessor := &enumerate.DeviceDiscoveryTestAccessor{Discovery: dd}
 	protoManager := accessor.GetProtoManager()
 	if protoManager == nil {
 		t.Log("Protocol manager not initialized (expected on test system)")
@@ -150,7 +151,7 @@ func TestDiscoveryService(t *testing.T) {
 		WithInterface("lo").
 		Build()
 
-	service := discovery.NewService(cfg, "lo", nil)
+	service := enumerate.NewService(cfg, "lo", nil)
 	if service == nil {
 		t.Fatal("NewService returned nil")
 	}
@@ -194,7 +195,7 @@ func TestDiscoveryService(t *testing.T) {
 
 func TestReload(t *testing.T) {
 	cfg := testutil.NewConfigBuilder().Build()
-	service := discovery.NewService(cfg, "lo", nil)
+	service := enumerate.NewService(cfg, "lo", nil)
 
 	// Test Reload without starting
 	err := service.Reload()
@@ -223,7 +224,7 @@ func TestReload(t *testing.T) {
 func TestScanWithContext(t *testing.T) {
 	cfg := testutil.NewConfigBuilder().Build()
 	cfg.NetworkDiscovery.ScanTimeout = 1 * time.Second
-	service := discovery.NewService(cfg, "lo", nil)
+	service := enumerate.NewService(cfg, "lo", nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
@@ -244,7 +245,7 @@ func TestScanWithContext(t *testing.T) {
 
 func TestClearDevicesService(t *testing.T) {
 	cfg := testutil.NewConfigBuilder().Build()
-	service := discovery.NewService(cfg, "lo", nil)
+	service := enumerate.NewService(cfg, "lo", nil)
 
 	// Clear (should work even with no devices)
 	service.ClearDevices()
@@ -273,7 +274,7 @@ func TestDiscoveryOptions(t *testing.T) {
 			cfg := testutil.NewConfigBuilder().
 				WithDiscoveryMethods(tt.arpScan, tt.icmpScan, tt.portScan).
 				Build()
-			service := discovery.NewService(cfg, "lo", nil)
+			service := enumerate.NewService(cfg, "lo", nil)
 
 			if err := service.Start(); err != nil {
 				t.Logf("Start failed for %s: %v", tt.name, err)
@@ -289,7 +290,7 @@ func TestDiscoveryOptions(t *testing.T) {
 }
 
 func TestDeviceCount(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	count := dd.Count()
 	if count != 0 {
@@ -298,7 +299,7 @@ func TestDeviceCount(t *testing.T) {
 }
 
 func TestIsScanning(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	if dd.IsScanning() {
 		t.Error("Expected IsScanning to be false initially")
@@ -306,7 +307,7 @@ func TestIsScanning(t *testing.T) {
 }
 
 func TestLastScan(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	lastScan := dd.LastScan()
 	if !lastScan.IsZero() {
@@ -315,14 +316,14 @@ func TestLastScan(t *testing.T) {
 }
 
 func TestGetSubnetInfo(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	subnet, localIP := dd.GetSubnetInfo()
 	t.Logf("Subnet: %s, LocalIP: %s", subnet, localIP)
 }
 
 func TestSetAdditionalSubnets(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	// Test setting additional subnets
 	err := dd.SetAdditionalSubnets([]string{"192.168.1.0/24"})
@@ -338,7 +339,7 @@ func TestSetAdditionalSubnets(t *testing.T) {
 }
 
 func TestDeviceDiscoveryStartStop(t *testing.T) {
-	dd := discovery.NewDeviceDiscovery("lo")
+	dd := enumerate.NewDeviceDiscovery("lo")
 
 	// Test Start
 	err := dd.Start()
@@ -355,7 +356,7 @@ func TestDeviceDiscoveryStartStop(t *testing.T) {
 
 func TestServiceInterface(t *testing.T) {
 	cfg := testutil.NewConfigBuilder().Build()
-	service := discovery.NewService(cfg, "lo", nil)
+	service := enumerate.NewService(cfg, "lo", nil)
 
 	// Test SetInterface
 	err := service.SetInterface("eth0")
@@ -366,7 +367,7 @@ func TestServiceInterface(t *testing.T) {
 
 func TestServiceGetDevice(t *testing.T) {
 	cfg := testutil.NewConfigBuilder().Build()
-	service := discovery.NewService(cfg, "lo", nil)
+	service := enumerate.NewService(cfg, "lo", nil)
 
 	// Test GetDevice for non-existent device
 	device := service.GetDevice("00:11:22:33:44:55")
@@ -377,7 +378,7 @@ func TestServiceGetDevice(t *testing.T) {
 
 func TestGetDeviceByIPService(t *testing.T) {
 	cfg := testutil.NewConfigBuilder().Build()
-	service := discovery.NewService(cfg, "lo", nil)
+	service := enumerate.NewService(cfg, "lo", nil)
 
 	// Test GetDeviceByIP for non-existent device
 	device := service.GetDeviceByIP("192.168.1.10")
@@ -388,7 +389,7 @@ func TestGetDeviceByIPService(t *testing.T) {
 
 func TestGetNeighbors(t *testing.T) {
 	cfg := testutil.NewConfigBuilder().Build()
-	service := discovery.NewService(cfg, "lo", nil)
+	service := enumerate.NewService(cfg, "lo", nil)
 
 	if err := service.Start(); err != nil {
 		t.Logf("Start failed: %v", err)
@@ -404,7 +405,7 @@ func TestGetNeighbors(t *testing.T) {
 
 func TestDeviceDiscoveryAccess(t *testing.T) {
 	cfg := testutil.NewConfigBuilder().Build()
-	service := discovery.NewService(cfg, "lo", nil)
+	service := enumerate.NewService(cfg, "lo", nil)
 
 	// Test DeviceDiscovery accessor
 	dd := service.DeviceDiscovery()

--- a/internal/discovery/enumerate/edp.go
+++ b/internal/discovery/enumerate/edp.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 // EDP (Extreme Discovery Protocol) support enables discovery of Extreme Networks equipment
 // and compatible devices that advertise their device ID, port information, VLAN membership,

--- a/internal/discovery/enumerate/export_test.go
+++ b/internal/discovery/enumerate/export_test.go
@@ -1,0 +1,107 @@
+package enumerate
+
+// This file is only compiled during testing (due to the _test.go suffix) and
+// provides access to enumerate-stage implementation details for in-package and
+// external tests. It moved here from the discovery kernel alongside the wired
+// collector (ADR-0018 Phase 6).
+
+import (
+	"net"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
+)
+
+// ExportIncrementIP exposes incrementIP for testing.
+func ExportIncrementIP(ip net.IP, n int) net.IP {
+	return incrementIP(ip, n)
+}
+
+// ExportNormalizeMac exposes normalizeMac for testing.
+func ExportNormalizeMac(mac string) string {
+	return normalizeMac(mac)
+}
+
+// ExportGuessOSFromTTL exposes guessOSFromTTL for testing.
+func ExportGuessOSFromTTL(ttl int) string {
+	return guessOSFromTTL(ttl)
+}
+
+// ExportSplitSubnetIntoChunks exposes splitSubnetIntoChunks for testing.
+func ExportSplitSubnetIntoChunks(subnet *net.IPNet, maxChunks int) []*net.IPNet {
+	return splitSubnetIntoChunks(subnet, maxChunks)
+}
+
+// ExportIsLocallyAdministeredMAC exposes isLocallyAdministeredMAC for testing.
+func ExportIsLocallyAdministeredMAC(mac string) bool {
+	return isLocallyAdministeredMAC(mac)
+}
+
+// ARPScannerTestAccessor provides access to ARPScanner's private fields for testing.
+type ARPScannerTestAccessor struct {
+	Scanner *ARPScanner
+}
+
+// GetInterfaceName returns the scanner's interface name.
+func (a *ARPScannerTestAccessor) GetInterfaceName() string {
+	return a.Scanner.interfaceName
+}
+
+// GetOUI returns the scanner's OUI database.
+func (a *ARPScannerTestAccessor) GetOUI() *resolve.OUIDatabase {
+	return a.Scanner.oui
+}
+
+// GetEntries returns the scanner's entries map.
+func (a *ARPScannerTestAccessor) GetEntries() map[string]*ARPEntry {
+	return a.Scanner.entries
+}
+
+// GetSubnet returns the scanner's subnet.
+func (a *ARPScannerTestAccessor) GetSubnet() *net.IPNet {
+	return a.Scanner.subnet
+}
+
+// SetSubnet sets the scanner's subnet.
+func (a *ARPScannerTestAccessor) SetSubnet(subnet *net.IPNet) {
+	a.Scanner.subnet = subnet
+}
+
+// GetLocalIP returns the scanner's local IP.
+func (a *ARPScannerTestAccessor) GetLocalIP() net.IP {
+	return a.Scanner.localIP
+}
+
+// IsScanning returns the scanner's scanning state.
+func (a *ARPScannerTestAccessor) IsScanning() bool {
+	return a.Scanner.scanning
+}
+
+// SetScanning sets the scanner's scanning state.
+func (a *ARPScannerTestAccessor) SetScanning(scanning bool) {
+	a.Scanner.scanning = scanning
+}
+
+// Lock locks the scanner's mutex.
+func (a *ARPScannerTestAccessor) Lock() {
+	a.Scanner.mu.Lock()
+}
+
+// Unlock unlocks the scanner's mutex.
+func (a *ARPScannerTestAccessor) Unlock() {
+	a.Scanner.mu.Unlock()
+}
+
+// IsInSubnet exposes the private isInSubnet method for testing.
+func (s *ARPScanner) IsInSubnet(ip string) bool {
+	return s.isInSubnet(ip)
+}
+
+// DeviceDiscoveryTestAccessor provides access to DeviceDiscovery's private fields for testing.
+type DeviceDiscoveryTestAccessor struct {
+	Discovery *DeviceDiscovery
+}
+
+// GetProtoManager returns the discovery's protocol manager.
+func (d *DeviceDiscoveryTestAccessor) GetProtoManager() *Manager {
+	return d.Discovery.protoManager
+}

--- a/internal/discovery/enumerate/icmp.go
+++ b/internal/discovery/enumerate/icmp.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 // ICMP ping support enables active probing of devices to verify reachability,
 // measure latency, and identify responsive hosts on the network. Supports both

--- a/internal/discovery/enumerate/lldp.go
+++ b/internal/discovery/enumerate/lldp.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 import (
 	"context"

--- a/internal/discovery/enumerate/mac_test.go
+++ b/internal/discovery/enumerate/mac_test.go
@@ -1,0 +1,58 @@
+package enumerate_test
+
+import (
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
+)
+
+// TestIsLocallyAdministeredMAC covers the moved isLocallyAdministeredMAC helper
+// (relocated from the discovery kernel with the wired collector, ADR-0018
+// Phase 6). It consolidates the former kernel TestIsLocallyAdministeredMAC and
+// TestIsLocallyAdministeredMAC_Comprehensive.
+func TestIsLocallyAdministeredMAC(t *testing.T) {
+	tests := []struct {
+		name     string
+		mac      string
+		expected bool
+	}{
+		// LAA MACs (second bit of first octet set)
+		{"laa_02", "02:00:00:00:00:00", true},
+		{"laa_06", "06:00:00:00:00:00", true},
+		{"laa_0A", "0A:11:22:33:44:55", true},
+		{"laa_0E", "0E:00:00:00:00:00", true},
+		{"laa_vmware", "02:50:56:00:00:01", true},
+		{"laa_hyperv", "02:15:5D:00:00:01", true},
+		{"laa_docker", "02:42:AC:11:00:02", true},
+		{"laa_xen", "02:00:00:00:00:01", true},
+
+		// UAA MACs (second bit NOT set)
+		{"uaa_00", "00:11:22:33:44:55", false},
+		{"uaa_04", "04:00:00:00:00:00", false},
+		{"uaa_08", "08:00:00:00:00:00", false},
+		{"uaa_apple", "A4:83:E7:12:34:56", false},
+		{"uaa_dell", "D0:67:E5:12:34:56", false},
+		{"uaa_cisco", "00:1A:2B:3C:4D:5E", false},
+
+		// Edge cases
+		{"empty", "", false},
+		{"too_short", "0", false},
+		{"single_char", "A", false},
+		{"lowercase_laa", "0a:11:22:33:44:55", true},
+		{"lowercase_uaa", "00:11:22:33:44:55", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := enumerate.ExportIsLocallyAdministeredMAC(tt.mac)
+			if result != tt.expected {
+				t.Errorf(
+					"isLocallyAdministeredMAC(%q) = %v, expected %v",
+					tt.mac,
+					result,
+					tt.expected,
+				)
+			}
+		})
+	}
+}

--- a/internal/discovery/enumerate/manager.go
+++ b/internal/discovery/enumerate/manager.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 //
 // This file implements the Manager, which orchestrates multiple discovery protocol

--- a/internal/discovery/enumerate/manager_test.go
+++ b/internal/discovery/enumerate/manager_test.go
@@ -1,27 +1,27 @@
-package discovery_test
+package enumerate_test
 
 import (
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 )
 
 func TestProtocolConstants(t *testing.T) {
-	if discovery.ProtocolLLDP != "lldp" {
-		t.Errorf("Expected ProtocolLLDP='lldp', got %q", discovery.ProtocolLLDP)
+	if enumerate.ProtocolLLDP != "lldp" {
+		t.Errorf("Expected ProtocolLLDP='lldp', got %q", enumerate.ProtocolLLDP)
 	}
-	if discovery.ProtocolCDP != "cdp" {
-		t.Errorf("Expected ProtocolCDP='cdp', got %q", discovery.ProtocolCDP)
+	if enumerate.ProtocolCDP != "cdp" {
+		t.Errorf("Expected ProtocolCDP='cdp', got %q", enumerate.ProtocolCDP)
 	}
-	if discovery.ProtocolEDP != "edp" {
-		t.Errorf("Expected ProtocolEDP='edp', got %q", discovery.ProtocolEDP)
+	if enumerate.ProtocolEDP != "edp" {
+		t.Errorf("Expected ProtocolEDP='edp', got %q", enumerate.ProtocolEDP)
 	}
 }
 
 func TestNeighbor_Fields(t *testing.T) {
-	n := discovery.Neighbor{
-		Protocol:          discovery.ProtocolLLDP,
+	n := enumerate.Neighbor{
+		Protocol:          enumerate.ProtocolLLDP,
 		ChassisID:         "00:11:22:33:44:55",
 		PortID:            "Gi0/1",
 		PortDescription:   "Uplink to Core",
@@ -37,7 +37,7 @@ func TestNeighbor_Fields(t *testing.T) {
 		SourceMAC:         "AA:BB:CC:DD:EE:FF",
 	}
 
-	if n.Protocol != discovery.ProtocolLLDP {
+	if n.Protocol != enumerate.ProtocolLLDP {
 		t.Errorf("Expected Protocol LLDP, got %v", n.Protocol)
 	}
 	if n.ChassisID != "00:11:22:33:44:55" {
@@ -82,7 +82,7 @@ func TestNeighbor_Fields(t *testing.T) {
 }
 
 func TestNewManager(t *testing.T) {
-	mgr := discovery.NewManager("lo")
+	mgr := enumerate.NewManager("lo")
 
 	if mgr == nil {
 		t.Fatal("NewManager returned nil")
@@ -93,7 +93,7 @@ func TestNewManager(t *testing.T) {
 }
 
 func TestManager_IsRunning(t *testing.T) {
-	mgr := discovery.NewManager("lo")
+	mgr := enumerate.NewManager("lo")
 
 	if mgr.IsRunning() {
 		t.Error("Manager should not be running initially")
@@ -101,7 +101,7 @@ func TestManager_IsRunning(t *testing.T) {
 }
 
 func TestManager_GetNeighbors_Empty(t *testing.T) {
-	mgr := discovery.NewManager("lo")
+	mgr := enumerate.NewManager("lo")
 
 	neighbors := mgr.GetNeighbors()
 	if len(neighbors) != 0 {
@@ -110,7 +110,7 @@ func TestManager_GetNeighbors_Empty(t *testing.T) {
 }
 
 func TestManager_GetLLDPNeighbors_Empty(t *testing.T) {
-	mgr := discovery.NewManager("lo")
+	mgr := enumerate.NewManager("lo")
 
 	neighbors := mgr.GetLLDPNeighbors()
 	if len(neighbors) != 0 {
@@ -119,7 +119,7 @@ func TestManager_GetLLDPNeighbors_Empty(t *testing.T) {
 }
 
 func TestManager_GetCDPNeighbors_Empty(t *testing.T) {
-	mgr := discovery.NewManager("lo")
+	mgr := enumerate.NewManager("lo")
 
 	neighbors := mgr.GetCDPNeighbors()
 	if len(neighbors) != 0 {
@@ -128,7 +128,7 @@ func TestManager_GetCDPNeighbors_Empty(t *testing.T) {
 }
 
 func TestManager_GetEDPNeighbors_Empty(t *testing.T) {
-	mgr := discovery.NewManager("lo")
+	mgr := enumerate.NewManager("lo")
 
 	neighbors := mgr.GetEDPNeighbors()
 	if len(neighbors) != 0 {
@@ -137,7 +137,7 @@ func TestManager_GetEDPNeighbors_Empty(t *testing.T) {
 }
 
 func TestManager_Stop_WhenNotRunning(t *testing.T) {
-	mgr := discovery.NewManager("lo")
+	mgr := enumerate.NewManager("lo")
 
 	// Stop when not running should be safe (no-op)
 	mgr.Stop()

--- a/internal/discovery/enumerate/ndp_darwin.go
+++ b/internal/discovery/enumerate/ndp_darwin.go
@@ -1,6 +1,6 @@
 //go:build darwin
 
-package discovery
+package enumerate
 
 // NDP (Neighbor Discovery Protocol) support for macOS is a stub implementation
 // as IPv6 neighbor discovery on macOS is complex and the primary production target is Linux.

--- a/internal/discovery/enumerate/ndp_linux.go
+++ b/internal/discovery/enumerate/ndp_linux.go
@@ -4,7 +4,7 @@
 // NDP (Neighbor Discovery Protocol) support for Linux enables IPv6 neighbor discovery
 // by reading from the kernel's neighbor table, allowing detection of IPv6-capable devices
 // and routers on the local network segment.
-package discovery
+package enumerate
 
 import (
 	"fmt"

--- a/internal/discovery/enumerate/ndp_windows.go
+++ b/internal/discovery/enumerate/ndp_windows.go
@@ -2,7 +2,7 @@
 
 // Windows-specific NDP (IPv6 Neighbor Discovery Protocol) implementation.
 // Uses GetIpNetTable2 to read IPv6 neighbor entries from Windows.
-package discovery
+package enumerate
 
 import (
 	"fmt"

--- a/internal/discovery/enumerate/options.go
+++ b/internal/discovery/enumerate/options.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 import (
 	"github.com/MustardSeedNetworks/seed/internal/capture"

--- a/internal/discovery/enumerate/protocol_capture.go
+++ b/internal/discovery/enumerate/protocol_capture.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 import (
 	"fmt"

--- a/internal/discovery/enumerate/service.go
+++ b/internal/discovery/enumerate/service.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 // Discovery service coordinates all discovery methods (ARP, NDP, LLDP, CDP, EDP, ICMP, profiling)
 // with direct settings configuration. Manages orchestration, timing, and aggregation of discovery results.
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
@@ -64,7 +65,7 @@ func NewService(
 	opts ...Option,
 ) *Service {
 	if profiler == nil {
-		profiler = NewDeviceProfiler(DefaultProfilerConfig(), &cfg.SNMP)
+		profiler = discovery.NewDeviceProfiler(discovery.DefaultProfilerConfig(), &cfg.SNMP)
 	}
 	return &Service{
 		cfg:           cfg,
@@ -76,7 +77,7 @@ func NewService(
 			opts...,
 		),
 		profiler: profiler,
-		metrics:  NewMetrics(),
+		metrics:  discovery.NewMetrics(),
 	}
 }
 
@@ -271,7 +272,7 @@ func (s *Service) Scan(ctx context.Context) error {
 
 	// Compute delta from previous scan
 	if s.previousScan != nil {
-		s.lastDelta = ComputeDelta(s.previousScan, devices)
+		s.lastDelta = discovery.ComputeDelta(s.previousScan, devices)
 		s.lastDeltaTime = time.Now()
 
 		if len(s.lastDelta.NewDevices) > 0 || len(s.lastDelta.RemovedDevices) > 0 {

--- a/internal/discovery/enumerate/utils_test.go
+++ b/internal/discovery/enumerate/utils_test.go
@@ -1,10 +1,10 @@
-package discovery_test
+package enumerate_test
 
 import (
 	"net"
 	"testing"
 
-	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 )
 
 func TestExportIncrementIP(t *testing.T) {
@@ -28,7 +28,7 @@ func TestExportIncrementIP(t *testing.T) {
 				t.Fatalf("Failed to parse IP: %s", tt.ip)
 			}
 
-			result := discovery.ExportIncrementIP(ip, tt.n)
+			result := enumerate.ExportIncrementIP(ip, tt.n)
 			if result == nil {
 				t.Fatalf("incrementIP returned nil for %s + %d", tt.ip, tt.n)
 			}
@@ -56,7 +56,7 @@ func TestExportNormalizeMac(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := discovery.ExportNormalizeMac(tt.mac)
+			result := enumerate.ExportNormalizeMac(tt.mac)
 			if result != tt.expected {
 				t.Errorf("normalizeMac(%q) = %q, expected %q", tt.mac, result, tt.expected)
 			}
@@ -84,7 +84,7 @@ func TestExportGuessOSFromTTL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := discovery.ExportGuessOSFromTTL(tt.ttl)
+			result := enumerate.ExportGuessOSFromTTL(tt.ttl)
 			if result != tt.expected {
 				t.Errorf("guessOSFromTTL(%d) = %q, expected %q", tt.ttl, result, tt.expected)
 			}
@@ -114,7 +114,7 @@ func TestExportSplitSubnetIntoChunks(t *testing.T) {
 				t.Fatalf("Failed to parse CIDR %s: %v", tt.cidr, err)
 			}
 
-			chunks := discovery.ExportSplitSubnetIntoChunks(subnet, tt.maxChunks)
+			chunks := enumerate.ExportSplitSubnetIntoChunks(subnet, tt.maxChunks)
 			if len(chunks) < tt.minExpected || len(chunks) > tt.maxExpected {
 				t.Errorf(
 					"splitSubnetIntoChunks(%s, %d) returned %d chunks, expected %d-%d",

--- a/internal/discovery/enumerate/wired_aliases.go
+++ b/internal/discovery/enumerate/wired_aliases.go
@@ -1,0 +1,82 @@
+package enumerate
+
+import "github.com/MustardSeedNetworks/seed/internal/discovery"
+
+// Kernel type aliases for the wired/active discovery collector (ADR-0018 Phase 6
+// enumerate split). DeviceDiscovery, Service, the protocol collectors, and the
+// Manager moved here from the kernel; the device data types, the DeviceProfiler
+// + SNMP result types, the metrics/retry infrastructure, and the registry stay
+// kernel-resident. Aliasing them lets the moved collector reference them
+// unqualified without inverting the kernel→stage dependency direction.
+// The grouping below mirrors the kernel files the symbols live in: device data
+// types, per-protocol sub-types, the profiler/SNMP result cluster, and the
+// metrics infrastructure. Each is an alias, not a redefinition. The blank line
+// below keeps this a free-standing comment rather than DiscoveredDevice's doc.
+
+type (
+	DiscoveredDevice  = discovery.DiscoveredDevice
+	Method            = discovery.Method
+	ConnectionType    = discovery.ConnectionType
+	WiFiPresence      = discovery.WiFiPresence
+	BluetoothPresence = discovery.BluetoothPresence
+	Status            = discovery.Status
+	DBDeviceWriter    = discovery.DBDeviceWriter
+	MDNSService       = discovery.MDNSService
+	OpenPort          = discovery.OpenPort
+
+	LLDPDeviceInfo = discovery.LLDPDeviceInfo
+	CDPDeviceInfo  = discovery.CDPDeviceInfo
+	EDPDeviceInfo  = discovery.EDPDeviceInfo
+	NDPDeviceInfo  = discovery.NDPDeviceInfo
+
+	DeviceProfiler        = discovery.DeviceProfiler
+	DeviceProfile         = discovery.DeviceProfile
+	ProfilingStatus       = discovery.ProfilingStatus
+	DeviceVulnerabilities = discovery.DeviceVulnerabilities
+	Vulnerability         = discovery.Vulnerability
+	SNMPFullData          = discovery.SNMPFullData
+	SNMPEntity            = discovery.SNMPEntity
+	SNMPInterface         = discovery.SNMPInterface
+	SNMPIPAddress         = discovery.SNMPIPAddress
+	SNMPLLDPNeighbor      = discovery.SNMPLLDPNeighbor
+	SNMPMACEntry          = discovery.SNMPMACEntry
+	SNMPVLAN              = discovery.SNMPVLAN
+
+	Metrics           = discovery.Metrics
+	ScanDelta         = discovery.ScanDelta
+	DegradationStatus = discovery.DegradationStatus
+)
+
+// Kernel constant aliases (device discovery methods).
+const (
+	MethodARP  = discovery.MethodARP
+	MethodPING = discovery.MethodPING
+	MethodLLDP = discovery.MethodLLDP
+	MethodCDP  = discovery.MethodCDP
+	MethodEDP  = discovery.MethodEDP
+	MethodNDP  = discovery.MethodNDP
+	MethodMDNS = discovery.MethodMDNS
+)
+
+// ErrScanInProgress is the kernel sentinel returned when a scan is requested
+// while one is already running; re-exported so the moved collector returns the
+// same value callers compare against. (Kernel functions like NewDeviceProfiler
+// are called qualified — discovery.NewDeviceProfiler — to avoid package-level
+// function aliases.)
+var ErrScanInProgress = discovery.ErrScanInProgress
+
+// Impl-tuning constants that moved with the collector (used only by the moved
+// devices.go / devices_scan.go, never by kernel-staying code).
+const (
+	ouiUpdateTimeoutMinutes = 2  // Timeout for OUI database updates
+	nameResGoroutineCount   = 2  // Number of name resolution goroutines
+	dbPersistTimeoutSeconds = 30 // Timeout for database persistence operations
+	deviceTTLHours          = 24 // Default device TTL in hours before expiration
+
+	macOctetMinLen  = 2    // Minimum length to parse a MAC octet
+	hexLetterOffset = 10   // Offset for A-F hex digits (after subtracting 'A'/'a')
+	localAdminBit   = 0x02 // Bit mask for locally administered MAC address check
+
+	// maxIPv6AddressesPerDevice caps IPv6 accumulation per device (fixes #884).
+	maxIPv6AddressesPerDevice = 16
+)

--- a/internal/discovery/enumerate/wol.go
+++ b/internal/discovery/enumerate/wol.go
@@ -1,4 +1,4 @@
-package discovery
+package enumerate
 
 // This file implements Wake-on-LAN (WoL) functionality for network device discovery.
 //
@@ -298,17 +298,4 @@ func WakeDevices(ctx context.Context, macs []string) []WoLResult {
 	}
 
 	return results
-}
-
-// containsAny reports whether s contains any of the given substrings. It is a
-// kernel-local helper (the OS-fingerprint heuristics in this file use it); it
-// lived in wifi_bridge.go historically but is not Wi-Fi-specific. The enumerate
-// stage keeps its own copy for the same reason it copies normalizeMAC.
-func containsAny(s string, subs ...string) bool {
-	for _, sub := range subs {
-		if strings.Contains(s, sub) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/discovery/export_test.go
+++ b/internal/discovery/export_test.go
@@ -2,91 +2,25 @@ package discovery
 
 // This file is only compiled during testing (due to _test.go suffix)
 // and provides access to internal implementation details.
+//
+// The wired-collector accessors (ARPScanner/DeviceDiscovery/Manager,
+// normalizeMac/incrementIP/guessOSFromTTL/splitSubnetIntoChunks/
+// isLocallyAdministeredMAC) moved to internal/discovery/enumerate/export_test.go
+// alongside the collector (ADR-0018 Phase 6).
 
-import (
-	"net"
-
-	"github.com/MustardSeedNetworks/seed/internal/discovery/resolve"
-)
-
-// ExportIncrementIP exposes incrementIP for testing.
-func ExportIncrementIP(ip net.IP, n int) net.IP {
-	return incrementIP(ip, n)
+// ExportEnsureConnectionType exposes ensureConnectionType for testing.
+func ExportEnsureConnectionType(types []ConnectionType, add ConnectionType) []ConnectionType {
+	return ensureConnectionType(types, add)
 }
 
-// ExportNormalizeMac exposes normalizeMac for testing.
-func ExportNormalizeMac(mac string) string {
-	return normalizeMac(mac)
+// ExportWiFiAPToDevice exposes wifiAPToDevice (ADR-0018 enumerate stage) for testing.
+func ExportWiFiAPToDevice(ap *WiFiAccessPoint) *DiscoveredDevice {
+	return wifiAPToDevice(ap)
 }
 
-// ExportGuessOSFromTTL exposes guessOSFromTTL for testing.
-func ExportGuessOSFromTTL(ttl int) string {
-	return guessOSFromTTL(ttl)
-}
-
-// ExportSplitSubnetIntoChunks exposes splitSubnetIntoChunks for testing.
-func ExportSplitSubnetIntoChunks(subnet *net.IPNet, maxChunks int) []*net.IPNet {
-	return splitSubnetIntoChunks(subnet, maxChunks)
-}
-
-// ARPScannerTestAccessor provides access to ARPScanner's private fields for testing.
-type ARPScannerTestAccessor struct {
-	Scanner *ARPScanner
-}
-
-// GetInterfaceName returns the scanner's interface name.
-func (a *ARPScannerTestAccessor) GetInterfaceName() string {
-	return a.Scanner.interfaceName
-}
-
-// GetOUI returns the scanner's OUI database.
-func (a *ARPScannerTestAccessor) GetOUI() *resolve.OUIDatabase {
-	return a.Scanner.oui
-}
-
-// GetEntries returns the scanner's entries map.
-func (a *ARPScannerTestAccessor) GetEntries() map[string]*ARPEntry {
-	return a.Scanner.entries
-}
-
-// GetSubnet returns the scanner's subnet.
-func (a *ARPScannerTestAccessor) GetSubnet() *net.IPNet {
-	return a.Scanner.subnet
-}
-
-// SetSubnet sets the scanner's subnet.
-func (a *ARPScannerTestAccessor) SetSubnet(subnet *net.IPNet) {
-	a.Scanner.subnet = subnet
-}
-
-// GetLocalIP returns the scanner's local IP.
-func (a *ARPScannerTestAccessor) GetLocalIP() net.IP {
-	return a.Scanner.localIP
-}
-
-// IsScanning returns the scanner's scanning state.
-func (a *ARPScannerTestAccessor) IsScanning() bool {
-	return a.Scanner.scanning
-}
-
-// SetScanning sets the scanner's scanning state.
-func (a *ARPScannerTestAccessor) SetScanning(scanning bool) {
-	a.Scanner.scanning = scanning
-}
-
-// Lock locks the scanner's mutex.
-func (a *ARPScannerTestAccessor) Lock() {
-	a.Scanner.mu.Lock()
-}
-
-// Unlock unlocks the scanner's mutex.
-func (a *ARPScannerTestAccessor) Unlock() {
-	a.Scanner.mu.Unlock()
-}
-
-// IsInSubnet exposes the private isInSubnet method for testing.
-func (s *ARPScanner) IsInSubnet(ip string) bool {
-	return s.isInSubnet(ip)
+// ExportBluetoothDeviceToDevice exposes bluetoothDeviceToDevice for testing.
+func ExportBluetoothDeviceToDevice(bt *BluetoothDevice) *DiscoveredDevice {
+	return bluetoothDeviceToDevice(bt)
 }
 
 // TracerTestAccessor provides access to Tracer's private fields for testing.
@@ -102,36 +36,6 @@ func (t *TracerTestAccessor) GetTimeout() any {
 // GetMaxHops returns the tracer's maxHops.
 func (t *TracerTestAccessor) GetMaxHops() int {
 	return t.Tracer.maxHops
-}
-
-// DeviceDiscoveryTestAccessor provides access to DeviceDiscovery's private fields for testing.
-type DeviceDiscoveryTestAccessor struct {
-	Discovery *DeviceDiscovery
-}
-
-// GetProtoManager returns the discovery's protocol manager.
-func (d *DeviceDiscoveryTestAccessor) GetProtoManager() *Manager {
-	return d.Discovery.protoManager
-}
-
-// ExportIsLocallyAdministeredMAC exposes isLocallyAdministeredMAC for testing.
-func ExportIsLocallyAdministeredMAC(mac string) bool {
-	return isLocallyAdministeredMAC(mac)
-}
-
-// ExportEnsureConnectionType exposes ensureConnectionType for testing.
-func ExportEnsureConnectionType(types []ConnectionType, add ConnectionType) []ConnectionType {
-	return ensureConnectionType(types, add)
-}
-
-// ExportWiFiAPToDevice exposes wifiAPToDevice (ADR-0018 enumerate stage) for testing.
-func ExportWiFiAPToDevice(ap *WiFiAccessPoint) *DiscoveredDevice {
-	return wifiAPToDevice(ap)
-}
-
-// ExportBluetoothDeviceToDevice exposes bluetoothDeviceToDevice for testing.
-func ExportBluetoothDeviceToDevice(bt *BluetoothDevice) *DiscoveredDevice {
-	return bluetoothDeviceToDevice(bt)
 }
 
 // NewEnumerateStageForTest builds the enumerate stage (no collectors) as its

--- a/internal/discovery/l2path.go
+++ b/internal/discovery/l2path.go
@@ -38,15 +38,24 @@ type PortInfo struct {
 	ConnectedTo string `json:"connectedTo"` // Device name/MAC on this port
 }
 
+// DeviceLocator is the narrow device-lookup port L2 path tracing needs from the
+// wired collector. The concrete collector (now in internal/discovery/enumerate)
+// satisfies it, so L2PathBuilder stays kernel-resident without importing the
+// enumerate stage (which would invert the kernel→stage direction).
+type DeviceLocator interface {
+	GetDeviceByIP(ip string) *DiscoveredDevice
+	GetDevices() []*DiscoveredDevice
+}
+
 // L2PathBuilder builds Layer 2 paths between devices using LLDP/CDP and SNMP.
 type L2PathBuilder struct {
-	deviceDiscovery *DeviceDiscovery
+	deviceDiscovery DeviceLocator
 	snmpConfig      *config.SNMPConfig
 }
 
 // NewL2PathBuilder creates a new L2 path builder.
 func NewL2PathBuilder(
-	deviceDiscovery *DeviceDiscovery,
+	deviceDiscovery DeviceLocator,
 	snmpConfig *config.SNMPConfig,
 ) *L2PathBuilder {
 	return &L2PathBuilder{

--- a/internal/discovery/registry.go
+++ b/internal/discovery/registry.go
@@ -227,7 +227,7 @@ func (r *DeviceRegistry) mergeNetworkIdentifiers(
 
 	// Add IPv6 addresses (merge, don't replace)
 	for _, addr := range incoming.IPv6Addresses {
-		if !containsIPv6(existing.IPv6Addresses, addr) {
+		if !slices.Contains(existing.IPv6Addresses, addr) {
 			existing.IPv6Addresses = append(existing.IPv6Addresses, addr)
 			changes["ipv6Addresses"] = existing.IPv6Addresses
 		}
@@ -254,7 +254,7 @@ func (r *DeviceRegistry) mergeDeviceMetadata(
 
 	// Merge discovery methods
 	for _, method := range incoming.DiscoveryMethod {
-		if !containsMethod(existing.DiscoveryMethod, method) {
+		if !slices.Contains(existing.DiscoveryMethod, method) {
 			existing.DiscoveryMethod = append(existing.DiscoveryMethod, method)
 			changes["discoveryMethod"] = existing.DiscoveryMethod
 		}


### PR DESCRIPTION
Complete ADR-0018 Phase 6 by moving the wired/active host-discovery collector
cluster from the discovery kernel into internal/discovery/enumerate, behind the
Engine's WiredCollectorPort. This is the last and largest enumerate relocation;
the kernel is now collector-free (registry, events, Engine, stage ports,
DiscoveredDevice data types, and the DeviceProfiler/SNMP cluster remain).

Moved (git mv + repackage): devices{,_scan,_copy}.go, arp{,_darwin,_linux,
_windows}.go, icmp.go, ndp_{darwin,linux,windows}.go, lldp.go, cdp.go, edp.go,
wol.go, manager.go (with the Neighbor + Protocol types), protocol_capture.go,
options.go, and service.go. Service moves too — it co-owns DeviceDiscovery and
reaches its unexported protoManager, so it cannot stay kernel-side once the
collector leaves; in enumerate it still reaches kernel.DeviceProfiler (allowed
stage->kernel direction). enumerate/wired_aliases.go aliases the kernel data
types the collector references; kernel functions (NewDeviceProfiler, NewMetrics,
RetryWithBackoff, ...) are called qualified to avoid package-level func aliases.

Kept kernel-resident:
- l2path.go behind a new narrow DeviceLocator port (GetDeviceByIP/GetDevices) so
  it tolerates the now-enumerate collector without a direction violation and the
  api (handlers_path.go) is untouched.
- containsIPv6/containsMethod inlined to slices.Contains at the registry call
  sites (removed the trivial wrappers); the wired impl-tuning + MAC-parse consts
  moved out of devices_types.go into enumerate (collector-only).

Consumers re-pointed (no handler-file churn): internal/api server.go/services.go/
server_init.go/broadcast.go/jobs_{vuln,devices}.go, internal/diagnostics/gateway,
cmd/seed/cmd_serve.go. Test layer split: the ARPScanner/DeviceDiscovery/Manager
accessors moved to enumerate/export_test.go; arp/manager/utils/discovery/devices
tests moved to enumerate_test; the duplicate isLocallyAdministeredMAC tests merged
into one enumerate test. depguard already direction-locks enumerate; build is
green on darwin/linux/windows, golden byte-identical, lint clean.
