### PR TITLE
refactor(api): strangle engine-status into a use-case (ADR-0020)

### DIFF
--- a/internal/api/handlers_engines.go
+++ b/internal/api/handlers_engines.go
@@ -1,8 +1,8 @@
 package api
 
 // /api/v1/engines — Stage A5.8 + #1383 enhancement. Read-only admin
-// endpoint listing every long-running subsystem registered with
-// services.Engines (probe, retention, snmp-poller, the 4 topology
+// endpoint listing every long-running subsystem registered with the
+// engine registry (probe, retention, snmp-poller, the 4 topology
 // reconcilers, the 2 alert pipelines, plus any opt-in listeners).
 //
 //   GET /api/v1/engines
@@ -14,26 +14,23 @@ package api
 //            "inflight": N
 //          }, ...] }
 //
-// Engines opt into rich status by implementing engine.Reporter. Those
-// that don't get a default {state: "ok"} payload — backward-compatible
-// with the V1.0 wire format and avoids forcing every engine to grow a
-// Status() method before operators see any signal.
+// The status logic lives in the engine-status use-case (s.engineStatus,
+// ADR-0020): engines that implement engine.Reporter contribute their
+// Status(), engines that don't default to {state: "ok"}. This handler
+// keeps only transport concerns — encoding the domain snapshot to the
+// V1.0 wire shape. No raw engine-registry reference remains in transport.
 
 import (
 	"net/http"
 
-	"github.com/MustardSeedNetworks/seed/internal/engine"
+	"github.com/MustardSeedNetworks/seed/internal/engine/status"
 )
 
 func (s *Server) handleEngines(w http.ResponseWriter, r *http.Request) {
-	if s.services == nil || s.services.Engines == nil {
-		writeJSON(w, r, map[string]any{jsonKeyCount: 0, "engines": []any{}})
-		return
-	}
-	engines := s.services.Engines.Engines()
-	out := make([]map[string]any, 0, len(engines))
-	for _, e := range engines {
-		out = append(out, encodeEngineEntry(e))
+	statuses := s.engineStatus.List()
+	out := make([]map[string]any, 0, len(statuses))
+	for _, st := range statuses {
+		out = append(out, encodeEngineEntry(st))
 	}
 	writeJSON(w, r, map[string]any{
 		jsonKeyCount: len(out),
@@ -41,22 +38,15 @@ func (s *Server) handleEngines(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// encodeEngineEntry flattens one engine into the wire shape. Engines
-// that implement engine.Reporter get their Status() surfaced; engines
-// that don't get StatusOK() so the response is uniform.
-func encodeEngineEntry(e engine.Engine) map[string]any {
-	status := engine.StatusOK()
-	if reporter, ok := e.(engine.Reporter); ok {
-		status = reporter.Status()
-		if status.State == "" {
-			status.State = engine.StateOK
-		}
-	}
+// encodeEngineEntry flattens one engine-status snapshot into the wire
+// shape. The status determination (Reporter vs StatusOK fallback) happens
+// in the use-case; this only shapes the response.
+func encodeEngineEntry(st status.EngineStatus) map[string]any {
 	return map[string]any{
-		jsonKeyName:  e.Name(),
-		"state":      status.State,
-		"lastTickAt": formatTime(status.LastTickAt),
-		"lastError":  status.LastError,
-		"inflight":   status.Inflight,
+		jsonKeyName:  st.Name,
+		"state":      st.State,
+		"lastTickAt": formatTime(st.LastTickAt),
+		"lastError":  st.LastError,
+		"inflight":   st.Inflight,
 	}
 }

--- a/internal/api/handlers_engines_internal_test.go
+++ b/internal/api/handlers_engines_internal_test.go
@@ -34,6 +34,7 @@ func (r *reportingEngine) Status() engine.Status       { return r.status }
 func TestHandleEngines_ReturnsRegistryContents(t *testing.T) {
 	s := &Server{services: NewServiceContainer()}
 	initDatabaseDependentServices(s.services, newTestDB(t))
+	s.initEngineUseCases()
 
 	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/engines", http.NoBody)
 	w := httptest.NewRecorder()
@@ -65,6 +66,7 @@ func TestHandleEngines_ReturnsRegistryContents(t *testing.T) {
 		}
 	}
 }
+
 func TestHandleEngines_NoServicesReturnsEmpty(t *testing.T) {
 	s := &Server{}
 	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/engines", http.NoBody)
@@ -87,6 +89,7 @@ func TestHandleEngines_EngineWithoutReporter_DefaultsToStateOK(t *testing.T) {
 	if regErr := s.services.Engines.Register(&minimalEngine{name: "plain"}); regErr != nil {
 		t.Fatalf("register: %v", regErr)
 	}
+	s.initEngineUseCases()
 
 	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/engines", http.NoBody)
 	w := httptest.NewRecorder()
@@ -126,6 +129,7 @@ func TestHandleEngines_EngineWithReporter_SurfacesStatus(t *testing.T) {
 	if regErr := s.services.Engines.Register(rep); regErr != nil {
 		t.Fatalf("register: %v", regErr)
 	}
+	s.initEngineUseCases()
 
 	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/engines", http.NoBody)
 	w := httptest.NewRecorder()
@@ -164,6 +168,7 @@ func TestHandleEngines_ReporterReturnsEmptyState_FillsOK(t *testing.T) {
 	}); regErr != nil {
 		t.Fatalf("register: %v", regErr)
 	}
+	s.initEngineUseCases()
 	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/engines", http.NoBody)
 	w := httptest.NewRecorder()
 	s.handleEngines(w, req)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -33,6 +33,8 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/problems"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
+	"github.com/MustardSeedNetworks/seed/internal/engine"
+	enginestatus "github.com/MustardSeedNetworks/seed/internal/engine/status"
 	"github.com/MustardSeedNetworks/seed/internal/health"
 	"github.com/MustardSeedNetworks/seed/internal/health/monitoring"
 	ssosync "github.com/MustardSeedNetworks/seed/internal/identity/oauth"
@@ -155,6 +157,7 @@ type Server struct {
 	bluetoothScans     *bluetooth.Service          // Bluetooth-discovery use-case (ADR-0020)
 	healthMonitoring   *monitoring.Service         // Health-monitoring use-case (ADR-0020)
 	updateLifecycle    *lifecycle.Service          // Update-lifecycle use-case (ADR-0020)
+	engineStatus       *enginestatus.Service       // Engine-status use-case (ADR-0020)
 	identityUsers      *users.Service              // User-management use-case (ADR-0020, ADR-0024)
 	identityTokens     *tokens.Service             // PAT mint/list/revoke use-case (ADR-0020, ADR-0024)
 	identityOAuth      *ssosync.Service            // SSO identity-sync use-case (ADR-0020, ADR-0024)
@@ -792,6 +795,7 @@ func (s *Server) db() *database.DB                           { return s.services
 func (s *Server) apiTokenRepo() *database.APITokenRepository { return s.services.Auth.APITokens }
 func (s *Server) licenseManager() *license.Manager           { return s.services.Auth.License }
 func (s *Server) updateService() *update.Service             { return s.services.Update }
+func (s *Server) engineRegistry() *engine.Registry           { return s.services.Engines }
 
 // initWiFiUseCases wires the Wi-Fi troubleshooting use-cases (ADR-0020) from the
 // composition root: the visibility-read, management, and discovery use-cases over
@@ -835,6 +839,13 @@ func (s *Server) initUpdateUseCases() {
 	s.updateLifecycle = app.NewUpdateLifecycle(s.updateService)
 }
 
+// initEngineUseCases wires the engine-status use-case (ADR-0020) from the
+// composition root over the server's lazy accessor for the engine registry,
+// so a nil or later-set registry (the api test harness) is honored.
+func (s *Server) initEngineUseCases() {
+	s.engineStatus = app.NewEngineStatus(s.engineRegistry)
+}
+
 // initIdentityUseCases wires the identity use-cases (ADR-0020, ADR-0024) from
 // the composition root over the server's lazy accessors for the database, the
 // token repository, and the license manager, so a nil or later-set collaborator
@@ -847,12 +858,13 @@ func (s *Server) initIdentityUseCases() {
 
 // initUseCases wires the ADR-0020 application use-cases that depend on the
 // discovery components existing: troubleshooting + discovery + health + update +
-// identity.
+// identity + engine-status.
 func (s *Server) initUseCases() {
 	s.initWiFiUseCases()
 	s.initDiscoveryUseCases()
 	s.initHealthUseCases()
 	s.initUpdateUseCases()
+	s.initEngineUseCases()
 	s.initIdentityUseCases()
 }
 

--- a/internal/app/engine.go
+++ b/internal/app/engine.go
@@ -1,0 +1,34 @@
+package app
+
+// engine.go wires the composition root to the engine-status application
+// (use-case) service (ADR-0020): listing registered long-running subsystems
+// and their health state. The adapter below implements the narrow
+// status.Registry port declared in internal/engine/status over the concrete
+// *engine.Registry, resolved through a lazy accessor so a later-set/nil
+// registry (the api test harness) is honored, and a nil registry degrades
+// the use-case to its empty-list behavior rather than panicking.
+
+import (
+	"github.com/MustardSeedNetworks/seed/internal/engine"
+	"github.com/MustardSeedNetworks/seed/internal/engine/status"
+)
+
+// NewEngineStatus builds the engine-status use-case (ADR-0020) over a lazy
+// accessor for the engine registry. A nil registry makes List return nil
+// (the pre-strangle empty-response path).
+func NewEngineStatus(reg func() *engine.Registry) *status.Service {
+	return status.NewService(engineRegistryAdapter{reg: reg})
+}
+
+// ── registry adapter ──────────────────────────────────────────────────────────
+
+// engineRegistryAdapter implements status.Registry over *engine.Registry,
+// resolving it lazily. Available is checked per call so a later-set value
+// (the api test harness) is honored; Engines is only invoked by the use-case
+// once Available reports true, so it assumes a non-nil registry.
+type engineRegistryAdapter struct {
+	reg func() *engine.Registry
+}
+
+func (a engineRegistryAdapter) Available() bool          { return a.reg() != nil }
+func (a engineRegistryAdapter) Engines() []engine.Engine { return a.reg().Engines() }

--- a/internal/engine/status/status.go
+++ b/internal/engine/status/status.go
@@ -1,0 +1,79 @@
+// Package status holds the engine-status application (use-case) layer
+// (ADR-0020). It owns the read-only query that lists every registered
+// long-running subsystem and their health state, previously inlined in
+// the api.Server handleEngines handler. Handlers keep transport concerns:
+// request decode, authorization, response shaping. The adapter satisfying
+// the port lives in the composition root (internal/app) and resolves the
+// engine registry lazily, so a nil registry degrades to an empty list
+// (the pre-strangle empty-response path) rather than panicking.
+package status
+
+import (
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/engine"
+)
+
+// Registry is the engine-registry surface the use-case reads, defined at
+// the consumer (ADR-0020) and satisfied by an adapter over *engine.Registry
+// in internal/app. Available reports whether a registry is wired (resolved
+// per call so the use-case can degrade gracefully); Engines is only invoked
+// once availability is confirmed.
+type Registry interface {
+	Available() bool
+	Engines() []engine.Engine
+}
+
+// EngineStatus is the domain result for one engine entry. Transport
+// encoding to the wire map stays in the handler so this struct is
+// protocol-agnostic and testable without HTTP.
+type EngineStatus struct {
+	Name       string
+	State      string
+	LastTickAt time.Time
+	LastError  string
+	Inflight   int
+}
+
+// Service is the engine-status use-case.
+type Service struct {
+	reg Registry
+}
+
+// NewService builds the use-case over its narrow registry dependency.
+func NewService(reg Registry) *Service {
+	return &Service{reg: reg}
+}
+
+// List returns a domain snapshot of every registered engine and its status.
+// Returns nil when the registry is not wired or reports unavailable —
+// callers treat nil/empty identically (the pre-strangle empty-response path).
+//
+// The status logic mirrors the pre-strangle encodeEngineEntry: engines that
+// implement engine.Reporter contribute their Status(); engines that don't
+// default to engine.StatusOK(). An empty State from a Reporter is normalised
+// to engine.StateOK so the wire response is uniform regardless of adoption.
+func (s *Service) List() []EngineStatus {
+	if s == nil || s.reg == nil || !s.reg.Available() {
+		return nil
+	}
+	engines := s.reg.Engines()
+	out := make([]EngineStatus, 0, len(engines))
+	for _, e := range engines {
+		st := engine.StatusOK()
+		if reporter, ok := e.(engine.Reporter); ok {
+			st = reporter.Status()
+			if st.State == "" {
+				st.State = engine.StateOK
+			}
+		}
+		out = append(out, EngineStatus{
+			Name:       e.Name(),
+			State:      st.State,
+			LastTickAt: st.LastTickAt,
+			LastError:  st.LastError,
+			Inflight:   st.Inflight,
+		})
+	}
+	return out
+}

--- a/internal/engine/status/status_test.go
+++ b/internal/engine/status/status_test.go
@@ -1,0 +1,142 @@
+package status_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/engine"
+	"github.com/MustardSeedNetworks/seed/internal/engine/status"
+)
+
+// ── test doubles ─────────────────────────────────────────────────────────────
+
+// fakeRegistry implements status.Registry for testing.
+type fakeRegistry struct {
+	available bool
+	engines   []engine.Engine
+}
+
+func (f *fakeRegistry) Available() bool          { return f.available }
+func (f *fakeRegistry) Engines() []engine.Engine { return f.engines }
+
+// minimalEngine implements engine.Engine but NOT engine.Reporter.
+type minimalEngine struct{ name string }
+
+func (m *minimalEngine) Name() string                { return m.name }
+func (*minimalEngine) Start(_ context.Context) error { return nil }
+func (*minimalEngine) Stop(_ context.Context) error  { return nil }
+
+// reportingEngine implements both engine.Engine and engine.Reporter.
+type reportingEngine struct {
+	name   string
+	status engine.Status
+}
+
+func (r *reportingEngine) Name() string                { return r.name }
+func (*reportingEngine) Start(_ context.Context) error { return nil }
+func (*reportingEngine) Stop(_ context.Context) error  { return nil }
+func (r *reportingEngine) Status() engine.Status       { return r.status }
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestList_NilRegistry_ReturnsNil(t *testing.T) {
+	svc := status.NewService(nil)
+	got := svc.List()
+	if got != nil {
+		t.Errorf("nil registry: want nil, got %v", got)
+	}
+}
+
+func TestList_UnavailableRegistry_ReturnsNil(t *testing.T) {
+	reg := &fakeRegistry{available: false, engines: []engine.Engine{&minimalEngine{name: "x"}}}
+	svc := status.NewService(reg)
+	got := svc.List()
+	if got != nil {
+		t.Errorf("unavailable registry: want nil, got %v", got)
+	}
+}
+
+func TestList_MinimalEngine_DefaultsToStateOK(t *testing.T) {
+	reg := &fakeRegistry{
+		available: true,
+		engines:   []engine.Engine{&minimalEngine{name: "plain"}},
+	}
+	svc := status.NewService(reg)
+	got := svc.List()
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+	e := got[0]
+	if e.Name != "plain" {
+		t.Errorf("Name = %q, want %q", e.Name, "plain")
+	}
+	if e.State != engine.StateOK {
+		t.Errorf("State = %q, want %q (no Reporter → default StatusOK)", e.State, engine.StateOK)
+	}
+	if e.LastError != "" {
+		t.Errorf("LastError = %q, want empty", e.LastError)
+	}
+	if e.Inflight != 0 {
+		t.Errorf("Inflight = %d, want 0", e.Inflight)
+	}
+}
+
+func TestList_ReportingEngine_SurfacesStatus(t *testing.T) {
+	tick := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	reg := &fakeRegistry{
+		available: true,
+		engines: []engine.Engine{
+			&reportingEngine{
+				name: "rich",
+				status: engine.Status{
+					State:      engine.StateDegraded,
+					LastTickAt: tick,
+					LastError:  "scan timeout",
+					Inflight:   3,
+				},
+			},
+		},
+	}
+	svc := status.NewService(reg)
+	got := svc.List()
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+	e := got[0]
+	if e.Name != "rich" {
+		t.Errorf("Name = %q, want %q", e.Name, "rich")
+	}
+	if e.State != engine.StateDegraded {
+		t.Errorf("State = %q, want %q", e.State, engine.StateDegraded)
+	}
+	if e.LastTickAt != tick {
+		t.Errorf("LastTickAt = %v, want %v", e.LastTickAt, tick)
+	}
+	if e.LastError != "scan timeout" {
+		t.Errorf("LastError = %q, want %q", e.LastError, "scan timeout")
+	}
+	if e.Inflight != 3 {
+		t.Errorf("Inflight = %d, want 3", e.Inflight)
+	}
+}
+
+func TestList_ReporterEmptyState_NormalisedToStateOK(t *testing.T) {
+	reg := &fakeRegistry{
+		available: true,
+		engines: []engine.Engine{
+			&reportingEngine{
+				name:   "blank-state",
+				status: engine.Status{}, // State left empty
+			},
+		},
+	}
+	svc := status.NewService(reg)
+	got := svc.List()
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+	if got[0].State != engine.StateOK {
+		t.Errorf("empty Reporter.State should normalise to %q, got %q", engine.StateOK, got[0].State)
+	}
+}


### PR DESCRIPTION
## What

Strangles the last `s.services.Engines` reach in the `GET /api/v1/engines` handler behind an ADR-0020 use-case, mirroring the just-merged C4 identity slice (ADR-0024).

- **New use-case** `internal/engine/status` — `Service` over a narrow `Registry` port (`Available()` + `Engines()`), returning protocol-agnostic `EngineStatus` domain structs. The Reporter-vs-`StatusOK()` determination moves here. `List()` is nil-receiver-safe.
- **Composition-root wiring** `internal/app/engine.go` — `NewEngineStatus` + a lazy `*engine.Registry` adapter, so a nil/later-set registry (test harness) degrades to an empty list instead of panicking.
- **Server** — `engineStatus` field, `engineRegistry()` accessor, `initEngineUseCases()` wired into `initUseCases()`.
- **Handler** — now pure transport: `s.engineStatus.List()` → existing wire map. Wire shape is **byte-identical** (`{count, engines:[{name,state,lastTickAt,lastError,inflight}]}`).
- **Tests** — service-based handler tests call `s.initEngineUseCases()`; the bare-`&Server{}` empty-path test is unchanged (nil use-case → nil list → empty response).

This removes the last `s.services.Engines` reference in the handler — **D1 prep** (Q4 of the internal/api strangle).

## Verification
- `go build ./...` clean
- `go test ./internal/engine/status/` ok · `go test ./internal/api/ -count=1` **ok** (39.6s, run alone)
- `golangci-lint` 0 issues on changed packages (pre-commit gate green)
- `scripts/check-route-policy.sh` ✓ · `scripts/check-output-escaping.sh` ✓ (route policy unchanged)
- No golden diffs; `git grep 's\.services\.Engines' internal/api/handlers_engines.go` → empty

Do not auto-merge — Opus-gated review pending.