### PR TITLE
refactor(api): clean-hexagonal discovery retrofit (ADR-0020)

### DIFF
--- a/internal/api/handlers_api_tokens_internal_test.go
+++ b/internal/api/handlers_api_tokens_internal_test.go
@@ -59,6 +59,10 @@ func apiTokenTestSetup(t *testing.T) (*Server, *license.Manager) {
 	s.services.Database.DB = db
 	s.services.Auth.APITokens = database.NewAPITokenRepository(db)
 	s.services.Auth.License = mgr
+	// Wire the discovery use-cases so routed handlers (e.g. the
+	// /discovery/engine/events SSE policy test) have a non-nil use-case; the
+	// engine stays nil here, so they degrade to the unavailable (503) path.
+	s.initDiscoveryUseCases()
 	return s, mgr
 }
 

--- a/internal/api/handlers_bluetooth.go
+++ b/internal/api/handlers_bluetooth.go
@@ -1,13 +1,19 @@
 package api
 
-// handlers_bluetooth.go contains Bluetooth discovery and scanning handlers.
+// handlers_bluetooth.go contains Bluetooth discovery and scanning handlers. The
+// handlers are pure transport (ADR-0020): they map the domain result onto the
+// flat wire DTOs and map a bluetooth use-case sentinel to its HTTP status; the
+// scan orchestration lives in internal/discovery/bluetooth, with the adapter in
+// internal/app.
 
 import (
+	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
-	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/bluetooth"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
@@ -146,6 +152,12 @@ func toBluetoothStats(stats *discovery.BluetoothDiscoveryStats) *BluetoothDiscov
 	}
 }
 
+// writeBluetoothUnavailable writes the pre-strangle 503 for an absent scanner.
+func writeBluetoothUnavailable(w http.ResponseWriter, logger *slog.Logger) {
+	sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
+		ErrCodeServiceUnavail, "Bluetooth scanner not available", "")
+}
+
 // handleBluetoothScan triggers a Bluetooth scan and returns results.
 //
 // POST /api/v1/security/bluetooth/scan
@@ -157,36 +169,19 @@ func toBluetoothStats(stats *discovery.BluetoothDiscoveryStats) *BluetoothDiscov
 func (s *Server) handleBluetoothScan(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	btScanner := s.bluetoothScanner()
-	if btScanner == nil {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Bluetooth scanner not available",
-			"",
-		)
-		return
-	}
-
-	result, err := btScanner.Scan(r.Context())
+	scan, err := s.bluetoothScans.Scan(r.Context())
 	if err != nil {
+		if errors.Is(err, bluetooth.ErrUnavailable) {
+			writeBluetoothUnavailable(w, logger)
+			return
+		}
 		logger.ErrorContext(r.Context(), "Bluetooth scan failed", "error", err)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			"Bluetooth scan failed: "+err.Error(),
-			"",
-		)
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, "Bluetooth scan failed: "+err.Error(), "")
 		return
 	}
 
-	resp := toBluetoothScanResponse(result, btScanner.GetStats())
-
-	sendJSONResponse(w, logger, http.StatusOK, resp)
+	sendJSONResponse(w, logger, http.StatusOK, toBluetoothScanResponse(scan.Result, scan.Stats))
 }
 
 // toBluetoothScanResponse maps a scan result + stats to the API wire shape.
@@ -215,20 +210,12 @@ func toBluetoothScanResponse(
 func (s *Server) handleBluetoothDevices(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	btScanner := s.bluetoothScanner()
-	if btScanner == nil {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Bluetooth scanner not available",
-			"",
-		)
+	lastScan, err := s.bluetoothScans.Devices()
+	if err != nil {
+		writeBluetoothUnavailable(w, logger)
 		return
 	}
 
-	lastScan := btScanner.GetLastScan()
 	if lastScan == nil {
 		sendJSONResponse(w, logger, http.StatusOK, BluetoothDevicesResponse{
 			Devices: []BluetoothDevice{},
@@ -253,20 +240,12 @@ func (s *Server) handleBluetoothDevices(w http.ResponseWriter, r *http.Request) 
 func (s *Server) handleBluetoothStats(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	btScanner := s.bluetoothScanner()
-	if btScanner == nil {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Bluetooth scanner not available",
-			"",
-		)
+	stats, err := s.bluetoothScans.Stats()
+	if err != nil {
+		writeBluetoothUnavailable(w, logger)
 		return
 	}
 
-	stats := btScanner.GetStats()
 	sendJSONResponse(w, logger, http.StatusOK, BluetoothStatsResponse{
 		Stats: toBluetoothStats(stats),
 	})
@@ -282,29 +261,18 @@ func (s *Server) handleBluetoothStats(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleBluetoothStatus(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	btScanner := s.bluetoothScanner()
-	available := btScanner != nil
+	status := s.bluetoothScans.Status()
 
 	var lastScanTime string
 	var deviceCount int
-	if available {
-		if lastScan := btScanner.GetLastScan(); lastScan != nil {
-			lastScanTime = lastScan.ScanTime.Format("2006-01-02T15:04:05Z07:00")
-			deviceCount = len(lastScan.Devices)
-		}
+	if status.LastScan != nil {
+		lastScanTime = status.LastScan.ScanTime.Format("2006-01-02T15:04:05Z07:00")
+		deviceCount = len(status.LastScan.Devices)
 	}
 
 	sendJSONResponse(w, logger, http.StatusOK, map[string]any{
-		"available":    available,
+		"available":    status.Available,
 		"lastScanTime": lastScanTime,
 		"deviceCount":  deviceCount,
 	})
-}
-
-// bluetoothScanner returns the Bluetooth scanner from the service container.
-func (s *Server) bluetoothScanner() *enumerate.BluetoothScanner {
-	if s.services == nil || s.services.Discovery == nil {
-		return nil
-	}
-	return s.services.Discovery.BluetoothScanner
 }

--- a/internal/api/handlers_engine.go
+++ b/internal/api/handlers_engine.go
@@ -9,12 +9,19 @@ import (
 	"strings"
 
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/devices"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
 // ============================================================================
 // Discovery Engine Handlers (new unified discovery system)
+//
+// These handlers are pure transport (ADR-0020): they decode/validate the
+// request, call one devices use-case method, and encode the response or map a
+// use-case sentinel to its HTTP status. The orchestration and the engine-nil
+// degraded behavior live in internal/discovery/devices; the engine adapter lives
+// in the composition root (internal/app).
 // ============================================================================
 
 // EngineDiscoveryResponse contains discovery engine results.
@@ -64,6 +71,49 @@ type EngineScanRequest struct {
 	AcknowledgeIDsRisk bool `json:"acknowledgeIdsRisk,omitempty"`
 }
 
+// engineResponse assembles the wire response from a use-case snapshot.
+func engineResponse(snap devices.Snapshot) EngineDiscoveryResponse {
+	return EngineDiscoveryResponse{
+		Devices:      snap.Devices,
+		Stats:        snap.Stats,
+		ScanResult:   snap.ScanResult,
+		Capabilities: snap.Capabilities,
+	}
+}
+
+// writeEngineError maps a devices use-case sentinel to its pre-strangle HTTP
+// response. ErrUnavailable is the golden-pinned 503 degraded path.
+func writeEngineError(w http.ResponseWriter, logger *slog.Logger, err error) {
+	switch {
+	case errors.Is(err, devices.ErrUnavailable):
+		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
+			ErrCodeServiceUnavail, "Discovery engine not available", "")
+	case errors.Is(err, devices.ErrDeviceNotFound):
+		sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
+			ErrCodeNotFound, "Device not found", "")
+	default:
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, "Discovery engine error", err.Error())
+	}
+}
+
+// writeEngineScanError maps a scan error to its response: the availability and
+// in-progress sentinels keep their dedicated status, any other failure is a 500
+// carrying the named scan and the underlying error detail.
+func writeEngineScanError(w http.ResponseWriter, logger *slog.Logger, scanName string, err error) {
+	switch {
+	case errors.Is(err, devices.ErrUnavailable):
+		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
+			ErrCodeServiceUnavail, "Discovery engine not available", "")
+	case errors.Is(err, devices.ErrScanInProgress):
+		sendErrorResponseWithDetails(w, logger, http.StatusConflict,
+			ErrCodeConflict, "A scan is already in progress", "")
+	default:
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, scanName+" failed", err.Error())
+	}
+}
+
 // handleEngineDiscovery returns all devices from the discovery engine registry.
 //
 // GET /api/v1/discovery/engine returns all discovered devices.
@@ -79,26 +129,12 @@ type EngineScanRequest struct {
 func (s *Server) handleEngineDiscovery(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	engine := s.services.Discovery.Engine
-	if engine == nil {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Discovery engine not available",
-			"",
-		)
+	snap, err := s.discoveryDevices.Snapshot()
+	if err != nil {
+		writeEngineError(w, logger, err)
 		return
 	}
-
-	resp := EngineDiscoveryResponse{
-		Devices:      engine.GetDevices(),
-		Stats:        engine.GetStats(),
-		ScanResult:   engine.GetLastScan(),
-		Capabilities: engine.GetCapabilities(),
-	}
-
-	sendJSONResponse(w, logger, http.StatusOK, resp)
+	sendJSONResponse(w, logger, http.StatusOK, engineResponse(snap))
 }
 
 // maxEngineCustomPorts bounds an engine-scan custom port list so a single
@@ -226,77 +262,36 @@ func parseEngineScanOpts(
 // Quick scan: Correlation of existing data, fast
 // Full scan: Fresh discovery + enrichment + assessment
 //
-// Request body (optional):
-//
-//	{
-//	  "scanType": "quick",          // or "full"
-//	  "includeWired": true,
-//	  "includeWifi": true,
-//	  "includeBluetooth": true,
-//	  "includeSnmp": true,
-//	  "includePortScan": true,
-//	  "includeVulnScan": true,
-//	  "freshWiredScan": true,
-//	  "freshWifiScan": true,
-//	  "freshBluetoothScan": true
-//	}
-//
 // Authentication: Required
 // Rate limiting: Yes (scans can be resource intensive).
 func (s *Server) handleEngineScan(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	engine := s.services.Discovery.Engine
-	if engine == nil {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Discovery engine not available",
-			"",
-		)
+	// Probe availability + in-progress before parsing the body so the engine-nil
+	// 503 and the in-progress 409 precede any request-validation error (the order
+	// the engine handler tests pin).
+	if !s.discoveryDevices.Available() {
+		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
+			ErrCodeServiceUnavail, "Discovery engine not available", "")
+		return
+	}
+	if s.discoveryDevices.Scanning() {
+		sendErrorResponseWithDetails(w, logger, http.StatusConflict,
+			ErrCodeConflict, "A scan is already in progress", "")
 		return
 	}
 
-	// Check if already scanning
-	if engine.IsScanning() {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusConflict,
-			ErrCodeConflict,
-			"A scan is already in progress",
-			"",
-		)
-		return
-	}
-
-	// Parse + validate options from body, default to quick scan.
 	opts, ok := parseEngineScanOpts(w, r, logger)
 	if !ok {
 		return
 	}
 
-	// Run scan
-	result, err := engine.Scan(r.Context(), opts)
+	snap, err := s.discoveryDevices.Scan(r.Context(), opts)
 	if err != nil {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			"Scan failed",
-			err.Error(),
-		)
+		writeEngineScanError(w, logger, "Scan", err)
 		return
 	}
-
-	resp := EngineDiscoveryResponse{
-		Devices:      engine.GetDevices(),
-		Stats:        engine.GetStats(),
-		ScanResult:   result,
-		Capabilities: engine.GetCapabilities(),
-	}
-
-	sendJSONResponse(w, logger, http.StatusOK, resp)
+	sendJSONResponse(w, logger, http.StatusOK, engineResponse(snap))
 }
 
 // scanType indicates the type of scan to perform.
@@ -307,7 +302,9 @@ const (
 	scanTypeFull
 )
 
-// executeScan is a helper that handles common scan logic.
+// executeScan runs a quick or full scan and writes the response. The use-case
+// applies the availability + in-progress guards in order, so the handler maps
+// the resulting sentinels to status.
 func (s *Server) executeScan(w http.ResponseWriter, r *http.Request, st scanType) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
@@ -323,61 +320,24 @@ func (s *Server) executeScan(w http.ResponseWriter, r *http.Request, st scanType
 		return
 	}
 
-	engine := s.services.Discovery.Engine
-	if engine == nil {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Discovery engine not available",
-			"",
-		)
-		return
-	}
-
-	if engine.IsScanning() {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusConflict,
-			ErrCodeConflict,
-			"A scan is already in progress",
-			"",
-		)
-		return
-	}
-
-	var result *discovery.ScanResult
+	var snap devices.Snapshot
 	var err error
 	var scanName string
 
 	switch st {
 	case scanTypeQuick:
 		scanName = "Quick scan"
-		result, err = engine.QuickScan(r.Context())
+		snap, err = s.discoveryDevices.QuickScan(r.Context())
 	case scanTypeFull:
 		scanName = "Full scan"
-		result, err = engine.FullScan(r.Context())
+		snap, err = s.discoveryDevices.FullScan(r.Context())
 	}
 
 	if err != nil {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			scanName+" failed",
-			err.Error(),
-		)
+		writeEngineScanError(w, logger, scanName, err)
 		return
 	}
-
-	resp := EngineDiscoveryResponse{
-		Devices:      engine.GetDevices(),
-		Stats:        engine.GetStats(),
-		ScanResult:   result,
-		Capabilities: engine.GetCapabilities(),
-	}
-
-	sendJSONResponse(w, logger, http.StatusOK, resp)
+	sendJSONResponse(w, logger, http.StatusOK, engineResponse(snap))
 }
 
 // handleEngineQuickScan triggers a quick discovery scan.
@@ -417,19 +377,11 @@ func (s *Server) handleEngineFullScan(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleEngineStats(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	engine := s.services.Discovery.Engine
-	if engine == nil {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Discovery engine not available",
-			"",
-		)
+	stats, err := s.discoveryDevices.Stats()
+	if err != nil {
+		writeEngineError(w, logger, err)
 		return
 	}
-
-	stats := engine.GetStats()
 	sendJSONResponse(w, logger, http.StatusOK, stats)
 }
 
@@ -442,19 +394,11 @@ func (s *Server) handleEngineStats(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleEngineCapabilities(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	engine := s.services.Discovery.Engine
-	if engine == nil {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Discovery engine not available",
-			"",
-		)
+	caps, err := s.discoveryDevices.Capabilities()
+	if err != nil {
+		writeEngineError(w, logger, err)
 		return
 	}
-
-	caps := engine.GetCapabilities()
 	sendJSONResponse(w, logger, http.StatusOK, caps)
 }
 
@@ -470,56 +414,34 @@ func (s *Server) handleEngineCapabilities(w http.ResponseWriter, r *http.Request
 func (s *Server) handleEngineDevice(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	engine := s.services.Discovery.Engine
-	if engine == nil {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Discovery engine not available",
-			"",
-		)
+	// Engine availability is checked first so a nil engine returns 503 before any
+	// path validation (the order the engine handler tests pin).
+	if !s.discoveryDevices.Available() {
+		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
+			ErrCodeServiceUnavail, "Discovery engine not available", "")
 		return
 	}
 
-	// Extract MAC from URL path
-	// URL format: /api/v1/discovery/engine/device/{mac}
+	// Extract MAC from URL path: /api/v1/discovery/engine/device/{mac}
 	path := r.URL.Path
 	prefix := APIVersionPrefix + "/discovery/engine/device/"
 	if !strings.HasPrefix(path, prefix) {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusBadRequest,
-			ErrCodeBadRequest,
-			"Invalid request path",
-			"",
-		)
+		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
+			ErrCodeBadRequest, "Invalid request path", "")
 		return
 	}
 	mac := strings.TrimPrefix(path, prefix)
 	if mac == "" {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusBadRequest,
-			ErrCodeBadRequest,
-			"MAC address required",
-			"",
-		)
+		sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
+			ErrCodeBadRequest, "MAC address required", "")
 		return
 	}
 
-	device := engine.GetDevice(mac)
-	if device == nil {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusNotFound,
-			ErrCodeNotFound,
-			"Device not found",
-			"",
-		)
+	device, err := s.discoveryDevices.Device(mac)
+	if err != nil {
+		writeEngineError(w, logger, err)
 		return
 	}
-
 	sendJSONResponse(w, logger, http.StatusOK, device)
 }
 
@@ -539,28 +461,19 @@ func (s *Server) handleEngineDevice(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleEngineEvents(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	engine := s.services.Discovery.Engine
-	if engine == nil {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Discovery engine not available",
-			"",
-		)
+	// Availability is checked before any SSE headers are written so the engine-nil
+	// case can still return a 503 status.
+	if !s.discoveryDevices.Available() {
+		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
+			ErrCodeServiceUnavail, "Discovery engine not available", "")
 		return
 	}
 
 	// Check if SSE is supported
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		sendErrorResponseWithDetails(
-			w, logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			"Streaming not supported",
-			"",
-		)
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, "Streaming not supported", "")
 		return
 	}
 
@@ -571,9 +484,9 @@ func (s *Server) handleEngineEvents(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Accel-Buffering", "no")
 
 	// Subscribe to all events
-	sub := engine.SubscribeAll(func(event *discovery.Event) {
-		data, err := json.Marshal(event)
-		if err != nil {
+	id, err := s.discoveryDevices.Subscribe(func(event *discovery.Event) {
+		data, marshalErr := json.Marshal(event)
+		if marshalErr != nil {
 			return
 		}
 		// Write SSE format
@@ -581,7 +494,11 @@ func (s *Server) handleEngineEvents(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("data: " + string(data) + "\n\n"))
 		flusher.Flush()
 	})
-	defer engine.Unsubscribe(sub.ID())
+	if err != nil {
+		writeEngineError(w, logger, err)
+		return
+	}
+	defer s.discoveryDevices.Unsubscribe(id)
 
 	// Keep connection open until client disconnects
 	<-r.Context().Done()

--- a/internal/api/handlers_problems.go
+++ b/internal/api/handlers_problems.go
@@ -1,11 +1,17 @@
 package api
 
-// handlers_problems.go extends the discovery API with network problem detection endpoints.
+// handlers_problems.go extends the discovery API with network problem detection
+// endpoints. The handlers are pure transport (ADR-0020): decode/encode and map
+// a problems use-case sentinel to its HTTP status; the detection orchestration
+// lives in internal/discovery/problems, with the adapter in internal/app.
 
 import (
+	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/problems"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
@@ -31,6 +37,12 @@ type ProblemScanResponse struct {
 	DurationMS   int64                           `json:"durationMs"`
 }
 
+// writeProblemsUnavailable writes the pre-strangle 503 for an absent detector.
+func writeProblemsUnavailable(w http.ResponseWriter, logger *slog.Logger) {
+	sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
+		ErrCodeServiceUnavail, "Problem detector not available", "")
+}
+
 // handleNetworkProblems returns current network problems.
 //
 // GET /api/v1/discovery/problems
@@ -41,26 +53,16 @@ type ProblemScanResponse struct {
 func (s *Server) handleNetworkProblems(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	detector := s.problemDetector()
-	if detector == nil {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Problem detector not available",
-			"",
-		)
+	active, err := s.networkProblems.Active()
+	if err != nil {
+		writeProblemsUnavailable(w, logger)
 		return
 	}
 
-	problems := detector.GetActiveProblems()
-	summary := detector.GetSummary()
-
 	sendJSONResponse(w, logger, http.StatusOK, NetworkProblemsResponse{
-		Problems: problems,
-		Summary:  summary,
-		Total:    len(problems),
+		Problems: active.Problems,
+		Summary:  active.Summary,
+		Total:    len(active.Problems),
 	})
 }
 
@@ -74,36 +76,15 @@ func (s *Server) handleNetworkProblems(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleProblemScan(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	detector := s.problemDetector()
-	if detector == nil {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Problem detector not available",
-			"",
-		)
-		return
-	}
-
-	// Get discovered devices from discovery service
-	var devices []*discovery.DiscoveredDevice
-	if s.discoveryService() != nil {
-		devices = s.discoveryService().GetDevices()
-	}
-
-	result, err := detector.Scan(r.Context(), devices)
+	result, err := s.networkProblems.Scan(r.Context())
 	if err != nil {
+		if errors.Is(err, problems.ErrUnavailable) {
+			writeProblemsUnavailable(w, logger)
+			return
+		}
 		logger.ErrorContext(r.Context(), "Problem scan failed", "error", err)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			"Problem scan failed: "+err.Error(),
-			"",
-		)
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, "Problem scan failed: "+err.Error(), "")
 		return
 	}
 
@@ -125,22 +106,18 @@ func (s *Server) handleProblemThresholds(w http.ResponseWriter, r *http.Request)
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
 
-	detector := s.problemDetector()
-	if detector == nil {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusServiceUnavailable,
-			ErrCodeServiceUnavail,
-			"Problem detector not available",
-			"",
-		)
+	if !s.networkProblems.Available() {
+		writeProblemsUnavailable(w, logger)
 		return
 	}
 
 	switch r.Method {
 	case http.MethodGet:
-		thresholds := detector.GetThresholds()
+		thresholds, err := s.networkProblems.Thresholds()
+		if err != nil {
+			writeProblemsUnavailable(w, logger)
+			return
+		}
 		sendJSONResponse(w, logger, http.StatusOK, thresholds)
 
 	case http.MethodPut:
@@ -148,29 +125,17 @@ func (s *Server) handleProblemThresholds(w http.ResponseWriter, r *http.Request)
 		if !decodeJSONStrictLocalized(w, r, &thresholds, MaxBodySizeJSON, logger, localizer) {
 			return
 		}
-
-		detector.SetThresholds(thresholds)
+		if err := s.networkProblems.SetThresholds(thresholds); err != nil {
+			writeProblemsUnavailable(w, logger)
+			return
+		}
 		sendJSONResponse(w, logger, http.StatusOK, map[string]string{
 			"status":  statusSuccess,
 			"message": "Thresholds updated",
 		})
 
 	default:
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusMethodNotAllowed,
-			ErrCodeMethodNotAllowed,
-			localizer.T("errors.api.methodNotAllowed"),
-			"",
-		)
+		sendErrorResponseWithDetails(w, logger, http.StatusMethodNotAllowed,
+			ErrCodeMethodNotAllowed, localizer.T("errors.api.methodNotAllowed"), "")
 	}
-}
-
-// problemDetector returns the problem detector from the service container.
-func (s *Server) problemDetector() *discovery.ProblemDetector {
-	if s.services == nil || s.services.Discovery == nil {
-		return nil
-	}
-	return s.services.Discovery.ProblemDetector
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -26,7 +26,11 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/iperf"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/speedtest"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/vlan"
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/bluetooth"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/devices"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/problems"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/health"
 	"github.com/MustardSeedNetworks/seed/internal/license"
@@ -139,6 +143,9 @@ type Server struct {
 	profiles           *catalog.Service            // Profile CRUD/active/import use-case (ADR-0020)
 	networkIP          *ipconfig.Service           // IP-config + MTU use-case (ADR-0020)
 	alertRules         *rules.Service              // Alert-rule CRUD use-case (ADR-0020)
+	discoveryDevices   *devices.Service            // Unified-discovery (engine) use-case (ADR-0020)
+	networkProblems    *problems.Service           // Network problem-detection use-case (ADR-0020)
+	bluetoothScans     *bluetooth.Service          // Bluetooth-discovery use-case (ADR-0020)
 	tlsFingerprint     tlsFingerprintCache         // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
 
@@ -250,8 +257,10 @@ func NewServer(
 	// Initialize discovery service and pipeline
 	s.initDiscovery(cfg)
 
-	// Wire the Wi-Fi troubleshooting use-cases now the discovery bridge exists.
+	// Wire the troubleshooting + discovery use-cases now the discovery
+	// components exist (ADR-0020).
 	s.initWiFiUseCases()
+	s.initDiscoveryUseCases()
 
 	// Wire the settings-persistence use-case (ADR-0020). The composition root
 	// builds the adapters; api passes its lazy db accessor + live config.
@@ -728,6 +737,15 @@ func (s *Server) netManager() *netif.Manager                  { return s.service
 func (s *Server) linkMonitor() *netif.LinkMonitor             { return s.services.Network.LinkMonitor }
 func (s *Server) deviceDiscovery() *enumerate.DeviceDiscovery { return s.services.Discovery.Device }
 func (s *Server) discoveryService() *enumerate.Service        { return s.services.Discovery.Service }
+func (s *Server) discoveryEngine() *discovery.Engine          { return s.services.Discovery.Engine }
+func (s *Server) problemDetector() *discovery.ProblemDetector {
+	return s.services.Discovery.ProblemDetector
+}
+
+func (s *Server) bluetoothScanner() *enumerate.BluetoothScanner {
+	return s.services.Discovery.BluetoothScanner
+}
+
 func (s *Server) vulnScanner() *vuln.VulnerabilityScanner {
 	return s.services.Discovery.Vulnerability
 }
@@ -760,6 +778,17 @@ func (s *Server) initWiFiUseCases() {
 	s.wifiQueries = app.NewWiFiQueries(s.wifiVisibility)
 	s.wifiManagement = app.NewWiFiManagement(s.wifiManager, s.wifiScanner, s.netManager, s.config, s.configPath)
 	s.wifiDiscovery = app.NewWiFiDiscovery(s.wifiBridge)
+}
+
+// initDiscoveryUseCases wires the discovery use-cases (ADR-0020) from the
+// composition root: the unified-discovery engine, the network problem detector,
+// and the Bluetooth scanner, each over the server's lazy accessors so a nil or
+// later-set collaborator (the test harness) is honored. The problem detector's
+// scan reads the discovered devices through the device-discovery accessor.
+func (s *Server) initDiscoveryUseCases() {
+	s.discoveryDevices = app.NewDiscoveryDevices(s.discoveryEngine)
+	s.networkProblems = app.NewProblems(s.problemDetector, s.discoveryService)
+	s.bluetoothScans = app.NewBluetooth(s.bluetoothScanner)
 }
 
 // webAuthnConfigFromServer derives the relying-party config for the

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -160,6 +160,7 @@ func NewTestServerWithConfig(cfg *config.Config) *Server {
 	s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)
 	s.alertRules = app.NewAlertRules(s.db)
 	s.initWiFiUseCases()
+	s.initDiscoveryUseCases()
 
 	// Setup routes
 	s.setupRoutes()

--- a/internal/app/discovery.go
+++ b/internal/app/discovery.go
@@ -1,0 +1,142 @@
+package app
+
+// discovery.go wires the composition root to the discovery application (use-case)
+// services (ADR-0020 clean-hexagonal): the device-inventory engine, the network
+// problem detector, and the Bluetooth scanner. The adapters below implement the
+// narrow ports declared in internal/discovery/{devices,problems,bluetooth} over
+// the concrete collaborators (the discovery engine, the problem detector, the
+// device-discovery service, and the Bluetooth scanner), so the API handlers
+// depend on use-cases instead of reaching into the service container directly.
+// Collaborators are resolved through lazy accessors on each call so a later-set
+// value (the api test harness) is honored, and a nil collaborator degrades the
+// use-case to its unavailable behavior rather than panicking.
+
+import (
+	"context"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/bluetooth"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/devices"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/problems"
+)
+
+// NewDiscoveryDevices builds the unified-discovery use-case (ADR-0020) over a lazy
+// accessor for the discovery engine. A nil engine makes every method degrade to
+// devices.ErrUnavailable (the golden-pinned 503 path).
+func NewDiscoveryDevices(eng func() *discovery.Engine) *devices.Service {
+	return devices.NewService(discoveryEngineAdapter{eng: eng})
+}
+
+// NewProblems builds the problem-detection use-case (ADR-0020) over lazy accessors
+// for the problem detector and the device-discovery source. A nil detector makes
+// every method degrade to problems.ErrUnavailable; a nil source yields no devices.
+func NewProblems(
+	detector func() *discovery.ProblemDetector,
+	deviceSrc func() *enumerate.Service,
+) *problems.Service {
+	return problems.NewService(
+		problemDetectorAdapter{detector: detector},
+		discoveryDeviceSource{deviceSrc: deviceSrc},
+	)
+}
+
+// NewBluetooth builds the Bluetooth-discovery use-case (ADR-0020) over a lazy
+// accessor for the Bluetooth scanner. A nil scanner makes the scan/devices/stats
+// methods degrade to bluetooth.ErrUnavailable, while Status reports unavailable.
+func NewBluetooth(scanner func() *enumerate.BluetoothScanner) *bluetooth.Service {
+	return bluetooth.NewService(bluetoothScannerAdapter{scanner: scanner})
+}
+
+// discoveryEngineAdapter implements devices.Engine over the discovery engine,
+// resolving the engine lazily. Methods beyond Available/Scanning are only invoked
+// by the use-case once Available reports true, so they assume a non-nil engine.
+type discoveryEngineAdapter struct {
+	eng func() *discovery.Engine
+}
+
+func (a discoveryEngineAdapter) Available() bool { return a.eng() != nil }
+func (a discoveryEngineAdapter) Scanning() bool  { return a.eng().IsScanning() }
+func (a discoveryEngineAdapter) Devices() []*discovery.DiscoveredDevice {
+	return a.eng().GetDevices()
+}
+
+func (a discoveryEngineAdapter) Device(mac string) *discovery.DiscoveredDevice {
+	return a.eng().GetDevice(mac)
+}
+func (a discoveryEngineAdapter) Stats() *discovery.EngineStats   { return a.eng().GetStats() }
+func (a discoveryEngineAdapter) LastScan() *discovery.ScanResult { return a.eng().GetLastScan() }
+func (a discoveryEngineAdapter) Capabilities() map[string]bool   { return a.eng().GetCapabilities() }
+
+func (a discoveryEngineAdapter) Scan(
+	ctx context.Context, opts *discovery.ScanOptions,
+) (*discovery.ScanResult, error) {
+	return a.eng().Scan(ctx, opts)
+}
+
+func (a discoveryEngineAdapter) SubscribeAll(handler func(*discovery.Event)) string {
+	return a.eng().SubscribeAll(handler).ID()
+}
+func (a discoveryEngineAdapter) Unsubscribe(id string) { a.eng().Unsubscribe(id) }
+
+// problemDetectorAdapter implements problems.Detector over the problem detector,
+// resolving it lazily.
+type problemDetectorAdapter struct {
+	detector func() *discovery.ProblemDetector
+}
+
+func (a problemDetectorAdapter) Available() bool { return a.detector() != nil }
+func (a problemDetectorAdapter) ActiveProblems() []discovery.NetworkProblem {
+	return a.detector().GetActiveProblems()
+}
+
+func (a problemDetectorAdapter) Summary() *discovery.ProblemSummary {
+	return a.detector().GetSummary()
+}
+
+func (a problemDetectorAdapter) Scan(
+	ctx context.Context, devs []*discovery.DiscoveredDevice,
+) (*discovery.ProblemDetectionResult, error) {
+	return a.detector().Scan(ctx, devs)
+}
+
+func (a problemDetectorAdapter) Thresholds() discovery.ProblemThresholds {
+	return a.detector().GetThresholds()
+}
+
+func (a problemDetectorAdapter) SetThresholds(t discovery.ProblemThresholds) {
+	a.detector().SetThresholds(t)
+}
+
+// discoveryDeviceSource implements problems.DeviceSource over the device-discovery
+// service, returning no devices when the service is absent.
+type discoveryDeviceSource struct {
+	deviceSrc func() *enumerate.Service
+}
+
+func (a discoveryDeviceSource) Devices() []*discovery.DiscoveredDevice {
+	svc := a.deviceSrc()
+	if svc == nil {
+		return nil
+	}
+	return svc.GetDevices()
+}
+
+// bluetoothScannerAdapter implements bluetooth.Scanner over the Bluetooth scanner,
+// resolving it lazily.
+type bluetoothScannerAdapter struct {
+	scanner func() *enumerate.BluetoothScanner
+}
+
+func (a bluetoothScannerAdapter) Available() bool { return a.scanner() != nil }
+func (a bluetoothScannerAdapter) Scan(ctx context.Context) (*discovery.BluetoothScanResult, error) {
+	return a.scanner().Scan(ctx)
+}
+
+func (a bluetoothScannerAdapter) LastScan() *discovery.BluetoothScanResult {
+	return a.scanner().GetLastScan()
+}
+
+func (a bluetoothScannerAdapter) Stats() *discovery.BluetoothDiscoveryStats {
+	return a.scanner().GetStats()
+}

--- a/internal/discovery/bluetooth/bluetooth.go
+++ b/internal/discovery/bluetooth/bluetooth.go
@@ -1,0 +1,95 @@
+// Package bluetooth holds the Bluetooth-discovery application (use-case) layer
+// (ADR-0020). It owns the orchestration that previously lived in the api.Server
+// Bluetooth handlers — triggering an active scan, returning the most recent
+// devices, reading aggregate statistics, and reporting adapter status — behind a
+// narrow consumer-defined port over the Bluetooth scanner. Handlers keep
+// transport concerns: response mapping (the flat wire DTOs), time formatting,
+// and error-to-status mapping. The adapter satisfying the port lives in the
+// composition root (internal/app) and resolves the scanner lazily; a nil scanner
+// degrades the scan/devices/stats methods to ErrUnavailable, while Status reports
+// availability=false rather than erroring (matching the pre-strangle behavior).
+package bluetooth
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
+)
+
+// ErrUnavailable signals the Bluetooth scanner is not wired (handlers map it to
+// 503, the pre-strangle degraded behavior).
+var ErrUnavailable = errors.New("bluetooth scanner not available")
+
+// Scanner is the Bluetooth-scanner surface the use-case drives, defined at the
+// consumer (ADR-0020) and satisfied by an adapter over *enumerate.BluetoothScanner
+// in internal/app. Available reports whether a scanner is wired (resolved per
+// call); the remaining methods are only invoked once availability is confirmed.
+type Scanner interface {
+	Available() bool
+	Scan(ctx context.Context) (*discovery.BluetoothScanResult, error)
+	LastScan() *discovery.BluetoothScanResult
+	Stats() *discovery.BluetoothDiscoveryStats
+}
+
+// ScanResult pairs a scan's result with the post-scan aggregate statistics, the
+// two pieces the scan response is assembled from.
+type ScanResult struct {
+	Result *discovery.BluetoothScanResult
+	Stats  *discovery.BluetoothDiscoveryStats
+}
+
+// Status is the use-case read model for the adapter-status response.
+type Status struct {
+	Available bool
+	LastScan  *discovery.BluetoothScanResult
+}
+
+// Service is the Bluetooth-discovery use-case.
+type Service struct {
+	scanner Scanner
+}
+
+// NewService builds the use-case over its narrow scanner dependency.
+func NewService(scanner Scanner) *Service {
+	return &Service{scanner: scanner}
+}
+
+// Scan triggers an active Bluetooth scan and returns the result plus the
+// post-scan statistics.
+func (s *Service) Scan(ctx context.Context) (ScanResult, error) {
+	if !s.scanner.Available() {
+		return ScanResult{}, ErrUnavailable
+	}
+	result, err := s.scanner.Scan(ctx)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	return ScanResult{Result: result, Stats: s.scanner.Stats()}, nil
+}
+
+// Devices returns the most recent scan (nil if no scan has run), letting the
+// handler render an empty device list for the no-scan case.
+func (s *Service) Devices() (*discovery.BluetoothScanResult, error) {
+	if !s.scanner.Available() {
+		return nil, ErrUnavailable
+	}
+	return s.scanner.LastScan(), nil
+}
+
+// Stats returns the aggregate Bluetooth discovery statistics.
+func (s *Service) Stats() (*discovery.BluetoothDiscoveryStats, error) {
+	if !s.scanner.Available() {
+		return nil, ErrUnavailable
+	}
+	return s.scanner.Stats(), nil
+}
+
+// Status reports adapter availability and the most recent scan. Unlike the other
+// methods it never errors: an absent scanner is a valid "unavailable" status.
+func (s *Service) Status() Status {
+	if !s.scanner.Available() {
+		return Status{Available: false}
+	}
+	return Status{Available: true, LastScan: s.scanner.LastScan()}
+}

--- a/internal/discovery/bluetooth/bluetooth_test.go
+++ b/internal/discovery/bluetooth/bluetooth_test.go
@@ -1,0 +1,91 @@
+package bluetooth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/bluetooth"
+)
+
+type fakeScanner struct {
+	available bool
+	result    *discovery.BluetoothScanResult
+	scanErr   error
+	last      *discovery.BluetoothScanResult
+	stats     *discovery.BluetoothDiscoveryStats
+}
+
+func (f *fakeScanner) Available() bool                           { return f.available }
+func (f *fakeScanner) LastScan() *discovery.BluetoothScanResult  { return f.last }
+func (f *fakeScanner) Stats() *discovery.BluetoothDiscoveryStats { return f.stats }
+func (f *fakeScanner) Scan(context.Context) (*discovery.BluetoothScanResult, error) {
+	return f.result, f.scanErr
+}
+
+func TestUnavailablePaths(t *testing.T) {
+	t.Parallel()
+	svc := bluetooth.NewService(&fakeScanner{available: false})
+
+	if _, err := svc.Scan(context.Background()); !errors.Is(err, bluetooth.ErrUnavailable) {
+		t.Errorf("Scan() err = %v, want ErrUnavailable", err)
+	}
+	if _, err := svc.Devices(); !errors.Is(err, bluetooth.ErrUnavailable) {
+		t.Errorf("Devices() err = %v, want ErrUnavailable", err)
+	}
+	if _, err := svc.Stats(); !errors.Is(err, bluetooth.ErrUnavailable) {
+		t.Errorf("Stats() err = %v, want ErrUnavailable", err)
+	}
+}
+
+func TestScanReturnsResultAndStats(t *testing.T) {
+	t.Parallel()
+	result := &discovery.BluetoothScanResult{}
+	stats := &discovery.BluetoothDiscoveryStats{}
+	svc := bluetooth.NewService(&fakeScanner{available: true, result: result, stats: stats})
+
+	scan, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan() err = %v", err)
+	}
+	if scan.Result != result || scan.Stats != stats {
+		t.Fatalf("Scan() = %+v, want the result + post-scan stats", scan)
+	}
+}
+
+func TestScanSurfacesScannerError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("adapter down")
+	svc := bluetooth.NewService(&fakeScanner{available: true, scanErr: sentinel})
+	if _, err := svc.Scan(context.Background()); !errors.Is(err, sentinel) {
+		t.Fatalf("Scan() err = %v, want the scanner error verbatim", err)
+	}
+}
+
+func TestDevicesReturnsLastScan(t *testing.T) {
+	t.Parallel()
+	last := &discovery.BluetoothScanResult{}
+	svc := bluetooth.NewService(&fakeScanner{available: true, last: last})
+	got, err := svc.Devices()
+	if err != nil || got != last {
+		t.Fatalf("Devices() = %v, %v; want the last scan, nil", got, err)
+	}
+}
+
+func TestStatusUnavailable(t *testing.T) {
+	t.Parallel()
+	status := bluetooth.NewService(&fakeScanner{available: false}).Status()
+	if status.Available || status.LastScan != nil {
+		t.Fatalf("Status() = %+v, want available=false, no last scan", status)
+	}
+}
+
+func TestStatusAvailable(t *testing.T) {
+	t.Parallel()
+	last := &discovery.BluetoothScanResult{}
+	status := bluetooth.NewService(&fakeScanner{available: true, last: last}).Status()
+	if !status.Available || status.LastScan != last {
+		t.Fatalf("Status() = %+v, want available=true with the last scan", status)
+	}
+}

--- a/internal/discovery/devices/devices.go
+++ b/internal/discovery/devices/devices.go
@@ -1,0 +1,166 @@
+// Package devices holds the unified-discovery application (use-case) layer
+// (ADR-0020). It owns the device-inventory orchestration that previously lived
+// in the api.Server discovery-engine handlers — querying the discovered-device
+// inventory, triggering quick/full/custom scans, looking up a device by MAC,
+// and subscribing to the live discovery event stream — behind a narrow
+// consumer-defined port over the discovery engine. Handlers keep transport
+// concerns: request decode, scan-option validation, MAC extraction, SSE framing,
+// and error-to-status mapping. The adapter satisfying the port lives in the
+// composition root (internal/app) and resolves the engine lazily so a later-set
+// engine (the api test harness) is honored; a nil engine degrades every method
+// to ErrUnavailable rather than panicking.
+package devices
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
+)
+
+// Sentinel errors, mapped by handlers to the pre-strangle HTTP responses.
+var (
+	// ErrUnavailable signals the discovery engine is not wired (handlers map
+	// it to 503, the golden-pinned degraded behavior).
+	ErrUnavailable = errors.New("discovery engine not available")
+	// ErrScanInProgress signals a scan is already running (handlers map it to 409).
+	ErrScanInProgress = errors.New("a scan is already in progress")
+	// ErrDeviceNotFound signals the requested MAC is unknown (handlers map it to 404).
+	ErrDeviceNotFound = errors.New("device not found")
+)
+
+// Engine is the discovery-engine surface the use-case drives, defined at the
+// consumer (ADR-0020) and satisfied by an adapter over *discovery.Engine in
+// internal/app. Available reports whether an engine is wired (resolved per call
+// so the use-case can degrade gracefully); the remaining methods are only
+// invoked once availability is confirmed.
+type Engine interface {
+	Available() bool
+	Scanning() bool
+	Devices() []*discovery.DiscoveredDevice
+	Device(mac string) *discovery.DiscoveredDevice
+	Stats() *discovery.EngineStats
+	LastScan() *discovery.ScanResult
+	Capabilities() map[string]bool
+	Scan(ctx context.Context, opts *discovery.ScanOptions) (*discovery.ScanResult, error)
+	SubscribeAll(handler func(*discovery.Event)) string
+	Unsubscribe(id string)
+}
+
+// Snapshot is the use-case read model for the discovery-engine responses: the
+// current device inventory, engine statistics, the most recent scan result, and
+// the engine's capability set.
+type Snapshot struct {
+	Devices      []*discovery.DiscoveredDevice
+	Stats        *discovery.EngineStats
+	ScanResult   *discovery.ScanResult
+	Capabilities map[string]bool
+}
+
+// Service is the unified-discovery use-case.
+type Service struct {
+	engine Engine
+}
+
+// NewService builds the use-case over its narrow engine dependency.
+func NewService(engine Engine) *Service {
+	return &Service{engine: engine}
+}
+
+// Available reports whether the discovery engine is wired. Handlers probe this
+// before parsing a request body or path so the engine-nil 503 precedes any
+// validation error (the order pinned by the engine handler tests).
+func (s *Service) Available() bool { return s.engine.Available() }
+
+// Scanning reports whether a scan is currently running. Handlers probe this to
+// surface a 409 before parsing a scan body.
+func (s *Service) Scanning() bool { return s.engine.Available() && s.engine.Scanning() }
+
+// Snapshot returns the current inventory snapshot (no last-scan trigger).
+func (s *Service) Snapshot() (Snapshot, error) {
+	if !s.engine.Available() {
+		return Snapshot{}, ErrUnavailable
+	}
+	return Snapshot{
+		Devices:      s.engine.Devices(),
+		Stats:        s.engine.Stats(),
+		ScanResult:   s.engine.LastScan(),
+		Capabilities: s.engine.Capabilities(),
+	}, nil
+}
+
+// Scan applies the shared guards (availability, in-progress) then runs a scan
+// with explicit options, returning the post-scan snapshot. The scan result is
+// the one just produced (not the cached last-scan); a scan failure is returned
+// verbatim so the handler can surface its message, while the guards return
+// sentinels.
+func (s *Service) Scan(ctx context.Context, opts *discovery.ScanOptions) (Snapshot, error) {
+	if !s.engine.Available() {
+		return Snapshot{}, ErrUnavailable
+	}
+	if s.engine.Scanning() {
+		return Snapshot{}, ErrScanInProgress
+	}
+	result, err := s.engine.Scan(ctx, opts)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return Snapshot{
+		Devices:      s.engine.Devices(),
+		Stats:        s.engine.Stats(),
+		ScanResult:   result,
+		Capabilities: s.engine.Capabilities(),
+	}, nil
+}
+
+// QuickScan correlates existing data without fresh discovery (the engine's
+// quick-scan defaults).
+func (s *Service) QuickScan(ctx context.Context) (Snapshot, error) {
+	return s.Scan(ctx, discovery.DefaultQuickScanOpts())
+}
+
+// FullScan runs fresh discovery, enrichment, and assessment (the engine's
+// full-scan defaults).
+func (s *Service) FullScan(ctx context.Context) (Snapshot, error) {
+	return s.Scan(ctx, discovery.DefaultFullScanOpts())
+}
+
+// Stats returns the engine statistics.
+func (s *Service) Stats() (*discovery.EngineStats, error) {
+	if !s.engine.Available() {
+		return nil, ErrUnavailable
+	}
+	return s.engine.Stats(), nil
+}
+
+// Capabilities returns the engine's capability set.
+func (s *Service) Capabilities() (map[string]bool, error) {
+	if !s.engine.Available() {
+		return nil, ErrUnavailable
+	}
+	return s.engine.Capabilities(), nil
+}
+
+// Device returns a single device by MAC, in any common MAC format.
+func (s *Service) Device(mac string) (*discovery.DiscoveredDevice, error) {
+	if !s.engine.Available() {
+		return nil, ErrUnavailable
+	}
+	device := s.engine.Device(mac)
+	if device == nil {
+		return nil, ErrDeviceNotFound
+	}
+	return device, nil
+}
+
+// Subscribe registers an event handler on the engine's stream and returns the
+// subscription id, which the caller passes to Unsubscribe on teardown.
+func (s *Service) Subscribe(handler func(*discovery.Event)) (string, error) {
+	if !s.engine.Available() {
+		return "", ErrUnavailable
+	}
+	return s.engine.SubscribeAll(handler), nil
+}
+
+// Unsubscribe removes a previously registered subscription.
+func (s *Service) Unsubscribe(id string) { s.engine.Unsubscribe(id) }

--- a/internal/discovery/devices/devices_test.go
+++ b/internal/discovery/devices/devices_test.go
@@ -1,0 +1,193 @@
+package devices_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/devices"
+)
+
+// fakeEngine drives the use-case in tests: availability/in-progress are
+// togglable, and the scan hook records the options it was called with.
+type fakeEngine struct {
+	available  bool
+	scanning   bool
+	devices    []*discovery.DiscoveredDevice
+	stats      *discovery.EngineStats
+	lastScan   *discovery.ScanResult
+	caps       map[string]bool
+	device     *discovery.DiscoveredDevice
+	scanResult *discovery.ScanResult
+	scanErr    error
+	scanOpts   *discovery.ScanOptions
+	subID      string
+	unsubbed   string
+}
+
+func (f *fakeEngine) Available() bool                            { return f.available }
+func (f *fakeEngine) Scanning() bool                             { return f.scanning }
+func (f *fakeEngine) Devices() []*discovery.DiscoveredDevice     { return f.devices }
+func (f *fakeEngine) Device(string) *discovery.DiscoveredDevice  { return f.device }
+func (f *fakeEngine) Stats() *discovery.EngineStats              { return f.stats }
+func (f *fakeEngine) LastScan() *discovery.ScanResult            { return f.lastScan }
+func (f *fakeEngine) Capabilities() map[string]bool              { return f.caps }
+func (f *fakeEngine) SubscribeAll(func(*discovery.Event)) string { return f.subID }
+func (f *fakeEngine) Unsubscribe(id string)                      { f.unsubbed = id }
+
+func (f *fakeEngine) Scan(
+	_ context.Context, opts *discovery.ScanOptions,
+) (*discovery.ScanResult, error) {
+	f.scanOpts = opts
+	return f.scanResult, f.scanErr
+}
+
+func TestSnapshotUnavailable(t *testing.T) {
+	t.Parallel()
+	svc := devices.NewService(&fakeEngine{available: false})
+	if _, err := svc.Snapshot(); !errors.Is(err, devices.ErrUnavailable) {
+		t.Fatalf("Snapshot() err = %v, want ErrUnavailable", err)
+	}
+}
+
+func TestSnapshotReturnsInventory(t *testing.T) {
+	t.Parallel()
+	eng := &fakeEngine{
+		available: true,
+		devices:   []*discovery.DiscoveredDevice{{}},
+		stats:     &discovery.EngineStats{},
+		lastScan:  &discovery.ScanResult{},
+		caps:      map[string]bool{"wired": true},
+	}
+	svc := devices.NewService(eng)
+
+	snap, err := svc.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot() err = %v", err)
+	}
+	if len(snap.Devices) != 1 || snap.Stats == nil || snap.ScanResult == nil || !snap.Capabilities["wired"] {
+		t.Fatalf("Snapshot() = %+v, missing inventory fields", snap)
+	}
+}
+
+func TestScanGuardsInOrder(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		available bool
+		scanning  bool
+		want      error
+	}{
+		{"unavailable beats in-progress", false, true, devices.ErrUnavailable},
+		{"in-progress when available", true, true, devices.ErrScanInProgress},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			svc := devices.NewService(&fakeEngine{available: tt.available, scanning: tt.scanning})
+			if _, err := svc.Scan(context.Background(), &discovery.ScanOptions{}); !errors.Is(err, tt.want) {
+				t.Fatalf("Scan() err = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestScanSurfacesEngineError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("boom")
+	svc := devices.NewService(&fakeEngine{available: true, scanErr: sentinel})
+	if _, err := svc.Scan(context.Background(), &discovery.ScanOptions{}); !errors.Is(err, sentinel) {
+		t.Fatalf("Scan() err = %v, want the engine error verbatim", err)
+	}
+}
+
+func TestScanReturnsFreshResult(t *testing.T) {
+	t.Parallel()
+	fresh := &discovery.ScanResult{}
+	eng := &fakeEngine{
+		available:  true,
+		lastScan:   &discovery.ScanResult{}, // different pointer than the fresh result
+		scanResult: fresh,
+	}
+	svc := devices.NewService(eng)
+
+	snap, err := svc.Scan(context.Background(), &discovery.ScanOptions{})
+	if err != nil {
+		t.Fatalf("Scan() err = %v", err)
+	}
+	if snap.ScanResult != fresh {
+		t.Fatalf("Scan() ScanResult = %p, want the freshly produced result %p", snap.ScanResult, fresh)
+	}
+}
+
+func TestQuickAndFullScanUseEngineDefaults(t *testing.T) {
+	t.Parallel()
+	eng := &fakeEngine{available: true, scanResult: &discovery.ScanResult{}}
+	svc := devices.NewService(eng)
+
+	if _, err := svc.QuickScan(context.Background()); err != nil {
+		t.Fatalf("QuickScan() err = %v", err)
+	}
+	if eng.scanOpts == nil {
+		t.Fatal("QuickScan() did not pass scan options to the engine")
+	}
+
+	if _, err := svc.FullScan(context.Background()); err != nil {
+		t.Fatalf("FullScan() err = %v", err)
+	}
+	if eng.scanOpts == nil {
+		t.Fatal("FullScan() did not pass scan options to the engine")
+	}
+}
+
+func TestDeviceNotFound(t *testing.T) {
+	t.Parallel()
+	svc := devices.NewService(&fakeEngine{available: true, device: nil})
+	if _, err := svc.Device("AA:BB:CC:DD:EE:FF"); !errors.Is(err, devices.ErrDeviceNotFound) {
+		t.Fatalf("Device() err = %v, want ErrDeviceNotFound", err)
+	}
+}
+
+func TestDeviceFound(t *testing.T) {
+	t.Parallel()
+	want := &discovery.DiscoveredDevice{}
+	svc := devices.NewService(&fakeEngine{available: true, device: want})
+	got, err := svc.Device("AA:BB:CC:DD:EE:FF")
+	if err != nil || got != want {
+		t.Fatalf("Device() = %v, %v; want the device, nil", got, err)
+	}
+}
+
+func TestSubscribeUnavailable(t *testing.T) {
+	t.Parallel()
+	svc := devices.NewService(&fakeEngine{available: false})
+	if _, err := svc.Subscribe(func(*discovery.Event) {}); !errors.Is(err, devices.ErrUnavailable) {
+		t.Fatalf("Subscribe() err = %v, want ErrUnavailable", err)
+	}
+}
+
+func TestSubscribeReturnsIDAndUnsubscribes(t *testing.T) {
+	t.Parallel()
+	eng := &fakeEngine{available: true, subID: "sub-1"}
+	svc := devices.NewService(eng)
+
+	id, err := svc.Subscribe(func(*discovery.Event) {})
+	if err != nil || id != "sub-1" {
+		t.Fatalf("Subscribe() = %q, %v; want sub-1, nil", id, err)
+	}
+	svc.Unsubscribe(id)
+	if eng.unsubbed != "sub-1" {
+		t.Fatalf("Unsubscribe propagated %q, want sub-1", eng.unsubbed)
+	}
+}
+
+func TestScanningProbeRequiresAvailable(t *testing.T) {
+	t.Parallel()
+	// A scanning-but-unavailable engine reports not-scanning: the probe must not
+	// claim a scan is running when there is no engine to run it.
+	svc := devices.NewService(&fakeEngine{available: false, scanning: true})
+	if svc.Scanning() {
+		t.Fatal("Scanning() = true for an unavailable engine, want false")
+	}
+}

--- a/internal/discovery/problems/problems.go
+++ b/internal/discovery/problems/problems.go
@@ -1,0 +1,100 @@
+// Package problems holds the network problem-detection application (use-case)
+// layer (ADR-0020). It owns the orchestration that previously lived in the
+// api.Server problem handlers — listing active problems, running a detection
+// scan over the currently discovered devices, and reading/updating the
+// detection thresholds — behind narrow consumer-defined ports over the problem
+// detector and the device-discovery source. Handlers keep transport concerns:
+// request decode, response mapping, and error-to-status mapping. The adapters
+// satisfying the ports live in the composition root (internal/app) and resolve
+// their collaborators lazily; a nil detector degrades every method to
+// ErrUnavailable rather than panicking.
+package problems
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
+)
+
+// ErrUnavailable signals the problem detector is not wired (handlers map it to
+// 503, the pre-strangle degraded behavior).
+var ErrUnavailable = errors.New("problem detector not available")
+
+// Detector is the problem-detector surface the use-case drives, defined at the
+// consumer (ADR-0020) and satisfied by an adapter over *discovery.ProblemDetector
+// in internal/app. Available reports whether a detector is wired (resolved per
+// call); the remaining methods are only invoked once availability is confirmed.
+type Detector interface {
+	Available() bool
+	ActiveProblems() []discovery.NetworkProblem
+	Summary() *discovery.ProblemSummary
+	Scan(ctx context.Context, devices []*discovery.DiscoveredDevice) (*discovery.ProblemDetectionResult, error)
+	Thresholds() discovery.ProblemThresholds
+	SetThresholds(t discovery.ProblemThresholds)
+}
+
+// DeviceSource supplies the discovered devices a detection scan runs against. A
+// nil source yields no devices (the scan still runs over an empty set), matching
+// the handler's historic nil-guard.
+type DeviceSource interface {
+	Devices() []*discovery.DiscoveredDevice
+}
+
+// Active is the use-case read model for the current-problems response.
+type Active struct {
+	Problems []discovery.NetworkProblem
+	Summary  *discovery.ProblemSummary
+}
+
+// Service is the problem-detection use-case.
+type Service struct {
+	detector Detector
+	devices  DeviceSource
+}
+
+// NewService builds the use-case over the detector and the device source.
+func NewService(detector Detector, devices DeviceSource) *Service {
+	return &Service{detector: detector, devices: devices}
+}
+
+// Available reports whether the problem detector is wired. Handlers probe this
+// once before branching by method so a nil detector returns 503 uniformly.
+func (s *Service) Available() bool { return s.detector.Available() }
+
+// Active returns the problems detected on the most recent scan plus the summary.
+func (s *Service) Active() (Active, error) {
+	if !s.detector.Available() {
+		return Active{}, ErrUnavailable
+	}
+	return Active{
+		Problems: s.detector.ActiveProblems(),
+		Summary:  s.detector.Summary(),
+	}, nil
+}
+
+// Scan runs problem detection over the currently discovered devices and returns
+// the full detection result.
+func (s *Service) Scan(ctx context.Context) (*discovery.ProblemDetectionResult, error) {
+	if !s.detector.Available() {
+		return nil, ErrUnavailable
+	}
+	return s.detector.Scan(ctx, s.devices.Devices())
+}
+
+// Thresholds returns the current detection thresholds.
+func (s *Service) Thresholds() (discovery.ProblemThresholds, error) {
+	if !s.detector.Available() {
+		return discovery.ProblemThresholds{}, ErrUnavailable
+	}
+	return s.detector.Thresholds(), nil
+}
+
+// SetThresholds updates the detection thresholds.
+func (s *Service) SetThresholds(t discovery.ProblemThresholds) error {
+	if !s.detector.Available() {
+		return ErrUnavailable
+	}
+	s.detector.SetThresholds(t)
+	return nil
+}

--- a/internal/discovery/problems/problems_test.go
+++ b/internal/discovery/problems/problems_test.go
@@ -1,0 +1,107 @@
+package problems_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/discovery"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/problems"
+)
+
+type fakeDetector struct {
+	available  bool
+	active     []discovery.NetworkProblem
+	summary    *discovery.ProblemSummary
+	result     *discovery.ProblemDetectionResult
+	scanErr    error
+	scanned    []*discovery.DiscoveredDevice
+	thresholds discovery.ProblemThresholds
+	setCalled  bool
+}
+
+func (f *fakeDetector) Available() bool                            { return f.available }
+func (f *fakeDetector) ActiveProblems() []discovery.NetworkProblem { return f.active }
+func (f *fakeDetector) Summary() *discovery.ProblemSummary         { return f.summary }
+func (f *fakeDetector) Thresholds() discovery.ProblemThresholds    { return f.thresholds }
+
+func (f *fakeDetector) Scan(
+	_ context.Context, devs []*discovery.DiscoveredDevice,
+) (*discovery.ProblemDetectionResult, error) {
+	f.scanned = devs
+	return f.result, f.scanErr
+}
+
+func (f *fakeDetector) SetThresholds(t discovery.ProblemThresholds) {
+	f.setCalled = true
+	f.thresholds = t
+}
+
+type fakeDeviceSource struct {
+	devices []*discovery.DiscoveredDevice
+}
+
+func (f fakeDeviceSource) Devices() []*discovery.DiscoveredDevice { return f.devices }
+
+func TestUnavailablePaths(t *testing.T) {
+	t.Parallel()
+	svc := problems.NewService(&fakeDetector{available: false}, fakeDeviceSource{})
+
+	if _, err := svc.Active(); !errors.Is(err, problems.ErrUnavailable) {
+		t.Errorf("Active() err = %v, want ErrUnavailable", err)
+	}
+	if _, err := svc.Scan(context.Background()); !errors.Is(err, problems.ErrUnavailable) {
+		t.Errorf("Scan() err = %v, want ErrUnavailable", err)
+	}
+	if _, err := svc.Thresholds(); !errors.Is(err, problems.ErrUnavailable) {
+		t.Errorf("Thresholds() err = %v, want ErrUnavailable", err)
+	}
+	if err := svc.SetThresholds(discovery.ProblemThresholds{}); !errors.Is(err, problems.ErrUnavailable) {
+		t.Errorf("SetThresholds() err = %v, want ErrUnavailable", err)
+	}
+}
+
+func TestActiveReturnsProblems(t *testing.T) {
+	t.Parallel()
+	det := &fakeDetector{
+		available: true,
+		active:    []discovery.NetworkProblem{{}, {}},
+		summary:   &discovery.ProblemSummary{},
+	}
+	svc := problems.NewService(det, fakeDeviceSource{})
+
+	active, err := svc.Active()
+	if err != nil {
+		t.Fatalf("Active() err = %v", err)
+	}
+	if len(active.Problems) != 2 || active.Summary == nil {
+		t.Fatalf("Active() = %+v, want 2 problems + summary", active)
+	}
+}
+
+func TestScanFeedsDiscoveredDevices(t *testing.T) {
+	t.Parallel()
+	devs := []*discovery.DiscoveredDevice{{}, {}, {}}
+	det := &fakeDetector{available: true, result: &discovery.ProblemDetectionResult{}}
+	svc := problems.NewService(det, fakeDeviceSource{devices: devs})
+
+	if _, err := svc.Scan(context.Background()); err != nil {
+		t.Fatalf("Scan() err = %v", err)
+	}
+	if len(det.scanned) != len(devs) {
+		t.Fatalf("Scan() ran over %d devices, want %d from the source", len(det.scanned), len(devs))
+	}
+}
+
+func TestSetThresholdsApplied(t *testing.T) {
+	t.Parallel()
+	det := &fakeDetector{available: true}
+	svc := problems.NewService(det, fakeDeviceSource{})
+
+	if err := svc.SetThresholds(discovery.ProblemThresholds{}); err != nil {
+		t.Fatalf("SetThresholds() err = %v", err)
+	}
+	if !det.setCalled {
+		t.Fatal("SetThresholds() did not reach the detector")
+	}
+}


### PR DESCRIPTION
## What

C1 of the `internal/api` clean-hexagonal strangle (ADR-0020): move the discovery-engine, problem-detection, and Bluetooth handlers off `ServiceContainer` into use-case packages behind consumer-defined ports, with adapters in the composition root.

**Three separate packages** (not co-located like B4 wifi) — they wrap three different backing types (`*discovery.Engine`, `*discovery.ProblemDetector`, `*enumerate.BluetoothScanner`), three route trees, zero shared state. B4's co-location was forced by a name collision with `internal/wifi/visibility`+`airspace`; no such forcing reason exists here. ADR-0020's "no over-packaging" warning targets *adapter* packages, which still all land in one `internal/app/discovery.go`.

## Layout

- `internal/discovery/devices` — unified-discovery engine use-case (`Engine` port). `Available()`/`Scanning()` probes preserve the **engine-nil 503** + in-progress 409 ordering the engine handler tests pin (`POST with options returns 503`, `empty mac returns unavailable (engine check first)`).
- `internal/discovery/problems` — problem-detection use-case (`Detector` + `DeviceSource` ports).
- `internal/discovery/bluetooth` — Bluetooth-discovery use-case (`Scanner` port).
- `internal/app/discovery.go` — lazy adapters (per-call resolution honors the test harness's later-set fields; a nil collaborator degrades to the unavailable path).
- `handlers_{engine,problems,bluetooth}.go` — pure transport; `problemDetector`/`bluetoothScanner` accessors move to `server.go` next to a new `discoveryEngine` accessor.

## Deferred (intentional)

`/api/v1/engines` (`handlers_engines.go`) is left for a later slice: it reads `internal/engine.Registry` (probe/retention/alerts/topology) — a cross-cutting concern, not discovery. Keeping C1 cohesively "discovery."

## Verification

- `go build ./...`, `go vet`, `golangci-lint` on changed pkgs — 0 issues in changed files (the 4 pre-existing gofumpt flags in untouched `handlers_*_test.go` are local v2.12.2-vs-CI-v2.12.1 drift).
- `go test ./internal/api/ -count=1` — `ok` (run alone). New use-case packages have table-driven unit tests with fakes (devices/problems/bluetooth all `ok`).
- Route-policy + output-escaping gates pass. **All HTTP goldens byte-identical** (no `testdata/golden` changes).