### PR TITLE
refactor!: camelcase the sso-config + cve-db apis; finish OUR de-grandfathering

### DIFF
--- a/internal/api/handlers_oauth.go
+++ b/internal/api/handlers_oauth.go
@@ -513,10 +513,10 @@ func (s *Server) handleSSOSettings(w http.ResponseWriter, r *http.Request) {
 type ssoUpdateRequest struct {
 	Provider     string   `json:"provider"`
 	Enabled      bool     `json:"enabled"`
-	ClientID     string   `json:"client_id"`
-	ClientSecret string   `json:"client_secret"`
-	RedirectURL  string   `json:"redirect_url"`
-	TenantID     string   `json:"tenant_id,omitempty"`
+	ClientID     string   `json:"clientId"`
+	ClientSecret string   `json:"clientSecret"`
+	RedirectURL  string   `json:"redirectUrl"`
+	TenantID     string   `json:"tenantId,omitempty"`
 	Scopes       []string `json:"scopes,omitempty"`
 }
 

--- a/internal/discovery/vuln/cve_local.go
+++ b/internal/discovery/vuln/cve_local.go
@@ -33,7 +33,7 @@ type localCVEEntry struct {
 	ID          string   `json:"id"`
 	Description string   `json:"description"`
 	Severity    string   `json:"severity"`
-	CVSSScore   float64  `json:"cvss_score"`
+	CVSSScore   float64  `json:"cvssScore"`
 	Published   string   `json:"published"`
 	Modified    string   `json:"modified"`
 	References  []string `json:"references"`
@@ -46,7 +46,7 @@ type localCVEEntry struct {
 // localCVEDatabase represents the structure of the local CVE JSON file.
 type localCVEDatabase struct {
 	Version     string          `json:"version"`
-	LastUpdated string          `json:"last_updated"`
+	LastUpdated string          `json:"lastUpdated"`
 	CVEs        []localCVEEntry `json:"cves"`
 }
 

--- a/scripts/check-json-casing.sh
+++ b/scripts/check-json-casing.sh
@@ -3,20 +3,26 @@
 #
 # ADR-0010: JSON API wire tags are camelCase. The config-file format
 # (internal/config) and SQL columns are snake_case by design and are NOT
-# scanned here. Protocol-mandated keys (OAuth client_id, etc.) keep their spec
-# casing and are grandfathered via the baseline.
+# scanned here.
+#
+# All of OUR own wire/domain tags are now camelCase (the Phase-8 normalization
+# is complete). The baseline is therefore NOT a debt list — it is an
+# EXTERNAL-BOUNDARY allow-list: the only remaining entries are the macOS
+# `system_profiler SPBluetoothDataType -json` keys that bluetooth_darwin.go
+# unmarshals verbatim (device_address, controller_state, …). Those keys are
+# Apple's external contract; matching the struct tags to them is the correct,
+# best-practice way to parse the OS tool's output, so they stay snake_case by
+# design. Do NOT add OUR keys here — fix the casing instead.
 #
 # This gate scans `json:"..."` struct tags in internal/api + internal/discovery
-# for snake_case keys and compares them to a committed baseline
+# for snake_case keys and compares them to the committed allow-list
 # (scripts/json-casing-baseline.txt). It is a RATCHET:
-#   - it FAILS if a NEW snake_case tag appears that is not in the baseline
+#   - it FAILS if a NEW snake_case tag appears that is not in the allow-list
 #     (i.e. new drift), and
 #   - it passes when violations only shrink.
-# Phase 8 normalizes the baselined tags to camelCase, regenerating the baseline
-# (smaller) each step until it is empty.
 #
-# Regenerate the baseline after cleaning (or to grandfather a legitimate
-# protocol key):  scripts/check-json-casing.sh --update
+# Regenerate the allow-list only when adding a genuinely-external contract key:
+#   scripts/check-json-casing.sh --update
 #
 # Run locally: scripts/check-json-casing.sh
 set -euo pipefail
@@ -61,6 +67,7 @@ if [[ -n "$new" ]]; then
 	exit 1
 fi
 
-# Informational: how much of the baseline remains to normalize.
+# Informational: size of the external-boundary allow-list (macOS system_profiler
+# keys). This is no longer "debt to normalize" — our own tags are all camelCase.
 remaining=$(current_violations | comm -12 - <(sort -u "$BASELINE") | wc -l | tr -d ' ')
-echo "JSON casing gate OK — no new snake_case wire tags. ${remaining} baselined tag(s) remain to normalize (ADR-0010 / Phase 8)."
+echo "JSON casing gate OK — no new snake_case wire tags. ${remaining} external-contract tag(s) on the allow-list (macOS system_profiler; ADR-0010)."

--- a/scripts/json-casing-baseline.txt
+++ b/scripts/json-casing-baseline.txt
@@ -1,7 +1,3 @@
-internal/api/handlers_oauth.go	client_id
-internal/api/handlers_oauth.go	client_secret
-internal/api/handlers_oauth.go	redirect_url
-internal/api/handlers_oauth.go	tenant_id
 internal/discovery/enumerate/bluetooth_darwin.go	controller_address
 internal/discovery/enumerate/bluetooth_darwin.go	controller_properties
 internal/discovery/enumerate/bluetooth_darwin.go	controller_state
@@ -15,5 +11,3 @@ internal/discovery/enumerate/bluetooth_darwin.go	device_minorType
 internal/discovery/enumerate/bluetooth_darwin.go	device_rssi
 internal/discovery/enumerate/bluetooth_darwin.go	device_services
 internal/discovery/enumerate/bluetooth_darwin.go	devices_not_connected
-internal/discovery/vuln/cve_local.go	cvss_score
-internal/discovery/vuln/cve_local.go	last_updated

--- a/ui/src/components/settings/sections/SsoSettings.tsx
+++ b/ui/src/components/settings/sections/SsoSettings.tsx
@@ -29,10 +29,10 @@ type ProviderName = 'google' | 'microsoft' | 'github';
 interface ProviderConfig {
   name: ProviderName;
   enabled: boolean;
-  client_id: string;
-  client_secret: string;
-  redirect_url: string;
-  tenant_id?: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUrl: string;
+  tenantId?: string;
   scopes?: string[];
 }
 
@@ -41,16 +41,16 @@ interface SettingsResponse {
 }
 
 const PROVIDER_DEFAULTS: Record<ProviderName, ProviderConfig> = {
-  google: { name: 'google', enabled: false, client_id: '', client_secret: '', redirect_url: '' },
+  google: { name: 'google', enabled: false, clientId: '', clientSecret: '', redirectUrl: '' },
   microsoft: {
     name: 'microsoft',
     enabled: false,
-    client_id: '',
-    client_secret: '',
-    redirect_url: '',
-    tenant_id: 'common',
+    clientId: '',
+    clientSecret: '',
+    redirectUrl: '',
+    tenantId: 'common',
   },
-  github: { name: 'github', enabled: false, client_id: '', client_secret: '', redirect_url: '' },
+  github: { name: 'github', enabled: false, clientId: '', clientSecret: '', redirectUrl: '' },
 };
 
 function defaultRedirectUrl(): string {
@@ -63,9 +63,9 @@ export function SsoSettings(): React.ReactElement {
   const { status: licenseStatus } = useLicense();
 
   const [providers, setProviders] = useState<Record<ProviderName, ProviderConfig>>(() => ({
-    google: { ...PROVIDER_DEFAULTS.google, redirect_url: defaultRedirectUrl() },
-    microsoft: { ...PROVIDER_DEFAULTS.microsoft, redirect_url: defaultRedirectUrl() },
-    github: { ...PROVIDER_DEFAULTS.github, redirect_url: defaultRedirectUrl() },
+    google: { ...PROVIDER_DEFAULTS.google, redirectUrl: defaultRedirectUrl() },
+    microsoft: { ...PROVIDER_DEFAULTS.microsoft, redirectUrl: defaultRedirectUrl() },
+    github: { ...PROVIDER_DEFAULTS.github, redirectUrl: defaultRedirectUrl() },
   }));
   const [loading, setLoading] = useState(true);
   const [savingProvider, setSavingProvider] = useState<ProviderName | null>(null);
@@ -116,15 +116,15 @@ export function SsoSettings(): React.ReactElement {
         await api.put('/api/v1/sso/update', {
           provider: cfg.name,
           enabled: cfg.enabled,
-          client_id: cfg.client_id,
-          client_secret: cfg.client_secret,
-          redirect_url: cfg.redirect_url || defaultRedirectUrl(),
-          tenant_id: cfg.tenant_id,
+          clientId: cfg.clientId,
+          clientSecret: cfg.clientSecret,
+          redirectUrl: cfg.redirectUrl || defaultRedirectUrl(),
+          tenantId: cfg.tenantId,
           scopes: cfg.scopes,
         });
         setSaveStatus(t('settings:sso.status.saved', { provider: name }));
         // Wipe the secret input now that it's saved server-side.
-        updateField(name, 'client_secret', '');
+        updateField(name, 'clientSecret', '');
         await refresh();
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to save SSO provider');
@@ -253,8 +253,8 @@ function ProviderCard({
         </label>
         <Input
           id={`sso-${name}-cid`}
-          value={cfg.client_id}
-          onChange={(e) => onChange(name, 'client_id', e.target.value)}
+          value={cfg.clientId}
+          onChange={(e) => onChange(name, 'clientId', e.target.value)}
           disabled={!canEdit || saving}
           data-testid={`sso-client-id-${name}`}
         />
@@ -267,8 +267,8 @@ function ProviderCard({
         <Input
           id={`sso-${name}-cs`}
           type="password"
-          value={cfg.client_secret}
-          onChange={(e) => onChange(name, 'client_secret', e.target.value)}
+          value={cfg.clientSecret}
+          onChange={(e) => onChange(name, 'clientSecret', e.target.value)}
           placeholder={t('settings:sso.fields.clientSecretMask')}
           disabled={!canEdit || saving}
           data-testid={`sso-client-secret-${name}`}
@@ -281,8 +281,8 @@ function ProviderCard({
         </label>
         <Input
           id={`sso-${name}-ru`}
-          value={cfg.redirect_url || defaultRedirectUrl()}
-          onChange={(e) => onChange(name, 'redirect_url', e.target.value)}
+          value={cfg.redirectUrl || defaultRedirectUrl()}
+          onChange={(e) => onChange(name, 'redirectUrl', e.target.value)}
           disabled={!canEdit || saving}
           data-testid={`sso-redirect-${name}`}
         />
@@ -298,8 +298,8 @@ function ProviderCard({
           </label>
           <Input
             id={`sso-${name}-tid`}
-            value={cfg.tenant_id ?? ''}
-            onChange={(e) => onChange(name, 'tenant_id', e.target.value)}
+            value={cfg.tenantId ?? ''}
+            onChange={(e) => onChange(name, 'tenantId', e.target.value)}
             placeholder="common | organizations | <tenant-guid>"
             disabled={!canEdit || saving}
             data-testid={`sso-tenant-${name}`}


### PR DESCRIPTION
Last batch of OUR snake_case wire keys (6): the SSO admin-config request
(handlers_oauth.go ssoUpdateRequest: clientId, clientSecret, redirectUrl,
tenantId — these are OUR admin API, not OAuth-protocol messages to the IdP, which
the oauth package handles separately) and the local CVE-database format
(vuln/cve_local.go: cvssScore, lastUpdated — we own configs/cve-database.json;
no committed db/fixtures to migrate).

Regenerated schemas + TS; updated the hand-written SsoSettings.tsx (interface +
defaults + POST body + onChange field-key strings + value reads) in lockstep.
tsc/biome clean; full api suite (164s) + golden green; schema/types drift green.

This empties OUR debt from the json-casing baseline. The only entries left are the
13 macOS system_profiler keys bluetooth_darwin.go unmarshals — Apple's external
JSON contract, where matching struct tags is the best-practice parse. Reframed the
gate: the baseline is now a documented EXTERNAL-BOUNDARY allow-list, not debt
(updated check-json-casing.sh header + message). No grandfathering of our own keys
remains.

BREAKING CHANGE: the SSO config API (/api/v1 sso update) and the CVE-database file
format now use camelCase keys (clientId, clientSecret, redirectUrl, tenantId,
cvssScore, lastUpdated) instead of snake_case. Pre-1.0, no external consumers.
