### PR TITLE
chore(cleanup): remove dead HTTP-redirector remnants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,11 +72,8 @@ RUN setcap 'cap_net_raw,cap_net_admin=+ep' /usr/bin/seed
 USER seed
 WORKDIR /var/lib/seed
 # Per CLAUDE.md Default Ports table:
-#   8443 = TLS canonical (post-Wave-1)
-#   8042 = HTTP->HTTPS 308 redirector (fallback port; the privileged
-#          port 80 isn't usable inside the container because we run
-#          as the unprivileged `seed` user).
-EXPOSE 8443 8042
+#   8443 = TLS canonical (HTTPS-only; the daemon binds no HTTP listener).
+EXPOSE 8443
 
 # OCI labels for traceability.
 ARG VERSION=dev

--- a/cmd/seed/cmd_serve.go
+++ b/cmd/seed/cmd_serve.go
@@ -42,8 +42,8 @@ func initServeCmd(state *cliState) {
 		Long: `Start The Seed network diagnostics server.
 
 The server provides a web-based UI for network diagnostics, monitoring,
-and analysis. It runs with HTTPS on port 8443. HTTPS is required —
-the HTTP listener exists only as a 308 redirector.`,
+and analysis. It serves HTTPS only on port 8443 — the daemon binds no
+plain-HTTP listener, so clients must use the https:// scheme.`,
 		Example: `  # Start with the default config
   seed serve
 
@@ -236,8 +236,8 @@ func loadAndConfigureConfig(configPath string) *config.Config {
 
 	migrateSNMPCredentials(cfg, configPath)
 
-	// HTTPS is required, unconditionally. The HTTP listener exists only as a
-	// 308 redirector. No --dev or env-var opt-out is supported.
+	// HTTPS is required, unconditionally — the daemon binds no HTTP listener.
+	// No --dev or env-var opt-out is supported.
 	cfg.Server.HTTPS = true
 
 	if validateErr := cfg.Validate(); validateErr != nil {

--- a/cmd/seed/serve_logic_test.go
+++ b/cmd/seed/serve_logic_test.go
@@ -78,7 +78,7 @@ func TestServeCmdLongDescriptionContent(t *testing.T) {
 		"server",
 		"web",
 		"HTTPS",
-		"redirector",
+		"listener",
 	}
 
 	for _, content := range expectedContent {

--- a/internal/auth/cookie.go
+++ b/internal/auth/cookie.go
@@ -28,9 +28,9 @@ const (
 // CookieConfig holds cookie scope settings.
 //
 // Security attributes (Secure, HttpOnly, SameSite) are hardcoded on every
-// auth cookie because the daemon enforces HTTPS for all auth endpoints
-// (HTTP listener redirects to HTTPS; no auth flow ever runs over plain
-// HTTP). They are intentionally NOT configurable.
+// auth cookie because the daemon serves HTTPS only — it binds no HTTP
+// listener, so no auth flow ever runs over plain HTTP. They are
+// intentionally NOT configurable.
 type CookieConfig struct {
 	// Domain sets the cookie domain
 	Domain string
@@ -59,7 +59,7 @@ func newAuthCookie(name, value string, expires time.Time, maxAge int, config Coo
 		Domain:   config.Domain,
 		Expires:  expires,
 		MaxAge:   maxAge,
-		Secure:   true,                    // HTTPS-only (HTTP listener redirects, never serves auth)
+		Secure:   true,                    // HTTPS-only (no HTTP listener; auth never served over plain HTTP)
 		HttpOnly: true,                    // Prevent JavaScript access (XSS protection)
 		SameSite: http.SameSiteStrictMode, // Block cross-site contexts (CSRF)
 	}


### PR DESCRIPTION
## What
Removes stale references to an HTTP→HTTPS 308 redirector that no longer exists.

The redirector was removed in #1277. Since then the daemon binds a single TLS
listener and **no HTTP listener** (per the CLAUDE.md Default Ports invariant:
typing the host without `https://` yields connection-refused, by design). These
remnants still claimed an HTTP listener exists:

- **Dockerfile** — dropped `EXPOSE 8042` and its 308-redirector comment block; now `EXPOSE 8443` only.
- **cmd/seed/cmd_serve.go** — `serve` long help and the HTTPS-enforcement comment no longer mention a redirector; they state there is no HTTP listener.
- **cmd/seed/serve_logic_test.go** — `TestServeCmdLongDescriptionContent` now asserts the help mentions `listener` (was `redirector`, which the help text no longer contains).
- **internal/auth/cookie.go** — doc comment + the `Secure` inline comment no longer claim "HTTP listener redirects"; HTTPS-only, no HTTP listener.

## Why
Q0 paper-cut from the 2026-06-10 fleet audit — dead remnants that mislead readers about the listener model.

## Risk
None — comments, CLI help text, and one unused `EXPOSE` line. No runtime behavior change.

## Evidence
- `gofmt -l` clean on touched files
- `go build ./...` OK
- `go test ./cmd/seed/ ./internal/auth/` green (incl. the updated long-description test)
- pre-commit: gitleaks clean, golangci-lint 0 issues