### PR TITLE
refactor(api): strangle update handlers into internal/update/lifecycle (C3)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -57,6 +57,8 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/settings/persistence"
 	"github.com/MustardSeedNetworks/seed/internal/timeseries/retention"
 	"github.com/MustardSeedNetworks/seed/internal/topology"
+	"github.com/MustardSeedNetworks/seed/internal/update"
+	"github.com/MustardSeedNetworks/seed/internal/update/lifecycle"
 	"github.com/MustardSeedNetworks/seed/internal/wifi"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/survey"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/troubleshooting"
@@ -149,6 +151,7 @@ type Server struct {
 	networkProblems    *problems.Service           // Network problem-detection use-case (ADR-0020)
 	bluetoothScans     *bluetooth.Service          // Bluetooth-discovery use-case (ADR-0020)
 	healthMonitoring   *monitoring.Service         // Health-monitoring use-case (ADR-0020)
+	updateLifecycle    *lifecycle.Service          // Update-lifecycle use-case (ADR-0020)
 	tlsFingerprint     tlsFingerprintCache         // Cached SHA-256 fingerprint of the active TLS cert, exposed via /__version
 }
 
@@ -780,6 +783,7 @@ func (s *Server) eventBus() *events.Bus                    { return s.services.R
 func (s *Server) jobsRunner() *jobs.Runner                 { return s.services.RealTime.Jobs }
 func (s *Server) jobIdempotency() jobIdempotencyStore      { return s.services.RealTime.JobIdempotency }
 func (s *Server) db() *database.DB                         { return s.services.Database.DB }
+func (s *Server) updateService() *update.Service           { return s.services.Update }
 
 // initWiFiUseCases wires the Wi-Fi troubleshooting use-cases (ADR-0020) from the
 // composition root: the visibility-read, management, and discovery use-cases over
@@ -816,12 +820,20 @@ func (s *Server) initHealthUseCases() {
 	)
 }
 
+// initUpdateUseCases wires the update-lifecycle use-case (ADR-0020) from the
+// composition root over the server's lazy accessor for the update service, so
+// a nil or later-set service (the test harness) is honored.
+func (s *Server) initUpdateUseCases() {
+	s.updateLifecycle = app.NewUpdateLifecycle(s.updateService)
+}
+
 // initUseCases wires the ADR-0020 application use-cases that depend on the
-// discovery components existing: troubleshooting + discovery + health.
+// discovery components existing: troubleshooting + discovery + health + update.
 func (s *Server) initUseCases() {
 	s.initWiFiUseCases()
 	s.initDiscoveryUseCases()
 	s.initHealthUseCases()
+	s.initUpdateUseCases()
 }
 
 // webAuthnConfigFromServer derives the relying-party config for the

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -76,11 +76,6 @@ func NewServiceContainer() *ServiceContainer {
 	}
 }
 
-// GetUpdateService returns the update service.
-func (sc *ServiceContainer) GetUpdateService() *update.Service {
-	return sc.Update
-}
-
 // AuthServices groups authentication and security-related services.
 type AuthServices struct {
 	Manager        *auth.Manager

--- a/internal/api/update.go
+++ b/internal/api/update.go
@@ -2,12 +2,21 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/update"
+	"github.com/MustardSeedNetworks/seed/internal/update/lifecycle"
 )
+
+// Software-update transport (ADR-0020). These handlers decode the request,
+// call the internal/update/lifecycle use-case via s.updateLifecycle, shape the
+// response, and map lifecycle.ErrUnavailable to the pre-strangle 503. All
+// orchestration (download/apply preconditions, status read-model assembly,
+// configuration patching) lives in the use-case.
 
 // sendUpdateError sends a standardized error response for update endpoints.
 func sendUpdateError(w http.ResponseWriter, r *http.Request, status int, message string) {
@@ -55,6 +64,17 @@ type UpdateConfigRequest struct {
 	IncludePrerelease *bool   `json:"includePrerelease,omitempty"`
 }
 
+// updateConfigResponse shapes a domain config into the transport DTO.
+func updateConfigResponse(config update.UpdateConfig) UpdateConfigResponse {
+	return UpdateConfigResponse{
+		Enabled:           config.Enabled,
+		CheckInterval:     config.CheckInterval.String(),
+		AutoDownload:      config.AutoDownload,
+		AutoApply:         config.AutoApply,
+		IncludePrerelease: config.IncludePrerelease,
+	}
+}
+
 // registerUpdateRoutes registers update-related HTTP routes.
 func (s *Server) registerUpdateRoutes() {
 	op := database.RoleOperator
@@ -76,14 +96,12 @@ func (s *Server) registerUpdateRoutes() {
 func (s *Server) handleUpdateCheck(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	updateService := s.services.GetUpdateService()
-	if updateService == nil {
-		sendUpdateError(w, r, http.StatusServiceUnavailable, "Update service not available")
-		return
-	}
-
-	info, err := updateService.CheckForUpdate(r.Context())
+	info, err := s.updateLifecycle.Check(r.Context())
 	if err != nil {
+		if errors.Is(err, lifecycle.ErrUnavailable) {
+			sendUpdateError(w, r, http.StatusServiceUnavailable, "Update service not available")
+			return
+		}
 		logger.WarnContext(r.Context(), "Update check failed", "error", err)
 		sendUpdateError(w, r, http.StatusInternalServerError, "Failed to check for updates")
 		return
@@ -94,28 +112,19 @@ func (s *Server) handleUpdateCheck(w http.ResponseWriter, r *http.Request) {
 
 // handleUpdateStatus returns the current update status.
 func (s *Server) handleUpdateStatus(w http.ResponseWriter, r *http.Request) {
-	updateService := s.services.GetUpdateService()
-	if updateService == nil {
+	status, err := s.updateLifecycle.Status()
+	if err != nil {
 		sendUpdateError(w, r, http.StatusServiceUnavailable, "Update service not available")
 		return
 	}
 
-	status := updateService.GetStatus()
-	lastCheck := updateService.GetLastCheckTime()
-	info := updateService.GetUpdateInfo()
-
 	resp := UpdateStatusResponse{
-		UpdateStatus: &status,
-		UpdateReady:  updateService.IsUpdateDownloaded(),
+		UpdateStatus:   &status.Status,
+		UpdateReady:    status.Ready,
+		RequiresAction: status.RequiresAction,
 	}
-
-	if !lastCheck.IsZero() {
-		resp.LastCheck = lastCheck.Format("2006-01-02T15:04:05Z07:00")
-	}
-
-	// Determine if user action is needed
-	if info != nil && info.Available && !updateService.IsUpdateDownloaded() {
-		resp.RequiresAction = true
+	if !status.LastCheck.IsZero() {
+		resp.LastCheck = status.LastCheck.Format(time.RFC3339)
 	}
 
 	sendUpdateJSON(w, r, http.StatusOK, resp)
@@ -123,20 +132,9 @@ func (s *Server) handleUpdateStatus(w http.ResponseWriter, r *http.Request) {
 
 // handleUpdateInfo returns information about available updates.
 func (s *Server) handleUpdateInfo(w http.ResponseWriter, r *http.Request) {
-	updateService := s.services.GetUpdateService()
-	if updateService == nil {
+	info, err := s.updateLifecycle.Info()
+	if err != nil {
 		sendUpdateError(w, r, http.StatusServiceUnavailable, "Update service not available")
-		return
-	}
-
-	info := updateService.GetUpdateInfo()
-	if info == nil {
-		// No update check has been performed yet
-		sendUpdateJSON(w, r, http.StatusOK, update.UpdateInfo{
-			Available:      false,
-			CurrentVersion: "",
-			LatestVersion:  "",
-		})
 		return
 	}
 
@@ -147,21 +145,14 @@ func (s *Server) handleUpdateInfo(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleUpdateDownload(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	updateService := s.services.GetUpdateService()
-	if updateService == nil {
+	switch err := s.updateLifecycle.Download(r.Context()); {
+	case errors.Is(err, lifecycle.ErrUnavailable):
 		sendUpdateError(w, r, http.StatusServiceUnavailable, "Update service not available")
 		return
-	}
-
-	info := updateService.GetUpdateInfo()
-	if info == nil || !info.Available {
+	case errors.Is(err, lifecycle.ErrNoUpdate):
 		sendUpdateError(w, r, http.StatusBadRequest, "No update available")
 		return
-	}
-
-	// Start download (this is blocking)
-	_, err := updateService.DownloadUpdate(r.Context(), nil)
-	if err != nil {
+	case err != nil:
 		logger.WarnContext(r.Context(), "Update download failed", "error", err)
 		sendUpdateError(w, r, http.StatusInternalServerError, "Failed to download update")
 		return
@@ -177,19 +168,14 @@ func (s *Server) handleUpdateDownload(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleUpdateApply(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	updateService := s.services.GetUpdateService()
-	if updateService == nil {
+	switch err := s.updateLifecycle.Apply(r.Context()); {
+	case errors.Is(err, lifecycle.ErrUnavailable):
 		sendUpdateError(w, r, http.StatusServiceUnavailable, "Update service not available")
 		return
-	}
-
-	if !updateService.IsUpdateDownloaded() {
+	case errors.Is(err, lifecycle.ErrNotDownloaded):
 		sendUpdateError(w, r, http.StatusBadRequest, "No update downloaded")
 		return
-	}
-
-	// Apply the update
-	if err := updateService.ApplyUpdate(r.Context()); err != nil {
+	case err != nil:
 		logger.WarnContext(r.Context(), "Update apply failed", "error", err)
 		sendUpdateError(w, r, http.StatusInternalServerError, "Failed to apply update")
 		return
@@ -205,13 +191,11 @@ func (s *Server) handleUpdateApply(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleUpdateRollback(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	updateService := s.services.GetUpdateService()
-	if updateService == nil {
+	switch err := s.updateLifecycle.Rollback(); {
+	case errors.Is(err, lifecycle.ErrUnavailable):
 		sendUpdateError(w, r, http.StatusServiceUnavailable, "Update service not available")
 		return
-	}
-
-	if err := updateService.Rollback(); err != nil {
+	case err != nil:
 		logger.WarnContext(r.Context(), "Update rollback failed", "error", err)
 		sendUpdateError(w, r, http.StatusInternalServerError, "Failed to rollback update")
 		return
@@ -225,31 +209,17 @@ func (s *Server) handleUpdateRollback(w http.ResponseWriter, r *http.Request) {
 
 // handleGetUpdateConfig returns the current update configuration.
 func (s *Server) handleGetUpdateConfig(w http.ResponseWriter, r *http.Request) {
-	updateService := s.services.GetUpdateService()
-	if updateService == nil {
+	config, err := s.updateLifecycle.Config()
+	if err != nil {
 		sendUpdateError(w, r, http.StatusServiceUnavailable, "Update service not available")
 		return
 	}
 
-	config := updateService.GetConfig()
-
-	sendUpdateJSON(w, r, http.StatusOK, UpdateConfigResponse{
-		Enabled:           config.Enabled,
-		CheckInterval:     config.CheckInterval.String(),
-		AutoDownload:      config.AutoDownload,
-		AutoApply:         config.AutoApply,
-		IncludePrerelease: config.IncludePrerelease,
-	})
+	sendUpdateJSON(w, r, http.StatusOK, updateConfigResponse(config))
 }
 
 // handleUpdateConfig updates the update configuration.
 func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
-	updateService := s.services.GetUpdateService()
-	if updateService == nil {
-		sendUpdateError(w, r, http.StatusServiceUnavailable, "Update service not available")
-		return
-	}
-
 	// Strict decode — unknown fields rejected, body size capped.
 	// This endpoint uses sendUpdateError (a localized variant with
 	// release-channel context), so we keep that envelope shape and just
@@ -263,28 +233,25 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	config := updateService.GetConfig()
-
-	if req.Enabled != nil {
-		config.Enabled = *req.Enabled
-	}
-	if req.AutoDownload != nil {
-		config.AutoDownload = *req.AutoDownload
-	}
-	if req.AutoApply != nil {
-		config.AutoApply = *req.AutoApply
-	}
-	if req.IncludePrerelease != nil {
-		config.IncludePrerelease = *req.IncludePrerelease
-	}
-
-	updateService.SetConfig(config)
-
-	sendUpdateJSON(w, r, http.StatusOK, UpdateConfigResponse{
-		Enabled:           config.Enabled,
-		CheckInterval:     config.CheckInterval.String(),
-		AutoDownload:      config.AutoDownload,
-		AutoApply:         config.AutoApply,
-		IncludePrerelease: config.IncludePrerelease,
+	config, err := s.updateLifecycle.Configure(lifecycle.ConfigPatch{
+		Enabled:           req.Enabled,
+		CheckInterval:     req.CheckInterval,
+		AutoDownload:      req.AutoDownload,
+		AutoApply:         req.AutoApply,
+		IncludePrerelease: req.IncludePrerelease,
 	})
+	switch {
+	case errors.Is(err, lifecycle.ErrUnavailable):
+		sendUpdateError(w, r, http.StatusServiceUnavailable, "Update service not available")
+		return
+	case errors.Is(err, lifecycle.ErrInvalidInterval):
+		sendUpdateError(w, r, http.StatusBadRequest,
+			"Invalid checkInterval: must be a duration of at least 1m")
+		return
+	case err != nil:
+		sendUpdateError(w, r, http.StatusInternalServerError, "Failed to update configuration")
+		return
+	}
+
+	sendUpdateJSON(w, r, http.StatusOK, updateConfigResponse(config))
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -1,0 +1,57 @@
+package app
+
+// update.go wires the composition root to the update-lifecycle application
+// (use-case) service (ADR-0020): the self-update surface — release checking,
+// status, download, apply, rollback, and configuration. The adapter below
+// implements the narrow port declared in internal/update/lifecycle over the
+// concrete update service, so the API handlers depend on the use-case instead
+// of reaching into the service container directly. The service is resolved
+// through a lazy accessor per call so a later-set value (the api test harness)
+// is honored, and a nil service degrades every method to ErrUnavailable rather
+// than panicking.
+
+import (
+	"context"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/update"
+	"github.com/MustardSeedNetworks/seed/internal/update/lifecycle"
+)
+
+// NewUpdateLifecycle builds the update-lifecycle use-case (ADR-0020) over a
+// lazy accessor for the concrete update service. A nil accessor result makes
+// every method degrade to lifecycle.ErrUnavailable (the 503 path).
+func NewUpdateLifecycle(svc func() *update.Service) *lifecycle.Service {
+	a := updater{svc: svc}
+	return lifecycle.NewService(a, a)
+}
+
+// updater implements lifecycle.Updater and lifecycle.ConfigStore over
+// *update.Service, resolving it lazily. Methods beyond Available are only
+// invoked by the use-case once Available reports true, so they assume a
+// non-nil service.
+type updater struct {
+	svc func() *update.Service
+}
+
+func (a updater) Available() bool { return a.svc() != nil }
+
+func (a updater) Check(ctx context.Context) (*update.UpdateInfo, error) {
+	return a.svc().CheckForUpdate(ctx)
+}
+
+func (a updater) Info() *update.UpdateInfo    { return a.svc().GetUpdateInfo() }
+func (a updater) Status() update.UpdateStatus { return a.svc().GetStatus() }
+func (a updater) LastCheck() time.Time        { return a.svc().GetLastCheckTime() }
+func (a updater) Downloaded() bool            { return a.svc().IsUpdateDownloaded() }
+
+func (a updater) Download(ctx context.Context) error {
+	_, err := a.svc().DownloadUpdate(ctx, nil)
+	return err
+}
+
+func (a updater) Apply(ctx context.Context) error { return a.svc().ApplyUpdate(ctx) }
+func (a updater) Rollback() error                 { return a.svc().Rollback() }
+
+func (a updater) Config() update.UpdateConfig       { return a.svc().GetConfig() }
+func (a updater) SetConfig(cfg update.UpdateConfig) { a.svc().SetConfig(cfg) }

--- a/internal/update/lifecycle/lifecycle.go
+++ b/internal/update/lifecycle/lifecycle.go
@@ -1,0 +1,208 @@
+// Package lifecycle holds the software-update application (use-case) layer
+// (ADR-0020). It owns the self-update lifecycle that previously lived in the
+// api.Server update handlers — checking for a new release, reporting updater
+// status and the latest check result, gating download on an available update
+// and apply on a completed download, rolling back, and applying partial
+// configuration changes — behind a narrow consumer-defined port over the
+// concrete update service. Handlers keep transport concerns: request decode,
+// response shaping, and error-to-status mapping. The adapter satisfying the
+// port lives in the composition root (internal/app) and resolves the service
+// lazily, so a nil service degrades every method to ErrUnavailable (the
+// pre-strangle 503) rather than panicking.
+//
+// The parent internal/update package is the domain core (checker, downloader,
+// applier); this subpackage is the application layer that orchestrates it for
+// the API, keeping the two cleanly separated.
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/update"
+)
+
+// Sentinel errors, mapped by handlers to the pre-strangle HTTP responses.
+var (
+	// ErrUnavailable signals the updater is not wired (handlers map it to
+	// 503, the pre-strangle degraded behavior).
+	ErrUnavailable = errors.New("update service not available")
+	// ErrNoUpdate signals there is no available update to download (handlers
+	// map it to 400).
+	ErrNoUpdate = errors.New("no update available")
+	// ErrNotDownloaded signals no update has been downloaded to apply
+	// (handlers map it to 400).
+	ErrNotDownloaded = errors.New("no update downloaded")
+	// ErrInvalidInterval signals an unparsable or out-of-range check interval
+	// in a configuration patch (handlers map it to 400).
+	ErrInvalidInterval = errors.New("invalid check interval")
+)
+
+// minCheckInterval is the floor for the configurable update-check interval; a
+// shorter interval would hammer the release host for no operational benefit.
+const minCheckInterval = time.Minute
+
+// Updater is the self-update surface the use-case drives, defined at the
+// consumer (ADR-0020) and satisfied by an adapter over *update.Service in
+// internal/app. Available reports whether the updater is wired; the remaining
+// methods are only invoked once availability is confirmed.
+type Updater interface {
+	Available() bool
+	Check(ctx context.Context) (*update.UpdateInfo, error)
+	Info() *update.UpdateInfo
+	Status() update.UpdateStatus
+	LastCheck() time.Time
+	Downloaded() bool
+	Download(ctx context.Context) error
+	Apply(ctx context.Context) error
+	Rollback() error
+}
+
+// ConfigStore is the update-configuration surface the use-case reads and
+// writes, segregated from Updater so configuration management stands apart
+// from the update state machine. In internal/app one adapter satisfies both.
+type ConfigStore interface {
+	Available() bool
+	Config() update.UpdateConfig
+	SetConfig(cfg update.UpdateConfig)
+}
+
+// Service is the update-lifecycle use-case.
+type Service struct {
+	updater Updater
+	config  ConfigStore
+}
+
+// NewService builds the use-case over its narrow dependencies.
+func NewService(updater Updater, config ConfigStore) *Service {
+	return &Service{updater: updater, config: config}
+}
+
+// Check queries the release host for an available update.
+func (s *Service) Check(ctx context.Context) (*update.UpdateInfo, error) {
+	if !s.updater.Available() {
+		return nil, ErrUnavailable
+	}
+	return s.updater.Check(ctx)
+}
+
+// Status is the use-case read model for the updater's current state: the
+// underlying operation status, when the last check ran (zero before the first
+// check), whether a downloaded update is ready to apply, and whether operator
+// action is required (an update is available but not yet downloaded).
+type Status struct {
+	Status         update.UpdateStatus
+	LastCheck      time.Time
+	Ready          bool
+	RequiresAction bool
+}
+
+// Status reports the updater's current state.
+func (s *Service) Status() (Status, error) {
+	if !s.updater.Available() {
+		return Status{}, ErrUnavailable
+	}
+	info := s.updater.Info()
+	downloaded := s.updater.Downloaded()
+	return Status{
+		Status:         s.updater.Status(),
+		LastCheck:      s.updater.LastCheck(),
+		Ready:          downloaded,
+		RequiresAction: info != nil && info.Available && !downloaded,
+	}, nil
+}
+
+// Info returns the most recent update information, defaulting to a
+// no-update-available zero value before the first check has run.
+func (s *Service) Info() (*update.UpdateInfo, error) {
+	if !s.updater.Available() {
+		return nil, ErrUnavailable
+	}
+	if info := s.updater.Info(); info != nil {
+		return info, nil
+	}
+	return &update.UpdateInfo{}, nil
+}
+
+// Download fetches the available update, returning ErrNoUpdate when no update
+// is available to download.
+func (s *Service) Download(ctx context.Context) error {
+	if !s.updater.Available() {
+		return ErrUnavailable
+	}
+	if info := s.updater.Info(); info == nil || !info.Available {
+		return ErrNoUpdate
+	}
+	return s.updater.Download(ctx)
+}
+
+// Apply installs the downloaded update, returning ErrNotDownloaded when no
+// update has been downloaded yet.
+func (s *Service) Apply(ctx context.Context) error {
+	if !s.updater.Available() {
+		return ErrUnavailable
+	}
+	if !s.updater.Downloaded() {
+		return ErrNotDownloaded
+	}
+	return s.updater.Apply(ctx)
+}
+
+// Rollback reverts to the previous version.
+func (s *Service) Rollback() error {
+	if !s.updater.Available() {
+		return ErrUnavailable
+	}
+	return s.updater.Rollback()
+}
+
+// Config returns the current update configuration.
+func (s *Service) Config() (update.UpdateConfig, error) {
+	if !s.config.Available() {
+		return update.UpdateConfig{}, ErrUnavailable
+	}
+	return s.config.Config(), nil
+}
+
+// ConfigPatch is a partial update to the update configuration; nil fields are
+// left unchanged.
+type ConfigPatch struct {
+	Enabled           *bool
+	CheckInterval     *string
+	AutoDownload      *bool
+	AutoApply         *bool
+	IncludePrerelease *bool
+}
+
+// Configure applies a partial configuration patch and returns the resulting
+// configuration. A CheckInterval that does not parse as a Go duration or is
+// shorter than one minute yields ErrInvalidInterval and leaves the
+// configuration unchanged.
+func (s *Service) Configure(patch ConfigPatch) (update.UpdateConfig, error) {
+	if !s.config.Available() {
+		return update.UpdateConfig{}, ErrUnavailable
+	}
+	cfg := s.config.Config()
+	if patch.Enabled != nil {
+		cfg.Enabled = *patch.Enabled
+	}
+	if patch.CheckInterval != nil {
+		interval, err := time.ParseDuration(*patch.CheckInterval)
+		if err != nil || interval < minCheckInterval {
+			return update.UpdateConfig{}, ErrInvalidInterval
+		}
+		cfg.CheckInterval = interval
+	}
+	if patch.AutoDownload != nil {
+		cfg.AutoDownload = *patch.AutoDownload
+	}
+	if patch.AutoApply != nil {
+		cfg.AutoApply = *patch.AutoApply
+	}
+	if patch.IncludePrerelease != nil {
+		cfg.IncludePrerelease = *patch.IncludePrerelease
+	}
+	s.config.SetConfig(cfg)
+	return cfg, nil
+}

--- a/internal/update/lifecycle/lifecycle_test.go
+++ b/internal/update/lifecycle/lifecycle_test.go
@@ -1,0 +1,310 @@
+package lifecycle_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/update"
+	"github.com/MustardSeedNetworks/seed/internal/update/lifecycle"
+)
+
+// --- fake ----------------------------------------------------------------------
+
+type fakeUpdater struct {
+	available  bool
+	info       *update.UpdateInfo
+	status     update.UpdateStatus
+	lastCheck  time.Time
+	downloaded bool
+	config     update.UpdateConfig
+	err        error
+
+	downloadCalled bool
+	applyCalled    bool
+	rollbackCalled bool
+	setConfig      *update.UpdateConfig
+}
+
+func (f *fakeUpdater) Available() bool { return f.available }
+func (f *fakeUpdater) Check(_ context.Context) (*update.UpdateInfo, error) {
+	return f.info, f.err
+}
+func (f *fakeUpdater) Info() *update.UpdateInfo    { return f.info }
+func (f *fakeUpdater) Status() update.UpdateStatus { return f.status }
+func (f *fakeUpdater) LastCheck() time.Time        { return f.lastCheck }
+func (f *fakeUpdater) Downloaded() bool            { return f.downloaded }
+func (f *fakeUpdater) Download(_ context.Context) error {
+	f.downloadCalled = true
+	return f.err
+}
+
+func (f *fakeUpdater) Apply(_ context.Context) error {
+	f.applyCalled = true
+	return f.err
+}
+
+func (f *fakeUpdater) Rollback() error {
+	f.rollbackCalled = true
+	return f.err
+}
+func (f *fakeUpdater) Config() update.UpdateConfig { return f.config }
+func (f *fakeUpdater) SetConfig(cfg update.UpdateConfig) {
+	f.setConfig = &cfg
+}
+
+// newService wires one fake as both the Updater and ConfigStore ports,
+// mirroring the production adapter.
+func newService(f *fakeUpdater) *lifecycle.Service {
+	return lifecycle.NewService(f, f)
+}
+
+// --- tests ---------------------------------------------------------------------
+
+func TestUnavailable(t *testing.T) {
+	t.Parallel()
+	svc := newService(&fakeUpdater{})
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{"check", func() error { _, err := svc.Check(context.Background()); return err }},
+		{"status", func() error { _, err := svc.Status(); return err }},
+		{"info", func() error { _, err := svc.Info(); return err }},
+		{"download", func() error { return svc.Download(context.Background()) }},
+		{"apply", func() error { return svc.Apply(context.Background()) }},
+		{"rollback", svc.Rollback},
+		{"config", func() error { _, err := svc.Config(); return err }},
+		{"configure", func() error { _, err := svc.Configure(lifecycle.ConfigPatch{}); return err }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tc.call(); !errors.Is(err, lifecycle.ErrUnavailable) {
+				t.Fatalf("want ErrUnavailable, got %v", err)
+			}
+		})
+	}
+}
+
+func TestStatus(t *testing.T) {
+	t.Parallel()
+	checked := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		info           *update.UpdateInfo
+		downloaded     bool
+		wantReady      bool
+		wantRequiresAc bool
+	}{
+		{"no check yet", nil, false, false, false},
+		{"update available, not downloaded", &update.UpdateInfo{Available: true}, false, false, true},
+		{"update available, downloaded", &update.UpdateInfo{Available: true}, true, true, false},
+		{"no update available", &update.UpdateInfo{Available: false}, false, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			svc := newService(&fakeUpdater{
+				available:  true,
+				info:       tc.info,
+				downloaded: tc.downloaded,
+				lastCheck:  checked,
+				status:     update.UpdateStatus{State: update.StateIdle},
+			})
+			got, err := svc.Status()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Ready != tc.wantReady {
+				t.Errorf("Ready = %v, want %v", got.Ready, tc.wantReady)
+			}
+			if got.RequiresAction != tc.wantRequiresAc {
+				t.Errorf("RequiresAction = %v, want %v", got.RequiresAction, tc.wantRequiresAc)
+			}
+			if !got.LastCheck.Equal(checked) {
+				t.Errorf("LastCheck = %v, want %v", got.LastCheck, checked)
+			}
+			if got.Status.State != update.StateIdle {
+				t.Errorf("Status.State = %v, want idle", got.Status.State)
+			}
+		})
+	}
+}
+
+func TestInfoDefaultsBeforeFirstCheck(t *testing.T) {
+	t.Parallel()
+	svc := newService(&fakeUpdater{available: true})
+
+	info, err := svc.Info()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info == nil || info.Available {
+		t.Fatalf("want zero-value info with Available=false, got %+v", info)
+	}
+}
+
+func TestInfoPassesThrough(t *testing.T) {
+	t.Parallel()
+	want := &update.UpdateInfo{Available: true, LatestVersion: "v9.9.9"}
+	svc := newService(&fakeUpdater{available: true, info: want})
+
+	info, err := svc.Info()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info != want {
+		t.Fatalf("want pass-through info, got %+v", info)
+	}
+}
+
+func TestDownload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		info       *update.UpdateInfo
+		wantErr    error
+		wantCalled bool
+	}{
+		{"no check yet", nil, lifecycle.ErrNoUpdate, false},
+		{"no update available", &update.UpdateInfo{Available: false}, lifecycle.ErrNoUpdate, false},
+		{"update available", &update.UpdateInfo{Available: true}, nil, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := &fakeUpdater{available: true, info: tc.info}
+			err := newService(f).Download(context.Background())
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("want %v, got %v", tc.wantErr, err)
+			}
+			if f.downloadCalled != tc.wantCalled {
+				t.Errorf("downloadCalled = %v, want %v", f.downloadCalled, tc.wantCalled)
+			}
+		})
+	}
+}
+
+func TestApply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		downloaded bool
+		wantErr    error
+		wantCalled bool
+	}{
+		{"not downloaded", false, lifecycle.ErrNotDownloaded, false},
+		{"downloaded", true, nil, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := &fakeUpdater{available: true, downloaded: tc.downloaded}
+			err := newService(f).Apply(context.Background())
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("want %v, got %v", tc.wantErr, err)
+			}
+			if f.applyCalled != tc.wantCalled {
+				t.Errorf("applyCalled = %v, want %v", f.applyCalled, tc.wantCalled)
+			}
+		})
+	}
+}
+
+func TestRollback(t *testing.T) {
+	t.Parallel()
+	f := &fakeUpdater{available: true}
+	if err := newService(f).Rollback(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !f.rollbackCalled {
+		t.Error("rollback not invoked on the port")
+	}
+}
+
+func TestConfigure(t *testing.T) {
+	t.Parallel()
+	base := update.UpdateConfig{
+		Enabled:       true,
+		CheckInterval: 24 * time.Hour,
+		GitHubOwner:   "MustardSeedNetworks",
+		GitHubRepo:    "seed",
+	}
+
+	tests := []struct {
+		name     string
+		patch    lifecycle.ConfigPatch
+		wantErr  error
+		wantCfg  func(update.UpdateConfig) bool
+		wantSets bool
+	}{
+		{
+			name:     "empty patch keeps config",
+			patch:    lifecycle.ConfigPatch{},
+			wantCfg:  func(c update.UpdateConfig) bool { return c == base },
+			wantSets: true,
+		},
+		{
+			name: "boolean fields applied",
+			patch: lifecycle.ConfigPatch{
+				Enabled:           new(false),
+				AutoDownload:      new(true),
+				AutoApply:         new(true),
+				IncludePrerelease: new(true),
+			},
+			wantCfg: func(c update.UpdateConfig) bool {
+				return !c.Enabled && c.AutoDownload && c.AutoApply && c.IncludePrerelease
+			},
+			wantSets: true,
+		},
+		{
+			name:     "check interval applied",
+			patch:    lifecycle.ConfigPatch{CheckInterval: new("1h")},
+			wantCfg:  func(c update.UpdateConfig) bool { return c.CheckInterval == time.Hour },
+			wantSets: true,
+		},
+		{
+			name:    "unparsable interval rejected",
+			patch:   lifecycle.ConfigPatch{CheckInterval: new("daily")},
+			wantErr: lifecycle.ErrInvalidInterval,
+		},
+		{
+			name:    "sub-minute interval rejected",
+			patch:   lifecycle.ConfigPatch{CheckInterval: new("5s")},
+			wantErr: lifecycle.ErrInvalidInterval,
+		},
+		{
+			name:    "negative interval rejected",
+			patch:   lifecycle.ConfigPatch{CheckInterval: new("-1h")},
+			wantErr: lifecycle.ErrInvalidInterval,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := &fakeUpdater{available: true, config: base}
+			got, err := newService(f).Configure(tc.patch)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("want %v, got %v", tc.wantErr, err)
+			}
+			if tc.wantErr != nil {
+				if f.setConfig != nil {
+					t.Fatal("rejected patch must not reach SetConfig")
+				}
+				return
+			}
+			if !tc.wantCfg(got) {
+				t.Errorf("unexpected resulting config: %+v", got)
+			}
+			if tc.wantSets && (f.setConfig == nil || *f.setConfig != got) {
+				t.Errorf("SetConfig got %+v, want %+v", f.setConfig, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

ADR-0020 strangle, slice **C3 Update** (follows C2 health, #1618). All 8 `/api/v1/updates/*` handlers stop reaching `s.services.GetUpdateService()` and become pure transport over a new use-case.

- **`internal/update/lifecycle`** (owner-named) — the self-update lifecycle use-case: check / status read-model / info / download / apply / rollback / config + patch. Ports are consumer-defined and segregated (`Updater` for the state machine, `ConfigStore` for configuration — also keeps the port under the interfacebloat cap for the right reason). Sentinel errors map to the pre-strangle statuses (`ErrUnavailable`→503, `ErrNoUpdate`/`ErrNotDownloaded`/`ErrInvalidInterval`→400).
- **`internal/app/update.go`** — one adapter satisfies both ports over a lazy `*update.Service` accessor; nil degrades to 503, later-set test-harness values are honored.
- **`internal/api/update.go`** — renamed from `handlers_update.go` (filename policy, #1617). Route registration byte-identical; route-policy manifest unchanged.
- **`ServiceContainer.GetUpdateService` deleted** — last caller gone (pre-alpha no-compat).

## Reviewed behavior fix (no golden pinned these endpoints)

`PATCH /api/v1/updates/config` accepted `checkInterval` in the request DTO and **silently ignored it** (dead field). It is now applied: parsed as a Go duration with a 1-minute floor; invalid values return 400. Pre-existing and unchanged: the running periodic-check ticker reads the interval only at startup (config is not hot-reloaded) — same as the other config fields' partial effectiveness; candidate for a later slice.

## Verification

- `go build ./...` ok
- `go test ./internal/api/ -count=1` **ALONE** → `ok 42.413s` (goldens byte-identical)
- `go test ./internal/update/...` → `ok` (new table-driven fake-port tests)
- `golangci-lint` → 0 issues in changed files (4 pre-existing gofumpt hits in untouched `handlers_*_test.go` are the known v2.12.2 vs CI v2.12.1 drift)
- `check-route-policy.sh` ✓ · `check-output-escaping.sh` ✓ · `check-schema-drift.sh` ✓ · `check-filename-policy.sh` (from #1617) ✓
- types-drift unaffected: zero DTO/schema changes (request/response DTOs byte-identical)

Next per plan: C4 Identity (last, coordinated with auth workstream) → D1 delete ServiceContainer.