### PR TITLE
refactor(api): clean-hexagonal profiles retrofit (ADR-0020)

### DIFF
--- a/internal/api/handlers_profiles.go
+++ b/internal/api/handlers_profiles.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
-	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
+	"github.com/MustardSeedNetworks/seed/internal/profiles/catalog"
 )
 
 // ProfileRequest represents a profile create/update request.
@@ -157,7 +157,7 @@ func (s *Server) handleCreateProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	profile, err := s.profiles.Create(r.Context(), profilesapp.NewProfile{
+	profile, err := s.profiles.Create(r.Context(), catalog.NewProfile{
 		Name:        req.Name,
 		Description: req.Description,
 		ConfigJSON:  string(req.Config),
@@ -165,10 +165,10 @@ func (s *Server) handleCreateProfile(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		switch {
-		case errors.Is(err, profilesapp.ErrNameRequired):
+		case errors.Is(err, catalog.ErrNameRequired):
 			sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
 				ErrCodeValidation, localizer.T("errors.profile.nameRequired"), "")
-		case errors.Is(err, profilesapp.ErrNameExists):
+		case errors.Is(err, catalog.ErrNameExists):
 			sendErrorResponseWithDetails(w, logger, http.StatusConflict,
 				ErrCodeConflict, localizer.T("errors.profile.nameExists"), "") // fixes #694
 		default:
@@ -189,7 +189,7 @@ func (s *Server) handleGetProfile(w http.ResponseWriter, r *http.Request, id str
 
 	profile, err := s.profiles.Get(r.Context(), id)
 	if err != nil {
-		if errors.Is(err, profilesapp.ErrNotFound) {
+		if errors.Is(err, catalog.ErrNotFound) {
 			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
 				ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
 			return
@@ -219,7 +219,7 @@ func (s *Server) handleUpdateProfile(w http.ResponseWriter, r *http.Request, id 
 		return
 	}
 
-	update := profilesapp.ProfileUpdate{
+	update := catalog.ProfileUpdate{
 		Name:        req.Name,
 		Description: req.Description,
 		IsDefault:   req.IsDefault,
@@ -235,13 +235,13 @@ func (s *Server) handleUpdateProfile(w http.ResponseWriter, r *http.Request, id 
 	profile, err := s.profiles.Update(r.Context(), id, update, parseIfMatch(r))
 	if err != nil {
 		switch {
-		case errors.Is(err, profilesapp.ErrNotFound):
+		case errors.Is(err, catalog.ErrNotFound):
 			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
 				ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
-		case errors.Is(err, profilesapp.ErrNameExists):
+		case errors.Is(err, catalog.ErrNameExists):
 			sendErrorResponseWithDetails(w, logger, http.StatusConflict,
 				ErrCodeConflict, localizer.T("errors.profile.nameExists"), "") // fixes #694
-		case errors.Is(err, profilesapp.ErrConflict):
+		case errors.Is(err, catalog.ErrConflict):
 			sendErrorResponseWithDetails(w, logger, http.StatusPreconditionFailed,
 				ErrCodeConflict, localizer.T("errors.profile.conflict"), "")
 		default:
@@ -258,7 +258,7 @@ func (s *Server) handleUpdateProfile(w http.ResponseWriter, r *http.Request, id 
 // profileETag returns the strong ETag for a profile — its row_version, the
 // monotonic optimistic-concurrency token, wrapped in quotes per RFC 9110. Unlike
 // the prior updated_at token it is exact, so a sub-second double-write conflicts.
-func profileETag(p profilesapp.Profile) string {
+func profileETag(p catalog.Profile) string {
 	return `"` + strconv.FormatInt(p.RowVersion, 10) + `"`
 }
 
@@ -285,13 +285,13 @@ func (s *Server) handleDeleteProfile(w http.ResponseWriter, r *http.Request, id 
 		sendJSONResponse(w, logger, http.StatusOK, map[string]string{
 			"message": "Profile deleted successfully",
 		})
-	case errors.Is(err, profilesapp.ErrNotFound):
+	case errors.Is(err, catalog.ErrNotFound):
 		sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
 			ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
-	case errors.Is(err, profilesapp.ErrDeleteDefault):
+	case errors.Is(err, catalog.ErrDeleteDefault):
 		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
 			ErrCodeBadRequest, localizer.T("errors.profile.cannotDeleteDefault"), "") // fixes #694
-	case errors.Is(err, profilesapp.ErrDeleteActive):
+	case errors.Is(err, catalog.ErrDeleteActive):
 		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
 			ErrCodeBadRequest, localizer.T("errors.profile.cannotDeleteActive"), "") // fixes #694
 	default:
@@ -336,16 +336,16 @@ func (s *Server) handleGetActiveProfile(w http.ResponseWriter, r *http.Request) 
 	profile, err := s.profiles.ActiveProfile(r.Context())
 	if err != nil {
 		switch {
-		case errors.Is(err, profilesapp.ErrNoActiveOrDefault):
+		case errors.Is(err, catalog.ErrNoActiveOrDefault):
 			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
 				ErrCodeNotFound, localizer.T("errors.profile.noActiveOrDefault"), "") // fixes #694
-		case errors.Is(err, profilesapp.ErrActiveNotFound):
+		case errors.Is(err, catalog.ErrActiveNotFound):
 			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
 				ErrCodeNotFound, localizer.T("errors.profile.activeNotFound"), "") // fixes #694
-		case errors.Is(err, profilesapp.ErrDefaultLookup):
+		case errors.Is(err, catalog.ErrDefaultLookup):
 			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
 				ErrCodeInternal, localizer.T("errors.profile.getDefaultFailed"), "") // fixes #694, #H7
-		case errors.Is(err, profilesapp.ErrActiveLookup):
+		case errors.Is(err, catalog.ErrActiveLookup):
 			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
 				ErrCodeInternal, localizer.T("errors.profile.getActiveFailed"), "") // fixes #694, #H7
 		default:
@@ -374,10 +374,10 @@ func (s *Server) handleSetActiveProfile(w http.ResponseWriter, r *http.Request) 
 	profile, err := s.profiles.SetActiveProfile(r.Context(), req.ProfileID)
 	if err != nil {
 		switch {
-		case errors.Is(err, profilesapp.ErrIDRequired):
+		case errors.Is(err, catalog.ErrIDRequired):
 			sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
 				ErrCodeValidation, localizer.T("errors.profile.idRequired"), "") // fixes #694
-		case errors.Is(err, profilesapp.ErrNotFound):
+		case errors.Is(err, catalog.ErrNotFound):
 			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
 				ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
 		default:
@@ -465,10 +465,10 @@ func (s *Server) handleDuplicateProfile(w http.ResponseWriter, r *http.Request) 
 	duplicate, err := s.profiles.Duplicate(r.Context(), id, req.Name)
 	if err != nil {
 		switch {
-		case errors.Is(err, profilesapp.ErrNotFound):
+		case errors.Is(err, catalog.ErrNotFound):
 			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
 				ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
-		case errors.Is(err, profilesapp.ErrNameExists):
+		case errors.Is(err, catalog.ErrNameExists):
 			sendErrorResponseWithDetails(w, logger, http.StatusConflict,
 				ErrCodeConflict, localizer.T("errors.profile.nameExists"), "") // fixes #694
 		default:
@@ -504,9 +504,9 @@ func (s *Server) handleImportProfiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := make([]profilesapp.ImportItem, 0, len(req.Profiles))
+	items := make([]catalog.ImportItem, 0, len(req.Profiles))
 	for _, p := range req.Profiles {
-		items = append(items, profilesapp.ImportItem{
+		items = append(items, catalog.ImportItem{
 			Name:        p.Name,
 			Description: p.Description,
 			ConfigJSON:  string(p.Config),
@@ -609,7 +609,7 @@ func (s *Server) enforceMultiClientGate(w http.ResponseWriter, r *http.Request) 
 }
 
 // profileToResponse converts a use-case profile to an API response.
-func profileToResponse(p profilesapp.Profile) ProfileResponse {
+func profileToResponse(p catalog.Profile) ProfileResponse {
 	var configJSON json.RawMessage
 	if p.ConfigJSON != "" {
 		configJSON = json.RawMessage(p.ConfigJSON)

--- a/internal/api/profiles_internal_test.go
+++ b/internal/api/profiles_internal_test.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/database"
-	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
+	"github.com/MustardSeedNetworks/seed/internal/profiles/catalog"
 )
 
 // newProfilesTestServer builds a Server wired to a real database (which seeds a
@@ -24,12 +25,12 @@ func newProfilesTestServer(t *testing.T) (*Server, *database.DB) {
 
 	s := &Server{services: NewServiceContainer()}
 	s.services.Database.DB = db
-	s.initProfilesUseCase()
+	s.profiles = app.NewProfiles(s.db)
 	return s, db
 }
 
 // TestProfilesUseCaseAdapterCRUD exercises the ADR-0016 phase-3 adapter against a
-// real database: the database.Profile <-> profilesapp.Profile mapping and the
+// real database: the database.Profile <-> catalog.Profile mapping and the
 // ErrProfileNotFound/ErrProfileNameExists -> sentinel translation.
 func TestProfilesUseCaseAdapterCRUD(t *testing.T) {
 	s, _ := newProfilesTestServer(t)
@@ -45,7 +46,7 @@ func TestProfilesUseCaseAdapterCRUD(t *testing.T) {
 	}
 
 	// Create.
-	created, err := s.profiles.Create(ctx, profilesapp.NewProfile{Name: "field-site", ConfigJSON: `{"k":1}`})
+	created, err := s.profiles.Create(ctx, catalog.NewProfile{Name: "field-site", ConfigJSON: `{"k":1}`})
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -54,9 +55,9 @@ func TestProfilesUseCaseAdapterCRUD(t *testing.T) {
 	}
 
 	// Duplicate name maps to the sentinel.
-	if _, dupErr := s.profiles.Create(ctx, profilesapp.NewProfile{Name: "field-site"}); !errors.Is(
+	if _, dupErr := s.profiles.Create(ctx, catalog.NewProfile{Name: "field-site"}); !errors.Is(
 		dupErr,
-		profilesapp.ErrNameExists,
+		catalog.ErrNameExists,
 	) {
 		t.Fatalf("duplicate create should map to ErrNameExists, got %v", dupErr)
 	}
@@ -68,7 +69,7 @@ func TestProfilesUseCaseAdapterCRUD(t *testing.T) {
 	}
 
 	// Missing id maps to ErrNotFound.
-	if _, missErr := s.profiles.Get(ctx, "nope"); !errors.Is(missErr, profilesapp.ErrNotFound) {
+	if _, missErr := s.profiles.Get(ctx, "nope"); !errors.Is(missErr, catalog.ErrNotFound) {
 		t.Fatalf("missing get should map to ErrNotFound, got %v", missErr)
 	}
 
@@ -82,12 +83,12 @@ func TestProfilesUseCaseAdapterCRUD(t *testing.T) {
 	}
 
 	// Cannot delete the active profile.
-	if delErr := s.profiles.Delete(ctx, created.ID); !errors.Is(delErr, profilesapp.ErrDeleteActive) {
+	if delErr := s.profiles.Delete(ctx, created.ID); !errors.Is(delErr, catalog.ErrDeleteActive) {
 		t.Fatalf("deleting active should be ErrDeleteActive, got %v", delErr)
 	}
 
 	// Cannot delete the default profile.
-	if defErr := s.profiles.Delete(ctx, list[0].ID); !errors.Is(defErr, profilesapp.ErrDeleteDefault) {
+	if defErr := s.profiles.Delete(ctx, list[0].ID); !errors.Is(defErr, catalog.ErrDeleteDefault) {
 		t.Fatalf("deleting default should be ErrDeleteDefault, got %v", defErr)
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -46,7 +46,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/snmpclient"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
 	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
-	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
+	"github.com/MustardSeedNetworks/seed/internal/profiles/catalog"
 	"github.com/MustardSeedNetworks/seed/internal/scheduler"
 	"github.com/MustardSeedNetworks/seed/internal/settings/persistence"
 	"github.com/MustardSeedNetworks/seed/internal/timeseries/retention"
@@ -136,7 +136,7 @@ type Server struct {
 	wifiManagement     *wifiapp.Management   // Wi-Fi settings/scan/status/connect use-case (ADR-0016 phase 2)
 	wifiDiscovery      *wifiapp.Discovery    // Enhanced Wi-Fi discovery use-case (ADR-0016 phase 2)
 	settingsStore      *persistence.Service  // Settings-to-profile persistence use-case (ADR-0020)
-	profiles           *profilesapp.Service  // Profile CRUD/active/import use-case (ADR-0016 phase 3)
+	profiles           *catalog.Service      // Profile CRUD/active/import use-case (ADR-0020)
 	networkIP          *ipconfig.Service     // IP-config + MTU use-case (ADR-0020)
 	alertRules         *rules.Service        // Alert-rule CRUD use-case (ADR-0020)
 	tlsFingerprint     tlsFingerprintCache   // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
@@ -258,8 +258,9 @@ func NewServer(
 	// builds the adapters; api passes its lazy db accessor + live config.
 	s.settingsStore = app.NewSettings(s.db, s.config)
 
-	// Wire the profiles use-case (ADR-0016 phase 3), also over the lazy db.
-	s.initProfilesUseCase()
+	// Wire the profiles catalog use-case (ADR-0020). The composition root builds
+	// the adapter; api passes its lazy db accessor.
+	s.profiles = app.NewProfiles(s.db)
 
 	// Wire the network IP-config + MTU use-case (ADR-0020). The composition root
 	// builds the adapters; api passes its lazy manager accessor + config.

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -153,7 +153,7 @@ func NewTestServerWithConfig(cfg *config.Config) *Server {
 	// Wire the ADR-0016 use-cases the same way NewServer does, so handlers that
 	// depend on them work under the test harness.
 	s.settingsStore = app.NewSettings(s.db, s.config)
-	s.initProfilesUseCase()
+	s.profiles = app.NewProfiles(s.db)
 	s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)
 	s.alertRules = app.NewAlertRules(s.db)
 

--- a/internal/app/profiles.go
+++ b/internal/app/profiles.go
@@ -1,10 +1,11 @@
-package api
+package app
 
-// profiles_usecases.go wires the API layer to the profiles application
-// (use-case) service (ADR-0016 strangle phase 3). The adapter implements the
-// narrow profilesapp.Store port over the database Profiles + Settings
-// repositories, mapping the repository's domain errors to the use-case's
-// sentinels and the database.Profile row to the use-case model.
+// profiles.go wires the composition root to the profiles catalog application
+// (use-case) service (ADR-0020). The adapter implements the narrow catalog.Store
+// port over the database Profiles + Settings repositories, mapping the
+// repository's domain errors to the use-case's sentinels and the
+// database.Profile row to the use-case model, so the profile handlers depend on
+// a use-case instead of reaching into the database repositories directly.
 
 import (
 	"context"
@@ -12,10 +13,10 @@ import (
 	"strconv"
 
 	"github.com/MustardSeedNetworks/seed/internal/database"
-	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
+	"github.com/MustardSeedNetworks/seed/internal/profiles/catalog"
 )
 
-// profilesStore implements profilesapp.Store over the database repositories.
+// profilesStore implements catalog.Store over the database repositories.
 // The database is resolved lazily; callers (handlers) gate on s.db() != nil
 // before invoking the use-case, so a nil db here is not expected.
 type profilesStore struct {
@@ -28,18 +29,18 @@ func mapProfileErr(err error) error {
 	case err == nil:
 		return nil
 	case errors.Is(err, database.ErrProfileNotFound):
-		return profilesapp.ErrNotFound
+		return catalog.ErrNotFound
 	case errors.Is(err, database.ErrProfileNameExists):
-		return profilesapp.ErrNameExists
+		return catalog.ErrNameExists
 	case errors.Is(err, database.ErrProfileConflict):
-		return profilesapp.ErrConflict
+		return catalog.ErrConflict
 	default:
 		return err
 	}
 }
 
-func dbToAppProfile(p *database.Profile) profilesapp.Profile {
-	return profilesapp.Profile{
+func dbToAppProfile(p *database.Profile) catalog.Profile {
+	return catalog.Profile{
 		ID:          p.ID,
 		Name:        p.Name,
 		Description: p.Description,
@@ -51,7 +52,7 @@ func dbToAppProfile(p *database.Profile) profilesapp.Profile {
 	}
 }
 
-func appToDBProfile(p profilesapp.Profile) *database.Profile {
+func appToDBProfile(p catalog.Profile) *database.Profile {
 	return &database.Profile{
 		ID:          p.ID,
 		Name:        p.Name,
@@ -64,53 +65,53 @@ func appToDBProfile(p profilesapp.Profile) *database.Profile {
 	}
 }
 
-func (s profilesStore) List(ctx context.Context) ([]profilesapp.Profile, error) {
+func (s profilesStore) List(ctx context.Context) ([]catalog.Profile, error) {
 	rows, err := s.db().Profiles().List(ctx)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]profilesapp.Profile, 0, len(rows))
+	out := make([]catalog.Profile, 0, len(rows))
 	for _, p := range rows {
 		out = append(out, dbToAppProfile(p))
 	}
 	return out, nil
 }
 
-func (s profilesStore) Get(ctx context.Context, id string) (profilesapp.Profile, error) {
+func (s profilesStore) Get(ctx context.Context, id string) (catalog.Profile, error) {
 	p, err := s.db().Profiles().Get(ctx, id)
 	if err != nil {
-		return profilesapp.Profile{}, mapProfileErr(err)
+		return catalog.Profile{}, mapProfileErr(err)
 	}
 	return dbToAppProfile(p), nil
 }
 
-func (s profilesStore) GetByName(ctx context.Context, name string) (profilesapp.Profile, bool, error) {
+func (s profilesStore) GetByName(ctx context.Context, name string) (catalog.Profile, bool, error) {
 	p, err := s.db().Profiles().GetByName(ctx, name)
 	if err != nil {
 		if errors.Is(err, database.ErrProfileNotFound) {
-			return profilesapp.Profile{}, false, nil
+			return catalog.Profile{}, false, nil
 		}
-		return profilesapp.Profile{}, false, err
+		return catalog.Profile{}, false, err
 	}
 	if p == nil {
-		return profilesapp.Profile{}, false, nil
+		return catalog.Profile{}, false, nil
 	}
 	return dbToAppProfile(p), true, nil
 }
 
-func (s profilesStore) GetDefault(ctx context.Context) (profilesapp.Profile, error) {
+func (s profilesStore) GetDefault(ctx context.Context) (catalog.Profile, error) {
 	p, err := s.db().Profiles().GetDefault(ctx)
 	if err != nil {
-		return profilesapp.Profile{}, mapProfileErr(err)
+		return catalog.Profile{}, mapProfileErr(err)
 	}
 	return dbToAppProfile(p), nil
 }
 
-func (s profilesStore) Create(ctx context.Context, p profilesapp.Profile) error {
+func (s profilesStore) Create(ctx context.Context, p catalog.Profile) error {
 	return mapProfileErr(s.db().Profiles().Create(ctx, appToDBProfile(p)))
 }
 
-func (s profilesStore) Update(ctx context.Context, p profilesapp.Profile, ifMatch string) error {
+func (s profilesStore) Update(ctx context.Context, p catalog.Profile, ifMatch string) error {
 	if ifMatch == "" {
 		return mapProfileErr(s.db().Profiles().Update(ctx, appToDBProfile(p)))
 	}
@@ -119,7 +120,7 @@ func (s profilesStore) Update(ctx context.Context, p profilesapp.Profile, ifMatc
 	// (412), not a 500 — treat it as a conflict without touching the row.
 	expectedVersion, err := strconv.ParseInt(ifMatch, 10, 64)
 	if err != nil {
-		return profilesapp.ErrConflict
+		return catalog.ErrConflict
 	}
 	return mapProfileErr(s.db().Profiles().UpdateIfMatch(ctx, appToDBProfile(p), expectedVersion))
 }
@@ -141,8 +142,10 @@ func (s profilesStore) SetActiveID(ctx context.Context, id string) error {
 	return s.db().Settings().Set(ctx, database.SettingKeyActiveProfile, id)
 }
 
-// initProfilesUseCase builds the profiles use-case over the lazy database
-// accessor (ADR-0016 phase 3).
-func (s *Server) initProfilesUseCase() {
-	s.profiles = profilesapp.NewService(profilesStore{db: s.db})
+// NewProfiles builds the profiles catalog use-case (ADR-0020) over the lazy db
+// accessor, assembling the catalog.Store adapter over the database Profiles +
+// Settings repositories. The database is resolved through db on each call so the
+// api test harness's later-set DB is honored; handlers gate on db() != nil first.
+func NewProfiles(db func() *database.DB) *catalog.Service {
+	return catalog.NewService(profilesStore{db: db})
 }

--- a/internal/profiles/catalog/catalog.go
+++ b/internal/profiles/catalog/catalog.go
@@ -1,11 +1,11 @@
-// Package profilesapp holds the profiles application (use-case) layer
-// (ADR-0016 strangle phase 3). It owns the CRUD, active-profile resolution,
-// duplicate, and import/export orchestration that previously lived in the
-// api.Server profile handlers, behind a narrow consumer-defined Store port — so
-// handlers depend on a use-case instead of reaching into the database
-// repositories. Handlers keep transport concerns (decode/encode, localized
-// error mapping), license feature-gating, and the config-apply/SSE side effects.
-package profilesapp
+// Package catalog holds the profiles application (use-case) layer (ADR-0020).
+// It owns the CRUD, active-profile resolution, duplicate, and import/export
+// orchestration that previously lived in the api.Server profile handlers,
+// behind a narrow consumer-defined Store port — so handlers depend on a
+// use-case instead of reaching into the database repositories. Handlers keep
+// transport concerns (decode/encode, localized error mapping), license
+// feature-gating, and the config-apply/SSE side effects.
+package catalog
 
 import (
 	"context"

--- a/internal/profiles/catalog/catalog_test.go
+++ b/internal/profiles/catalog/catalog_test.go
@@ -1,81 +1,81 @@
-package profilesapp_test
+package catalog_test
 
 import (
 	"context"
 	"errors"
 	"testing"
 
-	profilesapp "github.com/MustardSeedNetworks/seed/internal/profiles/app"
+	"github.com/MustardSeedNetworks/seed/internal/profiles/catalog"
 )
 
 // fakeStore is an in-memory Store for use-case tests.
 type fakeStore struct {
-	byID       map[string]profilesapp.Profile
+	byID       map[string]catalog.Profile
 	activeID   string
 	createErr  error
 	failGetDef bool
 }
 
-func newFakeStore() *fakeStore { return &fakeStore{byID: map[string]profilesapp.Profile{}} }
+func newFakeStore() *fakeStore { return &fakeStore{byID: map[string]catalog.Profile{}} }
 
-func (f *fakeStore) List(context.Context) ([]profilesapp.Profile, error) {
-	out := make([]profilesapp.Profile, 0, len(f.byID))
+func (f *fakeStore) List(context.Context) ([]catalog.Profile, error) {
+	out := make([]catalog.Profile, 0, len(f.byID))
 	for _, p := range f.byID {
 		out = append(out, p)
 	}
 	return out, nil
 }
 
-func (f *fakeStore) Get(_ context.Context, id string) (profilesapp.Profile, error) {
+func (f *fakeStore) Get(_ context.Context, id string) (catalog.Profile, error) {
 	p, ok := f.byID[id]
 	if !ok {
-		return profilesapp.Profile{}, profilesapp.ErrNotFound
+		return catalog.Profile{}, catalog.ErrNotFound
 	}
 	return p, nil
 }
 
-func (f *fakeStore) GetByName(_ context.Context, name string) (profilesapp.Profile, bool, error) {
+func (f *fakeStore) GetByName(_ context.Context, name string) (catalog.Profile, bool, error) {
 	for _, p := range f.byID {
 		if p.Name == name {
 			return p, true, nil
 		}
 	}
-	return profilesapp.Profile{}, false, nil
+	return catalog.Profile{}, false, nil
 }
 
-func (f *fakeStore) GetDefault(context.Context) (profilesapp.Profile, error) {
+func (f *fakeStore) GetDefault(context.Context) (catalog.Profile, error) {
 	if f.failGetDef {
-		return profilesapp.Profile{}, errors.New("db down")
+		return catalog.Profile{}, errors.New("db down")
 	}
 	for _, p := range f.byID {
 		if p.IsDefault {
 			return p, nil
 		}
 	}
-	return profilesapp.Profile{}, profilesapp.ErrNotFound
+	return catalog.Profile{}, catalog.ErrNotFound
 }
 
-func (f *fakeStore) Create(_ context.Context, p profilesapp.Profile) error {
+func (f *fakeStore) Create(_ context.Context, p catalog.Profile) error {
 	if f.createErr != nil {
 		return f.createErr
 	}
 	for _, ex := range f.byID {
 		if ex.Name == p.Name {
-			return profilesapp.ErrNameExists
+			return catalog.ErrNameExists
 		}
 	}
 	f.byID[p.ID] = p
 	return nil
 }
 
-func (f *fakeStore) Update(_ context.Context, p profilesapp.Profile, ifMatch string) error {
+func (f *fakeStore) Update(_ context.Context, p catalog.Profile, ifMatch string) error {
 	existing, ok := f.byID[p.ID]
 	if ifMatch != "" {
 		if !ok {
-			return profilesapp.ErrNotFound
+			return catalog.ErrNotFound
 		}
 		if existing.ConfigJSON != ifMatch { // tests use ConfigJSON as the version token
-			return profilesapp.ErrConflict
+			return catalog.ErrConflict
 		}
 	}
 	f.byID[p.ID] = p
@@ -93,13 +93,13 @@ func (f *fakeStore) SetActiveID(_ context.Context, id string) error {
 func ctx() context.Context { return context.Background() }
 
 func TestCreateValidatesNameAndStores(t *testing.T) {
-	svc := profilesapp.NewService(newFakeStore())
+	svc := catalog.NewService(newFakeStore())
 
-	if _, err := svc.Create(ctx(), profilesapp.NewProfile{Name: ""}); !errors.Is(err, profilesapp.ErrNameRequired) {
+	if _, err := svc.Create(ctx(), catalog.NewProfile{Name: ""}); !errors.Is(err, catalog.ErrNameRequired) {
 		t.Fatalf("empty name should be ErrNameRequired, got %v", err)
 	}
 
-	p, err := svc.Create(ctx(), profilesapp.NewProfile{Name: "alpha", ConfigJSON: `{"a":1}`})
+	p, err := svc.Create(ctx(), catalog.NewProfile{Name: "alpha", ConfigJSON: `{"a":1}`})
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -107,9 +107,9 @@ func TestCreateValidatesNameAndStores(t *testing.T) {
 		t.Fatalf("unexpected created profile: %+v", p)
 	}
 
-	if _, dupErr := svc.Create(ctx(), profilesapp.NewProfile{Name: "alpha"}); !errors.Is(
+	if _, dupErr := svc.Create(ctx(), catalog.NewProfile{Name: "alpha"}); !errors.Is(
 		dupErr,
-		profilesapp.ErrNameExists,
+		catalog.ErrNameExists,
 	) {
 		t.Fatalf("duplicate name should be ErrNameExists, got %v", dupErr)
 	}
@@ -117,11 +117,11 @@ func TestCreateValidatesNameAndStores(t *testing.T) {
 
 func TestUpdatePartialSemantics(t *testing.T) {
 	store := newFakeStore()
-	store.byID["p1"] = profilesapp.Profile{ID: "p1", Name: "orig", Description: "d", ConfigJSON: "{}"}
-	svc := profilesapp.NewService(store)
+	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "orig", Description: "d", ConfigJSON: "{}"}
+	svc := catalog.NewService(store)
 
 	// Empty name keeps existing; nil config keeps existing; description always applied.
-	got, err := svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{Name: "", Description: "new", ConfigJSON: nil}, "")
+	got, err := svc.Update(ctx(), "p1", catalog.ProfileUpdate{Name: "", Description: "new", ConfigJSON: nil}, "")
 	if err != nil {
 		t.Fatalf("update: %v", err)
 	}
@@ -130,14 +130,14 @@ func TestUpdatePartialSemantics(t *testing.T) {
 	}
 
 	cfg := `{"x":2}`
-	got, _ = svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{Name: "renamed", ConfigJSON: &cfg}, "")
+	got, _ = svc.Update(ctx(), "p1", catalog.ProfileUpdate{Name: "renamed", ConfigJSON: &cfg}, "")
 	if got.Name != "renamed" || got.ConfigJSON != cfg {
 		t.Fatalf("full update mismatch: %+v", got)
 	}
 
-	if _, missErr := svc.Update(ctx(), "missing", profilesapp.ProfileUpdate{}, ""); !errors.Is(
+	if _, missErr := svc.Update(ctx(), "missing", catalog.ProfileUpdate{}, ""); !errors.Is(
 		missErr,
-		profilesapp.ErrNotFound,
+		catalog.ErrNotFound,
 	) {
 		t.Fatalf("update missing should be ErrNotFound, got %v", missErr)
 	}
@@ -146,43 +146,43 @@ func TestUpdatePartialSemantics(t *testing.T) {
 func TestUpdateIfMatch(t *testing.T) {
 	store := newFakeStore()
 	// fakeStore.UpdateIfMatch treats ConfigJSON as the version token.
-	store.byID["p1"] = profilesapp.Profile{ID: "p1", Name: "n", ConfigJSON: "v1"}
-	svc := profilesapp.NewService(store)
+	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "n", ConfigJSON: "v1"}
+	svc := catalog.NewService(store)
 
 	// Matching ETag writes through.
 	upd := `v2`
-	if _, err := svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{ConfigJSON: &upd}, "v1"); err != nil {
+	if _, err := svc.Update(ctx(), "p1", catalog.ProfileUpdate{ConfigJSON: &upd}, "v1"); err != nil {
 		t.Fatalf("matching if-match should succeed: %v", err)
 	}
 
 	// Stale ETag (the row is now "v2") conflicts.
 	again := `v3`
-	if _, err := svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{ConfigJSON: &again}, "v1"); !errors.Is(
+	if _, err := svc.Update(ctx(), "p1", catalog.ProfileUpdate{ConfigJSON: &again}, "v1"); !errors.Is(
 		err,
-		profilesapp.ErrConflict,
+		catalog.ErrConflict,
 	) {
 		t.Fatalf("stale if-match should be ErrConflict, got %v", err)
 	}
 
 	// Empty if-match stays unconditional.
 	last := `v4`
-	if _, err := svc.Update(ctx(), "p1", profilesapp.ProfileUpdate{ConfigJSON: &last}, ""); err != nil {
+	if _, err := svc.Update(ctx(), "p1", catalog.ProfileUpdate{ConfigJSON: &last}, ""); err != nil {
 		t.Fatalf("unconditional update should succeed: %v", err)
 	}
 }
 
 func TestDeleteGuards(t *testing.T) {
 	store := newFakeStore()
-	store.byID["def"] = profilesapp.Profile{ID: "def", Name: "default", IsDefault: true}
-	store.byID["act"] = profilesapp.Profile{ID: "act", Name: "active"}
-	store.byID["ok"] = profilesapp.Profile{ID: "ok", Name: "ok"}
+	store.byID["def"] = catalog.Profile{ID: "def", Name: "default", IsDefault: true}
+	store.byID["act"] = catalog.Profile{ID: "act", Name: "active"}
+	store.byID["ok"] = catalog.Profile{ID: "ok", Name: "ok"}
 	store.activeID = "act"
-	svc := profilesapp.NewService(store)
+	svc := catalog.NewService(store)
 
-	if err := svc.Delete(ctx(), "def"); !errors.Is(err, profilesapp.ErrDeleteDefault) {
+	if err := svc.Delete(ctx(), "def"); !errors.Is(err, catalog.ErrDeleteDefault) {
 		t.Fatalf("deleting default should be ErrDeleteDefault, got %v", err)
 	}
-	if err := svc.Delete(ctx(), "act"); !errors.Is(err, profilesapp.ErrDeleteActive) {
+	if err := svc.Delete(ctx(), "act"); !errors.Is(err, catalog.ErrDeleteActive) {
 		t.Fatalf("deleting active should be ErrDeleteActive, got %v", err)
 	}
 	if err := svc.Delete(ctx(), "ok"); err != nil {
@@ -196,9 +196,9 @@ func TestDeleteGuards(t *testing.T) {
 func TestActiveProfileResolution(t *testing.T) {
 	t.Run("explicit active", func(t *testing.T) {
 		store := newFakeStore()
-		store.byID["p1"] = profilesapp.Profile{ID: "p1", Name: "one"}
+		store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one"}
 		store.activeID = "p1"
-		got, err := profilesapp.NewService(store).ActiveProfile(ctx())
+		got, err := catalog.NewService(store).ActiveProfile(ctx())
 		if err != nil || got.ID != "p1" {
 			t.Fatalf("want p1, got %+v err=%v", got, err)
 		}
@@ -206,25 +206,25 @@ func TestActiveProfileResolution(t *testing.T) {
 
 	t.Run("falls back to default when unset", func(t *testing.T) {
 		store := newFakeStore()
-		store.byID["d"] = profilesapp.Profile{ID: "d", Name: "def", IsDefault: true}
-		got, err := profilesapp.NewService(store).ActiveProfile(ctx())
+		store.byID["d"] = catalog.Profile{ID: "d", Name: "def", IsDefault: true}
+		got, err := catalog.NewService(store).ActiveProfile(ctx())
 		if err != nil || got.ID != "d" {
 			t.Fatalf("want default d, got %+v err=%v", got, err)
 		}
 	})
 
 	t.Run("no active and no default", func(t *testing.T) {
-		_, err := profilesapp.NewService(newFakeStore()).ActiveProfile(ctx())
-		if !errors.Is(err, profilesapp.ErrNoActiveOrDefault) {
+		_, err := catalog.NewService(newFakeStore()).ActiveProfile(ctx())
+		if !errors.Is(err, catalog.ErrNoActiveOrDefault) {
 			t.Fatalf("want ErrNoActiveOrDefault, got %v", err)
 		}
 	})
 
 	t.Run("stale active self-heals to default", func(t *testing.T) {
 		store := newFakeStore()
-		store.byID["d"] = profilesapp.Profile{ID: "d", Name: "def", IsDefault: true}
+		store.byID["d"] = catalog.Profile{ID: "d", Name: "def", IsDefault: true}
 		store.activeID = "ghost" // points at a deleted profile
-		got, err := profilesapp.NewService(store).ActiveProfile(ctx())
+		got, err := catalog.NewService(store).ActiveProfile(ctx())
 		if err != nil || got.ID != "d" {
 			t.Fatalf("want self-heal to d, got %+v err=%v", got, err)
 		}
@@ -236,13 +236,13 @@ func TestActiveProfileResolution(t *testing.T) {
 
 func TestSetActiveProfile(t *testing.T) {
 	store := newFakeStore()
-	store.byID["p1"] = profilesapp.Profile{ID: "p1", Name: "one"}
-	svc := profilesapp.NewService(store)
+	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one"}
+	svc := catalog.NewService(store)
 
-	if _, err := svc.SetActiveProfile(ctx(), ""); !errors.Is(err, profilesapp.ErrIDRequired) {
+	if _, err := svc.SetActiveProfile(ctx(), ""); !errors.Is(err, catalog.ErrIDRequired) {
 		t.Fatalf("empty id should be ErrIDRequired, got %v", err)
 	}
-	if _, err := svc.SetActiveProfile(ctx(), "missing"); !errors.Is(err, profilesapp.ErrNotFound) {
+	if _, err := svc.SetActiveProfile(ctx(), "missing"); !errors.Is(err, catalog.ErrNotFound) {
 		t.Fatalf("missing id should be ErrNotFound, got %v", err)
 	}
 	p, err := svc.SetActiveProfile(ctx(), "p1")
@@ -253,9 +253,9 @@ func TestSetActiveProfile(t *testing.T) {
 
 func TestDuplicateRetriesOnNameCollision(t *testing.T) {
 	store := newFakeStore()
-	store.byID["src"] = profilesapp.Profile{ID: "src", Name: "src", ConfigJSON: `{"k":1}`}
-	store.byID["copy"] = profilesapp.Profile{ID: "copy", Name: "src (Copy)"} // forces first-attempt collision
-	svc := profilesapp.NewService(store)
+	store.byID["src"] = catalog.Profile{ID: "src", Name: "src", ConfigJSON: `{"k":1}`}
+	store.byID["copy"] = catalog.Profile{ID: "copy", Name: "src (Copy)"} // forces first-attempt collision
+	svc := catalog.NewService(store)
 
 	dup, err := svc.Duplicate(ctx(), "src", "")
 	if err != nil {
@@ -271,10 +271,10 @@ func TestDuplicateRetriesOnNameCollision(t *testing.T) {
 
 func TestImportCreateUpdateSkip(t *testing.T) {
 	store := newFakeStore()
-	store.byID["e"] = profilesapp.Profile{ID: "e", Name: "exists", ConfigJSON: "{}"}
-	svc := profilesapp.NewService(store)
+	store.byID["e"] = catalog.Profile{ID: "e", Name: "exists", ConfigJSON: "{}"}
+	svc := catalog.NewService(store)
 
-	res := svc.Import(ctx(), []profilesapp.ImportItem{
+	res := svc.Import(ctx(), []catalog.ImportItem{
 		{Name: "fresh", ConfigJSON: `{"a":1}`},
 		{Name: ""},                              // skipped: name required
 		{Name: "exists", ConfigJSON: `{"b":2}`}, // skipped: no overwrite
@@ -287,7 +287,7 @@ func TestImportCreateUpdateSkip(t *testing.T) {
 		t.Fatalf("expected 2 errors, got %v", res.Errors)
 	}
 
-	res = svc.Import(ctx(), []profilesapp.ImportItem{{Name: "exists", ConfigJSON: `{"c":3}`}}, true)
+	res = svc.Import(ctx(), []catalog.ImportItem{{Name: "exists", ConfigJSON: `{"c":3}`}}, true)
 	if res.Updated != 1 || res.Created != 0 || res.Skipped != 0 {
 		t.Fatalf("import(overwrite) tally: %+v", res)
 	}


### PR DESCRIPTION
## What

B3 of the ADR-0020 `internal/api` clean-hexagonal strangle — retrofits the **profiles** domain to the locked convention, mirroring the network exemplar (#1611) and the alerts (#1612) + settings (#1613) retrofits.

- **Rename** `internal/profiles/app` (pkg `profilesapp`) → `internal/profiles/catalog` (pkg `catalog`, type `Service` unchanged). Kills the `…app` package-name hack; `catalog` is a single-word, underscore-free package name that reads cleanly as a prefix for its exports (`catalog.Service` / `catalog.Store` / `catalog.Profile`).
- **Move** the `profilesStore` adapter out of `internal/api/profiles_usecases.go` into the composition root (`internal/app/profiles.go`) behind `app.NewProfiles`; **delete** `profiles_usecases.go`.
- `internal/api` is now pure transport for profiles: it wires via `app.NewProfiles(s.db)`; no adapters, no `*_usecases.go`. `handlers_profiles.go` stays thin (only the package qualifier changed).
- **Rename** the now-stale `profiles_usecases_internal_test.go` → `profiles_internal_test.go` (the `*_usecases.go` file it was named for is gone).

## Invariants preserved

- Lazy-db resolution the test harness relies on (db resolved per-call).
- Every HTTP status / response shape — **goldens identical** (no rebaseline).
- Route policy unchanged; `api → app` stays one-way (root never imports api).

## Verification (run locally, api suite alone)

- `go build ./...` ✓
- `go test ./internal/api/ -count=1` → `ok 67s` (goldens green)
- `go test ./internal/profiles/catalog/` → `ok`
- `golangci-lint` on changed pkgs: 0 issues (4 pre-existing gofumpt flags in untouched `handlers_*_test.go` are v2.12.2-vs-v2.12.1 drift, left as-is)
- `scripts/check-route-policy.sh` ✓ · `scripts/check-output-escaping.sh` ✓