### PR TITLE
refactor(api): extract drainJobSubstrate + test the shutdown drain

### DIFF
--- a/internal/api/handlers_jobs.go
+++ b/internal/api/handlers_jobs.go
@@ -44,7 +44,8 @@ const (
 	// retention sweep may remove them.
 	jobsRetention = time.Hour
 
-	// jobsShutdownTimeout bounds the graceful drain of the runner and event bus.
+	// jobsShutdownTimeout bounds the graceful drain of the runner and event bus
+	// on Server.Shutdown (see drainJobSubstrate).
 	jobsShutdownTimeout = 5 * time.Second
 )
 

--- a/internal/api/server_shutdown.go
+++ b/internal/api/server_shutdown.go
@@ -118,26 +118,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// Drain the async job substrate (ADR-0004 / ADR-0005). The runner publishes
-	// lifecycle transitions onto the bus, so close it first, then the bus. Each
-	// drain is bounded by jobsShutdownTimeout so a stuck handler can't wedge
-	// shutdown. (Folded in from the former ServiceContainer.Stop() in D1.)
-	if s.jobRunner != nil {
-		logging.GetLogger().InfoContext(ctx, "Stopping job runner...")
-		drainCtx, cancel := context.WithTimeout(ctx, jobsShutdownTimeout)
-		if closeErr := s.jobRunner.Close(drainCtx); closeErr != nil {
-			logging.GetLogger().WarnContext(ctx, "job runner close returned error", "error", closeErr)
-		}
-		cancel()
-	}
-	if s.bus != nil {
-		logging.GetLogger().InfoContext(ctx, "Draining event bus...")
-		drainCtx, cancel := context.WithTimeout(ctx, jobsShutdownTimeout)
-		if closeErr := s.bus.Close(drainCtx); closeErr != nil {
-			logging.GetLogger().WarnContext(ctx, "event bus close returned error", "error", closeErr)
-		}
-		cancel()
-	}
+	s.drainJobSubstrate(ctx)
 
 	logging.GetLogger().InfoContext(ctx, "Stopping rate limiters...")
 	s.loginRateLimiter().Stop()
@@ -170,6 +151,36 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		return fmt.Errorf("shutdown main server: %w", err)
 	}
 	return nil
+}
+
+// drainJobSubstrate gracefully closes the async job runner and the in-process
+// event bus (ADR-0004 / ADR-0005). The runner publishes lifecycle transitions
+// onto the bus, so it is closed first, then the bus. Each close is bounded by
+// jobsShutdownTimeout so a wedged handler can't stall shutdown indefinitely.
+//
+// This teardown previously lived only in ServiceContainer.Stop(), which had no
+// callers — so the runner goroutines and bus were never actually drained on a
+// real shutdown. D1 restored the drain onto the live Shutdown path; this
+// extracts it behind a single seam so the close ordering is unit-testable.
+// Both fields may be nil (the lightweight test server never wires them), so
+// each is nil-guarded.
+func (s *Server) drainJobSubstrate(ctx context.Context) {
+	if s.jobRunner != nil {
+		logging.GetLogger().InfoContext(ctx, "Stopping job runner...")
+		drainCtx, cancel := context.WithTimeout(ctx, jobsShutdownTimeout)
+		if closeErr := s.jobRunner.Close(drainCtx); closeErr != nil {
+			logging.GetLogger().WarnContext(ctx, "job runner close returned error", "error", closeErr)
+		}
+		cancel()
+	}
+	if s.bus != nil {
+		logging.GetLogger().InfoContext(ctx, "Draining event bus...")
+		drainCtx, cancel := context.WithTimeout(ctx, jobsShutdownTimeout)
+		if closeErr := s.bus.Close(drainCtx); closeErr != nil {
+			logging.GetLogger().WarnContext(ctx, "event bus close returned error", "error", closeErr)
+		}
+		cancel()
+	}
 }
 
 // startMaintenance runs the periodic background maintenance loop: jobs retention

--- a/internal/api/server_shutdown_internal_test.go
+++ b/internal/api/server_shutdown_internal_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/platform/events"
+	"github.com/MustardSeedNetworks/seed/internal/platform/jobs"
+)
+
+// TestDrainJobSubstrate_ClosesRunnerAndBus proves Server.Shutdown's job-substrate
+// teardown actually closes the runner and the bus. Before D1 this drain lived
+// only in the dead ServiceContainer.Stop() (no callers), so on a real shutdown
+// the runner goroutines and bus were never drained.
+func TestDrainJobSubstrate_ClosesRunnerAndBus(t *testing.T) {
+	bus := events.New(slog.New(slog.DiscardHandler))
+	runner := jobs.New(bus, slog.New(slog.DiscardHandler), jobs.Config{})
+	s := &Server{bus: bus, jobRunner: runner}
+
+	s.drainJobSubstrate(context.Background())
+
+	// After the drain the runner rejects new work with ErrClosed — the
+	// observable proof it was closed.
+	if _, err := runner.Submit("noop", nil); !errors.Is(err, jobs.ErrClosed) {
+		t.Errorf("Submit after drain = %v, want jobs.ErrClosed", err)
+	}
+
+	// The bus is closed too: a second Close hits the idempotent already-closed
+	// path and returns nil immediately.
+	if err := bus.Close(context.Background()); err != nil {
+		t.Errorf("second bus Close = %v, want nil (already closed)", err)
+	}
+
+	// And the drain is a no-op on a bare Server — nil runner/bus must not panic
+	// (the lightweight test server never wires them).
+	(&Server{}).drainJobSubstrate(context.Background())
+}


### PR DESCRIPTION
Follow-up to #1627 (D1). That PR restored the job-runner/event-bus drain onto
`Server.Shutdown` — closing a real teardown gap (the drain previously lived only
in the dead `ServiceContainer.Stop()`) — but it landed **inline and untested**.

This extracts the drain behind a single `drainJobSubstrate(ctx)` seam so the
close ordering is unit-testable, and adds the missing test:

- runner is closed (`Submit` → `jobs.ErrClosed`),
- bus is closed (idempotent second `Close` returns nil),
- no-op / no panic on a bare `Server` (nil runner+bus).

Proven RED/GREEN: neutering the helper makes `Submit` return "unknown job kind"
(runner still open) instead of `ErrClosed`, failing the test.

Pure structural + test change; `Shutdown` behavior is identical to #1627.

## Gates
- `go build ./...` ✓ · `go test ./internal/api/ -count=1` ✓
- `golangci-lint run --new-from-rev=origin/main ./...` → 0 issues