### PR TITLE
feat(anomaly): persist the Wi-Fi anomaly stream + load-on-start (ADR-0021 phase 3)

### DIFF
--- a/cmd/seed/cmd_serve.go
+++ b/cmd/seed/cmd_serve.go
@@ -116,7 +116,7 @@ func initializeBackgroundComponents(cfg *config.Config, db *database.DB) *api.Ba
 	// Wi-Fi airspace visibility: holds the live airspace + anomaly engine, fed by
 	// the monitor-mode capture source. A malformed catalog is a programming error
 	// — log and continue without the component (handlers degrade gracefully).
-	if wifiVis, err := app.NewWiFiVisibility(); err != nil {
+	if wifiVis, err := app.NewWiFiVisibility(db.Anomalies()); err != nil {
 		logging.GetLogger().Error("Wi-Fi visibility init failed; feature disabled", "error", err)
 	} else {
 		components.WiFiVisibility = wifiVis

--- a/internal/anomaly/coordinator.go
+++ b/internal/anomaly/coordinator.go
@@ -96,6 +96,17 @@ func (c *Coordinator) Prune(ctx context.Context, cutoff time.Time) (int, error) 
 	return len(keys), nil
 }
 
+// Load seeds the engine from the store's active (unresolved) instances (ADR-0021
+// load-on-start). Call once before observation begins; returns the number
+// restored. A store error is returned without mutating the engine.
+func (c *Coordinator) Load(ctx context.Context) (int, error) {
+	recs, err := c.store.LoadActive(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return c.engine.Restore(recs), nil
+}
+
 // Engine returns the underlying in-memory engine for read-only projection
 // (Snapshot) by consumers that also read live state.
 func (c *Coordinator) Engine() *Engine { return c.engine }

--- a/internal/anomaly/coordinator_test.go
+++ b/internal/anomaly/coordinator_test.go
@@ -196,3 +196,61 @@ func TestCoordinatorResolvesOnPrune(t *testing.T) {
 		t.Error("Flush resurrected a pruned instance")
 	}
 }
+
+// TestEngineRestoreSeedsActiveInstances asserts Restore repopulates the live set
+// from records (load-on-start) and skips records whose def is uncatalogued.
+func TestEngineRestoreSeedsActiveInstances(t *testing.T) {
+	e := anomaly.NewEngine(coordTestCatalog(t))
+	t0 := time.Unix(1000, 0)
+	recs := []anomaly.Record{
+		{
+			ID: "open-ssid|bssid|aa", Source: anomaly.SourceWiFi,
+			Anomaly: anomaly.Anomaly{
+				DefKey: "open-ssid", Category: anomaly.CategorySecurity,
+				Severity:  anomaly.SeverityWarning,
+				Subject:   anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: "aa"},
+				FirstSeen: t0, LastSeen: t0.Add(time.Minute), Count: 4,
+			},
+		},
+		{ // uncatalogued def — must be skipped, not loaded
+			ID: "ghost|bssid|zz", Source: anomaly.SourceWiFi,
+			Anomaly: anomaly.Anomaly{
+				DefKey: "ghost", Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: "zz"},
+				Severity: anomaly.SeverityInfo, FirstSeen: t0, LastSeen: t0, Count: 1,
+			},
+		},
+	}
+	if n := e.Restore(recs); n != 1 {
+		t.Fatalf("Restore loaded %d, want 1 (ghost skipped)", n)
+	}
+	snap := e.Snapshot()
+	if len(snap) != 1 || snap[0].Subject.ID != "aa" {
+		t.Fatalf("snapshot = %+v, want one restored 'aa'", snap)
+	}
+	if snap[0].Count != 4 || !snap[0].FirstSeen.Equal(t0) {
+		t.Errorf("restored lifecycle: count=%d firstSeen=%v, want 4/%v", snap[0].Count, snap[0].FirstSeen, t0)
+	}
+}
+
+// TestCoordinatorLoad asserts Load pulls active instances from the store into the
+// engine.
+func TestCoordinatorLoad(t *testing.T) {
+	store := newFakeStore()
+	store.rows["open-ssid|bssid|aa"] = anomaly.Record{
+		ID: "open-ssid|bssid|aa", Source: anomaly.SourceWiFi,
+		Anomaly: anomaly.Anomaly{
+			DefKey: "open-ssid", Category: anomaly.CategorySecurity,
+			Severity:  anomaly.SeverityWarning,
+			Subject:   anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: "aa"},
+			FirstSeen: time.Unix(1, 0), LastSeen: time.Unix(2, 0), Count: 3,
+		},
+	}
+	c := newCoord(t, store)
+	n, err := c.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if n != 1 || c.Engine().Len() != 1 {
+		t.Fatalf("Load restored n=%d engineLen=%d, want 1/1", n, c.Engine().Len())
+	}
+}

--- a/internal/anomaly/engine.go
+++ b/internal/anomaly/engine.go
@@ -131,6 +131,41 @@ func (e *Engine) Observe(d Detection, at time.Time) error {
 	return err
 }
 
+// Restore seeds the live set from persisted records (ADR-0021 load-on-start), so
+// a restart continues coalescing onto the same instances instead of re-detecting
+// them as new. Each record's persisted (effective) severity becomes the restored
+// base severity (ADR-0021: the store holds the effective value); a live
+// re-detection then overrides it from the catalog default on the next Observe.
+// Records whose DefKey is no longer in the catalog are skipped — a catalog change
+// can orphan an old row. Intended to be called once, before Observe traffic
+// begins. Returns the number of instances restored.
+func (e *Engine) Restore(records []Record) int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	n := 0
+	for _, r := range records {
+		a := r.Anomaly
+		if _, ok := e.catalog.Lookup(a.DefKey); !ok {
+			continue
+		}
+		k := instanceKey{def: a.DefKey, kind: a.Subject.Kind, id: a.Subject.ID}
+		e.active[k] = &tracked{
+			det: Detection{
+				DefKey:   a.DefKey,
+				Subject:  a.Subject,
+				Severity: a.Severity,
+				Evidence: a.Evidence,
+			},
+			baseSeverity: a.Severity,
+			firstSeen:    a.FirstSeen,
+			lastSeen:     a.LastSeen,
+			count:        a.Count,
+		}
+		n++
+	}
+	return n
+}
+
 // baseSeverity is the detection's explicit severity, else the catalog default.
 func (e *Engine) baseSeverity(d Detection) Severity {
 	if d.Severity != "" {

--- a/internal/api/handlers_wifi_airspace_internal_test.go
+++ b/internal/api/handlers_wifi_airspace_internal_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"net/http"
@@ -67,7 +68,7 @@ func TestHandleWiFiAirspaceAndAnomaliesPopulated(t *testing.T) {
 	}
 	svc.SetSource("monitor0")
 	svc.Ingest(openBeacon(t), time.Now())
-	svc.Evaluate(time.Now())
+	svc.Evaluate(context.Background(), time.Now())
 	s := &Server{wifiQueries: troubleshooting.NewQueries(svc)}
 
 	// Airspace tree is populated and reports the active source.

--- a/internal/app/wifi_visibility.go
+++ b/internal/app/wifi_visibility.go
@@ -1,11 +1,17 @@
 package app
 
-import "github.com/MustardSeedNetworks/seed/internal/wifi/visibility"
+import (
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
+	"github.com/MustardSeedNetworks/seed/internal/wifi/visibility"
+)
 
-// NewWiFiVisibility builds the Wi-Fi airspace visibility component. It owns no
-// persistence (it is fed decoded frames by the capture source, not the DB), so
-// unlike NewReporting it takes no store adapters. It errors only if the Wi-Fi
-// anomaly catalog is malformed — a build-time programming error.
-func NewWiFiVisibility() (*visibility.Service, error) {
-	return visibility.New()
+// NewWiFiVisibility builds the Wi-Fi airspace visibility component. It is fed
+// decoded frames by the capture source (not the DB), but it persists its
+// detected-anomaly stream to the unified anomaly store (ADR-0021) when one is
+// supplied — pass db.Anomalies() so Wi-Fi anomalies survive restart and feed the
+// cross-source platform. A nil store leaves the engine purely in-memory. It
+// errors only if the Wi-Fi anomaly catalog is malformed — a build-time
+// programming error.
+func NewWiFiVisibility(store anomaly.Store) (*visibility.Service, error) {
+	return visibility.New(visibility.WithStore(store))
 }

--- a/internal/wifi/visibility/service.go
+++ b/internal/wifi/visibility/service.go
@@ -13,6 +13,7 @@ package visibility
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -51,6 +52,11 @@ type Service struct {
 	air      *airspace.Airspace
 	engine   *anomaly.Engine
 	detector *wifianomaly.Detector
+	// coordinator persists the engine's stream to the unified anomaly store
+	// (ADR-0021). Nil when no store is configured — the engine then stays purely
+	// in-memory (the prior behavior). When set, Evaluate writes through it.
+	coordinator *anomaly.Coordinator
+	logger      *slog.Logger
 
 	evalInterval time.Duration
 	retention    time.Duration
@@ -70,6 +76,8 @@ type config struct {
 	retention    time.Duration
 	detector     *wifianomaly.Detector
 	capabilities []string
+	store        anomaly.Store
+	logger       *slog.Logger
 }
 
 // WithEvalInterval sets the background evaluation cadence.
@@ -105,6 +113,24 @@ func WithCapabilities(caps ...string) Option {
 	return func(c *config) { c.capabilities = append(c.capabilities, caps...) }
 }
 
+// WithStore persists the anomaly stream to the unified store (ADR-0021): the
+// service writes detections through a Coordinator (write-through on a material
+// change, batched on recurrence, resolve-on-prune) and reloads active instances
+// on Start. A nil store leaves the engine purely in-memory.
+func WithStore(store anomaly.Store) Option {
+	return func(c *config) { c.store = store }
+}
+
+// WithLogger sets the logger for persistence diagnostics. Defaults to
+// [slog.Default].
+func WithLogger(l *slog.Logger) Option {
+	return func(c *config) {
+		if l != nil {
+			c.logger = l
+		}
+	}
+}
+
 // New builds a visibility service. It errors only if the Wi-Fi anomaly catalog
 // is malformed — a programming error surfaced at startup, never at runtime.
 func New(opts ...Option) (*Service, error) {
@@ -120,10 +146,21 @@ func New(opts ...Option) (*Service, error) {
 	if det == nil {
 		det = wifianomaly.NewDetector()
 	}
+	logger := cfg.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	engine := anomaly.NewEngine(cat, anomaly.WithCapabilities(cfg.capabilities...))
+	var coord *anomaly.Coordinator
+	if cfg.store != nil {
+		coord = anomaly.NewCoordinator(engine, cfg.store, anomaly.SourceWiFi)
+	}
 	return &Service{
 		air:          airspace.New(),
-		engine:       anomaly.NewEngine(cat, anomaly.WithCapabilities(cfg.capabilities...)),
+		engine:       engine,
 		detector:     det,
+		coordinator:  coord,
+		logger:       logger,
 		evalInterval: cfg.evalInterval,
 		retention:    cfg.retention,
 	}, nil
@@ -136,21 +173,46 @@ func (s *Service) Ingest(f *dot11.Frame, at time.Time) {
 }
 
 // Evaluate ages out stale entities, runs the Wi-Fi rules over the current
-// airspace, and folds the resulting detections into the persistent engine
-// (which coalesces, escalates on recurrence, and ages out resolved anomalies).
-func (s *Service) Evaluate(at time.Time) {
+// airspace, and folds the resulting detections into the engine (which coalesces,
+// escalates on recurrence, and ages out resolved anomalies). When a store is
+// configured it persists through the Coordinator: write-through on a material
+// change, a single batched Flush for the tick's recurrences, and resolve-on-prune.
+func (s *Service) Evaluate(ctx context.Context, at time.Time) {
 	cutoff := at.Add(-s.retention)
 	s.air.Prune(cutoff)
-	for _, d := range s.detector.Detect(s.air.Tree()) {
-		// Observe only errors on an uncatalogued def or invalid severity; the
-		// detector emits neither, so the error is structurally impossible here.
-		_ = s.engine.Observe(d, at)
+
+	if s.coordinator != nil {
+		s.evaluatePersistent(ctx, at, cutoff)
+	} else {
+		for _, d := range s.detector.Detect(s.air.Tree()) {
+			// Observe only errors on an uncatalogued def or invalid severity; the
+			// detector emits neither, so the error is structurally impossible.
+			_ = s.engine.Observe(d, at)
+		}
+		s.engine.Prune(cutoff)
 	}
-	s.engine.Prune(cutoff)
 
 	s.mu.Lock()
 	s.lastEvaluated = at
 	s.mu.Unlock()
+}
+
+// evaluatePersistent runs the detection + persistence path through the
+// Coordinator. Store errors are logged, not fatal — the in-memory engine stays
+// authoritative and the next tick re-persists.
+func (s *Service) evaluatePersistent(ctx context.Context, at, cutoff time.Time) {
+	for _, d := range s.detector.Detect(s.air.Tree()) {
+		if err := s.coordinator.Observe(ctx, d, at); err != nil {
+			s.logger.WarnContext(ctx, "anomaly persist (observe) failed",
+				"defKey", d.DefKey, "error", err)
+		}
+	}
+	if err := s.coordinator.Flush(ctx); err != nil {
+		s.logger.WarnContext(ctx, "anomaly persist (flush) failed", "error", err)
+	}
+	if _, err := s.coordinator.Prune(ctx, cutoff); err != nil {
+		s.logger.WarnContext(ctx, "anomaly persist (prune) failed", "error", err)
+	}
 }
 
 // Tree returns the current cross-referenced SSID → AP → BSSID → client view.
@@ -214,6 +276,18 @@ func (s *Service) Start(ctx context.Context) error {
 	s.cancel = cancel
 	s.mu.Unlock()
 
+	// Load-on-start: repopulate the engine from the unified store so a restart
+	// continues coalescing onto persisted instances (ADR-0021) rather than
+	// re-detecting them as new. Best-effort — a store error degrades to a
+	// cold-start, not a failed Start.
+	if s.coordinator != nil {
+		if n, err := s.coordinator.Load(ctx); err != nil {
+			s.logger.WarnContext(ctx, "anomaly load-on-start failed", "error", err)
+		} else if n > 0 {
+			s.logger.InfoContext(ctx, "restored persisted anomalies", "count", n)
+		}
+	}
+
 	s.wg.Add(1)
 	go s.loop(loopCtx)
 	return nil
@@ -228,7 +302,7 @@ func (s *Service) loop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.Evaluate(time.Now())
+			s.Evaluate(ctx, time.Now())
 		}
 	}
 }

--- a/internal/wifi/visibility/service_test.go
+++ b/internal/wifi/visibility/service_test.go
@@ -1,10 +1,13 @@
 package visibility_test
 
 import (
+	"context"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
 	wifianomaly "github.com/MustardSeedNetworks/seed/internal/wifi/anomaly"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/dot11"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/visibility"
@@ -75,7 +78,7 @@ func TestIngestAndEvaluateProducesAnomaly(t *testing.T) {
 	// An open network on 2.4 GHz channel 6: trips wifi-open-network (and is on a
 	// valid non-overlapping channel, so no adjacent-channel noise).
 	svc.Ingest(beacon(t, "00:11:22:33:44:55", "guest", dot11.SecurityOpen), now)
-	svc.Evaluate(now)
+	svc.Evaluate(context.Background(), now)
 
 	if len(svc.Tree()) == 0 {
 		t.Fatal("Tree empty after ingesting a beacon")
@@ -101,9 +104,9 @@ func TestEvaluateCoalesces(t *testing.T) {
 	now := time.Now()
 	b := beacon(t, "00:11:22:33:44:55", "guest", dot11.SecurityOpen)
 	svc.Ingest(b, now)
-	svc.Evaluate(now)
+	svc.Evaluate(context.Background(), now)
 	svc.Ingest(b, now.Add(time.Second))
-	svc.Evaluate(now.Add(time.Second))
+	svc.Evaluate(context.Background(), now.Add(time.Second))
 
 	open := 0
 	for _, a := range svc.Anomalies() {
@@ -138,7 +141,7 @@ func TestCustomDetectorAndOptions(t *testing.T) {
 		b.BSS.PMFRequired = true
 		svc.Ingest(b, now)
 	}
-	svc.Evaluate(now)
+	svc.Evaluate(context.Background(), now)
 
 	found := false
 	for _, a := range svc.Anomalies() {
@@ -197,5 +200,120 @@ func TestStartStopLifecycle(t *testing.T) {
 	// Stop is idempotent.
 	if stopErr := svc.Stop(); stopErr != nil {
 		t.Fatalf("second Stop: %v", stopErr)
+	}
+}
+
+// fakeAnomalyStore is an in-memory anomaly.Store for the persistence tests.
+type fakeAnomalyStore struct {
+	mu       sync.Mutex
+	rows     map[string]anomaly.Record
+	resolved map[string]time.Time
+	seed     []anomaly.Record // returned by LoadActive
+}
+
+func newFakeAnomalyStore() *fakeAnomalyStore {
+	return &fakeAnomalyStore{rows: map[string]anomaly.Record{}, resolved: map[string]time.Time{}}
+}
+
+func (f *fakeAnomalyStore) Upsert(_ context.Context, recs []anomaly.Record) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, r := range recs {
+		f.rows[r.ID] = r
+	}
+	return nil
+}
+
+func (f *fakeAnomalyStore) MarkResolved(_ context.Context, ids []string, at time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, id := range ids {
+		f.resolved[id] = at
+		delete(f.rows, id)
+	}
+	return nil
+}
+
+func (f *fakeAnomalyStore) LoadActive(_ context.Context) ([]anomaly.Record, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.seed, nil
+}
+
+func (f *fakeAnomalyStore) snapshot() []anomaly.Record {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]anomaly.Record, 0, len(f.rows))
+	for _, r := range f.rows {
+		out = append(out, r)
+	}
+	return out
+}
+
+// TestPersistsAnomaliesToStore asserts that with a store configured, evaluating
+// an open-network beacon writes the detected anomaly through to the store tagged
+// with the Wi-Fi source (ADR-0021 phase 3 producer).
+func TestPersistsAnomaliesToStore(t *testing.T) {
+	fake := newFakeAnomalyStore()
+	svc, err := visibility.New(visibility.WithStore(fake))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	now := time.Now()
+	svc.Ingest(beacon(t, "00:11:22:33:44:55", "guest", dot11.SecurityOpen), now)
+	svc.Evaluate(context.Background(), now)
+
+	rows := fake.snapshot()
+	if len(rows) == 0 {
+		t.Fatal("no anomalies persisted after evaluate")
+	}
+	var foundOpen bool
+	for _, r := range rows {
+		if r.Source != anomaly.SourceWiFi {
+			t.Errorf("persisted source = %q, want wifi", r.Source)
+		}
+		if r.Anomaly.DefKey == wifianomaly.DefOpenNetwork {
+			foundOpen = true
+		}
+	}
+	if !foundOpen {
+		t.Errorf("expected a persisted %s anomaly, got %+v", wifianomaly.DefOpenNetwork, rows)
+	}
+}
+
+// TestLoadOnStartRestoresAnomalies asserts Start repopulates the engine from the
+// store's active instances so a restart does not lose live anomalies.
+func TestLoadOnStartRestoresAnomalies(t *testing.T) {
+	fake := newFakeAnomalyStore()
+	t0 := time.Now().Add(-time.Minute)
+	fake.seed = []anomaly.Record{{
+		ID: wifianomaly.DefOpenNetwork + "|bssid|00:11:22:33:44:55", Source: anomaly.SourceWiFi,
+		Anomaly: anomaly.Anomaly{
+			DefKey:    wifianomaly.DefOpenNetwork,
+			Severity:  anomaly.SeverityWarning,
+			Subject:   anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: "00:11:22:33:44:55"},
+			FirstSeen: t0, LastSeen: t0, Count: 3,
+		},
+	}}
+	// Long eval interval so the background loop does not evaluate during the test;
+	// load-on-start runs synchronously inside Start.
+	svc, err := visibility.New(visibility.WithStore(fake), visibility.WithEvalInterval(time.Hour))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if startErr := svc.Start(t.Context()); startErr != nil {
+		t.Fatalf("Start: %v", startErr)
+	}
+	defer func() { _ = svc.Stop() }()
+
+	anoms := svc.Anomalies()
+	if len(anoms) != 1 || anoms[0].DefKey != wifianomaly.DefOpenNetwork {
+		t.Fatalf("restored anomalies = %+v, want one %s", anoms, wifianomaly.DefOpenNetwork)
+	}
+	if anoms[0].Count != 3 {
+		t.Errorf("restored count = %d, want 3", anoms[0].Count)
+	}
+	if svc.Status().Anomalies != 1 {
+		t.Errorf("Status.Anomalies = %d, want 1", svc.Status().Anomalies)
 	}
 }


### PR DESCRIPTION
## What & why

Phase 3 of ADR-0021 — the first **real producer** on the unified anomaly platform.
The long-lived Wi-Fi `visibility.Service` now writes its detected anomalies
through to the SQL store (added #1629) and **reloads them on boot**, so Wi-Fi
anomalies survive a restart and feed the cross-source platform. This is the
headline ADR-0021 win for the Wi-Fi source.

Per the owner's steer, this is the Wi-Fi-producer slice; **health convergence**
(delete the bespoke `health.AnomalyDetector`) and the **reader repoint** are the
next phases (and will change DTOs freely — pre-alpha, no compat).

## Changes

- **`anomaly.Engine.Restore`** — seed the live set from persisted records
  (load-on-start). Persisted (effective) severity becomes the restored base
  severity (per ADR-0021); a live re-detection overrides it from the catalog
  default next tick. Records whose `DefKey` is no longer catalogued are skipped
  (orphan-safe after a catalog change).
- **`anomaly.Coordinator.Load`** — pull active instances from the store into the
  engine.
- **`visibility.Service`** — `WithStore(anomaly.Store)` wraps the engine in a
  `Coordinator` (source=`wifi`). `Evaluate` persists on the owner-locked cadence:
  write-through on a material change, one batched `Flush` per tick for recurrence,
  resolve-on-`Prune`. `Start` does load-on-start. `WithLogger` for diagnostics;
  store errors are logged, never fatal (the in-memory engine stays
  authoritative). `Evaluate` now takes a `ctx` (threaded from the loop) rather
  than storing one — callers updated.
- **`app.NewWiFiVisibility(store)`** + `cmd_serve` passes `db.Anomalies()`. A nil
  store keeps the engine purely in-memory (unchanged behavior, e.g. tests).
- **Tests** — engine `Restore` (incl. orphan-skip), `Coordinator.Load`, and
  visibility write-through + load-on-start with a fake store.

## Gates (local)

- `go build ./...` → 0
- `golangci-lint run --new-from-rev=origin/main` → 0 issues
- `go test ./internal/anomaly/... ./internal/wifi/visibility/ ./internal/api/ ./cmd/seed/` → ok
- `check-output-escaping.sh` + `check-route-policy.sh` → OK · gofmt clean
- No migration this slice → no schema golden change