### PR TITLE
fix(api): require operator role on persistent-write routes

### DIFF
--- a/internal/api/handlers_alerts_internal_test.go
+++ b/internal/api/handlers_alerts_internal_test.go
@@ -81,6 +81,7 @@ func TestHandleAlerts_SeverityFilter(t *testing.T) {
 		t.Errorf("count = %d, want 1 (only error severity)", resp.Count)
 	}
 }
+
 func TestHandleAlerts_InvalidSinceReturns400(t *testing.T) {
 	s := newAlertsTestServer(t)
 	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alerts?since=not-a-date", http.NoBody)
@@ -134,6 +135,7 @@ func TestHandleAlertAction_Resolve(t *testing.T) {
 		t.Error("alert should be resolved in DB")
 	}
 }
+
 func TestHandleAlertAction_BadPathReturns400(t *testing.T) {
 	s := newAlertsTestServer(t)
 	tests := []struct{ name, path string }{

--- a/internal/api/handlers_config_test.go
+++ b/internal/api/handlers_config_test.go
@@ -224,6 +224,7 @@ func TestHandleConfigBackupDelete(t *testing.T) {
 		t.Error("Backup file should be deleted")
 	}
 }
+
 func TestHandleConfigRestore_MissingBackupName(t *testing.T) {
 	// Use testutil for consistent test configuration
 	s := &api.Server{}

--- a/internal/api/handlers_topology_internal_test.go
+++ b/internal/api/handlers_topology_internal_test.go
@@ -97,6 +97,7 @@ func TestHandleTopologyNodes_ReturnsSeedededNodes(t *testing.T) {
 		t.Fatalf("nodes = %d, want 2", len(resp.Nodes))
 	}
 }
+
 func TestHandleTopologyNodes_DeviceTypeFilter(t *testing.T) {
 	s := newTopologyTestServer(t)
 	seedTopology(t, s.db())
@@ -280,6 +281,7 @@ func TestHandleTopologyARP_FilterByNodeID(t *testing.T) {
 		t.Errorf("count = %d, want 2 (both bindings live on node-test-1)", resp.Count)
 	}
 }
+
 func TestHandleTopologyARP_InvalidSinceReturns400(t *testing.T) {
 	s := newTopologyTestServer(t)
 	req := httptest.NewRequest(http.MethodGet,

--- a/internal/api/route_policy_internal_test.go
+++ b/internal/api/route_policy_internal_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
 // apiPath strips a Go 1.22 method prefix ("GET /api/v1/x" -> "/api/v1/x").
@@ -70,5 +72,41 @@ func TestMethodGateRejectsUndeclaredMethod(t *testing.T) {
 	s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 	if rec.Code != http.StatusOK {
 		t.Errorf("GET %s: got status %d, want 200", path, rec.Code)
+	}
+}
+
+// TestPersistentWriteRoutesRequireOperator pins the operator-role gate on routes
+// whose mutating methods persist state (config-to-disk or a live kernel change).
+// These bypassed writeGated until the role gate was added; this guards against a
+// future edit silently dropping minRole and re-opening the write to any viewer.
+func TestPersistentWriteRoutesRequireOperator(t *testing.T) {
+	s := NewTestServer()
+	defer s.Close()
+
+	// Persistent-write routes that MUST require operator+ on their mutating
+	// methods. (Diagnostic-action POSTs — scans/probes/speedtest — are
+	// deliberately ungated and intentionally absent from this list.)
+	wantOperator := map[string]bool{
+		APIVersionPrefix + "/interface":                  true, // PUT persists active NIC
+		APIVersionPrefix + "/telemetry/vlan/interface":   true, // POST creates kernel VLAN
+		APIVersionPrefix + "/security/discovery/options": true, // PUT saves discovery config
+		APIVersionPrefix + "/security/devices/subnets":   true, // CRUD on persisted subnets
+	}
+
+	seen := make(map[string]bool, len(wantOperator))
+	for _, rt := range s.manifest {
+		if !wantOperator[apiPath(rt.path)] {
+			continue
+		}
+		seen[apiPath(rt.path)] = true
+		if rt.minRole != database.RoleOperator {
+			t.Errorf("route %q: minRole = %q, want %q (persistent write must be operator-gated)",
+				rt.path, rt.minRole, database.RoleOperator)
+		}
+	}
+	for path := range wantOperator {
+		if !seen[path] {
+			t.Errorf("expected persistent-write route %q not found in manifest", path)
+		}
 	}
 }

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -245,7 +245,12 @@ func (s *Server) setupCoreRoutes() {
 			maxBodyBytes: cfgBody,
 		},
 		{path: APIVersionPrefix + "/interfaces", handler: s.handleInterfaces, methods: get},
-		{path: APIVersionPrefix + "/interface", handler: s.handleInterface, methods: getPut},
+		{
+			path:    APIVersionPrefix + "/interface",
+			handler: s.handleInterface,
+			methods: getPut,
+			minRole: op, // PUT persists the active NIC to disk (writeGated: operator+)
+		},
 		{
 			path:    APIVersionPrefix + "/network/mtu",
 			handler: s.handleSetMTU,
@@ -406,6 +411,7 @@ func (s *Server) setupTelemetryRoutes() {
 			path:    APIVersionPrefix + "/telemetry/vlan/interface",
 			handler: s.handleVLANInterface,
 			methods: getPostPut,
+			minRole: op, // POST creates a live kernel VLAN sub-interface (writeGated: operator+)
 		},
 		{
 			path:        APIVersionPrefix + "/telemetry/speedtest",
@@ -544,6 +550,7 @@ func (s *Server) setupSecurityRoutes() {
 			path:    APIVersionPrefix + "/security/discovery/options",
 			handler: s.handleDiscoveryOptions,
 			methods: getPut,
+			minRole: op, // PUT saves discovery options to disk (writeGated: operator+)
 		},
 		{
 			path:    APIVersionPrefix + "/security/discovery/service/status",
@@ -577,6 +584,7 @@ func (s *Server) setupSecurityRoutes() {
 			path:    APIVersionPrefix + "/security/devices/subnets",
 			handler: s.handleDevicesSubnets,
 			methods: crud,
+			minRole: op, // POST/PUT/DELETE mutate persisted subnet entries (writeGated: operator+)
 		},
 		// Vulnerability scan + guest-audit run are compliance_advanced (Pro,
 		// LICENSE_STRATEGY §2); read-only results/status/settings stay open so prior

--- a/internal/api/testdata/golden/capabilities.txt
+++ b/internal/api/testdata/golden/capabilities.txt
@@ -147,6 +147,7 @@ body:
       "GET",
       "PUT"
     ],
+    "minRole": "operator",
     "path": "/api/v1/interface"
   },
   {
@@ -522,6 +523,7 @@ body:
       "POST",
       "PUT"
     ],
+    "minRole": "operator",
     "path": "/api/v1/telemetry/vlan/interface"
   },
   {
@@ -711,6 +713,7 @@ body:
       "GET",
       "PUT"
     ],
+    "minRole": "operator",
     "path": "/api/v1/security/discovery/options"
   },
   {
@@ -767,6 +770,7 @@ body:
       "PUT",
       "DELETE"
     ],
+    "minRole": "operator",
     "path": "/api/v1/security/devices/subnets"
   },
   {


### PR DESCRIPTION
## Summary

A cross-repo security-invariant audit found four mutating routes in `internal/api` that persist state (config-to-disk or a live kernel change) but lacked `minRole`, so `writeGated` never wrapped them — **any authenticated viewer could trigger the write**. CSRF was intact; the gap was the operator role gate the security invariant requires for persistent writes.

| Route | Persists |
|---|---|
| `PUT /api/v1/interface` | active NIC to disk |
| `POST /api/v1/telemetry/vlan/interface` | live kernel VLAN sub-interface |
| `PUT /api/v1/security/discovery/options` | discovery config to disk |
| `CRUD /api/v1/security/devices/subnets` | persisted subnet entries |

Fix: add `minRole: op` to each (matches sibling routes `/settings/cable`, `/network/mtu`, `/security/devices/settings`).

## Tests
- New `TestPersistentWriteRoutesRequireOperator` pins the gate at the manifest level (guards against a future edit silently dropping it).
- Capabilities golden refreshed — diff is exactly the four `minRole: "operator"` additions.
- Full `internal/api` package green; `golangci-lint` 0 issues; route-policy CI gate ✅.

2nd commit is unrelated pre-existing gofumpt drift in three test files (format-only) so the lint job is green.

## Follow-up (not in this PR)
Audit also flagged correctness bugs: `vlan/interface` declares `getPostPut` but the handler serves POST/DELETE; `dhcp/rogue/servers` has an unreachable DELETE. Method/route mismatches, no security impact — separate fix.