### PR TITLE
ci(release-please): honor pre-major bump config; force next release to 0.211.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,7 +50,13 @@ jobs:
           # secret isn't set, so the workflow doesn't break if the PAT
           # expires before being renewed (cascade is lost until renewed).
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          release-type: go
+          # NOTE: do NOT pass release-type here. It is declared per-package in
+          # release-please-config.json (release-type: go). Passing it as a direct
+          # action input forces a mode that ignores the config-file's per-package
+          # options — including bump-minor-pre-major / bump-patch-for-minor-pre-major
+          # — which made release-please propose a 1.0.0 major bump off a pre-1.0
+          # breaking change. We are pre-alpha and stay on 0.x; the config governs
+          # versioning. (seed #1602)
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 


### PR DESCRIPTION
release-please kept proposing a 1.0.0 major bump off the pre-1.0 wi-fi camelCase
breaking change (#1602), ignoring bump-minor-pre-major. Root cause: the workflow
passed release-type: go as a direct action input alongside config-file +
manifest-file, which makes the action ignore the config-file's per-package bump
options. Removed the redundant direct input (release-type is already declared in
release-please-config.json) so the config governs versioning and breaking changes
bump the 0.x minor, not the major.

We are pre-alpha and stay on 0.x. The footer below forces the immediate next
release to 0.211.0 regardless, so #1602's spurious 1.0.0 is superseded.

Release-As: 0.211.0
