### PR TITLE
refactor(api)!: camelcase the mfa + auth-login apis (no grandfathering)

### DIFF
--- a/docs/schemas/api/login-response.schema.json
+++ b/docs/schemas/api/login-response.schema.json
@@ -11,10 +11,10 @@
         "expires": {
           "type": "integer"
         },
-        "mfa_required": {
+        "mfaRequired": {
           "type": "boolean"
         },
-        "mfa_token": {
+        "mfaToken": {
           "type": "string"
         }
       },

--- a/internal/api/handlers_auth.go
+++ b/internal/api/handlers_auth.go
@@ -39,8 +39,8 @@ type LoginRequest struct {
 type LoginResponse struct {
 	Token       string `json:"token,omitempty"`
 	Expires     int64  `json:"expires,omitempty"`
-	MFARequired bool   `json:"mfa_required,omitempty"`
-	MFAToken    string `json:"mfa_token,omitempty"`
+	MFARequired bool   `json:"mfaRequired,omitempty"`
+	MFAToken    string `json:"mfaToken,omitempty"`
 }
 
 // handleLoginRateLimited checks and handles rate limiting, returns true if blocked.

--- a/internal/api/handlers_mfa.go
+++ b/internal/api/handlers_mfa.go
@@ -195,8 +195,8 @@ func recordMFAAuditEvent(
 // <img src="data:image/png;base64,..." />.
 type totpSetupResponse struct {
 	Secret          string `json:"secret"`
-	ProvisioningURI string `json:"provisioning_uri"`
-	QRCodePNGBase64 string `json:"qr_code_png_base64"`
+	ProvisioningURI string `json:"provisioningUri"`
+	QRCodePNGBase64 string `json:"qrCodePngBase64"`
 }
 
 // handleTOTPSetup generates a fresh TOTP secret for the authenticated
@@ -393,8 +393,8 @@ func (s *Server) handleTOTPDisable(w http.ResponseWriter, r *http.Request) {
 
 // totpLoginRequest is the body for POST /api/v1/auth/login/totp.
 type totpLoginRequest struct {
-	MFAToken string `json:"mfa_token" validate:"required"`
-	Code     string `json:"code"      validate:"required,numeric,len=6"`
+	MFAToken string `json:"mfaToken" validate:"required"`
+	Code     string `json:"code"     validate:"required,numeric,len=6"`
 }
 
 // handleLoginTOTP trades an mfa_pending token + a valid TOTP code for
@@ -800,9 +800,9 @@ func (s *Server) handleWebAuthnLoginFinish(w http.ResponseWriter, r *http.Reques
 
 // mfaStatusResponse is returned by GET /api/v1/auth/mfa/status.
 type mfaStatusResponse struct {
-	TOTPEnabled       bool `json:"totp_enabled"`
-	WebAuthnEnabled   bool `json:"webauthn_enabled"`
-	WebAuthnCredCount int  `json:"webauthn_credential_count"`
+	TOTPEnabled       bool `json:"totpEnabled"`
+	WebAuthnEnabled   bool `json:"webauthnEnabled"`
+	WebAuthnCredCount int  `json:"webauthnCredentialCount"`
 }
 
 // handleMFAStatus returns a compact MFA enrolment summary for the UI.

--- a/internal/api/handlers_mfa_test.go
+++ b/internal/api/handlers_mfa_test.go
@@ -130,8 +130,8 @@ func TestTOTPEnrollmentFlow(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, "setup body: %s", w.Body.String())
 	var setupResp struct {
 		Secret          string `json:"secret"`
-		ProvisioningURI string `json:"provisioning_uri"`
-		QRCodePNGBase64 string `json:"qr_code_png_base64"`
+		ProvisioningURI string `json:"provisioningUri"`
+		QRCodePNGBase64 string `json:"qrCodePngBase64"`
 	}
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&setupResp))
 	assert.NotEmpty(t, setupResp.Secret)
@@ -162,8 +162,8 @@ func TestTOTPEnrollmentFlow(t *testing.T) {
 
 	// 5. POST the code to /login/totp and expect a real token
 	w = f.post(t, "/api/v1/auth/login/totp", map[string]string{
-		"mfa_token": loginResp.MFAToken,
-		"code":      codeNow(t, setupResp.Secret),
+		"mfaToken": loginResp.MFAToken,
+		"code":     codeNow(t, setupResp.Secret),
 	}, "")
 	require.Equal(t, http.StatusOK, w.Code, "login/totp body: %s", w.Body.String())
 	var final api.LoginResponse
@@ -194,8 +194,8 @@ func TestLoginTOTP_BadMFAToken(t *testing.T) {
 	f := newMFAFixture(t)
 
 	w := f.post(t, "/api/v1/auth/login/totp", map[string]string{
-		"mfa_token": "not-a-real-jwt",
-		"code":      "123456",
+		"mfaToken": "not-a-real-jwt",
+		"code":     "123456",
 	}, "")
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
@@ -266,9 +266,9 @@ func TestMFAStatus(t *testing.T) {
 	f.handler.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 	var status struct {
-		TOTPEnabled       bool `json:"totp_enabled"`
-		WebAuthnEnabled   bool `json:"webauthn_enabled"`
-		WebAuthnCredCount int  `json:"webauthn_credential_count"`
+		TOTPEnabled       bool `json:"totpEnabled"`
+		WebAuthnEnabled   bool `json:"webauthnEnabled"`
+		WebAuthnCredCount int  `json:"webauthnCredentialCount"`
 	}
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&status))
 	assert.False(t, status.TOTPEnabled)

--- a/scripts/json-casing-baseline.txt
+++ b/scripts/json-casing-baseline.txt
@@ -1,11 +1,3 @@
-internal/api/handlers_auth.go	mfa_required
-internal/api/handlers_auth.go	mfa_token
-internal/api/handlers_mfa.go	mfa_token
-internal/api/handlers_mfa.go	provisioning_uri
-internal/api/handlers_mfa.go	qr_code_png_base64
-internal/api/handlers_mfa.go	totp_enabled
-internal/api/handlers_mfa.go	webauthn_credential_count
-internal/api/handlers_mfa.go	webauthn_enabled
 internal/api/handlers_oauth.go	client_id
 internal/api/handlers_oauth.go	client_secret
 internal/api/handlers_oauth.go	redirect_url

--- a/ui/src/components/cards/MfaCard.tsx
+++ b/ui/src/components/cards/MfaCard.tsx
@@ -27,16 +27,16 @@ import { Shield } from '../ui/icons';
 
 /** Backend response shape for GET /api/v1/auth/mfa/status. */
 interface MfaStatus {
-  totp_enabled: boolean;
-  webauthn_enabled: boolean;
-  webauthn_credential_count: number;
+  totpEnabled: boolean;
+  webauthnEnabled: boolean;
+  webauthnCredentialCount: number;
 }
 
 /** Backend response shape for POST /api/v1/auth/totp/setup. */
 interface TotpSetup {
   secret: string;
-  provisioning_uri: string;
-  qr_code_png_base64: string;
+  provisioningUri: string;
+  qrCodePngBase64: string;
 }
 
 export function MfaCard(): JSX.Element {
@@ -115,13 +115,13 @@ export function MfaCard(): JSX.Element {
     if (!status) {
       return t('mfa.loading', 'Loading…');
     }
-    if (status.totp_enabled && status.webauthn_enabled) {
+    if (status.totpEnabled && status.webauthnEnabled) {
       return t('mfa.bothEnabled', 'TOTP + Passkey enabled');
     }
-    if (status.totp_enabled) {
+    if (status.totpEnabled) {
       return t('mfa.totpEnabled', 'TOTP enabled');
     }
-    if (status.webauthn_enabled) {
+    if (status.webauthnEnabled) {
       return t('mfa.passkeyEnabled', 'Passkey enabled');
     }
     return t('mfa.none', 'No second factor enrolled');
@@ -131,13 +131,13 @@ export function MfaCard(): JSX.Element {
     <Card
       title={t('mfa.title', 'Multi-factor authentication')}
       icon={<Shield className={iconTokens.size.md} />}
-      status={status?.totp_enabled || status?.webauthn_enabled ? 'success' : 'unknown'}
+      status={status?.totpEnabled || status?.webauthnEnabled ? 'success' : 'unknown'}
     >
       <div className="stack-sm">
         <p className="body-small text-text-muted">{statusLine}</p>
         {error ? <p className="body-small text-status-error">{error}</p> : null}
 
-        {!(status?.totp_enabled || setup) ? (
+        {!(status?.totpEnabled || setup) ? (
           <button
             type="button"
             className="btn btn-secondary"
@@ -154,7 +154,7 @@ export function MfaCard(): JSX.Element {
           <div className="stack-sm">
             <img
               alt={t('mfa.qrAlt', 'TOTP QR code')}
-              src={`data:image/png;base64,${setup.qr_code_png_base64}`}
+              src={`data:image/png;base64,${setup.qrCodePngBase64}`}
               width={200}
               height={200}
             />

--- a/ui/src/types/generated/login-response.ts
+++ b/ui/src/types/generated/login-response.ts
@@ -8,6 +8,6 @@
 export interface LoginResponse {
   token?: string;
   expires?: number;
-  mfa_required?: boolean;
-  mfa_token?: string;
+  mfaRequired?: boolean;
+  mfaToken?: string;
 }


### PR DESCRIPTION
De-grandfather the last OURS API snake_case surface (8 keys): the MFA status +
TOTP-enroll responses (handlers_mfa.go: totpEnabled, webauthnEnabled,
webauthnCredentialCount, provisioningUri, qrCodePngBase64, mfaToken) and the login
response's MFA challenge fields (handlers_auth.go: mfaRequired, mfaToken).

Regenerated the login-response schema + generated TS type. Updated the hand-written
MfaCard.tsx interfaces + reads in lockstep; the login/TOTP flow consumes the
mfaRequired/mfaToken challenge via the generated types (no direct snake reads in
UI). tsc/biome clean; golden + schema/types drift green. Baseline drops all 8 keys,
zero added.

Owner directive: zero grandfathering, pre-alpha so breaking is fine. This clears
the OURS API keys; what remains in the baseline is external-protocol (Apple
system_profiler, OAuth, CVSS) which stays snake_case by design, plus the local
CVE-database file format — to be handled as external boundaries, not camelCased.

BREAKING CHANGE: the MFA (/api/v1 mfa) and auth-login responses now use camelCase
json keys (totpEnabled, provisioningUri, qrCodePngBase64, mfaRequired, mfaToken,
etc.) instead of snake_case. Pre-1.0, no external consumers; the bundled UI is
updated in lockstep.
