### PR TITLE
feat(anomaly): TTL-purge resolved anomalies in retention (ADR-0021 phase 2)

### DIFF
--- a/docs/architecture/decisions/0021-persist-and-converge-anomaly-engine.md
+++ b/docs/architecture/decisions/0021-persist-and-converge-anomaly-engine.md
@@ -167,3 +167,26 @@ Critical`) refines ADR-0011's three levels and is a **separate, additive change*
 adding `Error` later needs no schema change. Subsequent phases (per the Consequences list): load-on-
 start + TTL/rollup retention; health-source convergence + delete the bespoke detector; repoint the
 monitoring/Wi-Fi/Survey readers; catalog growth as each source lands.
+
+**Phase 2 (as-built) — resolved-anomaly TTL purge, live.** `AnomalyRepository.DeleteResolvedOlderThan`
+deletes `is_resolved = 1 AND resolved_at < cutoff` and is wired as a `RetentionPolicy` task
+(`AnomalyResolvedDays`, default 90) into the existing periodic `DB.RunCleanup` maintenance loop —
+so the "keep active forever, age out resolved at 90d" decision is enforced in production now, bounding
+table growth on appliances. Active rows are structurally safe (their `resolved_at` is NULL, so the
+predicate never matches them). Two items the original phase-2 sketch bundled were **re-sequenced**,
+deliberately:
+- **Daily rollups → deferred (own design pass).** The `timeseries/retention.RollupSource` framework
+  is a poor fit for mutable anomaly *instances* (its `PurgeRaw(cutoff)` would age out active rows, and
+  its 7-day raw floor / hourly tier don't apply). The legacy health-style rollup is the right model,
+  but health's own `CreateDailyRollup` has no scheduled caller today — rollups need a dedicated
+  design that doesn't copy that latent gap. The TTL purge already delivers the growth-bounding win;
+  rollups are long-term history, separable.
+- **Load-on-start → folded into the producer phase.** Repopulating the in-memory engine from
+  `LoadActive` is only meaningful once a long-lived, server-owned `Coordinator` exists (the per-request
+  Wi-Fi engines are transient). Persistence already satisfies the "anomalies survive restart" *query*
+  promise; engine count/escalation *continuity* is secondary, so load-on-start lands with the server
+  Coordinator + producers rather than in isolation. **Note for that phase:** persisted `severity` is
+  the effective (post-escalation) value; on reload the engine seeds `baseSeverity` from it, which can
+  let an already-escalated instance bump one further level on continued recurrence after a restart — an
+  accepted, bounded artifact (a persistent cross-restart problem reading as more urgent), not a second
+  stored column.

--- a/internal/api/server_shutdown.go
+++ b/internal/api/server_shutdown.go
@@ -200,6 +200,10 @@ func (s *Server) startMaintenance(retentionDays int) {
 		GatewayResultDays:  retentionDays,
 		AuditLogDays:       retentionDays * retentionAuditLogMultiplier,       // Keep audit logs longest
 		InactiveDeviceDays: retentionDays * retentionInactiveDeviceMultiplier, // Keep inactive device records longer
+		// Resolved anomalies age out on their own fixed 90d window (ADR-0021);
+		// active anomalies are never purged, so this is independent of the
+		// operator's general retention window.
+		AnomalyResolvedDays: database.DefaultRetentionPolicy().AnomalyResolvedDays,
 	}
 
 	for {
@@ -235,7 +239,7 @@ func (s *Server) startMaintenance(retentionDays int) {
 			totalDeleted := result.MetricsDeleted + result.AlertsDeleted +
 				result.SpeedTestsDeleted + result.DNSResultsDeleted +
 				result.GatewayResultsDeleted + result.AuditLogsDeleted +
-				result.DevicesDeleted
+				result.DevicesDeleted + result.AnomaliesResolvedDeleted
 			if totalDeleted > 0 {
 				logging.GetLogger().Info("Data retention cleanup completed",
 					"metrics_deleted", result.MetricsDeleted,
@@ -245,6 +249,7 @@ func (s *Server) startMaintenance(retentionDays int) {
 					"dns_deleted", result.DNSResultsDeleted,
 					"gateway_deleted", result.GatewayResultsDeleted,
 					"audit_deleted", result.AuditLogsDeleted,
+					"anomalies_resolved_deleted", result.AnomaliesResolvedDeleted,
 					"duration", result.Duration)
 			}
 		}

--- a/internal/database/repository_anomalies.go
+++ b/internal/database/repository_anomalies.go
@@ -115,6 +115,25 @@ func (r *AnomalyRepository) MarkResolved(ctx context.Context, ids []string, at t
 	})
 }
 
+// DeleteResolvedOlderThan removes resolved anomalies whose resolved_at predates
+// cutoff, bounding table growth on appliances (ADR-0021 retention: TTL-age
+// resolved). Active instances are NEVER deleted regardless of age — a long-idle
+// but still-open anomaly is kept until it actually resolves. Returns the number
+// of rows removed.
+func (r *AnomalyRepository) DeleteResolvedOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	result, err := r.db.Exec(ctx, `
+		DELETE FROM anomalies WHERE is_resolved = 1 AND resolved_at < ?
+	`, cutoff.UTC().Format(time.RFC3339))
+	if err != nil {
+		return 0, fmt.Errorf("delete resolved anomalies: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("delete resolved anomalies rows affected: %w", err)
+	}
+	return affected, nil
+}
+
 // LoadActive returns every unresolved instance, ordered by id for determinism,
 // so the engine can be repopulated on start.
 func (r *AnomalyRepository) LoadActive(ctx context.Context) ([]anomaly.Record, error) {

--- a/internal/database/repository_anomalies_test.go
+++ b/internal/database/repository_anomalies_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
-func setupAnomalyTest(t *testing.T) (*database.AnomalyRepository, context.Context) {
+func setupAnomalyDB(t *testing.T) (*database.DB, context.Context) {
 	t.Helper()
 	tmpFile, err := os.CreateTemp(t.TempDir(), "seed-anomalies-*.db")
 	if err != nil {
@@ -27,7 +27,13 @@ func setupAnomalyTest(t *testing.T) (*database.AnomalyRepository, context.Contex
 		t.Fatalf("open db: %v", openErr)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	return db.Anomalies(), context.Background()
+	return db, context.Background()
+}
+
+func setupAnomalyTest(t *testing.T) (*database.AnomalyRepository, context.Context) {
+	t.Helper()
+	db, ctx := setupAnomalyDB(t)
+	return db.Anomalies(), ctx
 }
 
 func sampleRecord(id string) anomaly.Record {
@@ -186,5 +192,90 @@ func TestAnomalyEmptyBatchesAreNoops(t *testing.T) {
 	}
 	if len(active) != 0 {
 		t.Errorf("empty store returned %d records", len(active))
+	}
+}
+
+// TestAnomalyDeleteResolvedOlderThan asserts the TTL purge removes only resolved
+// instances past the cutoff, never active ones (ADR-0021 retention).
+func TestAnomalyDeleteResolvedOlderThan(t *testing.T) {
+	t.Parallel()
+	repo, ctx := setupAnomalyTest(t)
+
+	for _, id := range []string{"old-resolved", "recent-resolved", "active"} {
+		if err := repo.Upsert(ctx, []anomaly.Record{sampleRecord(id)}); err != nil {
+			t.Fatalf("Upsert %q: %v", id, err)
+		}
+	}
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	// old-resolved cleared 100d ago; recent-resolved cleared 1d ago; active stays open.
+	if err := repo.MarkResolved(ctx, []string{"old-resolved"}, now.AddDate(0, 0, -100)); err != nil {
+		t.Fatalf("MarkResolved old: %v", err)
+	}
+	if err := repo.MarkResolved(ctx, []string{"recent-resolved"}, now.AddDate(0, 0, -1)); err != nil {
+		t.Fatalf("MarkResolved recent: %v", err)
+	}
+
+	// Purge resolved older than 90d: only old-resolved qualifies.
+	cutoff := now.AddDate(0, 0, -90)
+	deleted, err := repo.DeleteResolvedOlderThan(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("DeleteResolvedOlderThan: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1 (only old-resolved)", deleted)
+	}
+
+	// active is untouched and still loadable.
+	active, err := repo.LoadActive(ctx)
+	if err != nil {
+		t.Fatalf("LoadActive: %v", err)
+	}
+	if len(active) != 1 || active[0].ID != "active" {
+		t.Fatalf("active set = %+v, want only 'active'", active)
+	}
+
+	// recent-resolved survived the first purge; a purge at `now` removes it,
+	// proving it was still present (not collaterally deleted).
+	deleted2, err := repo.DeleteResolvedOlderThan(ctx, now)
+	if err != nil {
+		t.Fatalf("second DeleteResolvedOlderThan: %v", err)
+	}
+	if deleted2 != 1 {
+		t.Errorf("second purge deleted = %d, want 1 (recent-resolved)", deleted2)
+	}
+}
+
+// TestRunCleanupPurgesResolvedAnomalies proves the retention task is wired into
+// RunCleanup: a resolved anomaly past the window is reported deleted while an
+// active one survives.
+func TestRunCleanupPurgesResolvedAnomalies(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupAnomalyDB(t)
+	repo := db.Anomalies()
+
+	for _, id := range []string{"stale-resolved", "open"} {
+		if err := repo.Upsert(ctx, []anomaly.Record{sampleRecord(id)}); err != nil {
+			t.Fatalf("Upsert %q: %v", id, err)
+		}
+	}
+	// Resolve one well beyond the 90d window (relative to now, since RunCleanup
+	// computes its cutoff from time.Now).
+	if err := repo.MarkResolved(ctx, []string{"stale-resolved"}, time.Now().UTC().AddDate(0, 0, -120)); err != nil {
+		t.Fatalf("MarkResolved: %v", err)
+	}
+
+	result, err := db.RunCleanup(ctx, database.RetentionPolicy{AnomalyResolvedDays: 90})
+	if err != nil {
+		t.Fatalf("RunCleanup: %v", err)
+	}
+	if result.AnomaliesResolvedDeleted != 1 {
+		t.Errorf("AnomaliesResolvedDeleted = %d, want 1", result.AnomaliesResolvedDeleted)
+	}
+	active, err := repo.LoadActive(ctx)
+	if err != nil {
+		t.Fatalf("LoadActive: %v", err)
+	}
+	if len(active) != 1 || active[0].ID != "open" {
+		t.Errorf("active set = %+v, want only 'open'", active)
 	}
 }

--- a/internal/database/retention.go
+++ b/internal/database/retention.go
@@ -38,6 +38,11 @@ const (
 
 	// defaultHealthCheckDailyDays is the default retention for daily rollups (365 days).
 	defaultHealthCheckDailyDays = 365
+
+	// defaultAnomalyResolvedDays is the default retention for resolved anomalies
+	// (90 days). Active anomalies are kept indefinitely (ADR-0021); only resolved
+	// instances age out, bounding table growth on appliances.
+	defaultAnomalyResolvedDays = 90
 )
 
 // SQL query fragment constants.
@@ -86,6 +91,10 @@ type RetentionPolicy struct {
 
 	// HealthCheckDailyDays is how many days to keep daily rollups (0 = forever)
 	HealthCheckDailyDays int
+
+	// AnomalyResolvedDays is how many days to keep RESOLVED anomalies (0 =
+	// forever). Active anomalies are never aged out (ADR-0021).
+	AnomalyResolvedDays int
 }
 
 // DefaultRetentionPolicy returns the default retention policy.
@@ -101,6 +110,7 @@ func DefaultRetentionPolicy() RetentionPolicy {
 		HealthCheckRawDays:    defaultHealthCheckRawDays,
 		HealthCheckHourlyDays: defaultHealthCheckHourlyDays,
 		HealthCheckDailyDays:  defaultHealthCheckDailyDays,
+		AnomalyResolvedDays:   defaultAnomalyResolvedDays,
 	}
 }
 
@@ -116,6 +126,7 @@ type CleanupResult struct {
 	HealthCheckRawDeleted    int64
 	HealthCheckHourlyDeleted int64
 	HealthCheckDailyDeleted  int64
+	AnomaliesResolvedDeleted int64
 	Duration                 time.Duration
 }
 
@@ -161,6 +172,7 @@ func (db *DB) RunCleanup(ctx context.Context, policy RetentionPolicy) (*CleanupR
 		{policy.HealthCheckRawDays, db.cleanupHealthCheckRaw, "health check raw"},
 		{policy.HealthCheckHourlyDays, db.cleanupHealthCheckHourly, "health check hourly"},
 		{policy.HealthCheckDailyDays, db.cleanupHealthCheckDaily, "health check daily"},
+		{policy.AnomalyResolvedDays, db.cleanupResolvedAnomalies, "resolved anomalies"},
 	}
 
 	results := make([]int64, len(tasks))
@@ -182,6 +194,7 @@ func (db *DB) RunCleanup(ctx context.Context, policy RetentionPolicy) (*CleanupR
 	result.HealthCheckRawDeleted = results[7]
 	result.HealthCheckHourlyDeleted = results[8]
 	result.HealthCheckDailyDeleted = results[9]
+	result.AnomaliesResolvedDeleted = results[10]
 	result.Duration = time.Since(start)
 
 	return result, nil
@@ -318,6 +331,11 @@ func (db *DB) cleanupHealthCheckHourly(ctx context.Context, cutoff time.Time) (i
 // cleanupHealthCheckDaily wraps HealthChecks().DeleteDailyRollupsOlderThan.
 func (db *DB) cleanupHealthCheckDaily(ctx context.Context, cutoff time.Time) (int64, error) {
 	return db.HealthChecks().DeleteDailyRollupsOlderThan(ctx, cutoff)
+}
+
+// cleanupResolvedAnomalies wraps Anomalies().DeleteResolvedOlderThan (ADR-0021).
+func (db *DB) cleanupResolvedAnomalies(ctx context.Context, cutoff time.Time) (int64, error) {
+	return db.Anomalies().DeleteResolvedOlderThan(ctx, cutoff)
 }
 
 // RecordAuditLog records an audit log entry.


### PR DESCRIPTION
## What & why

Phase 2 of ADR-0021. Enforces the owner-locked retention decision — **keep
active anomalies forever, age out resolved ones at 90d** — so the `anomalies`
table (added in #1629) stays bounded on appliances. Wired **live** into the
existing periodic data-retention maintenance loop.

## Changes

- **`AnomalyRepository.DeleteResolvedOlderThan`** — `DELETE WHERE is_resolved = 1
  AND resolved_at < cutoff`. Active rows are *structurally* safe: their
  `resolved_at` is `NULL`, so the predicate never matches them — a long-idle but
  still-open anomaly is never purged.
- **`RetentionPolicy.AnomalyResolvedDays`** (default 90) + a `RunCleanup` task +
  `CleanupResult.AnomaliesResolvedDeleted`. The periodic retention goroutine
  (`server_shutdown.go`) sets the field from `DefaultRetentionPolicy()` and logs
  the count — so the purge runs on every retention tick in production.
- **Tests** — repo-level (active never purged; only resolved-past-cutoff removed;
  recent-resolved survives the first purge) + a `RunCleanup`-level test proving
  the task wiring populates the result field.

## Re-sequenced (documented in the ADR)

Two items the original phase-2 sketch bundled were deliberately moved:

- **Daily rollups → own design pass.** The `timeseries/retention.RollupSource`
  framework fits time-bucketed *raw* rows, not mutable anomaly *instances* (its
  `PurgeRaw(cutoff)` would age out active rows; the 7-day raw floor / hourly tier
  don't apply). The legacy health-style rollup is the right model, but health's
  own `CreateDailyRollup` has **no scheduled caller** today — a latent gap not
  worth copying. The TTL purge already delivers the growth-bounding win; rollups
  are long-term history, separable.
- **Load-on-start → producer phase.** Repopulating the in-memory engine from
  `LoadActive` only matters once a long-lived server-owned `Coordinator` exists
  (the Wi-Fi engines are per-request transient). Persistence already satisfies
  the "survive restart" *query* promise. The ADR records the severity-on-reload
  semantics for when that lands.

## Gates (local)

- `go build ./internal/...` → 0
- `golangci-lint run --new-from-rev=origin/main` → 0 issues
- `go test ./internal/database/` → ok · `go test ./internal/api/` → ok
- `check-output-escaping.sh` + `check-route-policy.sh` → OK · gofmt clean
- No migration this slice → no schema golden change