### PR TITLE
refactor(api): clean-hexagonal alerts retrofit (ADR-0020)

### DIFF
--- a/internal/alerts/rules/rules.go
+++ b/internal/alerts/rules/rules.go
@@ -1,10 +1,11 @@
-// Package alertsapp holds the alerts application (use-case) layer (ADR-0016
-// strangle). It owns the operator-defined alert-rule orchestration (and, over
-// time, the alert acknowledge/resolve flow) that previously reached into the
-// database repositories from the api.Server handlers, behind a narrow
-// consumer-defined Store port. Handlers keep transport concerns: request
-// decode, field validation, JSON encoding, and error→HTTP mapping.
-package alertsapp
+// Package rules holds the alert-rule application (use-case) layer (ADR-0020). It
+// owns the operator-defined alert-rule orchestration (and, over time, the alert
+// acknowledge/resolve flow) that previously reached into the database
+// repositories from the api.Server handlers, behind a narrow consumer-defined
+// Store port. Handlers keep transport concerns: request decode, field
+// validation, JSON encoding, and error→HTTP mapping. The adapter satisfying the
+// Store port lives in the composition root (internal/app).
+package rules
 
 import (
 	"context"
@@ -12,8 +13,8 @@ import (
 	"time"
 )
 
-// ErrRuleNotFound is returned when no alert rule has the given id.
-var ErrRuleNotFound = errors.New("alert rule not found")
+// ErrNotFound is returned when no alert rule has the given id.
+var ErrNotFound = errors.New("alert rule not found")
 
 // ValidationError carries a repository-level validation message verbatim so the
 // handler can echo it as a 400, preserving the pre-strangle response body.
@@ -40,11 +41,11 @@ type Rule struct {
 	UpdatedAt            time.Time
 }
 
-// RuleStore is the persistence surface the rule use-case needs, defined at the
-// consumer (ADR-0016). The adapter satisfies it over the database AlertRules
-// repository, mapping ErrAlertRuleNotFound -> ErrRuleNotFound and the repo's
+// Store is the persistence surface the rule use-case needs, defined at the
+// consumer (ADR-0020). The adapter satisfies it over the database AlertRules
+// repository, mapping ErrAlertRuleNotFound -> ErrNotFound and the repo's
 // "alert_rules:"-prefixed validation errors -> *ValidationError.
-type RuleStore interface {
+type Store interface {
 	List(ctx context.Context, enabledOnly bool) ([]Rule, error)
 	Get(ctx context.Context, id int64) (Rule, error)
 	// Create stores r and returns it with the generated ID + timestamps.
@@ -53,14 +54,14 @@ type RuleStore interface {
 	Delete(ctx context.Context, id int64) error
 }
 
-// RuleService is the alert-rule use-case.
-type RuleService struct {
-	store RuleStore
+// Service is the alert-rule use-case.
+type Service struct {
+	store Store
 }
 
-// NewRuleService builds the use-case over its Store port.
-func NewRuleService(store RuleStore) *RuleService {
-	return &RuleService{store: store}
+// NewService builds the use-case over its Store port.
+func NewService(store Store) *Service {
+	return &Service{store: store}
 }
 
 // minThreshold mirrors the pre-strangle max(threshold, 1): a rule fires on the
@@ -73,17 +74,17 @@ func minThreshold(n int) int {
 }
 
 // List returns alert rules, optionally only the enabled ones.
-func (s *RuleService) List(ctx context.Context, enabledOnly bool) ([]Rule, error) {
+func (s *Service) List(ctx context.Context, enabledOnly bool) ([]Rule, error) {
 	return s.store.List(ctx, enabledOnly)
 }
 
-// Get returns one alert rule (ErrRuleNotFound when absent).
-func (s *RuleService) Get(ctx context.Context, id int64) (Rule, error) {
+// Get returns one alert rule (ErrNotFound when absent).
+func (s *Service) Get(ctx context.Context, id int64) (Rule, error) {
 	return s.store.Get(ctx, id)
 }
 
 // Create stores a new rule and returns the persisted row.
-func (s *RuleService) Create(ctx context.Context, r Rule) (Rule, error) {
+func (s *Service) Create(ctx context.Context, r Rule) (Rule, error) {
 	r.ID = 0
 	r.ThresholdCount = minThreshold(r.ThresholdCount)
 	return s.store.Create(ctx, r)
@@ -91,7 +92,7 @@ func (s *RuleService) Create(ctx context.Context, r Rule) (Rule, error) {
 
 // Update writes the rule at id and returns the freshly-read row so callers see
 // the new updated_at; on a post-write read failure it echoes the written rule.
-func (s *RuleService) Update(ctx context.Context, id int64, r Rule) (Rule, error) {
+func (s *Service) Update(ctx context.Context, id int64, r Rule) (Rule, error) {
 	r.ID = id
 	r.ThresholdCount = minThreshold(r.ThresholdCount)
 	if err := s.store.Update(ctx, r); err != nil {
@@ -105,7 +106,7 @@ func (s *RuleService) Update(ctx context.Context, id int64, r Rule) (Rule, error
 	return r, nil
 }
 
-// Delete removes the rule at id (ErrRuleNotFound when absent).
-func (s *RuleService) Delete(ctx context.Context, id int64) error {
+// Delete removes the rule at id (ErrNotFound when absent).
+func (s *Service) Delete(ctx context.Context, id int64) error {
 	return s.store.Delete(ctx, id)
 }

--- a/internal/alerts/rules/rules_test.go
+++ b/internal/alerts/rules/rules_test.go
@@ -1,26 +1,26 @@
-package alertsapp_test
+package rules_test
 
 import (
 	"context"
 	"errors"
 	"testing"
 
-	alertsapp "github.com/MustardSeedNetworks/seed/internal/alerts/app"
+	"github.com/MustardSeedNetworks/seed/internal/alerts/rules"
 )
 
 type fakeRuleStore struct {
-	byID      map[int64]alertsapp.Rule
+	byID      map[int64]rules.Rule
 	nextID    int64
 	createErr error
 	updateErr error
 }
 
 func newFakeRuleStore() *fakeRuleStore {
-	return &fakeRuleStore{byID: map[int64]alertsapp.Rule{}, nextID: 1}
+	return &fakeRuleStore{byID: map[int64]rules.Rule{}, nextID: 1}
 }
 
-func (f *fakeRuleStore) List(_ context.Context, enabledOnly bool) ([]alertsapp.Rule, error) {
-	out := make([]alertsapp.Rule, 0, len(f.byID))
+func (f *fakeRuleStore) List(_ context.Context, enabledOnly bool) ([]rules.Rule, error) {
+	out := make([]rules.Rule, 0, len(f.byID))
 	for _, r := range f.byID {
 		if enabledOnly && !r.Enabled {
 			continue
@@ -30,17 +30,17 @@ func (f *fakeRuleStore) List(_ context.Context, enabledOnly bool) ([]alertsapp.R
 	return out, nil
 }
 
-func (f *fakeRuleStore) Get(_ context.Context, id int64) (alertsapp.Rule, error) {
+func (f *fakeRuleStore) Get(_ context.Context, id int64) (rules.Rule, error) {
 	r, ok := f.byID[id]
 	if !ok {
-		return alertsapp.Rule{}, alertsapp.ErrRuleNotFound
+		return rules.Rule{}, rules.ErrNotFound
 	}
 	return r, nil
 }
 
-func (f *fakeRuleStore) Create(_ context.Context, r alertsapp.Rule) (alertsapp.Rule, error) {
+func (f *fakeRuleStore) Create(_ context.Context, r rules.Rule) (rules.Rule, error) {
 	if f.createErr != nil {
-		return alertsapp.Rule{}, f.createErr
+		return rules.Rule{}, f.createErr
 	}
 	r.ID = f.nextID
 	f.nextID++
@@ -48,12 +48,12 @@ func (f *fakeRuleStore) Create(_ context.Context, r alertsapp.Rule) (alertsapp.R
 	return r, nil
 }
 
-func (f *fakeRuleStore) Update(_ context.Context, r alertsapp.Rule) error {
+func (f *fakeRuleStore) Update(_ context.Context, r rules.Rule) error {
 	if f.updateErr != nil {
 		return f.updateErr
 	}
 	if _, ok := f.byID[r.ID]; !ok {
-		return alertsapp.ErrRuleNotFound
+		return rules.ErrNotFound
 	}
 	f.byID[r.ID] = r
 	return nil
@@ -61,7 +61,7 @@ func (f *fakeRuleStore) Update(_ context.Context, r alertsapp.Rule) error {
 
 func (f *fakeRuleStore) Delete(_ context.Context, id int64) error {
 	if _, ok := f.byID[id]; !ok {
-		return alertsapp.ErrRuleNotFound
+		return rules.ErrNotFound
 	}
 	delete(f.byID, id)
 	return nil
@@ -71,9 +71,9 @@ func ctx() context.Context { return context.Background() }
 
 func TestCreateNormalizesThresholdAndIgnoresInputID(t *testing.T) {
 	store := newFakeRuleStore()
-	svc := alertsapp.NewRuleService(store)
+	svc := rules.NewService(store)
 
-	got, err := svc.Create(ctx(), alertsapp.Rule{ID: 999, Name: "n", ThresholdCount: 0})
+	got, err := svc.Create(ctx(), rules.Rule{ID: 999, Name: "n", ThresholdCount: 0})
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -87,11 +87,11 @@ func TestCreateNormalizesThresholdAndIgnoresInputID(t *testing.T) {
 
 func TestCreateErrorPropagates(t *testing.T) {
 	store := newFakeRuleStore()
-	store.createErr = &alertsapp.ValidationError{Msg: "alert_rules: bad matchKind"}
-	svc := alertsapp.NewRuleService(store)
+	store.createErr = &rules.ValidationError{Msg: "alert_rules: bad matchKind"}
+	svc := rules.NewService(store)
 
-	_, err := svc.Create(ctx(), alertsapp.Rule{Name: "n"})
-	var ve *alertsapp.ValidationError
+	_, err := svc.Create(ctx(), rules.Rule{Name: "n"})
+	var ve *rules.ValidationError
 	if !errors.As(err, &ve) || ve.Msg != "alert_rules: bad matchKind" {
 		t.Fatalf("want ValidationError carrying the message, got %v", err)
 	}
@@ -99,10 +99,10 @@ func TestCreateErrorPropagates(t *testing.T) {
 
 func TestUpdateReadsBackAndMaps(t *testing.T) {
 	store := newFakeRuleStore()
-	created, _ := store.Create(ctx(), alertsapp.Rule{Name: "orig", ThresholdCount: 3})
-	svc := alertsapp.NewRuleService(store)
+	created, _ := store.Create(ctx(), rules.Rule{Name: "orig", ThresholdCount: 3})
+	svc := rules.NewService(store)
 
-	got, err := svc.Update(ctx(), created.ID, alertsapp.Rule{Name: "updated", ThresholdCount: 0})
+	got, err := svc.Update(ctx(), created.ID, rules.Rule{Name: "updated", ThresholdCount: 0})
 	if err != nil {
 		t.Fatalf("update: %v", err)
 	}
@@ -110,26 +110,26 @@ func TestUpdateReadsBackAndMaps(t *testing.T) {
 		t.Fatalf("update mismatch: %+v", got)
 	}
 
-	if _, missErr := svc.Update(ctx(), 404, alertsapp.Rule{Name: "x"}); !errors.Is(missErr, alertsapp.ErrRuleNotFound) {
-		t.Fatalf("update missing should be ErrRuleNotFound, got %v", missErr)
+	if _, missErr := svc.Update(ctx(), 404, rules.Rule{Name: "x"}); !errors.Is(missErr, rules.ErrNotFound) {
+		t.Fatalf("update missing should be ErrNotFound, got %v", missErr)
 	}
 }
 
 func TestGetDeleteNotFound(t *testing.T) {
-	svc := alertsapp.NewRuleService(newFakeRuleStore())
-	if _, err := svc.Get(ctx(), 1); !errors.Is(err, alertsapp.ErrRuleNotFound) {
+	svc := rules.NewService(newFakeRuleStore())
+	if _, err := svc.Get(ctx(), 1); !errors.Is(err, rules.ErrNotFound) {
 		t.Fatalf("get missing: %v", err)
 	}
-	if err := svc.Delete(ctx(), 1); !errors.Is(err, alertsapp.ErrRuleNotFound) {
+	if err := svc.Delete(ctx(), 1); !errors.Is(err, rules.ErrNotFound) {
 		t.Fatalf("delete missing: %v", err)
 	}
 }
 
 func TestListEnabledOnly(t *testing.T) {
 	store := newFakeRuleStore()
-	_, _ = store.Create(ctx(), alertsapp.Rule{Name: "on", Enabled: true})
-	_, _ = store.Create(ctx(), alertsapp.Rule{Name: "off", Enabled: false})
-	svc := alertsapp.NewRuleService(store)
+	_, _ = store.Create(ctx(), rules.Rule{Name: "on", Enabled: true})
+	_, _ = store.Create(ctx(), rules.Rule{Name: "off", Enabled: false})
+	svc := rules.NewService(store)
 
 	all, _ := svc.List(ctx(), false)
 	enabled, _ := svc.List(ctx(), true)

--- a/internal/api/handlers_alert_rules.go
+++ b/internal/api/handlers_alert_rules.go
@@ -17,7 +17,7 @@ import (
 	"strconv"
 	"strings"
 
-	alertsapp "github.com/MustardSeedNetworks/seed/internal/alerts/app"
+	"github.com/MustardSeedNetworks/seed/internal/alerts/rules"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
@@ -83,15 +83,15 @@ func (s *Server) listAlertRules(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	enabledOnly := r.URL.Query().Get("enabled_only") == "true"
-	rules, err := s.alertRules.List(r.Context(), enabledOnly)
+	ruleList, err := s.alertRules.List(r.Context(), enabledOnly)
 	if err != nil {
 		logger.ErrorContext(r.Context(), "list alert_rules failed", "error", err)
 		http.Error(w, "Failed to list rules", http.StatusInternalServerError)
 		return
 	}
 	writeJSON(w, r, map[string]any{
-		jsonKeyCount: len(rules),
-		"rules":      encodeAlertRules(rules),
+		jsonKeyCount: len(ruleList),
+		"rules":      encodeAlertRules(ruleList),
 	})
 }
 
@@ -103,7 +103,7 @@ func (s *Server) getAlertRule(w http.ResponseWriter, r *http.Request, id int64) 
 	}
 	rule, err := s.alertRules.Get(r.Context(), id)
 	if err != nil {
-		if errors.Is(err, alertsapp.ErrRuleNotFound) {
+		if errors.Is(err, rules.ErrNotFound) {
 			http.Error(w, "Rule not found", http.StatusNotFound)
 			return
 		}
@@ -127,7 +127,7 @@ func (s *Server) createAlertRule(w http.ResponseWriter, r *http.Request) {
 	}
 	rule, createErr := s.alertRules.Create(r.Context(), inputToRule(in))
 	if createErr != nil {
-		var ve *alertsapp.ValidationError
+		var ve *rules.ValidationError
 		if errors.As(createErr, &ve) {
 			http.Error(w, ve.Msg, http.StatusBadRequest)
 			return
@@ -155,7 +155,7 @@ func (s *Server) updateAlertRule(w http.ResponseWriter, r *http.Request, id int6
 	// JSON reflects updated_at (falling back to the written shape on re-read).
 	rule, updateErr := s.alertRules.Update(r.Context(), id, inputToRule(in))
 	if updateErr != nil {
-		if errors.Is(updateErr, alertsapp.ErrRuleNotFound) {
+		if errors.Is(updateErr, rules.ErrNotFound) {
 			http.Error(w, "Rule not found", http.StatusNotFound)
 			return
 		}
@@ -173,7 +173,7 @@ func (s *Server) deleteAlertRule(w http.ResponseWriter, r *http.Request, id int6
 		return
 	}
 	if err := s.alertRules.Delete(r.Context(), id); err != nil {
-		if errors.Is(err, alertsapp.ErrRuleNotFound) {
+		if errors.Is(err, rules.ErrNotFound) {
 			http.Error(w, "Rule not found", http.StatusNotFound)
 			return
 		}
@@ -205,8 +205,8 @@ func decodeAlertRuleInput(r *http.Request) (*alertRuleInput, error) {
 
 // inputToRule maps the wire input to the use-case model. The ThresholdCount
 // floor (>=1) is applied by the use-case, so it is passed through raw here.
-func inputToRule(in *alertRuleInput) alertsapp.Rule {
-	return alertsapp.Rule{
+func inputToRule(in *alertRuleInput) rules.Rule {
+	return rules.Rule{
 		Name:                 in.Name,
 		Enabled:              in.Enabled,
 		MatchKind:            in.MatchKind,
@@ -221,7 +221,7 @@ func inputToRule(in *alertRuleInput) alertsapp.Rule {
 	}
 }
 
-func encodeAlertRule(rule alertsapp.Rule) map[string]any {
+func encodeAlertRule(rule rules.Rule) map[string]any {
 	return map[string]any{
 		"id":                   rule.ID,
 		jsonKeyName:            rule.Name,
@@ -240,9 +240,9 @@ func encodeAlertRule(rule alertsapp.Rule) map[string]any {
 	}
 }
 
-func encodeAlertRules(rules []alertsapp.Rule) []map[string]any {
-	out := make([]map[string]any, 0, len(rules))
-	for _, r := range rules {
+func encodeAlertRules(ruleList []rules.Rule) []map[string]any {
+	out := make([]map[string]any, 0, len(ruleList))
+	for _, r := range ruleList {
 		out = append(out, encodeAlertRule(r))
 	}
 	return out

--- a/internal/api/handlers_alert_rules_internal_test.go
+++ b/internal/api/handlers_alert_rules_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
@@ -17,7 +18,7 @@ func newAlertRulesTestServer(t *testing.T) *Server {
 	db := newTestDB(t)
 	s := &Server{services: NewServiceContainer()}
 	s.services.Database = &DatabaseServices{DB: db}
-	s.initAlertsUseCase()
+	s.alertRules = app.NewAlertRules(s.db)
 	return s
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"time"
 
-	alertsapp "github.com/MustardSeedNetworks/seed/internal/alerts/app"
 	alertpipeline "github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
+	"github.com/MustardSeedNetworks/seed/internal/alerts/rules"
 	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/auth"
 	"github.com/MustardSeedNetworks/seed/internal/config"
@@ -138,7 +138,7 @@ type Server struct {
 	settingsStore      *settingsapp.Persistence // Settings-to-profile persistence use-case (ADR-0016 phase 3)
 	profiles           *profilesapp.Service     // Profile CRUD/active/import use-case (ADR-0016 phase 3)
 	networkIP          *ipconfig.Service        // IP-config + MTU use-case (ADR-0020)
-	alertRules         *alertsapp.RuleService   // Alert-rule CRUD use-case (ADR-0016)
+	alertRules         *rules.Service           // Alert-rule CRUD use-case (ADR-0020)
 	tlsFingerprint     tlsFingerprintCache      // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
 
@@ -265,8 +265,9 @@ func NewServer(
 	// builds the adapters; api passes its lazy manager accessor + config.
 	s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)
 
-	// Wire the alert-rule use-case (ADR-0016), over the lazy db.
-	s.initAlertsUseCase()
+	// Wire the alert-rule use-case (ADR-0020). The composition root builds the
+	// adapter; api passes its lazy db accessor.
+	s.alertRules = app.NewAlertRules(s.db)
 
 	// Initialize vulnerability scanner if enabled
 	s.initVulnerabilityScanner(cfg)

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -155,7 +155,7 @@ func NewTestServerWithConfig(cfg *config.Config) *Server {
 	s.initSettingsUseCase()
 	s.initProfilesUseCase()
 	s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)
-	s.initAlertsUseCase()
+	s.alertRules = app.NewAlertRules(s.db)
 
 	// Setup routes
 	s.setupRoutes()

--- a/internal/app/alerts.go
+++ b/internal/app/alerts.go
@@ -1,29 +1,36 @@
-package api
+package app
 
-// alerts_usecases.go wires the API layer to the alerts application (use-case)
-// service (ADR-0016 strangle). The adapter implements the narrow
-// alertsapp.RuleStore port over the database AlertRules repository, mapping the
-// database.AlertRule row to the use-case model and the repo's
-// ErrAlertRuleNotFound / "alert_rules:"-prefixed validation errors to the
-// use-case's sentinels.
+// alerts.go wires the composition root to the alert-rule application (use-case)
+// service (ADR-0020). The adapter implements the narrow rules.Store port over
+// the database AlertRules repository, mapping the database.AlertRule row to the
+// use-case model and the repo's ErrAlertRuleNotFound / "alert_rules:"-prefixed
+// validation errors to the use-case's sentinels.
 
 import (
 	"context"
 	"errors"
 	"strings"
 
-	alertsapp "github.com/MustardSeedNetworks/seed/internal/alerts/app"
+	"github.com/MustardSeedNetworks/seed/internal/alerts/rules"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
-// alertRuleStore implements alertsapp.RuleStore over the database repository.
-// The database is resolved lazily; handlers gate on s.db() != nil first.
+// NewAlertRules builds the alert-rule use-case (ADR-0020) over the lazy db
+// accessor, assembling the rules.Store adapter over the database repository.
+// The database is resolved through db on each call so the api test harness's
+// later-set DB is honored; handlers gate on db() != nil first.
+func NewAlertRules(db func() *database.DB) *rules.Service {
+	return rules.NewService(alertRuleStore{db: db})
+}
+
+// alertRuleStore implements rules.Store over the database repository. The
+// database is resolved lazily; handlers gate on db() != nil first.
 type alertRuleStore struct {
 	db func() *database.DB
 }
 
-func toAppRule(r *database.AlertRule) alertsapp.Rule {
-	return alertsapp.Rule{
+func toAppRule(r *database.AlertRule) rules.Rule {
+	return rules.Rule{
 		ID:                   r.ID,
 		Name:                 r.Name,
 		Enabled:              r.Enabled,
@@ -41,7 +48,7 @@ func toAppRule(r *database.AlertRule) alertsapp.Rule {
 	}
 }
 
-func toDBRule(r alertsapp.Rule) *database.AlertRule {
+func toDBRule(r rules.Rule) *database.AlertRule {
 	return &database.AlertRule{
 		ID:                   r.ID,
 		Name:                 r.Name,
@@ -62,53 +69,48 @@ func toDBRule(r alertsapp.Rule) *database.AlertRule {
 
 func mapAlertRuleErr(err error) error {
 	if errors.Is(err, database.ErrAlertRuleNotFound) {
-		return alertsapp.ErrRuleNotFound
+		return rules.ErrNotFound
 	}
 	return err
 }
 
-func (a alertRuleStore) List(ctx context.Context, enabledOnly bool) ([]alertsapp.Rule, error) {
+func (a alertRuleStore) List(ctx context.Context, enabledOnly bool) ([]rules.Rule, error) {
 	rows, err := a.db().AlertRules().List(ctx, enabledOnly)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]alertsapp.Rule, 0, len(rows))
+	out := make([]rules.Rule, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, toAppRule(r))
 	}
 	return out, nil
 }
 
-func (a alertRuleStore) Get(ctx context.Context, id int64) (alertsapp.Rule, error) {
+func (a alertRuleStore) Get(ctx context.Context, id int64) (rules.Rule, error) {
 	r, err := a.db().AlertRules().Get(ctx, id)
 	if err != nil {
-		return alertsapp.Rule{}, mapAlertRuleErr(err)
+		return rules.Rule{}, mapAlertRuleErr(err)
 	}
 	return toAppRule(r), nil
 }
 
-func (a alertRuleStore) Create(ctx context.Context, r alertsapp.Rule) (alertsapp.Rule, error) {
+func (a alertRuleStore) Create(ctx context.Context, r rules.Rule) (rules.Rule, error) {
 	row := toDBRule(r)
 	if err := a.db().AlertRules().Create(ctx, row); err != nil {
 		// The repo signals validation failures with an "alert_rules:" prefix;
 		// surface them verbatim so the handler returns a 400 with the message.
 		if strings.HasPrefix(err.Error(), "alert_rules:") {
-			return alertsapp.Rule{}, &alertsapp.ValidationError{Msg: err.Error()}
+			return rules.Rule{}, &rules.ValidationError{Msg: err.Error()}
 		}
-		return alertsapp.Rule{}, err
+		return rules.Rule{}, err
 	}
 	return toAppRule(row), nil
 }
 
-func (a alertRuleStore) Update(ctx context.Context, r alertsapp.Rule) error {
+func (a alertRuleStore) Update(ctx context.Context, r rules.Rule) error {
 	return mapAlertRuleErr(a.db().AlertRules().Update(ctx, toDBRule(r)))
 }
 
 func (a alertRuleStore) Delete(ctx context.Context, id int64) error {
 	return mapAlertRuleErr(a.db().AlertRules().Delete(ctx, id))
-}
-
-// initAlertsUseCase builds the alert-rule use-case over the lazy db accessor.
-func (s *Server) initAlertsUseCase() {
-	s.alertRules = alertsapp.NewRuleService(alertRuleStore{db: s.db})
 }


### PR DESCRIPTION
## What

**B1** of the `internal/api` clean-hexagonal strangle (ADR-0020) — retrofits the **alerts** domain to the convention the network exemplar (#1611) established. First Phase B slice.

- rename `internal/alerts/app` (pkg `alertsapp`) → `internal/alerts/rules` (pkg `rules`); `RuleService`→`Service`, `RuleStore`→`Store`, `ErrRuleNotFound`→`ErrNotFound`, de-stuttered against the package
- move the `alertRuleStore` adapter out of `internal/api/alerts_usecases.go` into the composition root (`internal/app/alerts.go`) behind `app.NewAlertRules`; delete `alerts_usecases.go`
- `internal/api` is now pure transport for alerts — handlers wire via `app.NewAlertRules` passing the lazy db accessor; no adapters, no `*_usecases.go`. `handlers_alert_rules.go` stays thin (local `rules` var → `ruleList` to avoid shadowing the package).

No backwards-compat alias kept (pre-alpha). `api → app` import stays one-way; lazy-db resolution the test harness relies on is preserved.

## Verification (run alone)

- `go build ./...` ✅
- `go test ./internal/api/ -count=1` → `ok 73.352s` ✅ (alone — concurrent runs produce false 10m timeouts, #1597 lesson)
- `go test ./internal/alerts/rules/` → `ok` ✅
- `go vet` clean; `golangci-lint` 0 issues in changed files ✅
- Goldens **byte-identical** (no testdata churn) ✅
- `check-route-policy.sh` + `check-output-escaping.sh` pass — route policy unchanged, no security invariant moved off the registry edge ✅

Refs ADR-0020, ADR-0016.