### PR TITLE
feat(anomaly): persist the anomaly engine in SQL (ADR-0021 phase 1)

### DIFF
--- a/docs/architecture/decisions/0021-persist-and-converge-anomaly-engine.md
+++ b/docs/architecture/decisions/0021-persist-and-converge-anomaly-engine.md
@@ -1,6 +1,7 @@
 # ADR-0021: Persist the anomaly engine in SQL and converge every source on it
 
-**Status:** Proposed — 2026-06-10 · completes the deferred persistence clause of
+**Status:** Accepted — 2026-06-11 (owner-confirmed the cadence/retention/phase
+decisions below on 2026-06-10) · completes the deferred persistence clause of
 [ADR-0011](0011-network-anomaly-engine.md); builds on [ADR-0006](0006-migrations-sql-goose-strict.md)
 (goose/STRICT migrations), [ADR-0004](0004-event-bus.md)/[ADR-0017](0017-transactional-outbox-relay.md)
 (events), [ADR-0002](0002-capability-registry.md) (Pro gating), [ADR-0010](0010-identifier-casing-conventions.md) (casing).
@@ -76,9 +77,12 @@ ADR-0011's architecture; it implements its persistence clause and enforces its s
    `/wifi/anomalies` endpoint, and Survey analysis all read persisted anomalies (with history +
    lifecycle), not per-detector in-memory snapshots. Pro sources stay gated via `requireFeature`
    (ADR-0002); the engine and store are tier-neutral.
-5. **Lifecycle + retention** (defaults below, to confirm): persist on state change (new/escalated/
-   resolved), debounced; keep active anomalies indefinitely; age resolved ones via TTL with
-   optional daily rollups mirroring `health_check_rollups_*`.
+5. **Lifecycle + retention (owner-confirmed 2026-06-10).** **Write cadence: write-through on
+   material state change** (a new anomaly or a severity escalation) for durability, with the
+   high-frequency recurrence updates (`last_seen`/`count`) **batched via a periodic flush** — so a
+   scan burst is one write, not one per observation. Resolution (Prune) is written through. **Retention:
+   keep active anomalies indefinitely; TTL-age resolved ones (default 90d) with daily per-(def,subject)
+   rollups** mirroring `health_check_rollups_*`, for bounded growth on appliances.
 
 6. **Catalog model & severity (per ADR-0011's `AnomalyDef`).** Each anomaly *type* is a catalog
    entry that gives the operator a guided answer, not just a flag: a one-line **title** (the
@@ -142,11 +146,24 @@ ADR-0011's architecture; it implements its persistence clause and enforces its s
   (3) health source convergence + delete bespoke detector; (4) repoint readers (monitoring/wifi/
   Survey); (5) catalog growth (wired/SNMP/etc.) as those sources land.
 
-## Decisions to confirm (owner)
+## Confirmed decisions (owner, 2026-06-10)
 
-1. **Write cadence** — write-through on state change, debounced (recommended) vs periodic flush
-   vs write-through every Observe. Trade-off: durability vs write volume.
-2. **Retention** — keep active forever + TTL-age resolved with daily rollups (recommended) vs
-   raw-forever vs TTL-everything.
-3. **Phase label** — standalone "Anomaly Platform" workstream (recommended) vs a phase appended
-   to the strangle plan.
+1. **Write cadence** — write-through on material state change, recurrence batched via periodic
+   flush. (Resolved over "write every Observe" — durability for events that matter without a
+   per-scan write storm.)
+2. **Retention** — keep active forever + TTL-age resolved (90d default) with daily rollups.
+3. **Phase label** — tracked as the "Anomaly Platform" workstream in the master roadmap; the
+   bespoke `internal/health.AnomalyDetector` is deleted outright in the producer slice (pre-alpha,
+   no compat).
+
+## Implementation phasing (as-built status)
+
+Phase 1 (this slice) lands the **persistence foundation** the rest builds on: the `anomaly.Store`
+port + `Record`/`Source` model, the `anomalies` migration, the `database.AnomalyRepository`
+implementation, and the persistence-aware `anomaly.Coordinator` (write-through on material change,
+batched `Flush`, resolve-on-`Prune`). The four-level severity ladder (`Info → Warning → Error →
+Critical`) refines ADR-0011's three levels and is a **separate, additive change** (engine
+`rank`/escalation + catalog defaults); the persistence layer stores the severity string verbatim, so
+adding `Error` later needs no schema change. Subsequent phases (per the Consequences list): load-on-
+start + TTL/rollup retention; health-source convergence + delete the bespoke detector; repoint the
+monitoring/Wi-Fi/Survey readers; catalog growth as each source lands.

--- a/internal/anomaly/anomaly.go
+++ b/internal/anomaly/anomaly.go
@@ -157,6 +157,13 @@ type instanceKey struct {
 	id   string
 }
 
+// recordID renders the key as the stable persistence id (store.go). It must
+// equal RecordID(def, SubjectRef{kind, id}) — the engine key and the stored id
+// are the same identity, which is what makes restart re-load idempotent.
+func (k instanceKey) recordID() string {
+	return k.def + "|" + string(k.kind) + "|" + k.id
+}
+
 // Anomaly is the projected, JSON-serializable view of a live detection: the
 // catalog copy (title/description/recommendation/standards) merged with the
 // instance evidence and lifecycle (firstSeen/lastSeen/count). Wire tags are

--- a/internal/anomaly/coordinator.go
+++ b/internal/anomaly/coordinator.go
@@ -1,0 +1,116 @@
+package anomaly
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Coordinator couples the in-memory Engine to a persistent Store (ADR-0021).
+// Material state changes — a newly detected anomaly or a severity escalation —
+// are written through to the Store immediately, so durable events survive a
+// restart. High-frequency recurrence (lastSeen/count) is NOT written per
+// observation; it is accumulated and persisted by Flush on a periodic tick, so a
+// scan burst costs one batched write, not one per detection. Resolution (Prune)
+// is written through. The pure Engine is unchanged and remains usable
+// standalone; the Coordinator is the long-lived, persisted instance.
+type Coordinator struct {
+	engine *Engine
+	store  Store
+	source Source
+
+	mu    sync.Mutex
+	dirty map[instanceKey]struct{}
+}
+
+// NewCoordinator wraps engine with write-through persistence to store, tagging
+// every persisted instance with source.
+func NewCoordinator(engine *Engine, store Store, source Source) *Coordinator {
+	return &Coordinator{
+		engine: engine,
+		store:  store,
+		source: source,
+		dirty:  make(map[instanceKey]struct{}),
+	}
+}
+
+// Observe folds a detection into the engine and persists per the write cadence:
+// write-through on a material change, deferred (marked for the next Flush) on
+// mere recurrence. A Store error after a successful in-memory update is returned
+// but does not roll back the engine — the next Flush re-persists the instance.
+func (c *Coordinator) Observe(ctx context.Context, d Detection, at time.Time) error {
+	res, err := c.engine.observe(d, at)
+	if err != nil {
+		return err
+	}
+	if res.material {
+		return c.store.Upsert(ctx, c.records([]instanceKey{res.key}))
+	}
+	c.mu.Lock()
+	c.dirty[res.key] = struct{}{}
+	c.mu.Unlock()
+	return nil
+}
+
+// Flush persists every instance touched by recurrence since the last Flush — the
+// batched write path for the high-frequency lastSeen/count updates. It is a
+// no-op when nothing is pending.
+func (c *Coordinator) Flush(ctx context.Context) error {
+	c.mu.Lock()
+	keys := make([]instanceKey, 0, len(c.dirty))
+	for k := range c.dirty {
+		keys = append(keys, k)
+	}
+	c.dirty = make(map[instanceKey]struct{})
+	c.mu.Unlock()
+
+	recs := c.records(keys)
+	if len(recs) == 0 {
+		return nil
+	}
+	return c.store.Upsert(ctx, recs)
+}
+
+// Prune clears instances idle since cutoff and marks exactly those resolved in
+// the store as of cutoff (the idle boundary). Returns the number cleared.
+func (c *Coordinator) Prune(ctx context.Context, cutoff time.Time) (int, error) {
+	keys := c.engine.pruneKeys(cutoff)
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	ids := make([]string, len(keys))
+	for i, k := range keys {
+		ids[i] = k.recordID()
+	}
+	// The pruned instances are gone from the engine; drop any pending dirty
+	// marks so a later Flush does not resurrect a resolved row.
+	c.mu.Lock()
+	for _, k := range keys {
+		delete(c.dirty, k)
+	}
+	c.mu.Unlock()
+
+	if err := c.store.MarkResolved(ctx, ids, cutoff); err != nil {
+		return len(keys), err
+	}
+	return len(keys), nil
+}
+
+// Engine returns the underlying in-memory engine for read-only projection
+// (Snapshot) by consumers that also read live state.
+func (c *Coordinator) Engine() *Engine { return c.engine }
+
+// records projects keys into persistable Records, tagging source and the stable
+// id and skipping keys no longer live.
+func (c *Coordinator) records(keys []instanceKey) []Record {
+	anoms := c.engine.snapshotKeys(keys)
+	out := make([]Record, 0, len(anoms))
+	for _, a := range anoms {
+		out = append(out, Record{
+			ID:      RecordID(a.DefKey, a.Subject),
+			Source:  c.source,
+			Anomaly: a,
+		})
+	}
+	return out
+}

--- a/internal/anomaly/coordinator_test.go
+++ b/internal/anomaly/coordinator_test.go
@@ -1,0 +1,198 @@
+package anomaly_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
+)
+
+// fakeStore is an in-memory anomaly.Store recording the calls a Coordinator
+// makes, so tests can assert the write cadence (write-through vs batched) without
+// a database.
+type fakeStore struct {
+	rows      map[string]anomaly.Record
+	upserts   int // number of Upsert CALLS (not rows) — distinguishes batching
+	upsertRow int // number of records passed across all Upsert calls
+	resolved  map[string]time.Time
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{rows: map[string]anomaly.Record{}, resolved: map[string]time.Time{}}
+}
+
+func (f *fakeStore) Upsert(_ context.Context, recs []anomaly.Record) error {
+	f.upserts++
+	for _, r := range recs {
+		f.upsertRow++
+		f.rows[r.ID] = r
+		delete(f.resolved, r.ID) // re-detection revives
+	}
+	return nil
+}
+
+func (f *fakeStore) MarkResolved(_ context.Context, ids []string, at time.Time) error {
+	for _, id := range ids {
+		f.resolved[id] = at
+		delete(f.rows, id)
+	}
+	return nil
+}
+
+func (f *fakeStore) LoadActive(_ context.Context) ([]anomaly.Record, error) {
+	out := make([]anomaly.Record, 0, len(f.rows))
+	for _, r := range f.rows {
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+func coordTestCatalog(t *testing.T) *anomaly.Catalog {
+	t.Helper()
+	c, err := anomaly.NewCatalog(
+		anomaly.Def{
+			ID: "open-ssid", Category: anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Title:           "Open network", Description: "No encryption.",
+			Recommendation: "Enable WPA2/WPA3.",
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewCatalog: %v", err)
+	}
+	return c
+}
+
+func newCoord(t *testing.T, store anomaly.Store, opts ...anomaly.Option) *anomaly.Coordinator {
+	t.Helper()
+	return anomaly.NewCoordinator(anomaly.NewEngine(coordTestCatalog(t), opts...), store, anomaly.SourceWiFi)
+}
+
+func openSSID(id string) anomaly.Detection {
+	return anomaly.Detection{DefKey: "open-ssid", Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: id}}
+}
+
+// TestCoordinatorWritesThroughOnCreate asserts a brand-new anomaly is persisted
+// immediately (write-through), tagged with the coordinator's source.
+func TestCoordinatorWritesThroughOnCreate(t *testing.T) {
+	store := newFakeStore()
+	c := newCoord(t, store)
+	at := time.Unix(1000, 0)
+
+	if err := c.Observe(context.Background(), openSSID("aa"), at); err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	if store.upserts != 1 || store.upsertRow != 1 {
+		t.Fatalf("create: upsert calls/rows = %d/%d, want 1/1 (write-through)", store.upserts, store.upsertRow)
+	}
+	got, ok := store.rows["open-ssid|bssid|aa"]
+	if !ok {
+		t.Fatalf("instance not persisted; rows=%v", store.rows)
+	}
+	if got.Source != anomaly.SourceWiFi {
+		t.Errorf("source = %q, want wifi", got.Source)
+	}
+}
+
+// TestCoordinatorBatchesRecurrence asserts pure recurrence does NOT write per
+// observation — it accumulates and is persisted by a single Flush.
+func TestCoordinatorBatchesRecurrence(t *testing.T) {
+	store := newFakeStore()
+	c := newCoord(t, store) // default escalateAfter=5, so recurrences below stay non-material
+	ctx := context.Background()
+	at := time.Unix(1000, 0)
+
+	// First observation = create (write-through).
+	if err := c.Observe(ctx, openSSID("aa"), at); err != nil {
+		t.Fatalf("create Observe: %v", err)
+	}
+	// Three more recurrences (counts 2,3,4 — below the escalation threshold).
+	for i := range 3 {
+		if err := c.Observe(ctx, openSSID("aa"), at.Add(time.Duration(i+1)*time.Second)); err != nil {
+			t.Fatalf("recurrence Observe: %v", err)
+		}
+	}
+	if store.upserts != 1 {
+		t.Fatalf("recurrence wrote through: upsert calls = %d, want 1 (only the create)", store.upserts)
+	}
+
+	if err := c.Flush(ctx); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if store.upserts != 2 {
+		t.Fatalf("after Flush: upsert calls = %d, want 2 (create + one batched flush)", store.upserts)
+	}
+	if store.rows["open-ssid|bssid|aa"].Anomaly.Count != 4 {
+		t.Errorf("flushed count = %d, want 4", store.rows["open-ssid|bssid|aa"].Anomaly.Count)
+	}
+}
+
+// TestCoordinatorWritesThroughOnEscalation asserts crossing the escalation
+// threshold is treated as a material change and written through, even though the
+// underlying observation is a recurrence.
+func TestCoordinatorWritesThroughOnEscalation(t *testing.T) {
+	store := newFakeStore()
+	c := newCoord(t, store, anomaly.WithEscalateAfter(3))
+	ctx := context.Background()
+	at := time.Unix(1000, 0)
+
+	if err := c.Observe(ctx, openSSID("aa"), at); err != nil { // count 1, create
+		t.Fatalf("Observe 1: %v", err)
+	}
+	if err := c.Observe(ctx, openSSID("aa"), at); err != nil { // count 2, recurrence (deferred)
+		t.Fatalf("Observe 2: %v", err)
+	}
+	if store.upserts != 1 {
+		t.Fatalf("before threshold: upsert calls = %d, want 1", store.upserts)
+	}
+	if err := c.Observe(ctx, openSSID("aa"), at); err != nil { // count 3 == threshold: escalation crossing
+		t.Fatalf("Observe 3: %v", err)
+	}
+	if store.upserts != 2 {
+		t.Fatalf("escalation crossing should write through: upsert calls = %d, want 2", store.upserts)
+	}
+	if store.rows["open-ssid|bssid|aa"].Anomaly.Severity != anomaly.SeverityCritical {
+		t.Errorf("persisted severity = %q, want critical (escalated)",
+			store.rows["open-ssid|bssid|aa"].Anomaly.Severity)
+	}
+}
+
+// TestCoordinatorResolvesOnPrune asserts pruning idle instances marks exactly
+// those resolved in the store and clears pending dirty marks.
+func TestCoordinatorResolvesOnPrune(t *testing.T) {
+	store := newFakeStore()
+	c := newCoord(t, store)
+	ctx := context.Background()
+
+	old := time.Unix(100, 0)
+	fresh := time.Unix(10000, 0)
+	if err := c.Observe(ctx, openSSID("stale"), old); err != nil {
+		t.Fatalf("Observe stale: %v", err)
+	}
+	if err := c.Observe(ctx, openSSID("live"), fresh); err != nil {
+		t.Fatalf("Observe live: %v", err)
+	}
+
+	n, err := c.Prune(ctx, time.Unix(5000, 0))
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("Prune cleared %d, want 1", n)
+	}
+	if _, resolved := store.resolved["open-ssid|bssid|stale"]; !resolved {
+		t.Errorf("stale instance not marked resolved; resolved=%v", store.resolved)
+	}
+	if _, live := store.rows["open-ssid|bssid|live"]; !live {
+		t.Errorf("live instance should remain; rows=%v", store.rows)
+	}
+
+	// A Flush after prune must not resurrect the resolved row.
+	if flushErr := c.Flush(ctx); flushErr != nil {
+		t.Fatalf("Flush: %v", flushErr)
+	}
+	if _, revived := store.rows["open-ssid|bssid|stale"]; revived {
+		t.Error("Flush resurrected a pruned instance")
+	}
+}

--- a/internal/anomaly/engine.go
+++ b/internal/anomaly/engine.go
@@ -66,42 +66,69 @@ func NewEngine(catalog *Catalog, opts ...Option) *Engine {
 	return e
 }
 
-// Observe folds one detection into the stream at observation time `at`. A new
+// observeResult reports the effect of one Observe on the live stream so the
+// persistence Coordinator (store.go) can tell a material change — written
+// through immediately — from mere recurrence, which is batched into the next
+// Flush. Package-internal: external callers use Observe and ignore it.
+type observeResult struct {
+	key      instanceKey
+	created  bool // a new instance was inserted
+	material bool // created, OR base severity changed, OR escalation threshold crossed
+}
+
+// observe folds one detection into the stream and reports what changed. A new
 // (type, subject) pair creates an instance; a repeat updates lastSeen and the
 // recurrence count (which can escalate severity). It errors if the detection's
 // DefKey is not in the catalog or its severity override is invalid — a rule
 // source must only emit defined anomalies.
-func (e *Engine) Observe(d Detection, at time.Time) error {
+func (e *Engine) observe(d Detection, at time.Time) (observeResult, error) {
 	if _, ok := e.catalog.Lookup(d.DefKey); !ok {
-		return fmt.Errorf("anomaly: detection references unknown def %q", d.DefKey)
+		return observeResult{}, fmt.Errorf("anomaly: detection references unknown def %q", d.DefKey)
 	}
 	if d.Severity != "" && !d.Severity.valid() {
-		return fmt.Errorf("anomaly: detection for %q has invalid severity %q", d.DefKey, d.Severity)
+		return observeResult{}, fmt.Errorf(
+			"anomaly: detection for %q has invalid severity %q", d.DefKey, d.Severity)
 	}
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	k := d.key()
+	newBase := e.baseSeverity(d)
 	t, ok := e.active[k]
 	if !ok {
 		e.active[k] = &tracked{
 			det:          d,
-			baseSeverity: e.baseSeverity(d),
+			baseSeverity: newBase,
 			firstSeen:    at,
 			lastSeen:     at,
 			count:        1,
 		}
-		return nil
+		return observeResult{key: k, created: true, material: true}, nil
 	}
-	// Coalesce: refresh evidence + lifecycle, keep the earliest firstSeen.
+	// Coalesce: refresh evidence + lifecycle, keep the earliest firstSeen. A
+	// material change — a base-severity change or crossing the escalation
+	// threshold — warrants a durable write; a plain recurrence does not.
+	beforeEff := e.effectiveSeverityOf(t.baseSeverity, t.count)
+	baseChanged := t.baseSeverity != newBase
 	t.det = d
-	t.baseSeverity = e.baseSeverity(d)
+	t.baseSeverity = newBase
 	t.count++
 	if at.After(t.lastSeen) {
 		t.lastSeen = at
 	}
-	return nil
+	afterEff := e.effectiveSeverityOf(t.baseSeverity, t.count)
+	return observeResult{key: k, material: baseChanged || afterEff != beforeEff}, nil
+}
+
+// Observe folds one detection into the stream at observation time `at`. A new
+// (type, subject) pair creates an instance; a repeat updates lastSeen and the
+// recurrence count (which can escalate severity). It errors if the detection's
+// DefKey is not in the catalog or its severity override is invalid — a rule
+// source must only emit defined anomalies.
+func (e *Engine) Observe(d Detection, at time.Time) error {
+	_, err := e.observe(d, at)
+	return err
 }
 
 // baseSeverity is the detection's explicit severity, else the catalog default.
@@ -113,13 +140,18 @@ func (e *Engine) baseSeverity(d Detection) Severity {
 	return def.DefaultSeverity
 }
 
-// effectiveSeverity applies recurrence escalation: a base severity bumps one
-// level once count reaches escalateAfter, capped at critical.
+// effectiveSeverity applies recurrence escalation to a tracked instance.
 func (e *Engine) effectiveSeverity(t *tracked) Severity {
-	if e.escalateAfter <= 0 || t.count < e.escalateAfter {
-		return t.baseSeverity
+	return e.effectiveSeverityOf(t.baseSeverity, t.count)
+}
+
+// effectiveSeverityOf bumps base one level once count reaches escalateAfter,
+// capped at critical (escalateAfter <= 0 disables escalation).
+func (e *Engine) effectiveSeverityOf(base Severity, count int) Severity {
+	if e.escalateAfter <= 0 || count < e.escalateAfter {
+		return base
 	}
-	switch t.baseSeverity {
+	switch base {
 	case SeverityInfo:
 		return SeverityWarning
 	case SeverityWarning:
@@ -127,23 +159,67 @@ func (e *Engine) effectiveSeverity(t *tracked) Severity {
 	case SeverityCritical:
 		return SeverityCritical
 	default:
-		return t.baseSeverity
+		return base
 	}
 }
 
 // Prune clears instances not re-observed since cutoff (the anomaly's condition
 // is considered resolved). Returns the number cleared.
 func (e *Engine) Prune(cutoff time.Time) int {
+	return len(e.pruneKeys(cutoff))
+}
+
+// pruneKeys clears instances not re-observed since cutoff and returns their
+// keys, so the persistence Coordinator can mark exactly those resolved.
+func (e *Engine) pruneKeys(cutoff time.Time) []instanceKey {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	n := 0
+	var cleared []instanceKey
 	for k, t := range e.active {
 		if t.lastSeen.Before(cutoff) {
+			cleared = append(cleared, k)
 			delete(e.active, k)
-			n++
 		}
 	}
-	return n
+	return cleared
+}
+
+// project builds the Anomaly view of one tracked instance, merging catalog copy
+// with instance evidence/lifecycle and degrading capability-gated auto
+// follow-ups to prompts. The caller holds e.mu.
+func (e *Engine) project(t *tracked) Anomaly {
+	def, _ := e.catalog.Lookup(t.det.DefKey)
+	return Anomaly{
+		DefKey:         def.ID,
+		Category:       def.Category,
+		Severity:       e.effectiveSeverity(t),
+		Subject:        t.det.Subject,
+		Title:          def.Title,
+		Description:    def.Description,
+		Impact:         def.Impact,
+		Recommendation: def.Recommendation,
+		Standards:      def.Standards,
+		Evidence:       t.det.Evidence,
+		FollowUps:      e.projectFollowUps(def.FollowUps),
+		FirstSeen:      t.firstSeen,
+		LastSeen:       t.lastSeen,
+		Count:          t.count,
+	}
+}
+
+// snapshotKeys projects the named live instances, skipping any no longer
+// present. Used by the persistence Coordinator to build write-through and Flush
+// records without re-projecting the whole stream.
+func (e *Engine) snapshotKeys(keys []instanceKey) []Anomaly {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	out := make([]Anomaly, 0, len(keys))
+	for _, k := range keys {
+		if t, ok := e.active[k]; ok {
+			out = append(out, e.project(t))
+		}
+	}
+	return out
 }
 
 // Snapshot projects the live stream as deterministically-ordered Anomaly views,
@@ -156,23 +232,7 @@ func (e *Engine) Snapshot() []Anomaly {
 
 	out := make([]Anomaly, 0, len(e.active))
 	for _, t := range e.active {
-		def, _ := e.catalog.Lookup(t.det.DefKey)
-		out = append(out, Anomaly{
-			DefKey:         def.ID,
-			Category:       def.Category,
-			Severity:       e.effectiveSeverity(t),
-			Subject:        t.det.Subject,
-			Title:          def.Title,
-			Description:    def.Description,
-			Impact:         def.Impact,
-			Recommendation: def.Recommendation,
-			Standards:      def.Standards,
-			Evidence:       t.det.Evidence,
-			FollowUps:      e.projectFollowUps(def.FollowUps),
-			FirstSeen:      t.firstSeen,
-			LastSeen:       t.lastSeen,
-			Count:          t.count,
-		})
+		out = append(out, e.project(t))
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if ri, rj := out[i].Severity.rank(), out[j].Severity.rank(); ri != rj {

--- a/internal/anomaly/store.go
+++ b/internal/anomaly/store.go
@@ -1,0 +1,69 @@
+package anomaly
+
+import (
+	"context"
+	"time"
+)
+
+// Source identifies the subsystem that produced an anomaly instance. The single
+// shared store stays source-neutral while remaining filterable by producer
+// (ADR-0021); new sources are added here as they come online.
+type Source string
+
+const (
+	// SourceWiFi is the Wi-Fi visibility/troubleshooting stack (internal/wifi).
+	SourceWiFi Source = "wifi"
+	// SourceWired is wired/link health (duplex, errors, STP/VLAN).
+	SourceWired Source = "wired"
+	// SourceSNMP is SNMP polling (interface errors, utilization, device down).
+	SourceSNMP Source = "snmp"
+	// SourceBluetooth is Bluetooth live capture.
+	SourceBluetooth Source = "bluetooth"
+	// SourceHealth is endpoint/latency health monitoring.
+	SourceHealth Source = "health"
+	// SourceSecurity is the security/authorization framework.
+	SourceSecurity Source = "security"
+	// SourceAutoTest is automated test outcomes (RFC/standards conformance).
+	SourceAutoTest Source = "autotest"
+)
+
+// Record is the persistence-facing view of one live anomaly instance: the
+// projected Anomaly plus the columns the in-memory model lacks — a stable id,
+// the producing Source, and the resolve/acknowledge lifecycle (ADR-0021). The
+// catalog-static Impact and FollowUps are intentionally NOT persisted; they are
+// re-derived from the catalog by DefKey on read, so the store never duplicates
+// static catalog copy.
+type Record struct {
+	ID      string
+	Source  Source
+	Anomaly Anomaly
+
+	Resolved       bool
+	ResolvedAt     time.Time
+	AcknowledgedBy string
+	AcknowledgedAt time.Time
+}
+
+// RecordID derives the stable persistence id for an instance from its coalescing
+// identity (anomaly type + subject), so a restart re-loads the exact row a
+// re-detection updates. It MUST match the engine's in-memory key (see
+// Detection.key) — that equality is the restart-idempotency guarantee.
+func RecordID(defKey string, subject SubjectRef) string {
+	return defKey + "|" + string(subject.Kind) + "|" + subject.ID
+}
+
+// Store is the persistence port the engine's Coordinator writes anomaly
+// instances through (ADR-0021), implemented by internal/database. It is the
+// single SQL system of record for detected anomalies across every source.
+type Store interface {
+	// Upsert idempotently persists instances keyed by Record.ID: write-through
+	// on a material change and in batches from the periodic Flush. A re-detected
+	// instance clears any prior resolution (it is live again).
+	Upsert(ctx context.Context, recs []Record) error
+	// MarkResolved flags the given instance ids resolved as of at (their
+	// condition cleared on Prune). Unknown or already-resolved ids are ignored.
+	MarkResolved(ctx context.Context, ids []string, at time.Time) error
+	// LoadActive returns all unresolved instances, to repopulate the engine on
+	// start. (Wired by a later phase; defined now so the port is complete.)
+	LoadActive(ctx context.Context) ([]Record, error)
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -83,6 +83,7 @@ type DB struct {
 	topology          *TopologyRepository
 	alertRules        *AlertRulesRepository
 	alertSuppressions *AlertSuppressionsRepository
+	anomalies         *AnomalyRepository
 }
 
 // Config holds database configuration options.
@@ -594,6 +595,19 @@ func (db *DB) AlertSuppressions() *AlertSuppressionsRepository {
 		db.alertSuppressions = &AlertSuppressionsRepository{db: db}
 	}
 	return db.alertSuppressions
+}
+
+// Anomalies returns the anomaly repository (ADR-0021, Anomaly Platform). It is
+// the SQL system of record the engine's persistence Coordinator writes detected
+// anomalies through and reads active instances back from on start.
+func (db *DB) Anomalies() *AnomalyRepository {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.anomalies == nil {
+		db.anomalies = &AnomalyRepository{db: db}
+	}
+	return db.anomalies
 }
 
 // Exec executes a query without returning any rows.

--- a/internal/database/migrations/00006_anomalies.sql
+++ b/internal/database/migrations/00006_anomalies.sql
@@ -1,0 +1,51 @@
+-- 00006_anomalies.sql — persistent anomaly store (ADR-0021, Anomaly Platform
+-- phase 1). One source-neutral table is the system of record for every detected
+-- anomaly across all producers (Wi-Fi, wired, SNMP, Bluetooth, health, security,
+-- AutoTest), completing ADR-0011's deferred persistence clause. The engine's
+-- persistence Coordinator (internal/anomaly) writes rows through here on a
+-- material change (new instance / severity escalation) and in batches from its
+-- periodic Flush; resolution is written by MarkResolved on prune.
+--
+-- One row per live instance, keyed by the stable id `defKey|subjectKind|subjectId`
+-- (the engine's in-memory coalescing key) so a re-detection updates the same row
+-- and a restart re-loads it idempotently. Catalog-static fields (impact,
+-- follow-ups) are NOT stored — they are re-derived from the embedded catalog by
+-- def_key on read, so the store never duplicates static copy. evidence/standards
+-- are per-instance/JSON. STRICT + explicit CHECKs, consistent with the baseline.
+-- Regenerate the gate golden after edits:
+--   UPDATE_SCHEMA_GOLDEN=1 go test ./internal/database/ -run TestSchemaSnapshot
+
+-- +goose Up
+CREATE TABLE anomalies (
+	id              TEXT    NOT NULL PRIMARY KEY,          -- defKey|subjectKind|subjectId
+	def_key         TEXT    NOT NULL CHECK (def_key <> ''),
+	source          TEXT    NOT NULL CHECK (source <> ''), -- wifi|wired|snmp|bluetooth|health|security|autotest
+	category        TEXT    NOT NULL CHECK (category <> ''),
+	severity        TEXT    NOT NULL CHECK (severity <> ''),
+	subject_kind    TEXT    NOT NULL CHECK (subject_kind <> ''),
+	subject_id      TEXT    NOT NULL,
+	title           TEXT    NOT NULL,
+	description     TEXT    NOT NULL,
+	recommendation  TEXT    NOT NULL,
+	evidence        TEXT,                                  -- JSON object (map[string]string)
+	standards       TEXT,                                  -- JSON array (IEEE/RFC cites)
+	count           INTEGER NOT NULL CHECK (count >= 0),
+	first_seen      TEXT    NOT NULL,                       -- RFC3339
+	last_seen       TEXT    NOT NULL,                       -- RFC3339
+	resolved_at     TEXT,                                   -- RFC3339, NULL while active
+	is_resolved     INTEGER NOT NULL DEFAULT 0 CHECK (is_resolved IN (0, 1)),
+	acknowledged_by TEXT,
+	acknowledged_at TEXT
+) STRICT;
+
+-- Query patterns: recency, by producer, by subject (cross-source correlation),
+-- by severity, and the active/resolved split.
+CREATE INDEX idx_anomalies_last_seen ON anomalies(last_seen);
+CREATE INDEX idx_anomalies_source ON anomalies(source);
+CREATE INDEX idx_anomalies_subject ON anomalies(subject_kind, subject_id);
+CREATE INDEX idx_anomalies_severity ON anomalies(severity);
+-- Active-instance scan (LoadActive on start) stays tiny — spans only unresolved rows.
+CREATE INDEX idx_anomalies_active ON anomalies(id) WHERE is_resolved = 0;
+
+-- +goose Down
+DROP TABLE IF EXISTS anomalies;

--- a/internal/database/repository_anomalies.go
+++ b/internal/database/repository_anomalies.go
@@ -1,0 +1,223 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
+)
+
+// AnomalyRepository is the SQL system of record for detected anomalies across
+// every source (ADR-0021). It implements anomaly.Store: the engine's persistence
+// Coordinator writes instances through here on a material change and in batched
+// flushes, marks them resolved on prune, and loads active instances to
+// repopulate the engine on start. Catalog-static copy (impact, follow-ups) is not
+// stored — it is re-derived from the embedded catalog by def_key on read.
+type AnomalyRepository struct {
+	db *DB
+}
+
+// Compile-time proof the repository satisfies the engine's persistence port.
+var _ anomaly.Store = (*AnomalyRepository)(nil)
+
+const anomalyUpsertSQL = `
+	INSERT INTO anomalies
+	(id, def_key, source, category, severity, subject_kind, subject_id,
+	 title, description, recommendation, evidence, standards,
+	 count, first_seen, last_seen, resolved_at, is_resolved,
+	 acknowledged_by, acknowledged_at)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 0, NULL, NULL)
+	ON CONFLICT(id) DO UPDATE SET
+		severity = excluded.severity,
+		title = excluded.title,
+		description = excluded.description,
+		recommendation = excluded.recommendation,
+		evidence = excluded.evidence,
+		standards = excluded.standards,
+		count = excluded.count,
+		last_seen = excluded.last_seen,
+		resolved_at = NULL,
+		is_resolved = 0`
+
+// Upsert idempotently persists instances by their stable id in one transaction.
+// On conflict it refreshes the mutable columns and clears any prior resolution
+// (a re-detected instance is live again); first_seen and operator
+// acknowledgement are preserved.
+func (r *AnomalyRepository) Upsert(ctx context.Context, recs []anomaly.Record) error {
+	if len(recs) == 0 {
+		return nil
+	}
+	return r.db.WithTx(ctx, func(tx *sql.Tx) error {
+		stmt, err := tx.PrepareContext(ctx, anomalyUpsertSQL)
+		if err != nil {
+			return fmt.Errorf("prepare anomaly upsert: %w", err)
+		}
+		defer func() { _ = stmt.Close() }()
+
+		for _, rec := range recs {
+			if execErr := upsertAnomaly(ctx, stmt, rec); execErr != nil {
+				return execErr
+			}
+		}
+		return nil
+	})
+}
+
+// upsertAnomaly encodes one record's JSON columns and executes the prepared
+// upsert.
+func upsertAnomaly(ctx context.Context, stmt *sql.Stmt, rec anomaly.Record) error {
+	evidence, err := marshalAnomalyJSON(rec.Anomaly.Evidence)
+	if err != nil {
+		return fmt.Errorf("marshal evidence for %q: %w", rec.ID, err)
+	}
+	standards, err := marshalAnomalyJSON(rec.Anomaly.Standards)
+	if err != nil {
+		return fmt.Errorf("marshal standards for %q: %w", rec.ID, err)
+	}
+	a := rec.Anomaly
+	_, err = stmt.ExecContext(ctx,
+		rec.ID, a.DefKey, string(rec.Source), string(a.Category), string(a.Severity),
+		string(a.Subject.Kind), a.Subject.ID, a.Title, a.Description, a.Recommendation,
+		evidence, standards, a.Count,
+		a.FirstSeen.UTC().Format(time.RFC3339), a.LastSeen.UTC().Format(time.RFC3339))
+	if err != nil {
+		return fmt.Errorf("upsert anomaly %q: %w", rec.ID, err)
+	}
+	return nil
+}
+
+// MarkResolved flags the given ids resolved as of at, leaving rows that are
+// already resolved untouched (idempotent).
+func (r *AnomalyRepository) MarkResolved(ctx context.Context, ids []string, at time.Time) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	resolvedAt := at.UTC().Format(time.RFC3339)
+	return r.db.WithTx(ctx, func(tx *sql.Tx) error {
+		stmt, err := tx.PrepareContext(ctx, `
+			UPDATE anomalies SET is_resolved = 1, resolved_at = ?
+			WHERE id = ? AND is_resolved = 0
+		`)
+		if err != nil {
+			return fmt.Errorf("prepare anomaly resolve: %w", err)
+		}
+		defer func() { _ = stmt.Close() }()
+
+		for _, id := range ids {
+			if _, execErr := stmt.ExecContext(ctx, resolvedAt, id); execErr != nil {
+				return fmt.Errorf("resolve anomaly %q: %w", id, execErr)
+			}
+		}
+		return nil
+	})
+}
+
+// LoadActive returns every unresolved instance, ordered by id for determinism,
+// so the engine can be repopulated on start.
+func (r *AnomalyRepository) LoadActive(ctx context.Context) ([]anomaly.Record, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, def_key, source, category, severity, subject_kind, subject_id,
+		       title, description, recommendation, evidence, standards,
+		       count, first_seen, last_seen, resolved_at, is_resolved,
+		       acknowledged_by, acknowledged_at
+		FROM anomalies
+		WHERE is_resolved = 0
+		ORDER BY id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query active anomalies: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []anomaly.Record
+	for rows.Next() {
+		rec, scanErr := scanAnomaly(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, rec)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("iterate active anomalies: %w", rowsErr)
+	}
+	return out, nil
+}
+
+// scanAnomaly maps one row back into a Record, decoding the JSON columns and
+// nullable lifecycle timestamps.
+func scanAnomaly(rows *sql.Rows) (anomaly.Record, error) {
+	var (
+		rec                        anomaly.Record
+		a                          anomaly.Anomaly
+		source, category, severity string
+		subjectKind                string
+		evidence, standards        sql.NullString
+		firstSeen, lastSeen        string
+		resolvedAt, ackBy, ackAt   sql.NullString
+		isResolved                 int
+	)
+	if err := rows.Scan(
+		&rec.ID, &a.DefKey, &source, &category, &severity, &subjectKind, &a.Subject.ID,
+		&a.Title, &a.Description, &a.Recommendation, &evidence, &standards,
+		&a.Count, &firstSeen, &lastSeen, &resolvedAt, &isResolved, &ackBy, &ackAt,
+	); err != nil {
+		return anomaly.Record{}, fmt.Errorf("scan anomaly: %w", err)
+	}
+
+	a.Category = anomaly.Category(category)
+	a.Severity = anomaly.Severity(severity)
+	a.Subject.Kind = anomaly.SubjectKind(subjectKind)
+	if err := json.Unmarshal([]byte(evidence.String), &a.Evidence); evidence.Valid && err != nil {
+		return anomaly.Record{}, fmt.Errorf("unmarshal evidence for %q: %w", rec.ID, err)
+	}
+	if err := json.Unmarshal([]byte(standards.String), &a.Standards); standards.Valid && err != nil {
+		return anomaly.Record{}, fmt.Errorf("unmarshal standards for %q: %w", rec.ID, err)
+	}
+	a.FirstSeen = parseAnomalyTime(firstSeen)
+	a.LastSeen = parseAnomalyTime(lastSeen)
+
+	rec.Source = anomaly.Source(source)
+	rec.Anomaly = a
+	rec.Resolved = isResolved != 0
+	if resolvedAt.Valid {
+		rec.ResolvedAt = parseAnomalyTime(resolvedAt.String)
+	}
+	rec.AcknowledgedBy = ackBy.String
+	if ackAt.Valid {
+		rec.AcknowledgedAt = parseAnomalyTime(ackAt.String)
+	}
+	return rec, nil
+}
+
+// marshalAnomalyJSON encodes a JSON column, returning a NULL for an empty
+// value so absent evidence/standards are stored as NULL rather than "null".
+func marshalAnomalyJSON(v any) (sql.NullString, error) {
+	switch t := v.(type) {
+	case map[string]string:
+		if len(t) == 0 {
+			return sql.NullString{}, nil
+		}
+	case []string:
+		if len(t) == 0 {
+			return sql.NullString{}, nil
+		}
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return sql.NullString{}, err
+	}
+	return sql.NullString{String: string(b), Valid: true}, nil
+}
+
+// parseAnomalyTime parses an RFC3339 timestamp, returning the zero time on a
+// malformed value (defensive — the writer always formats RFC3339).
+func parseAnomalyTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}

--- a/internal/database/repository_anomalies_test.go
+++ b/internal/database/repository_anomalies_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package database_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+func setupAnomalyTest(t *testing.T) (*database.AnomalyRepository, context.Context) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp(t.TempDir(), "seed-anomalies-*.db")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	tmpPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() { _ = os.Remove(tmpPath) })
+
+	db, openErr := database.Open(tmpPath)
+	if openErr != nil {
+		t.Fatalf("open db: %v", openErr)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db.Anomalies(), context.Background()
+}
+
+func sampleRecord(id string) anomaly.Record {
+	t0 := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	return anomaly.Record{
+		ID:     id,
+		Source: anomaly.SourceWiFi,
+		Anomaly: anomaly.Anomaly{
+			DefKey:         "open-ssid",
+			Category:       anomaly.CategorySecurity,
+			Severity:       anomaly.SeverityWarning,
+			Subject:        anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: "aa:bb"},
+			Title:          "Open network",
+			Description:    "No encryption.",
+			Recommendation: "Enable WPA2/WPA3.",
+			Standards:      []string{"IEEE 802.11i-2004"},
+			Evidence:       map[string]string{"rssi": "-42"},
+			FirstSeen:      t0,
+			LastSeen:       t0,
+			Count:          1,
+		},
+	}
+}
+
+// TestAnomalyUpsertRoundTrip stores a record and reads it back through
+// LoadActive, asserting the JSON columns and lifecycle survive the round trip.
+func TestAnomalyUpsertRoundTrip(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupAnomalyTest(t)
+
+	rec := sampleRecord("open-ssid|bssid|aa:bb")
+	if err := repo.Upsert(ctx, []anomaly.Record{rec}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	active, err := repo.LoadActive(ctx)
+	if err != nil {
+		t.Fatalf("LoadActive: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("LoadActive returned %d records, want 1", len(active))
+	}
+	got := active[0]
+	if got.ID != rec.ID || got.Source != anomaly.SourceWiFi {
+		t.Errorf("id/source = %q/%q, want %q/wifi", got.ID, got.Source, rec.ID)
+	}
+	if got.Anomaly.Severity != anomaly.SeverityWarning || got.Anomaly.Category != anomaly.CategorySecurity {
+		t.Errorf("severity/category = %q/%q", got.Anomaly.Severity, got.Anomaly.Category)
+	}
+	if got.Anomaly.Subject != rec.Anomaly.Subject {
+		t.Errorf("subject = %+v, want %+v", got.Anomaly.Subject, rec.Anomaly.Subject)
+	}
+	if got.Anomaly.Evidence["rssi"] != "-42" {
+		t.Errorf("evidence = %+v, want rssi=-42", got.Anomaly.Evidence)
+	}
+	if len(got.Anomaly.Standards) != 1 || got.Anomaly.Standards[0] != "IEEE 802.11i-2004" {
+		t.Errorf("standards = %+v", got.Anomaly.Standards)
+	}
+	if !got.Anomaly.FirstSeen.Equal(rec.Anomaly.FirstSeen) {
+		t.Errorf("firstSeen = %v, want %v", got.Anomaly.FirstSeen, rec.Anomaly.FirstSeen)
+	}
+	if got.Resolved {
+		t.Error("new record should not be resolved")
+	}
+}
+
+// TestAnomalyUpsertIsIdempotentByID re-upserts the same id with a higher count
+// and later lastSeen, asserting one row is updated (not duplicated) and
+// first_seen is preserved.
+func TestAnomalyUpsertIsIdempotentByID(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupAnomalyTest(t)
+
+	rec := sampleRecord("open-ssid|bssid|aa:bb")
+	if err := repo.Upsert(ctx, []anomaly.Record{rec}); err != nil {
+		t.Fatalf("first Upsert: %v", err)
+	}
+
+	later := rec
+	later.Anomaly.Count = 7
+	later.Anomaly.LastSeen = rec.Anomaly.LastSeen.Add(time.Hour)
+	later.Anomaly.Severity = anomaly.SeverityCritical
+	if err := repo.Upsert(ctx, []anomaly.Record{later}); err != nil {
+		t.Fatalf("second Upsert: %v", err)
+	}
+
+	active, err := repo.LoadActive(ctx)
+	if err != nil {
+		t.Fatalf("LoadActive: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("got %d rows, want 1 (upsert must not duplicate)", len(active))
+	}
+	got := active[0]
+	if got.Anomaly.Count != 7 || got.Anomaly.Severity != anomaly.SeverityCritical {
+		t.Errorf("count/severity = %d/%q, want 7/critical", got.Anomaly.Count, got.Anomaly.Severity)
+	}
+	if !got.Anomaly.FirstSeen.Equal(rec.Anomaly.FirstSeen) {
+		t.Errorf("firstSeen = %v, want %v (preserved on conflict)", got.Anomaly.FirstSeen, rec.Anomaly.FirstSeen)
+	}
+	if !got.Anomaly.LastSeen.Equal(later.Anomaly.LastSeen) {
+		t.Errorf("lastSeen = %v, want %v (refreshed)", got.Anomaly.LastSeen, later.Anomaly.LastSeen)
+	}
+}
+
+// TestAnomalyMarkResolved removes a record from the active set and a re-upsert
+// revives it (resolution cleared on re-detection).
+func TestAnomalyMarkResolved(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupAnomalyTest(t)
+
+	rec := sampleRecord("open-ssid|bssid|aa:bb")
+	if err := repo.Upsert(ctx, []anomaly.Record{rec}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	resolvedAt := time.Date(2026, 6, 11, 13, 0, 0, 0, time.UTC)
+	if err := repo.MarkResolved(ctx, []string{rec.ID}, resolvedAt); err != nil {
+		t.Fatalf("MarkResolved: %v", err)
+	}
+	active, err := repo.LoadActive(ctx)
+	if err != nil {
+		t.Fatalf("LoadActive: %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("resolved record still active: %d rows", len(active))
+	}
+
+	// Re-detection revives it.
+	if upErr := repo.Upsert(ctx, []anomaly.Record{rec}); upErr != nil {
+		t.Fatalf("revive Upsert: %v", upErr)
+	}
+	active, err = repo.LoadActive(ctx)
+	if err != nil {
+		t.Fatalf("LoadActive after revive: %v", err)
+	}
+	if len(active) != 1 || active[0].Resolved {
+		t.Fatalf("re-detected record should be active again: %+v", active)
+	}
+}
+
+// TestAnomalyEmptyBatchesAreNoops guards the len==0 fast paths.
+func TestAnomalyEmptyBatchesAreNoops(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupAnomalyTest(t)
+
+	if err := repo.Upsert(ctx, nil); err != nil {
+		t.Errorf("Upsert(nil): %v", err)
+	}
+	if err := repo.MarkResolved(ctx, nil, time.Now()); err != nil {
+		t.Errorf("MarkResolved(nil): %v", err)
+	}
+	active, err := repo.LoadActive(ctx)
+	if err != nil {
+		t.Errorf("LoadActive: %v", err)
+	}
+	if len(active) != 0 {
+		t.Errorf("empty store returned %d records", len(active))
+	}
+}

--- a/internal/database/testdata/schema.sql
+++ b/internal/database/testdata/schema.sql
@@ -26,6 +26,21 @@ CREATE INDEX idx_alerts_severity ON alerts(severity);
 -- index: idx_alerts_type
 CREATE INDEX idx_alerts_type ON alerts(type);
 
+-- index: idx_anomalies_active
+CREATE INDEX idx_anomalies_active ON anomalies(id) WHERE is_resolved = 0;
+
+-- index: idx_anomalies_last_seen
+CREATE INDEX idx_anomalies_last_seen ON anomalies(last_seen);
+
+-- index: idx_anomalies_severity
+CREATE INDEX idx_anomalies_severity ON anomalies(severity);
+
+-- index: idx_anomalies_source
+CREATE INDEX idx_anomalies_source ON anomalies(source);
+
+-- index: idx_anomalies_subject
+CREATE INDEX idx_anomalies_subject ON anomalies(subject_kind, subject_id);
+
 -- index: idx_api_tokens_active
 CREATE INDEX idx_api_tokens_active ON api_tokens(revoked_at);
 
@@ -702,6 +717,29 @@ CREATE TABLE alerts (
 				metadata_json TEXT, client_id TEXT NOT NULL DEFAULT 'default' REFERENCES clients(id),
 				FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE SET NULL
 			) STRICT;
+
+-- table: anomalies
+CREATE TABLE anomalies (
+	id              TEXT    NOT NULL PRIMARY KEY,          -- defKey|subjectKind|subjectId
+	def_key         TEXT    NOT NULL CHECK (def_key <> ''),
+	source          TEXT    NOT NULL CHECK (source <> ''), -- wifi|wired|snmp|bluetooth|health|security|autotest
+	category        TEXT    NOT NULL CHECK (category <> ''),
+	severity        TEXT    NOT NULL CHECK (severity <> ''),
+	subject_kind    TEXT    NOT NULL CHECK (subject_kind <> ''),
+	subject_id      TEXT    NOT NULL,
+	title           TEXT    NOT NULL,
+	description     TEXT    NOT NULL,
+	recommendation  TEXT    NOT NULL,
+	evidence        TEXT,                                  -- JSON object (map[string]string)
+	standards       TEXT,                                  -- JSON array (IEEE/RFC cites)
+	count           INTEGER NOT NULL CHECK (count >= 0),
+	first_seen      TEXT    NOT NULL,                       -- RFC3339
+	last_seen       TEXT    NOT NULL,                       -- RFC3339
+	resolved_at     TEXT,                                   -- RFC3339, NULL while active
+	is_resolved     INTEGER NOT NULL DEFAULT 0 CHECK (is_resolved IN (0, 1)),
+	acknowledged_by TEXT,
+	acknowledged_at TEXT
+) STRICT;
 
 -- table: api_tokens
 CREATE TABLE "api_tokens" (


### PR DESCRIPTION
## What & why

Phase 1 of the **unified anomaly platform** (ADR-0021, completing ADR-0011's
deferred persistence clause). Today the source-neutral `internal/anomaly` engine
is in-memory only — detected anomalies evaporate on restart, with no history,
acknowledgement, or query surface. This lands the **persistence foundation** the
rest of the platform builds on: one SQL store the engine writes through.

This is a foundation slice — it is exercised by tests (repo round-trip +
coordinator cadence) ahead of production producer/consumer wiring, which are the
ADR's later phases. No production path is repointed yet.

## Changes

- **ADR-0021 → Accepted.** Folds in the owner-confirmed decisions (write-through
  on material change + batched recurrence flush; active-forever + TTL-age
  resolved 90d + daily rollups) and records the as-built phasing.
- **`00006_anomalies.sql`** — one STRICT `anomalies` table keyed by the stable
  instance id `defKey|subjectKind|subjectId` (the engine's coalescing key, so a
  restart re-loads the same row a re-detection updates). Indexed for last_seen /
  source / (subject_kind,subject_id) / severity / active. Catalog-static copy
  (impact, follow-ups) is **not** stored — re-derived from the embedded catalog
  by def_key on read.
- **`anomaly.Store` port + `Record`/`Source`** model. Engine gains an internal
  `observe()` that classifies *material* (new / severity escalation) vs *mere
  recurrence*, plus `snapshotKeys`/`pruneKeys`; `Observe`/`Prune` stay thin
  public wrappers (zero churn for the two wifi callers).
- **`anomaly.Coordinator`** — couples the in-memory engine to the store:
  write-through on create/escalation, batched `Flush` for recurrence,
  resolve-on-`Prune`. The pure engine stays usable standalone.
- **`database.AnomalyRepository`** implements `anomaly.Store`
  (upsert/markResolved/loadActive) + `DB.Anomalies()` accessor. Schema golden
  regenerated.

## Deferred to later ADR-0021 phases

Four-level severity ladder (Info→Warning→**Error**→Critical), load-on-start,
TTL/rollup retention, deleting the bespoke `health.AnomalyDetector`, repointing
the monitoring/wifi/Survey readers, catalog growth. Persistence stores the
severity string verbatim, so adding `Error` later needs **no schema change**.

## Gates (run locally)

- `go build ./internal/...` → 0
- `golangci-lint run --new-from-rev=origin/main` → 0 issues
- `go test ./internal/anomaly/... ./internal/database/` → ok (+ full wifi suite,
  confirming the engine refactor is safe)
- `scripts/check-output-escaping.sh` → OK · `gofmt` clean · schema golden updated

> Note: held off `--auto` merge — this introduces a new persisted table + accepts
> an ADR, worth a glance before it lands. Enable auto-merge if it looks good.