### PR TITLE
docs(adr): hygiene pass — honest statuses + two as-built ADRs

### DIFF
--- a/docs/architecture/decisions/0007-discovery-orchestrator-convergence.md
+++ b/docs/architecture/decisions/0007-discovery-orchestrator-convergence.md
@@ -1,6 +1,6 @@
 # ADR-0007: Discovery orchestrator convergence — engine vs pipeline, deferred to Phase 7
 
-**Status:** Accepted — 2026-06-03
+**Status:** Accepted — 2026-06-03 · partially superseded by [ADR-0008](0008-pure-data-discovery-types-in-schema.md) (2026-06-04) on the schema/types-extraction deferral; the Pipeline→Engine fold still stands
 
 ## Context
 
@@ -52,6 +52,15 @@ Engine endpoint — which is the same Phase 7 frontend migration.
   frontend consuming Engine). Until a consumer exists, the ~150-field cluster stays
   an opaque `any` job result / unregistered DTO rather than a speculative generated
   schema maintained against no client.
+
+> **Partial supersession — [ADR-0008](0008-pure-data-discovery-types-in-schema.md)
+> (2026-06-04):** the schema/types bullet above was revisited sooner than Phase 7.
+> ADR-0008 registers `EngineDiscoveryResponse` directly by reflecting `discovery`'s
+> pure-data types (drift-gated by `cmd/seed-schema`) and **withdraws the
+> `internal/discovery/types` extraction as unnecessary** — the wire contract is
+> generated from the domain structs and visible in review, not decoupled behind a
+> new package. The rest of this ADR — deferring the Pipeline→Engine orchestrator
+> fold to Phase 7 — is unaffected and still pending.
 
 ## Consequences
 

--- a/docs/architecture/decisions/0011-network-anomaly-engine.md
+++ b/docs/architecture/decisions/0011-network-anomaly-engine.md
@@ -1,6 +1,6 @@
 # ADR-0011: Network-wide anomaly engine (one typed stream, data-driven catalog)
 
-**Status:** Accepted — 2026-06-05 · implementation pending (Wi-Fi feature W4)
+**Status:** Accepted — 2026-06-05 · in-memory engine (`internal/anomaly`) + Wi-Fi source implemented; SQL persistence and health-source convergence deferred to [ADR-0021](0021-persist-and-converge-anomaly-engine.md). The bespoke `internal/health.AnomalyDetector` is an unfed stub that ADR-0021 removes.
 
 ## Context
 

--- a/docs/architecture/decisions/0012-wifi-monitor-capture-decode.md
+++ b/docs/architecture/decisions/0012-wifi-monitor-capture-decode.md
@@ -1,6 +1,6 @@
 # ADR-0012: Wi-Fi monitor-mode capture port + 802.11 decode pipeline
 
-**Status:** Accepted — 2026-06-05 · implementation pending (Wi-Fi feature W1–W6)
+**Status:** Accepted — 2026-06-05 · capture port + CGO-free 802.11 decode (`internal/wifi/{capture,dot11,visibility}`) + SSID→AP→BSSID airspace hierarchy implemented; opt-in and unreleased (monitor capture activates only when `SEED_WIFI_MONITOR_IFACE` is set, empty airspace otherwise). Full client-tracking + W1–W6 feature surface still pending.
 
 ## Context
 

--- a/docs/architecture/decisions/0013-bluetooth-live-capture.md
+++ b/docs/architecture/decisions/0013-bluetooth-live-capture.md
@@ -1,6 +1,6 @@
 # ADR-0013: Bluetooth live-scan capture port
 
-**Status:** Accepted — 2026-06-05 · implementation pending (BT live-scan upgrade)
+**Status:** Accepted — 2026-06-05 · `Scanner` port + data types defined (`internal/discovery/bluetooth`); per-OS live-scan drivers (CoreBluetooth / BlueZ D-Bus / WinRT) not yet implemented, so live BLE advertisement sweep remains pending.
 
 ## Context
 

--- a/docs/architecture/decisions/0022-passive-ingress-listeners.md
+++ b/docs/architecture/decisions/0022-passive-ingress-listeners.md
@@ -1,0 +1,84 @@
+# ADR-0022: Passive-ingress listeners share the engine lifecycle and a sink seam
+
+**Status:** Accepted — 2026-06-10 · as-built (documents `internal/listener`, shipped during the V1.0 NMS expansion)
+
+## Context
+
+The active diagnostics path *initiates* network conversations: the SNMP poller
+(ADR-0023) reaches out to targets, discovery probes hosts. But an NMS also has to
+receive **unsolicited** signals — syslog messages, SNMP traps, later NetFlow/IPFIX
+— that devices push at us over UDP with no request on our side. These arrive
+continuously, from many sources, on privileged low ports, and must be persisted
+without back-pressuring the receive loop.
+
+These passive endpoints share a shape: bind a socket, parse a wire format, emit a
+normalized record, and run for the lifetime of the daemon. The risk was that each
+one grows its own ad-hoc goroutine, its own start/stop handling, and its own
+database writes — the same "per-subsystem bucket" sprawl the re-architecture is
+removing elsewhere. We already have a uniform lifecycle owner: the `engine.Engine`
+registry that supervises the probe, retention, and snmp-poller engines (Name +
+Start + Stop, with `Status` reporting). Passive listeners fit that shape exactly.
+
+## Decision
+
+A single small contract package, **`internal/listener`**, defines the passive
+ingress seam; concrete listeners live in subpackages and persistence lives behind
+a port.
+
+- **`Listener` is `engine.Engine`-shaped** — `Name() string`, `Start(ctx) error`,
+  `Stop(ctx) error`, both idempotent. Listeners register directly with the engine
+  registry; there is **no listener-specific supervisor**. Start binds the socket
+  and streams; Stop closes it and drains in-flight handlers within the context
+  deadline.
+
+- **Listeners own no persistence — they publish to a `Sink` port.** `Sink.Publish(
+  ctx, Event) error` is the only outbound seam. The default implementation
+  (`internal/listener/sink`) inserts into the `listener_events` table; tests inject
+  a recording fake. A listener never imports the database.
+
+- **`Event` is the normalized record** — `Kind` (which listener), `SourceAddr`,
+  `Severity` (listener-native string), `Timestamp`, and an opaque listener-specific
+  `Payload json.RawMessage` whose schema each subpackage documents. `ClientID`,
+  `TargetKind`, and `TargetID` are **enrichment outputs**, not listener concerns:
+  the listener emits the raw `SourceAddr` and a later step resolves it.
+
+- **Concrete listeners (V1.0):** `internal/listener/syslog` (RFC 3164 / RFC 5424
+  over UDP) and `internal/listener/snmptrap` (SNMPv2c traps over UDP/162).
+
+- **Binding is opt-in and fail-soft.** The composition root wires listeners in
+  `initListeners` (`internal/api/server.go`); a bind failure logs a warning and the
+  listener is simply not registered, rather than aborting daemon startup — a busy
+  `:514`/`:162` or an unprivileged deployment must not take the server down.
+
+## Consequences
+
+- A new passive source (NetFlow, IPFIX, a TLS syslog variant) is a new subpackage
+  implementing `Listener` plus a registry registration — no new supervisor, no new
+  persistence path, no change to `internal/listener` itself.
+- Because `Sink` is the only write seam, the storage decision (currently one row
+  per event in `listener_events`) can change in one place without touching any
+  listener, and the alerts pipeline (`internal/alerts/pipeline/listener_pipeline.go`)
+  consumes the same persisted stream.
+- Publishing is decoupled from receiving: a slow sink must not block the UDP read
+  loop, so sink errors are logged rather than propagated back into the hot path.
+- Listeners inherit the engine registry's uniform `Status`/lifecycle, so the same
+  health surface that covers the poller covers ingress — no bespoke monitoring.
+
+## Implementation status (2026-06-10)
+
+- **`internal/listener`** — `Listener`, `Event`, `Sink` contracts (no I/O).
+- **`internal/listener/syslog`** — UDP listener, RFC 3164 + RFC 5424 parse,
+  default bind `:514`, remappable for unprivileged hosts. **TLS/TCP syslog
+  (RFC 5425) is deferred** — it is a separate `Listener` type, not a flag on this
+  one.
+- **`internal/listener/snmptrap`** — SNMPv2c traps over UDP/162. **SNMPv3 (auth/priv)
+  traps are out of scope for V1.0.**
+- **`internal/listener/sink`** — default `Sink` over `database.ListenerEvents()`
+  (`listener_events`, migration `00001_init.sql`).
+- **Wiring** — `initListeners` in `internal/api/server.go` constructs the persist
+  sink and both listeners and registers them with the engine registry.
+- **Enrichment is NOT wired yet (Stage A4).** `ClientID` is `"default"` and
+  `TargetKind`/`TargetID` are empty/`"unknown_ip"` on every event until the step
+  that resolves `SourceAddr` against `polling_targets` / `discovered_devices`
+  lands. Events persist and flow to the alerts pipeline; they are simply not yet
+  attributed to a known device.

--- a/docs/architecture/decisions/0023-snmp-polling-orchestrator.md
+++ b/docs/architecture/decisions/0023-snmp-polling-orchestrator.md
@@ -1,0 +1,89 @@
+# ADR-0023: SNMP polling as one engine driving per-target collector chains
+
+**Status:** Accepted — 2026-06-10 · as-built (documents `internal/polling/snmp`, the Stage A0 NMS scaffold)
+
+## Context
+
+The V1.0 NMS expansion replaces three legacy polling services —
+`internal/services/estatepoll`, `internal/services/servermon`, and the
+SNMP-polling half of `internal/services/microburst` — with one coherent active
+poller (Stage A3 of the NMS plan). Those legacy services each owned their own
+scheduling, their own SNMP session handling, and their own idea of what to read,
+which is exactly the duplication the re-architecture removes.
+
+Two cross-cutting constraints shaped the replacement:
+
+1. **Different targets need different reads.** A switch wants LLDP/CDP/FDB/iftable;
+   a server wants host-resources; a router wants routing/BGP. A single fixed poll
+   loop either over-reads every device or special-cases device types in code.
+
+2. **The protocol primitives already have an owner.** `internal/protocols/snmp`
+   owns OID definitions, gosnmp session wrappers, and MIB parsing. The poller must
+   *use* that, not re-implement wire-level SNMP, and must keep CGO/transport
+   concerns out of the orchestration logic.
+
+## Decision
+
+**`internal/polling/snmp`** is one `engine.Engine`-shaped `Poller` per Seed
+instance that schedules and runs an **ordered, per-target collector chain**.
+
+- **`Poller` is an engine.** `Name() "snmp-poller"`, `Start`/`Stop`, and a
+  `Status()` reporting last-chain time, last error, and in-flight count to the same
+  registry that owns probes, retention, and listeners (ADR-0022). On `Start` it
+  loads every enabled row from `polling_targets` and registers **one
+  `scheduler.Job` per target** at that target's `PollIntervalSec`.
+
+- **Parallel across targets, serial within a chain.** Each target is an independent
+  scheduler job, so targets poll concurrently; within a single target the collector
+  chain runs sequentially. One slow device never blocks another; one slow collector
+  only delays later collectors for the *same* device.
+
+- **`Collector` is a pluggable port.** `Name() string` + `Collect(ctx, Target,
+  ResolvedCredentials) error`. A target's `collector_chain` is a JSON array of
+  collector names in `polling_targets`; the poller looks each up by name. A chain
+  entry with **no registered collector is skipped with a warning**
+  (`ErrCollectorNotRegistered`) and the rest of the chain still runs — collectors
+  can be rolled out or disabled via config without a code change.
+
+- **Non-fatal collection.** A collector returning an error is logged; the chain
+  continues. After the chain runs, `last_status` / `last_error` / `last_polled_at`
+  are written back to the target row, so one broken OID surface (e.g. iftable)
+  doesn't lose the data the other collectors gathered (arp, fdb).
+
+- **`Client` / `ClientFactory` abstract the session.** Collectors talk to a
+  `Client` (`Get` scalar OIDs in order, `Walk` a subtree); production builds a
+  gosnmp-backed client via `internal/protocols/snmp`, tests inject a fake. The
+  poller owns session lifecycle and credential resolution; collectors never open
+  connections.
+
+- **Observations land via a shared sink**, so every collector persists through one
+  seam rather than each reaching into the database.
+
+## Consequences
+
+- Adding a metric surface is a new collector package implementing the port plus a
+  registration in `orchestrator.Build` — no scheduler, session, or persistence code.
+  V1.0 ships ten: `sysinfo`, `iftable`, `lldp`, `cdp`, `fdp`, `arp`, `fdb`,
+  `routing`, `hostresources`, `bgp4`.
+- Per-target chains make device-appropriate polling a **data** decision
+  (`collector_chain` column), not a code branch on device type.
+- The `Client` port keeps the orchestration package CGO-free and unit-testable; the
+  gosnmp/transport detail stays in `internal/protocols/snmp`.
+- The poller is visible in the engine registry's health surface like every other
+  long-running component, with real in-flight/last-error telemetry.
+
+## Implementation status (2026-06-10)
+
+- **`internal/polling/snmp`** — `Poller` (engine + scheduler wiring), `Collector` /
+  `Client` / `ClientFactory` ports, `Target` / `ResolvedCredentials` types.
+- **`internal/polling/snmp/orchestrator`** — `Build` wires the `Poller` with the ten
+  collectors above against a persisting sink.
+- **`internal/polling/snmp/collectors/*`** — one package per collector.
+- **Wiring** — registered with the engine registry from `internal/api/server.go`.
+- **Credential decryption is a STUB.** `credentialsForTarget()` (`poller.go`)
+  returns an empty `ResolvedCredentials{}`; nothing yet decrypts a target's
+  `CredentialsID` against the `device_credentials` store. Until Stage A3.x wires the
+  secret/license manager in, the poller schedules and runs chains but cannot
+  authenticate against real SNMPv2c/v3 devices — this path is scaffolding, not a
+  shipped feature. The poll loop, chaining, status write-back, and persistence are
+  real and tested with fake clients; only the credential resolution is missing.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -14,7 +14,7 @@ See the [Re-Architecture Blueprint](../RE_ARCHITECTURE_BLUEPRINT.md) for the ful
 | [0004](0004-event-bus.md) | In-process domain event bus | Amended |
 | [0005](0005-unified-jobs.md) | Unified async job runner | Accepted |
 | [0006](0006-migrations-sql-goose-strict.md) | Schema as embedded `.sql` files, goose, STRICT tables | Accepted |
-| [0007](0007-discovery-orchestrator-convergence.md) | Discovery orchestrator convergence — engine vs pipeline, deferred to Phase 7 | Accepted |
+| [0007](0007-discovery-orchestrator-convergence.md) | Discovery orchestrator convergence — engine vs pipeline, deferred to Phase 7 | Amended |
 | [0008](0008-pure-data-discovery-types-in-schema.md) | Pure-data discovery types may be reflected into the published schema | Accepted |
 | [0009](0009-profile-ui-types-are-a-curated-view.md) | profile.ts/settings.ts are a curated UI view, not a config.Config mirror | Accepted |
 | [0010](0010-identifier-casing-conventions.md) | Identifier casing — camelCase JSON wire, snake_case files/SQL | Accepted |
@@ -29,3 +29,5 @@ See the [Re-Architecture Blueprint](../RE_ARCHITECTURE_BLUEPRINT.md) for the ful
 | [0019](0019-ed25519-signed-license-tokens.md) | Replace forgeable rotor-cipher license key with Ed25519-signed tokens | Accepted |
 | [0020](0020-clean-hexagonal-api-foundation.md) | Clean-hexagonal `internal/api` foundation — use-cases + composition root | Accepted |
 | [0021](0021-persist-and-converge-anomaly-engine.md) | Persist the anomaly engine in SQL and converge every source on it | Proposed |
+| [0022](0022-passive-ingress-listeners.md) | Passive-ingress listeners share the engine lifecycle and a sink seam | Accepted |
+| [0023](0023-snmp-polling-orchestrator.md) | SNMP polling as one engine driving per-target collector chains | Accepted |


### PR DESCRIPTION
## What
Q0 ADR-hygiene paper-cut from the 2026-06-10 fleet audit. Two parts: correct stale ADR statuses to match the **actual (pre-alpha, incomplete)** code, and add the two missing as-built ADRs.

### Status corrections — verified against code, not asserted
- **0007** — adds the partial-supersession note: ADR-0008 registered `EngineDiscoveryResponse` by reflecting `discovery`'s pure-data types and **withdrew** the `internal/discovery/types` extraction; the Pipeline→Engine fold still stands. README status → `Amended`.
- **0011** — in-memory anomaly engine (`internal/anomaly`) + Wi-Fi source are implemented, but **SQL persistence + health-source convergence are deferred to ADR-0021**, and `internal/health.AnomalyDetector` is an unfed stub ADR-0021 removes.
- **0012** — capture port + CGO-free 802.11 decode (`internal/wifi/{capture,dot11,visibility}`) + airspace hierarchy are implemented, but **opt-in/unreleased** (`SEED_WIFI_MONITOR_IFACE`); client tracking + W1–W6 surface pending.
- **0013** — `Scanner` port + data types defined; **per-OS live-scan drivers (CoreBluetooth/BlueZ/WinRT) not implemented**.

### New as-built ADRs — document the real decisions *and* the scaffolding honestly
- **0022 `internal/listener`** — passive-ingress listeners are `engine.Engine`-shaped and publish to a `Sink` port; syslog + snmptrap wired in `initListeners`. Honest caveat: enrichment (Stage A4) not wired, so events aren't yet attributed to a known device; TLS syslog + SNMPv3 traps deferred.
- **0023 `internal/polling/snmp`** — one engine driving per-target collector chains; ten collectors wired via `orchestrator.Build`. Honest caveat: **credential decryption is a stub** (`credentialsForTarget()` returns empty creds), so authed polling against real devices is pending Stage A3.x — the loop/chaining/persistence are real and fake-client-tested.

## Why
Stale "implementation pending" / "Accepted" labels misrepresented what's actually in the tree. Per owner guidance, the code is **not complete** — these statuses now say exactly what is and isn't built, so the ADR set is a trustworthy map of reality.

## Risk
None — documentation only. No Go code touched. All referenced paths verified to exist; cross-ADR links resolve.

## Evidence
- Each status/claim verified by reading the cited packages (capture port, anomaly engine + the unfed `health.AnomalyDetector`, the `Scanner` port, `initListeners` wiring, and the `credentialsForTarget` stub).
- pre-commit: gitleaks clean.