### PR TITLE
refactor(api): route handler license reads through s.licenseManager() (D1 prep)

### DIFF
--- a/internal/api/handlers_profiles.go
+++ b/internal/api/handlers_profiles.go
@@ -587,7 +587,7 @@ func (s *Server) enforceMultiClientGate(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// 2nd+ profile. Check the license.
-	mgr := s.services.Auth.License
+	mgr := s.licenseManager()
 	if mgr == nil {
 		// License disabled (dev / test builds) — permit.
 		return true
@@ -666,7 +666,7 @@ func (s *Server) enforceMultiInterfaceGate(w http.ResponseWriter, r *http.Reques
 		return true
 	}
 
-	mgr := s.services.Auth.License
+	mgr := s.licenseManager()
 	if mgr == nil {
 		return true
 	}

--- a/internal/api/handlers_survey.go
+++ b/internal/api/handlers_survey.go
@@ -455,7 +455,7 @@ func filterSamplePointsRoam(in []*survey.SamplePoint) []*survey.SamplePoint {
 // stripped. Centralizes the gate so getSurvey + listSurveys share the
 // same policy.
 func (s *Server) applyRoamFilterIfGated(in *survey.Survey) *survey.Survey {
-	mgr := s.services.Auth.License
+	mgr := s.licenseManager()
 	if mgr == nil || mgr.HasFeature("wifi_roam_analysis") {
 		return in
 	}

--- a/internal/api/middleware_license.go
+++ b/internal/api/middleware_license.go
@@ -41,7 +41,7 @@ type FeatureGateResponse struct {
 // the gating layer never breaks local development workflows.
 func (s *Server) requireFeature(feature string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		mgr := s.services.Auth.License
+		mgr := s.licenseManager()
 		if mgr == nil || mgr.HasFeature(feature) {
 			next(w, r)
 			return

--- a/internal/api/tokens.go
+++ b/internal/api/tokens.go
@@ -108,7 +108,8 @@ type LicenseStatusResponse struct {
 
 // handleLicenseStatus exposes the local license state to the UI. The
 // unlicensed (Free) state is a valid result, not an error condition.
-// Out of scope for C4 (ADR-0024): reads s.services.Auth.License directly.
+// Reads the license manager through s.licenseManager() — the single
+// Server accessor that D1 will repoint off the service container.
 func (s *Server) handleLicenseStatus(w http.ResponseWriter, r *http.Request) {
 	resp := LicenseStatusResponse{
 		Tier:          license.TierFree.String(),
@@ -116,7 +117,7 @@ func (s *Server) handleLicenseStatus(w http.ResponseWriter, r *http.Request) {
 		CanMintTokens: false,
 	}
 
-	mgr := s.services.Auth.License
+	mgr := s.licenseManager()
 	if mgr == nil {
 		// License disabled (dev / test build) — allow minting so the
 		// feature stays usable. Matches the tokens use-case LicenseGate

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -553,7 +553,7 @@ func (s *Server) writeGated(next http.HandlerFunc) http.HandlerFunc {
 // grants it; Free + Starter do not. A nil license manager is treated
 // as "license disabled" (dev / test) and permits.
 func (s *Server) licenseAllowsMultiUser() bool {
-	mgr := s.services.Auth.License
+	mgr := s.licenseManager()
 	if mgr == nil {
 		return true
 	}


### PR DESCRIPTION
## What

Six handlers read the license manager via `s.services.Auth.License` directly. Route them all through the **existing** `s.licenseManager()` accessor:

- `handlers_profiles.go` (×2), `handlers_survey.go`, `middleware_license.go`, `users.go`, `tokens.go`

Pure mechanical swap, **no behavior change** — the accessor returns the same `*license.Manager`. The only remaining `s.services.Auth.License` reference is the accessor body itself (`server.go:793`), which is the single seam D1 will repoint off the service container.

Part of the internal/api strangle (ADR-0016/0020) D1 prep: after this, no handler reaches `s.services.Auth.License`.

## Verification
- `go build ./...` clean
- `go test ./internal/api/ -count=1` **ok** (62.8s, run alone)
- pre-commit golangci-lint **0 issues** on changed files (the 4 repo-wide gofumpt flags are pre-existing drift in untouched test files)
- `scripts/check-route-policy.sh` ✓ · `scripts/check-output-escaping.sh` ✓ (route policy unchanged)
- `git grep 's\.services\.Auth\.License' internal/api/*.go` (excl. tests) → only the `server.go` accessor remains

Do not auto-merge — Opus-gated review pending.