### PR TITLE
refactor(api): clean-hexagonal network exemplar + ADR-0020

### DIFF
--- a/docs/architecture/decisions/0020-clean-hexagonal-api-foundation.md
+++ b/docs/architecture/decisions/0020-clean-hexagonal-api-foundation.md
@@ -1,0 +1,140 @@
+# ADR-0020: Clean-hexagonal `internal/api` foundation — domain-meaningful use-case packages, adapters in the composition root
+
+**Status:** Accepted — 2026-06-09
+
+**Refines:** ADR-0016 (strangle `internal/api` into use-cases). ADR-0016 set the
+thin-handler → use-case → encode direction; ADR-0020 locks the package layout,
+naming, and adapter placement that the remaining strangle PRs follow. Where the
+two differ, ADR-0020 wins.
+
+## Context
+
+ADR-0016 introduced per-domain use-case packages but left two things loose, and
+the first implementations drifted as a result:
+
+1. **Package naming.** ADR-0016 §Naming mandated the `<domain>app` suffix
+   (`networkapp`, `wifiapp`, …) purely to dodge an import-alias clash with the
+   `internal/app` composition root. The suffix names the *layer*, not what the
+   package *provides* — the opposite of idiomatic Go (`net/http`, not
+   `net/httplayer`). It was a workaround, not a convention worth keeping.
+
+2. **Adapter placement.** ADR-0016 §Decision rule 4 says the composition root
+   wires the use-cases. In practice the network/settings/profiles/alerts
+   adapters were defined *inside* `internal/api` in `<domain>_usecases.go` files
+   (`networkHardware`, `networkConfigStore`, `initNetworkUseCase`, …). That keeps
+   concrete knowledge of `netif`, the config store, and the database in the
+   transport layer — exactly the coupling the strangle is meant to remove. The
+   Wi-Fi capture/visibility/reporting components, by contrast, are correctly
+   built in `internal/app` and injected. The api-layer wiring was the outlier.
+
+We are pre-alpha (no backwards-compatibility burden, see master CLAUDE.md), so we
+fix the convention now rather than grandfather the drift, and retrofit every
+already-migrated domain to the corrected shape before adding new slices.
+
+## Decision
+
+A migrated domain is laid out in three rings with a single composition seam.
+
+### 1. Feature core — `internal/<domain>/...` (unchanged)
+
+The persistence-free domain logic. No `net/http`, no SQL. Unchanged by the
+strangle.
+
+### 2. Application service + ports — `internal/<domain>/<capability>`
+
+The use-case service and the **consumer-defined ports** it drives live in a
+**domain-meaningful package named for the capability it provides, not the layer**:
+
+- `internal/network/ipconfig` (package `ipconfig`) — IP-configuration + MTU.
+- `internal/discovery/scanning` (package `scanning`) — device discovery.
+- …never `internal/<domain>/usecase` or `internal/<domain>/app`.
+
+The service type de-stutters against its package: `ipconfig.Service`,
+`ipconfig.NewService` — not `ipconfig.IPService`. The ports (`Hardware`,
+`ConfigStore`, …) are declared **here, at the consumer** (interface segregation,
+ADR-0016 rule 3): the service names the small interface it needs; the adapter
+satisfies it. No `net/http`, no SQL, no concrete infra types in this ring.
+
+Because the package is named for its capability, the `<domain>app` alias hack is
+gone: `internal/app` imports `ipconfig`, `scanning`, … with no alias collision.
+
+### 3. Adapters — the composition root `internal/app` (package `app`)
+
+Infra adapters that satisfy the consumer-defined ports live in the composition
+root **by default**. `internal/app` is the one layer that legitimately knows
+every concrete (`netif.Manager`, the config store, the database, the engines), so
+it is where port-to-concrete glue belongs. The root exposes one constructor per
+use-case that builds the adapters and assembles the service:
+
+```go
+// internal/app/network.go
+func NewNetworkIP(mgr func() *netif.Manager, cfg *config.Config, path string) *ipconfig.Service {
+    return ipconfig.NewService(networkHardware{mgr: mgr}, networkConfigStore{cfg: cfg, path: path})
+}
+```
+
+Promote an adapter to its own `internal/<domain>/<infra>` package **only** when it
+is substantial or reused (e.g. `internal/reporting/store`). There is no generic
+`adapter` package and no per-domain adapter package for thin glue — that was
+considered (Option 1) and rejected as over-packaging.
+
+### 4. Transport — `internal/api` is pure transport
+
+Handlers decode the request → call **one** use-case method → encode the result,
+mapping domain sentinels to HTTP status. `internal/api` holds **no adapter
+definitions and no `<domain>_usecases.go` files.** It imports `internal/app` and
+invokes the root's constructors, passing its own lazy accessors, then stores the
+returned service on `Server`:
+
+```go
+s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)
+```
+
+`s.netManager` is a method value that reads `s.services.Network.Manager`, so a
+manager set or replaced after construction (the test harness does this) is
+honored — the lazy seam that previously justified building in-package is
+preserved without keeping the adapters in `internal/api`. `internal/app` never
+imports `internal/api`; the dependency edge is one-way (`api → app`), matching the
+existing `cmd/seed → app` wiring.
+
+### 5. Security policy stays at the registry edge (unchanged, load-bearing)
+
+Authorization, CSRF, and rate-limiting stay where ADR-0002 puts them —
+`methodGate` / `writeGated` / `requireRole` / `requireFeature` at route
+registration. The strangle **must not** move policy into use-cases or weaken any
+Wave-4/5 invariant. Each PR verifies the route-policy manifest is byte-identical
+(`scripts/check-route-policy.sh`) and output escaping is intact
+(`scripts/check-output-escaping.sh`).
+
+### 6. Goldens are a reviewed change-gate, not a freeze
+
+`TestGoldenHTTP*` stays byte-identical across a structural move. Because we carry
+no backwards-compatibility burden pre-v1.0.0, a genuinely wrong status code or
+response shape *is* fixed when found — but every golden diff is reviewed and
+intended, never blindly re-baselined to lock in cruft.
+
+## Consequences
+
+- **Positive:** package names read as capabilities; the transport layer is free
+  of infra knowledge; adapters live in the one place allowed to know concretes;
+  the `<domain>app` alias hack disappears; the layout is uniform across domains.
+- **Cost:** every already-migrated domain (network, alerts, settings, profiles,
+  wifi) is retrofitted to the corrected shape — mechanical, golden-pinned PRs.
+- **Edge:** `internal/api → internal/app` is a new, intentional import. It is
+  acyclic (the root never imports transport) and is the minimal seam that
+  preserves the lazy-manager resolution the test harness relies on.
+
+## Implementation phasing
+
+- **A1 (this ADR's PR) — exemplar: `network`.** Rename `internal/network/app`
+  (`networkapp`) → `internal/network/ipconfig` (`ipconfig`), `IPService` →
+  `Service`; move `networkHardware` + `networkConfigStore` into
+  `internal/app/network.go`; delete `internal/api/network_usecases.go`; api wires
+  via `app.NewNetworkIP`. This is the reference implementation and the
+  directory/naming exemplar.
+- **B1–B4 — retrofit** alerts, settings, profiles, wifi to the same shape.
+- **C1–C4 — new slices** (discovery, health, update, identity) land directly in
+  this shape; identity replaces raw `Database.DB` handler access with repository
+  ports.
+- **D1 — terminal:** when no handler reaches `ServiceContainer`, delete it and the
+  god accessors; mark ADR-0016 Completed and this ADR remains Accepted.

--- a/internal/api/handlers_network.go
+++ b/internal/api/handlers_network.go
@@ -13,7 +13,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/netif"
-	networkapp "github.com/MustardSeedNetworks/seed/internal/network/app"
+	"github.com/MustardSeedNetworks/seed/internal/network/ipconfig"
 	"github.com/MustardSeedNetworks/seed/internal/phy"
 	"github.com/MustardSeedNetworks/seed/internal/validation"
 )
@@ -756,7 +756,7 @@ func (s *Server) handleIPSettingsPut(
 	}
 
 	iface := s.getInterfaceFromRequest(r)
-	err := s.networkIP.Apply(iface, req.Mode, networkapp.StaticIP{
+	err := s.networkIP.Apply(iface, req.Mode, ipconfig.StaticIP{
 		Address: req.Address, Netmask: req.Netmask, Gateway: req.Gateway, DNS: req.DNS,
 	})
 	if err != nil {
@@ -782,16 +782,16 @@ func (s *Server) writeIPApplyError(
 	err error,
 ) {
 	switch {
-	case errors.Is(err, networkapp.ErrInvalidMode):
+	case errors.Is(err, ipconfig.ErrInvalidMode):
 		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
 			ErrCodeValidation, localizer.T("errors.netif.invalidMode"), "")
-	case errors.Is(err, networkapp.ErrStaticConfig):
+	case errors.Is(err, ipconfig.ErrStaticConfig):
 		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
 			ErrCodeInternal, localizer.T("errors.netif.staticConfigFailed"), "")
-	case errors.Is(err, networkapp.ErrDHCPConfig):
+	case errors.Is(err, ipconfig.ErrDHCPConfig):
 		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
 			ErrCodeInternal, localizer.T("errors.netif.dhcpConfigFailed"), "")
-	case errors.Is(err, networkapp.ErrSave):
+	case errors.Is(err, ipconfig.ErrSave):
 		logger.ErrorContext(r.Context(), "Failed to save config", "error", err)
 		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
 			ErrCodeInternal, localizer.T("errors.config.failedToSave"), "")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -15,6 +15,7 @@ import (
 
 	alertsapp "github.com/MustardSeedNetworks/seed/internal/alerts/app"
 	alertpipeline "github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
+	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/auth"
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
@@ -35,7 +36,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/mibdb"
 	"github.com/MustardSeedNetworks/seed/internal/netif"
-	networkapp "github.com/MustardSeedNetworks/seed/internal/network/app"
+	"github.com/MustardSeedNetworks/seed/internal/network/ipconfig"
 	"github.com/MustardSeedNetworks/seed/internal/oauth"
 	"github.com/MustardSeedNetworks/seed/internal/paths"
 	"github.com/MustardSeedNetworks/seed/internal/pipeline/publicip"
@@ -136,7 +137,7 @@ type Server struct {
 	wifiDiscovery      *wifiapp.Discovery       // Enhanced Wi-Fi discovery use-case (ADR-0016 phase 2)
 	settingsStore      *settingsapp.Persistence // Settings-to-profile persistence use-case (ADR-0016 phase 3)
 	profiles           *profilesapp.Service     // Profile CRUD/active/import use-case (ADR-0016 phase 3)
-	networkIP          *networkapp.IPService    // IP-config + MTU use-case (ADR-0016 phase 3)
+	networkIP          *ipconfig.Service        // IP-config + MTU use-case (ADR-0020)
 	alertRules         *alertsapp.RuleService   // Alert-rule CRUD use-case (ADR-0016)
 	tlsFingerprint     tlsFingerprintCache      // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
@@ -260,8 +261,9 @@ func NewServer(
 	// Wire the profiles use-case (ADR-0016 phase 3), also over the lazy db.
 	s.initProfilesUseCase()
 
-	// Wire the network IP-config + MTU use-case (ADR-0016 phase 3).
-	s.initNetworkUseCase()
+	// Wire the network IP-config + MTU use-case (ADR-0020). The composition root
+	// builds the adapters; api passes its lazy manager accessor + config.
+	s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)
 
 	// Wire the alert-rule use-case (ADR-0016), over the lazy db.
 	s.initAlertsUseCase()

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 
+	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/auth"
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
@@ -153,7 +154,7 @@ func NewTestServerWithConfig(cfg *config.Config) *Server {
 	// depend on them work under the test harness.
 	s.initSettingsUseCase()
 	s.initProfilesUseCase()
-	s.initNetworkUseCase()
+	s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)
 	s.initAlertsUseCase()
 
 	// Setup routes

--- a/internal/app/network.go
+++ b/internal/app/network.go
@@ -1,24 +1,29 @@
-package api
-
-// network_usecases.go wires the API layer to the network application (use-case)
-// service (ADR-0016 strangle phase 3). The adapters implement the narrow
-// networkapp ports over the netif manager and the live config, so the IP-config
-// and MTU handlers depend on a use-case instead of reaching into s.netManager()
-// and s.config directly.
+package app
 
 import (
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/netif"
-	networkapp "github.com/MustardSeedNetworks/seed/internal/network/app"
+	"github.com/MustardSeedNetworks/seed/internal/network/ipconfig"
 )
 
-// networkHardware implements networkapp.Hardware over the netif manager. The
+// NewNetworkIP builds the IP-config + MTU use-case (ADR-0020), assembling the
+// ipconfig ports over the netif manager and the live config. The manager is
+// resolved through mgr on each call so a later-set manager (the api test
+// harness) is honored; cfg/path are fixed for the process lifetime.
+func NewNetworkIP(mgr func() *netif.Manager, cfg *config.Config, path string) *ipconfig.Service {
+	return ipconfig.NewService(
+		networkHardware{mgr: mgr},
+		networkConfigStore{cfg: cfg, path: path},
+	)
+}
+
+// networkHardware implements ipconfig.Hardware over the netif manager. The
 // manager is resolved lazily so a later-set manager (tests) is honored.
 type networkHardware struct {
 	mgr func() *netif.Manager
 }
 
-func (a networkHardware) ConfigureStaticIP(iface string, ip networkapp.StaticIP) error {
+func (a networkHardware) ConfigureStaticIP(iface string, ip ipconfig.StaticIP) error {
 	return a.mgr().ConfigureStaticIP(iface, &netif.StaticIPConfig{
 		Address: ip.Address,
 		Netmask: ip.Netmask,
@@ -34,18 +39,18 @@ func (a networkHardware) SetMTU(iface string, mtu int) error {
 func (a networkHardware) CurrentInterface() string { return a.mgr().GetCurrentInterface() }
 func (a networkHardware) RefreshInterfaces() error { return a.mgr().RefreshInterfaces() }
 
-// networkConfigStore implements networkapp.ConfigStore over the live config,
+// networkConfigStore implements ipconfig.ConfigStore over the live config,
 // owning the lock + on-disk save the port abstracts away.
 type networkConfigStore struct {
 	cfg  *config.Config
 	path string
 }
 
-func (c networkConfigStore) IPSettings() networkapp.Settings {
+func (c networkConfigStore) IPSettings() ipconfig.Settings {
 	c.cfg.RLock()
 	defer c.cfg.RUnlock()
 
-	s := networkapp.Settings{Mode: c.cfg.IP.Mode}
+	s := ipconfig.Settings{Mode: c.cfg.IP.Mode}
 	if c.cfg.IP.Static != nil {
 		s.Address = c.cfg.IP.Static.Address
 		s.Netmask = c.cfg.IP.Static.Netmask
@@ -55,11 +60,11 @@ func (c networkConfigStore) IPSettings() networkapp.Settings {
 	return s
 }
 
-func (c networkConfigStore) PersistStatic(ip networkapp.StaticIP) error {
+func (c networkConfigStore) PersistStatic(ip ipconfig.StaticIP) error {
 	// Lock for the in-memory mutation only; Save acquires its own RLock and so
 	// must run unlocked to avoid the historic deadlock (fixes #783).
 	c.cfg.Lock()
-	c.cfg.IP.Mode = ipModeStatic
+	c.cfg.IP.Mode = ipconfig.ModeStatic
 	c.cfg.IP.Static = &config.StaticIP{
 		Address: ip.Address,
 		Netmask: ip.Netmask,
@@ -72,16 +77,8 @@ func (c networkConfigStore) PersistStatic(ip networkapp.StaticIP) error {
 
 func (c networkConfigStore) PersistDHCP() error {
 	c.cfg.Lock()
-	c.cfg.IP.Mode = ipModeDHCP
+	c.cfg.IP.Mode = ipconfig.ModeDHCP
 	c.cfg.IP.Static = nil
 	c.cfg.Unlock()
 	return c.cfg.Save(c.path)
-}
-
-// initNetworkUseCase builds the IP-config + MTU use-case (ADR-0016 phase 3).
-func (s *Server) initNetworkUseCase() {
-	s.networkIP = networkapp.NewIPService(
-		networkHardware{mgr: s.netManager},
-		networkConfigStore{cfg: s.config, path: s.configPath},
-	)
 }

--- a/internal/network/ipconfig/ipconfig.go
+++ b/internal/network/ipconfig/ipconfig.go
@@ -1,11 +1,12 @@
-// Package networkapp holds the network application (use-case) layer
-// (ADR-0016 strangle phase 3). It owns the IP-configuration and MTU
-// orchestration that previously lived in the api.Server network handlers —
-// the multi-step "configure the interface, persist the config, refresh"
-// sequence — behind narrow consumer-defined ports over the netif manager and
-// the config store. Handlers keep transport concerns: request decode, input
-// validation, interface-from-query resolution, and localized error mapping.
-package networkapp
+// Package ipconfig holds the network IP-configuration application (use-case)
+// layer (ADR-0020). It owns the IP-configuration and MTU orchestration that
+// previously lived in the api.Server network handlers — the multi-step
+// "configure the interface, persist the config, refresh" sequence — behind
+// narrow consumer-defined ports over the netif manager and the config store.
+// Handlers keep transport concerns: request decode, input validation,
+// interface-from-query resolution, and localized error mapping. The adapters
+// satisfying the ports live in the composition root (internal/app).
+package ipconfig
 
 import "errors"
 
@@ -43,7 +44,7 @@ type Settings struct {
 }
 
 // Hardware is the netif surface the use-case drives, defined at the consumer
-// (ADR-0016) and satisfied by an adapter over *netif.Manager.
+// (ADR-0020) and satisfied by an adapter over *netif.Manager in internal/app.
 type Hardware interface {
 	ConfigureStaticIP(iface string, ip StaticIP) error
 	ConfigureDHCP(iface string) error
@@ -60,19 +61,19 @@ type ConfigStore interface {
 	PersistDHCP() error
 }
 
-// IPService is the IP-configuration + MTU use-case.
-type IPService struct {
+// Service is the IP-configuration + MTU use-case.
+type Service struct {
 	hw    Hardware
 	store ConfigStore
 }
 
-// NewIPService builds the use-case over its narrow dependencies.
-func NewIPService(hw Hardware, store ConfigStore) *IPService {
-	return &IPService{hw: hw, store: store}
+// NewService builds the use-case over its narrow dependencies.
+func NewService(hw Hardware, store ConfigStore) *Service {
+	return &Service{hw: hw, store: store}
 }
 
 // Settings returns the current IP configuration.
-func (s *IPService) Settings() Settings {
+func (s *Service) Settings() Settings {
 	return s.store.IPSettings()
 }
 
@@ -80,7 +81,7 @@ func (s *IPService) Settings() Settings {
 // config, then refreshes the interface table. Hardware configuration runs first
 // so the persisted config only changes after the interface accepts it; each step
 // maps to its own sentinel for faithful handler error mapping.
-func (s *IPService) Apply(iface, mode string, ip StaticIP) error {
+func (s *Service) Apply(iface, mode string, ip StaticIP) error {
 	switch mode {
 	case ModeStatic:
 		if err := s.hw.ConfigureStaticIP(iface, ip); err != nil {
@@ -109,7 +110,7 @@ func (s *IPService) Apply(iface, mode string, ip StaticIP) error {
 // SetMTU sets the interface MTU, defaulting to the current interface when iface
 // is empty, and refreshes interfaces best-effort. It returns the resolved
 // interface name so the handler can echo it.
-func (s *IPService) SetMTU(iface string, mtu int) (string, error) {
+func (s *Service) SetMTU(iface string, mtu int) (string, error) {
 	if iface == "" {
 		iface = s.hw.CurrentInterface()
 	}

--- a/internal/network/ipconfig/ipconfig_test.go
+++ b/internal/network/ipconfig/ipconfig_test.go
@@ -1,10 +1,10 @@
-package networkapp_test
+package ipconfig_test
 
 import (
 	"errors"
 	"testing"
 
-	networkapp "github.com/MustardSeedNetworks/seed/internal/network/app"
+	"github.com/MustardSeedNetworks/seed/internal/network/ipconfig"
 )
 
 type fakeHW struct {
@@ -15,7 +15,7 @@ type fakeHW struct {
 	refreshed                              int
 }
 
-func (h *fakeHW) ConfigureStaticIP(iface string, _ networkapp.StaticIP) error {
+func (h *fakeHW) ConfigureStaticIP(iface string, _ ipconfig.StaticIP) error {
 	h.staticIface = iface
 	return h.staticErr
 }
@@ -30,14 +30,14 @@ func (h *fakeHW) CurrentInterface() string { return h.current }
 func (h *fakeHW) RefreshInterfaces() error { h.refreshed++; return h.refreshErr }
 
 type fakeStore struct {
-	settings    networkapp.Settings
+	settings    ipconfig.Settings
 	persisted   string // "static" | "dhcp"
 	persistErr  error
-	persistedIP networkapp.StaticIP
+	persistedIP ipconfig.StaticIP
 }
 
-func (s *fakeStore) IPSettings() networkapp.Settings { return s.settings }
-func (s *fakeStore) PersistStatic(ip networkapp.StaticIP) error {
+func (s *fakeStore) IPSettings() ipconfig.Settings { return s.settings }
+func (s *fakeStore) PersistStatic(ip ipconfig.StaticIP) error {
 	s.persisted, s.persistedIP = "static", ip
 	return s.persistErr
 }
@@ -45,9 +45,9 @@ func (s *fakeStore) PersistDHCP() error { s.persisted = "dhcp"; return s.persist
 
 func TestApplyStaticHappyPath(t *testing.T) {
 	hw, store := &fakeHW{}, &fakeStore{}
-	svc := networkapp.NewIPService(hw, store)
+	svc := ipconfig.NewService(hw, store)
 
-	err := svc.Apply("eth0", networkapp.ModeStatic, networkapp.StaticIP{Address: "10.0.0.5"})
+	err := svc.Apply("eth0", ipconfig.ModeStatic, ipconfig.StaticIP{Address: "10.0.0.5"})
 	if err != nil {
 		t.Fatalf("apply static: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestApplyStaticHappyPath(t *testing.T) {
 
 func TestApplyDHCPHappyPath(t *testing.T) {
 	hw, store := &fakeHW{}, &fakeStore{}
-	if err := networkapp.NewIPService(hw, store).Apply("eth1", networkapp.ModeDHCP, networkapp.StaticIP{}); err != nil {
+	if err := ipconfig.NewService(hw, store).Apply("eth1", ipconfig.ModeDHCP, ipconfig.StaticIP{}); err != nil {
 		t.Fatalf("apply dhcp: %v", err)
 	}
 	if hw.dhcpIface != "eth1" || store.persisted != "dhcp" || hw.refreshed != 1 {
@@ -82,39 +82,39 @@ func TestApplyErrorMapping(t *testing.T) {
 		mode string
 		want error
 	}{
-		{"invalid mode", &fakeHW{}, &fakeStore{}, "bogus", networkapp.ErrInvalidMode},
+		{"invalid mode", &fakeHW{}, &fakeStore{}, "bogus", ipconfig.ErrInvalidMode},
 		{
 			"static hw fails",
 			&fakeHW{staticErr: errors.New("x")},
 			&fakeStore{},
-			networkapp.ModeStatic,
-			networkapp.ErrStaticConfig,
+			ipconfig.ModeStatic,
+			ipconfig.ErrStaticConfig,
 		},
 		{
 			"dhcp hw fails",
 			&fakeHW{dhcpErr: errors.New("x")},
 			&fakeStore{},
-			networkapp.ModeDHCP,
-			networkapp.ErrDHCPConfig,
+			ipconfig.ModeDHCP,
+			ipconfig.ErrDHCPConfig,
 		},
 		{
 			"persist fails",
 			&fakeHW{},
 			&fakeStore{persistErr: errors.New("x")},
-			networkapp.ModeStatic,
-			networkapp.ErrSave,
+			ipconfig.ModeStatic,
+			ipconfig.ErrSave,
 		},
 		{
 			"refresh fails",
 			&fakeHW{refreshErr: errors.New("x")},
 			&fakeStore{},
-			networkapp.ModeStatic,
-			networkapp.ErrRefresh,
+			ipconfig.ModeStatic,
+			ipconfig.ErrRefresh,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := networkapp.NewIPService(tc.hw, tc.st).Apply("eth0", tc.mode, networkapp.StaticIP{})
+			err := ipconfig.NewService(tc.hw, tc.st).Apply("eth0", tc.mode, ipconfig.StaticIP{})
 			if !errors.Is(err, tc.want) {
 				t.Fatalf("want %v, got %v", tc.want, err)
 			}
@@ -124,7 +124,7 @@ func TestApplyErrorMapping(t *testing.T) {
 
 func TestApplyDoesNotPersistWhenHardwareFails(t *testing.T) {
 	hw, store := &fakeHW{staticErr: errors.New("nope")}, &fakeStore{}
-	_ = networkapp.NewIPService(hw, store).Apply("eth0", networkapp.ModeStatic, networkapp.StaticIP{})
+	_ = ipconfig.NewService(hw, store).Apply("eth0", ipconfig.ModeStatic, ipconfig.StaticIP{})
 	if store.persisted != "" {
 		t.Fatalf("config must not be persisted when hardware config fails, got %q", store.persisted)
 	}
@@ -132,7 +132,7 @@ func TestApplyDoesNotPersistWhenHardwareFails(t *testing.T) {
 
 func TestSetMTUResolvesCurrentInterface(t *testing.T) {
 	hw := &fakeHW{current: "wlan0"}
-	got, err := networkapp.NewIPService(hw, &fakeStore{}).SetMTU("", 9000)
+	got, err := ipconfig.NewService(hw, &fakeStore{}).SetMTU("", 9000)
 	if err != nil {
 		t.Fatalf("set mtu: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestSetMTUResolvesCurrentInterface(t *testing.T) {
 
 func TestSetMTUError(t *testing.T) {
 	hw := &fakeHW{mtuErr: errors.New("eio")}
-	if _, err := networkapp.NewIPService(hw, &fakeStore{}).SetMTU("eth0", 1500); !errors.Is(err, networkapp.ErrSetMTU) {
+	if _, err := ipconfig.NewService(hw, &fakeStore{}).SetMTU("eth0", 1500); !errors.Is(err, ipconfig.ErrSetMTU) {
 		t.Fatalf("want ErrSetMTU, got %v", err)
 	}
 }


### PR DESCRIPTION
## What

Phase A1 of the `internal/api` clean-hexagonal strangle (D2 plan). Records the owner-locked convention as **ADR-0020** (refines ADR-0016) and converts the **network** domain as the reference implementation every later slice follows.

## Changes

- **ADR-0020** — locks: domain-meaningful use-case package names (named for the capability, not the layer), consumer-defined ports in that package, **infra adapters in the composition root `internal/app`**, `internal/api` as pure transport (no adapters, no `*_usecases.go`), security policy stays at the registry edge, goldens are a reviewed change-gate.
- **Rename** `internal/network/app` (pkg `networkapp`) → `internal/network/ipconfig` (pkg `ipconfig`); `IPService` → `Service` (de-stuttered). Kills the `<domain>app` alias hack.
- **Move adapters** `networkHardware` + `networkConfigStore` out of `internal/api/network_usecases.go` into `internal/app/network.go` behind `app.NewNetworkIP(...)`; **delete** `network_usecases.go`.
- **`internal/api`** wires via `app.NewNetworkIP(s.netManager, s.config, s.configPath)` in both `NewServer` and the test harness. `handlers_network.go` stays thin.

The `api → app` import is one-way (the composition root never imports transport) and preserves the lazy `netManager` resolution the test harness relies on.

## Verification (run locally, alone)

- `go build ./...` → exit 0
- `golangci-lint run ./internal/...` → 0 issues in changed/new files (4 gofumpt flags are in untouched test files, local v2.12.2 vs CI-pinned v2.12.1 drift; clean under the pinned version)
- `go test ./internal/network/ipconfig/` → ok · `go test ./internal/api/ -count=1` → **ok** (71.2s)
- Goldens byte-identical (no golden file in the diff)
- `scripts/check-route-policy.sh` ✓ · `scripts/check-output-escaping.sh` ✓

## Follow-ups (D2 plan)

B1–B4 retrofit alerts/settings/profiles/wifi to this shape; C1–C4 new slices; D1 deletes `ServiceContainer`.