### PR TITLE
refactor(api): clean-hexagonal settings retrofit (ADR-0020)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -48,7 +48,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
 	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
 	"github.com/MustardSeedNetworks/seed/internal/scheduler"
-	settingsapp "github.com/MustardSeedNetworks/seed/internal/settings/app"
+	"github.com/MustardSeedNetworks/seed/internal/settings/persistence"
 	"github.com/MustardSeedNetworks/seed/internal/timeseries/retention"
 	"github.com/MustardSeedNetworks/seed/internal/topology"
 	"github.com/MustardSeedNetworks/seed/internal/wifi"
@@ -128,18 +128,18 @@ type Server struct {
 	services *ServiceContainer
 
 	// Runtime state
-	icmpAvailable      bool                     // Whether raw ICMP sockets are available
-	startTime          time.Time                // Application start time for uptime tracking (fixes #540)
-	setupModeStartTime time.Time                // Security fix #891: Track when setup mode started
-	background         *BackgroundComponents    // Long-lived components with background lifecycle (report scheduler)
-	wifiQueries        *wifiapp.Queries         // Wi-Fi visibility read use-case (ADR-0016 strangle exemplar)
-	wifiManagement     *wifiapp.Management      // Wi-Fi settings/scan/status/connect use-case (ADR-0016 phase 2)
-	wifiDiscovery      *wifiapp.Discovery       // Enhanced Wi-Fi discovery use-case (ADR-0016 phase 2)
-	settingsStore      *settingsapp.Persistence // Settings-to-profile persistence use-case (ADR-0016 phase 3)
-	profiles           *profilesapp.Service     // Profile CRUD/active/import use-case (ADR-0016 phase 3)
-	networkIP          *ipconfig.Service        // IP-config + MTU use-case (ADR-0020)
-	alertRules         *rules.Service           // Alert-rule CRUD use-case (ADR-0020)
-	tlsFingerprint     tlsFingerprintCache      // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
+	icmpAvailable      bool                  // Whether raw ICMP sockets are available
+	startTime          time.Time             // Application start time for uptime tracking (fixes #540)
+	setupModeStartTime time.Time             // Security fix #891: Track when setup mode started
+	background         *BackgroundComponents // Long-lived components with background lifecycle (report scheduler)
+	wifiQueries        *wifiapp.Queries      // Wi-Fi visibility read use-case (ADR-0016 strangle exemplar)
+	wifiManagement     *wifiapp.Management   // Wi-Fi settings/scan/status/connect use-case (ADR-0016 phase 2)
+	wifiDiscovery      *wifiapp.Discovery    // Enhanced Wi-Fi discovery use-case (ADR-0016 phase 2)
+	settingsStore      *persistence.Service  // Settings-to-profile persistence use-case (ADR-0020)
+	profiles           *profilesapp.Service  // Profile CRUD/active/import use-case (ADR-0016 phase 3)
+	networkIP          *ipconfig.Service     // IP-config + MTU use-case (ADR-0020)
+	alertRules         *rules.Service        // Alert-rule CRUD use-case (ADR-0020)
+	tlsFingerprint     tlsFingerprintCache   // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
 
 // NewServer creates a new server instance.
@@ -254,9 +254,9 @@ func NewServer(
 	// Wire the Wi-Fi use-cases now that the discovery bridge exists (ADR-0016).
 	s.initWiFiUseCases()
 
-	// Wire the settings-persistence use-case (ADR-0016 phase 3). The adapter
-	// resolves the database lazily, so it tolerates a nil or later-set db.
-	s.initSettingsUseCase()
+	// Wire the settings-persistence use-case (ADR-0020). The composition root
+	// builds the adapters; api passes its lazy db accessor + live config.
+	s.settingsStore = app.NewSettings(s.db, s.config)
 
 	// Wire the profiles use-case (ADR-0016 phase 3), also over the lazy db.
 	s.initProfilesUseCase()

--- a/internal/api/settings_usecases_internal_test.go
+++ b/internal/api/settings_usecases_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
@@ -33,7 +34,7 @@ func TestSettingsUseCasePersistsToDefaultProfile(t *testing.T) {
 		services: NewServiceContainer(),
 	}
 	s.services.Database.DB = db
-	s.initSettingsUseCase()
+	s.settingsStore = app.NewSettings(s.db, s.config)
 
 	if saveErr := s.settingsStore.SaveToActiveProfile(t.Context()); saveErr != nil {
 		t.Fatalf("SaveToActiveProfile: %v", saveErr)
@@ -63,7 +64,7 @@ func TestSettingsUseCaseNoDatabaseIsNoOp(t *testing.T) {
 		config:   config.DefaultConfig(),
 		services: NewServiceContainer(),
 	}
-	s.initSettingsUseCase()
+	s.settingsStore = app.NewSettings(s.db, s.config)
 
 	if err := s.settingsStore.SaveToActiveProfile(t.Context()); err != nil {
 		t.Fatalf("expected no-op without a db, got %v", err)

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -152,7 +152,7 @@ func NewTestServerWithConfig(cfg *config.Config) *Server {
 
 	// Wire the ADR-0016 use-cases the same way NewServer does, so handlers that
 	// depend on them work under the test harness.
-	s.initSettingsUseCase()
+	s.settingsStore = app.NewSettings(s.db, s.config)
 	s.initProfilesUseCase()
 	s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)
 	s.alertRules = app.NewAlertRules(s.db)

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -1,10 +1,10 @@
-package api
+package app
 
-// settings_usecases.go wires the API layer to the settings application
-// (use-case) service (ADR-0016 strangle phase 3). The adapters below implement
-// the narrow ports declared in internal/settings/app over the concrete database
-// repositories and the live config, so the settings handlers depend on a
-// use-case instead of reaching into ServiceContainer / s.db() directly.
+// settings.go wires the composition root to the settings-persistence
+// application (use-case) service (ADR-0020). The adapters below implement the
+// narrow ports declared in internal/settings/persistence over the concrete
+// database repositories and the live config, so the settings handlers depend on
+// a use-case instead of reaching into ServiceContainer / s.db() directly.
 
 import (
 	"context"
@@ -12,13 +12,23 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
-	settingsapp "github.com/MustardSeedNetworks/seed/internal/settings/app"
+	"github.com/MustardSeedNetworks/seed/internal/settings/persistence"
 )
 
-// settingsProfileStore implements settingsapp.ProfileStore over the database
+// NewSettings builds the settings-persistence use-case (ADR-0020) from the lazy
+// database accessor and the live config. The database is resolved through db on
+// each call so a nil or later-assigned db is tolerated, preserving the handlers'
+// historic "no db -> persist to config file only" behavior.
+func NewSettings(db func() *database.DB, cfg *config.Config) *persistence.Service {
+	return persistence.NewService(
+		settingsProfileStore{db: db},
+		settingsConfigSource{cfg: cfg},
+	)
+}
+
+// settingsProfileStore implements persistence.ProfileStore over the database
 // repositories. It resolves the *database.DB lazily (via the accessor) so it
-// tolerates a nil or later-assigned database, preserving the handlers' historic
-// "no db -> persist to config file only" behavior.
+// tolerates a nil or later-assigned database.
 type settingsProfileStore struct {
 	db func() *database.DB
 }
@@ -34,12 +44,12 @@ func (s settingsProfileStore) ActiveProfileID(ctx context.Context) (string, erro
 func (s settingsProfileStore) DefaultProfileID(ctx context.Context) (string, error) {
 	db := s.db()
 	if db == nil {
-		return "", settingsapp.ErrNoProfile
+		return "", persistence.ErrNoProfile
 	}
 	profile, err := db.Profiles().GetDefault(ctx)
 	if err != nil {
 		// No default profile exists — nothing to persist to (not an error).
-		return "", settingsapp.ErrNoProfile
+		return "", persistence.ErrNoProfile
 	}
 	return profile.ID, nil
 }
@@ -57,7 +67,7 @@ func (s settingsProfileStore) SaveProfileConfig(ctx context.Context, id, configJ
 	return db.Profiles().Update(ctx, profile)
 }
 
-// settingsConfigSource implements settingsapp.ConfigSource over the live config,
+// settingsConfigSource implements persistence.ConfigSource over the live config,
 // serializing it with the single-source-of-truth profile encoder.
 type settingsConfigSource struct {
 	cfg *config.Config
@@ -65,13 +75,4 @@ type settingsConfigSource struct {
 
 func (c settingsConfigSource) ProfileJSON() (string, error) {
 	return c.cfg.ToProfileJSON()
-}
-
-// initSettingsUseCase builds the settings-persistence use-case (ADR-0016 phase
-// 3) from the lazy database accessor and the live config.
-func (s *Server) initSettingsUseCase() {
-	s.settingsStore = settingsapp.NewPersistence(
-		settingsProfileStore{db: s.db},
-		settingsConfigSource{cfg: s.config},
-	)
 }

--- a/internal/settings/persistence/persistence.go
+++ b/internal/settings/persistence/persistence.go
@@ -1,10 +1,11 @@
-// Package settingsapp holds the settings application (use-case) layer
-// (ADR-0016 strangle phase 3). It owns the orchestration that previously lived
-// in the api.Server settings handlers — resolving the active profile and
-// persisting the current configuration to it — behind narrow, consumer-defined
-// ports, so handlers depend on a use-case instead of reaching into the database
-// repositories and the config directly.
-package settingsapp
+// Package persistence holds the settings-persistence application (use-case)
+// layer (ADR-0020). It owns the orchestration that previously lived in the
+// api.Server settings handlers — resolving the active profile and persisting the
+// current configuration to it — behind narrow, consumer-defined ports, so
+// handlers depend on a use-case instead of reaching into the database
+// repositories and the config directly. The adapters satisfying the ports live
+// in the composition root (internal/app).
+package persistence
 
 import (
 	"context"
@@ -18,7 +19,7 @@ import (
 var ErrNoProfile = errors.New("no profile to persist settings to")
 
 // ProfileStore is the narrow persistence surface the settings use-case needs.
-// It is defined here at the consumer (ADR-0016 interface-segregation) and
+// It is defined here at the consumer (ADR-0020 interface-segregation) and
 // satisfied by an adapter that owns the database.Profile type, the database
 // repositories, and the row read-modify-write.
 type ProfileStore interface {
@@ -37,17 +38,17 @@ type ConfigSource interface {
 	ProfileJSON() (string, error)
 }
 
-// Persistence is the settings-persistence use-case: it writes the current
+// Service is the settings-persistence use-case: it writes the current
 // configuration to the active profile. Handlers depend on it instead of
 // reaching into the database repositories.
-type Persistence struct {
+type Service struct {
 	store ProfileStore
 	cfg   ConfigSource
 }
 
-// NewPersistence builds the use-case over its narrow dependencies.
-func NewPersistence(store ProfileStore, cfg ConfigSource) *Persistence {
-	return &Persistence{store: store, cfg: cfg}
+// NewService builds the use-case over its narrow dependencies.
+func NewService(store ProfileStore, cfg ConfigSource) *Service {
+	return &Service{store: store, cfg: cfg}
 }
 
 // SaveToActiveProfile persists current settings to the active (or default)
@@ -55,7 +56,7 @@ func NewPersistence(store ProfileStore, cfg ConfigSource) *Persistence {
 // profile exists (ErrNoProfile) — settings still live in the config file. Any
 // other failure (serialization, the row write) propagates, so a genuinely
 // broken save surfaces as an error instead of being silently dropped.
-func (p *Persistence) SaveToActiveProfile(ctx context.Context) error {
+func (p *Service) SaveToActiveProfile(ctx context.Context) error {
 	if p == nil || p.store == nil {
 		return nil
 	}

--- a/internal/settings/persistence/persistence_test.go
+++ b/internal/settings/persistence/persistence_test.go
@@ -1,11 +1,11 @@
-package settingsapp_test
+package persistence_test
 
 import (
 	"context"
 	"errors"
 	"testing"
 
-	settingsapp "github.com/MustardSeedNetworks/seed/internal/settings/app"
+	"github.com/MustardSeedNetworks/seed/internal/settings/persistence"
 )
 
 type fakeStore struct {
@@ -43,7 +43,7 @@ func (f fakeConfig) ProfileJSON() (string, error) { return f.json, f.err }
 
 func TestSaveToActiveProfileUsesActiveID(t *testing.T) {
 	store := &fakeStore{activeID: "active-1"}
-	uc := settingsapp.NewPersistence(store, fakeConfig{json: `{"k":"v"}`})
+	uc := persistence.NewService(store, fakeConfig{json: `{"k":"v"}`})
 
 	if err := uc.SaveToActiveProfile(context.Background()); err != nil {
 		t.Fatalf("SaveToActiveProfile: %v", err)
@@ -69,7 +69,7 @@ func TestSaveToActiveProfileFallsBackToDefault(t *testing.T) {
 		{"active lookup error", &fakeStore{activeErr: errors.New("boom"), defaultID: "default-1"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			uc := settingsapp.NewPersistence(tc.store, fakeConfig{json: "{}"})
+			uc := persistence.NewService(tc.store, fakeConfig{json: "{}"})
 			if err := uc.SaveToActiveProfile(context.Background()); err != nil {
 				t.Fatalf("SaveToActiveProfile: %v", err)
 			}
@@ -81,8 +81,8 @@ func TestSaveToActiveProfileFallsBackToDefault(t *testing.T) {
 }
 
 func TestSaveToActiveProfileNoProfileIsNoOp(t *testing.T) {
-	store := &fakeStore{activeID: "", defaultErr: settingsapp.ErrNoProfile}
-	uc := settingsapp.NewPersistence(store, fakeConfig{json: "{}"})
+	store := &fakeStore{activeID: "", defaultErr: persistence.ErrNoProfile}
+	uc := persistence.NewService(store, fakeConfig{json: "{}"})
 
 	if err := uc.SaveToActiveProfile(context.Background()); err != nil {
 		t.Fatalf("expected nil (no-op), got %v", err)
@@ -95,7 +95,7 @@ func TestSaveToActiveProfileNoProfileIsNoOp(t *testing.T) {
 func TestSaveToActiveProfileSerializeErrorPropagates(t *testing.T) {
 	wantErr := errors.New("serialize failed")
 	store := &fakeStore{activeID: "active-1"}
-	uc := settingsapp.NewPersistence(store, fakeConfig{err: wantErr})
+	uc := persistence.NewService(store, fakeConfig{err: wantErr})
 
 	if err := uc.SaveToActiveProfile(context.Background()); !errors.Is(err, wantErr) {
 		t.Fatalf("expected serialize error to propagate, got %v", err)
@@ -110,7 +110,7 @@ func TestSaveToActiveProfileDefaultLookupErrorPropagates(t *testing.T) {
 	// (only ErrNoProfile is the legitimate no-op).
 	wantErr := errors.New("db down")
 	store := &fakeStore{activeID: "", defaultErr: wantErr}
-	uc := settingsapp.NewPersistence(store, fakeConfig{json: "{}"})
+	uc := persistence.NewService(store, fakeConfig{json: "{}"})
 
 	if err := uc.SaveToActiveProfile(context.Background()); !errors.Is(err, wantErr) {
 		t.Fatalf("expected default lookup error to propagate, got %v", err)
@@ -120,7 +120,7 @@ func TestSaveToActiveProfileDefaultLookupErrorPropagates(t *testing.T) {
 func TestSaveToActiveProfileSaveErrorPropagates(t *testing.T) {
 	wantErr := errors.New("update failed")
 	store := &fakeStore{activeID: "active-1", saveErr: wantErr}
-	uc := settingsapp.NewPersistence(store, fakeConfig{json: "{}"})
+	uc := persistence.NewService(store, fakeConfig{json: "{}"})
 
 	if err := uc.SaveToActiveProfile(context.Background()); !errors.Is(err, wantErr) {
 		t.Fatalf("expected save error to propagate, got %v", err)
@@ -128,11 +128,11 @@ func TestSaveToActiveProfileSaveErrorPropagates(t *testing.T) {
 }
 
 func TestSaveToActiveProfileNilStoreIsNoOp(t *testing.T) {
-	uc := settingsapp.NewPersistence(nil, fakeConfig{json: "{}"})
+	uc := persistence.NewService(nil, fakeConfig{json: "{}"})
 	if err := uc.SaveToActiveProfile(context.Background()); err != nil {
 		t.Fatalf("nil store should be a no-op, got %v", err)
 	}
-	var nilUC *settingsapp.Persistence
+	var nilUC *persistence.Service
 	if err := nilUC.SaveToActiveProfile(context.Background()); err != nil {
 		t.Fatalf("nil use-case should be a no-op, got %v", err)
 	}


### PR DESCRIPTION
## What

**B2** of the `internal/api` clean-hexagonal strangle (ADR-0020) — retrofits the **settings** domain to the convention from the network exemplar (#1611), continuing Phase B after alerts (#1612).

- rename `internal/settings/app` (pkg `settingsapp`) → `internal/settings/persistence` (pkg `persistence`); `Persistence`→`Service`, `NewPersistence`→`NewService`, de-stuttered (ports `ProfileStore`/`ConfigSource` + `ErrNoProfile` unchanged)
- move `settingsProfileStore` + `settingsConfigSource` adapters out of `internal/api/settings_usecases.go` into the composition root (`internal/app/settings.go`) behind `app.NewSettings`; delete `settings_usecases.go`
- `internal/api` is now pure transport for settings — wires via `app.NewSettings` passing the lazy db accessor + live config; no adapters, no `*_usecases.go`. `handlers_settings.go` unchanged (already used only the `s.settingsStore` field).

No backwards-compat alias kept (pre-alpha). `api → app` stays one-way; preserves the lazy-db resolution and the "no db → persist to config file only" path.

## Verification (run alone)

- `go build ./...` ✅ · `go vet` ✅
- `go test ./internal/api/ -count=1` → `ok 78.333s` ✅ (alone)
- `go test ./internal/settings/persistence/` → `ok` ✅
- `golangci-lint` 0 issues in changed files ✅
- Goldens **byte-identical** ✅
- `check-route-policy.sh` + `check-output-escaping.sh` pass ✅

Refs ADR-0020, ADR-0016.