### PR TITLE
feat(anomaly): probe is the active-monitoring anomaly producer (ADR-0025)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -57,6 +57,7 @@ import (
 	snmporchestrator "github.com/MustardSeedNetworks/seed/internal/polling/snmp/orchestrator"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/snmpclient"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
+	probeanomaly "github.com/MustardSeedNetworks/seed/internal/probe/anomaly"
 	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
 	"github.com/MustardSeedNetworks/seed/internal/profiles/catalog"
 	"github.com/MustardSeedNetworks/seed/internal/scheduler"
@@ -196,6 +197,7 @@ type Server struct {
 	// --- Unified probe engine + substrate (Stage A1.8) ---
 	probeEngine     *probe.Engine
 	probeScheduler  *scheduler.Scheduler
+	probeAnomaly    *probeanomaly.Producer
 	retentionEngine *retention.Engine
 
 	// --- Wi-Fi visibility (scan, manage, survey) ---
@@ -482,6 +484,25 @@ func (s *Server) initProbeEngine(db *database.DB) {
 	s.probeScheduler = sched
 	if regErr := s.registerEngineIfLicensed(probeEngine); regErr != nil {
 		logging.GetLogger().Warn("probe engine registry registration failed", "error", regErr)
+	}
+
+	// Wire the active-monitoring anomaly producer (ADR-0025): it subscribes to
+	// the probe engine's ResultEvent channel here (so it does not miss events
+	// before its own Start) and persists threshold breaches as anomalies under
+	// source=probe. Subscription happens now; the consume/maintenance loops start
+	// with the lifecycle. A catalog error is logged and skips the producer rather
+	// than aborting probe startup.
+	producer, prodErr := probeanomaly.New(
+		probeEngine.Subscribe(), db.Anomalies(),
+		probeanomaly.WithLogger(logging.GetLogger()),
+	)
+	if prodErr != nil {
+		logging.GetLogger().Warn("probe anomaly producer not wired", "error", prodErr)
+		return
+	}
+	s.probeAnomaly = producer
+	if regErr := s.registerEngineIfLicensed(producer); regErr != nil {
+		logging.GetLogger().Warn("probe anomaly producer registry registration failed", "error", regErr)
 	}
 }
 

--- a/internal/api/server_engine_tiers.go
+++ b/internal/api/server_engine_tiers.go
@@ -25,7 +25,7 @@ import (
 // the operator deliberately puts it on a paid tier.
 func minTierForEngine(name string) license.Tier {
 	switch name {
-	case "probe", "retention":
+	case "probe", "probe-anomaly", "retention":
 		return license.TierFree
 	case "snmp-poller",
 		"topology-sysinfo-reconciler",

--- a/internal/probe/anomaly/catalog.go
+++ b/internal/probe/anomaly/catalog.go
@@ -1,0 +1,81 @@
+// Package probeanomaly is the active-monitoring anomaly source (ADR-0025): it
+// maps the probe engine's threshold breaches onto the unified anomaly engine's
+// detections and runs the long-lived producer that persists them under
+// source=probe. The probe engine (internal/probe) stays unaware of anomalies; it
+// emits ResultEvents on a fan-out channel and this package consumes them, exactly
+// as internal/wifi/visibility consumes the Wi-Fi airspace. CGO-free, no I/O of
+// its own beyond the anomaly store.
+package probeanomaly
+
+import "github.com/MustardSeedNetworks/seed/internal/anomaly"
+
+// Exported def IDs are the stable catalog keys for active-monitoring anomalies.
+// A probe Breach selects one by its Field; the API/UI key off these and tests
+// assert against them, so they live as constants rather than scattered literals.
+const (
+	// DefUnreachable is the probe failing outright (Breach.Field == "success").
+	DefUnreachable = "probe-unreachable"
+	// DefHighLatency is a latency threshold breach (Breach.Field == "latency_ms").
+	DefHighLatency = "probe-high-latency"
+	// DefThresholdBreach is the generic fallback for any other breached field a
+	// checker reports (cert days-remaining, BGP state, …) before that field has a
+	// dedicated def. It keeps a breach from being silently dropped.
+	DefThresholdBreach = "probe-threshold-breach"
+)
+
+// Catalog builds and validates the probe anomaly catalog. It fails fast if a
+// definition is malformed, so a typo in the data below cannot ship a blank card.
+func Catalog() (*anomaly.Catalog, error) {
+	return anomaly.NewCatalog(Defs()...)
+}
+
+// Defs returns the probe anomaly definitions. Copy is authored originally; the
+// severities are catalog defaults — a Breach overrides per detection (warning vs
+// critical threshold), and the engine may escalate on recurrence. All are
+// CategoryNetHealth: active-monitoring observations of a target's reachability
+// and responsiveness.
+func Defs() []anomaly.Def {
+	return []anomaly.Def{
+		{
+			ID:              DefUnreachable,
+			Category:        anomaly.CategoryNetHealth,
+			DefaultSeverity: anomaly.SeverityCritical,
+			Title:           "Monitored target unreachable",
+			Description: "A scheduled probe failed: the target did not respond, or the " +
+				"observation could not complete. The service this probe checks is unavailable " +
+				"from this vantage point.",
+			Impact: "The monitored service is down or unreachable from the appliance. " +
+				"Dependent users or systems cannot reach it until it recovers.",
+			Recommendation: "Confirm the target is up and the path to it (DNS, routing, " +
+				"firewall) is intact. Check the probe's recent results for when it last " +
+				"succeeded, and whether other probes to the same target or segment also fail.",
+		},
+		{
+			ID:              DefHighLatency,
+			Category:        anomaly.CategoryNetHealth,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Title:           "Monitored target latency over threshold",
+			Description: "A scheduled probe's measured latency exceeded its configured " +
+				"warning or critical threshold. The target is reachable but responding more " +
+				"slowly than the operator's defined bound.",
+			Impact: "Elevated response time degrades the user or system experience of the " +
+				"monitored service and can foreshadow saturation or an upstream problem.",
+			Recommendation: "Compare current latency against the probe's baseline history. " +
+				"Check for path congestion, target load, or an intermediate hop adding delay; " +
+				"correlate with other probes sharing the path.",
+		},
+		{
+			ID:              DefThresholdBreach,
+			Category:        anomaly.CategoryNetHealth,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Title:           "Monitored target threshold breach",
+			Description: "A scheduled probe reported a value outside its configured " +
+				"threshold for a check-specific field (for example a certificate's remaining " +
+				"days, or a protocol-state field). The exact field is in the anomaly evidence.",
+			Impact: "A monitored condition has crossed the operator's defined bound and " +
+				"needs attention before it escalates to an outage.",
+			Recommendation: "Read the breached field, threshold, and actual value in the " +
+				"evidence, then remediate that specific condition on the target.",
+		},
+	}
+}

--- a/internal/probe/anomaly/detect.go
+++ b/internal/probe/anomaly/detect.go
@@ -1,0 +1,76 @@
+package probeanomaly
+
+import (
+	"fmt"
+
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// Detections maps one probe ResultEvent onto anomaly detections — one per
+// threshold breach (ADR-0025). A clean run (no breaches) yields none, so the
+// probe's instances age out on silence (the producer's Prune). The coalescing
+// subject is the probe itself (SubjectProbe keyed by ProbeID), so repeated
+// breaches of the same probe update one instance rather than piling up.
+func Detections(re probe.ResultEvent) []anomaly.Detection {
+	if len(re.Breaches) == 0 {
+		return nil
+	}
+	out := make([]anomaly.Detection, 0, len(re.Breaches))
+	for _, b := range re.Breaches {
+		out = append(out, anomaly.Detection{
+			DefKey:   defKeyForField(b.Field),
+			Subject:  anomaly.SubjectRef{Kind: anomaly.SubjectProbe, ID: b.ProbeID},
+			Severity: severityFor(b.Severity),
+			Evidence: evidence(re.Result, b),
+		})
+	}
+	return out
+}
+
+// defKeyForField selects the catalog def for a breached field, falling back to
+// the generic threshold-breach def so a new checker-specific field is surfaced
+// rather than dropped.
+func defKeyForField(field string) string {
+	switch field {
+	case "success":
+		return DefUnreachable
+	case "latency_ms":
+		return DefHighLatency
+	default:
+		return DefThresholdBreach
+	}
+}
+
+// severityFor maps a probe breach severity string onto an anomaly severity. An
+// unrecognized value returns "" so the engine applies the catalog default rather
+// than rejecting the detection.
+func severityFor(s string) anomaly.Severity {
+	switch s {
+	case "info":
+		return anomaly.SeverityInfo
+	case "warning":
+		return anomaly.SeverityWarning
+	case "critical":
+		return anomaly.SeverityCritical
+	default:
+		return ""
+	}
+}
+
+// evidence captures the live measured values behind a breach so the anomaly card
+// shows what tripped: the breached field with its threshold and actual, plus the
+// probe kind and any error string. Values are stringified (the wire model is
+// map[string]string).
+func evidence(r probe.Result, b probe.Breach) map[string]string {
+	ev := map[string]string{
+		"field":     b.Field,
+		"threshold": fmt.Sprint(b.Threshold),
+		"actual":    fmt.Sprint(b.Actual),
+		"kind":      r.Kind,
+	}
+	if r.Error != "" {
+		ev["error"] = r.Error
+	}
+	return ev
+}

--- a/internal/probe/anomaly/detect_test.go
+++ b/internal/probe/anomaly/detect_test.go
@@ -1,0 +1,134 @@
+package probeanomaly_test
+
+import (
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+	probeanomaly "github.com/MustardSeedNetworks/seed/internal/probe/anomaly"
+)
+
+func TestCatalogBuildsAndCoversMappedDefs(t *testing.T) {
+	t.Parallel()
+	cat, err := probeanomaly.Catalog()
+	if err != nil {
+		t.Fatalf("Catalog: %v", err)
+	}
+	// Every def the mapper can emit must resolve, or the engine would reject the
+	// detection at runtime (no orphan defKeys).
+	for _, id := range []string{
+		probeanomaly.DefUnreachable,
+		probeanomaly.DefHighLatency,
+		probeanomaly.DefThresholdBreach,
+	} {
+		if _, ok := cat.Lookup(id); !ok {
+			t.Errorf("catalog missing def %q", id)
+		}
+	}
+}
+
+func TestDetectionsMapsBreaches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		event     probe.ResultEvent
+		wantDef   string
+		wantSev   anomaly.Severity
+		wantSubID string
+	}{
+		{
+			name: "latency breach -> high-latency",
+			event: probe.ResultEvent{
+				Result: probe.Result{ProbeID: "p1", Kind: "http"},
+				Breaches: []probe.Breach{
+					{
+						ProbeID:   "p1",
+						Severity:  "critical",
+						Field:     "latency_ms",
+						Threshold: 100.0,
+						Actual:    250.0,
+					},
+				},
+			},
+			wantDef: probeanomaly.DefHighLatency, wantSev: anomaly.SeverityCritical, wantSubID: "p1",
+		},
+		{
+			name: "success breach -> unreachable",
+			event: probe.ResultEvent{
+				Result: probe.Result{ProbeID: "p2", Kind: "ping"},
+				Breaches: []probe.Breach{
+					{
+						ProbeID:   "p2",
+						Severity:  "critical",
+						Field:     "success",
+						Threshold: true,
+						Actual:    false,
+					},
+				},
+			},
+			wantDef: probeanomaly.DefUnreachable, wantSev: anomaly.SeverityCritical, wantSubID: "p2",
+		},
+		{
+			name: "unknown field -> generic threshold breach",
+			event: probe.ResultEvent{
+				Result: probe.Result{ProbeID: "p3", Kind: "tls"},
+				Breaches: []probe.Breach{
+					{
+						ProbeID:   "p3",
+						Severity:  "warning",
+						Field:     "cert_days_remaining",
+						Threshold: 14,
+						Actual:    3,
+					},
+				},
+			},
+			wantDef: probeanomaly.DefThresholdBreach, wantSev: anomaly.SeverityWarning, wantSubID: "p3",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := probeanomaly.Detections(tc.event)
+			if len(got) != 1 {
+				t.Fatalf("want 1 detection, got %d", len(got))
+			}
+			d := got[0]
+			if d.DefKey != tc.wantDef {
+				t.Errorf("defKey = %q, want %q", d.DefKey, tc.wantDef)
+			}
+			if d.Severity != tc.wantSev {
+				t.Errorf("severity = %q, want %q", d.Severity, tc.wantSev)
+			}
+			if d.Subject.Kind != anomaly.SubjectProbe || d.Subject.ID != tc.wantSubID {
+				t.Errorf("subject = %+v, want {probe %q}", d.Subject, tc.wantSubID)
+			}
+			if d.Evidence["field"] == "" || d.Evidence["kind"] == "" {
+				t.Errorf("evidence missing field/kind: %+v", d.Evidence)
+			}
+		})
+	}
+}
+
+func TestDetectionsCleanRunYieldsNothing(t *testing.T) {
+	t.Parallel()
+	got := probeanomaly.Detections(
+		probe.ResultEvent{Result: probe.Result{ProbeID: "p1", Success: true}},
+	)
+	if got != nil {
+		t.Fatalf("clean run must yield no detections, got %+v", got)
+	}
+}
+
+func TestDetectionsEvidenceIncludesError(t *testing.T) {
+	t.Parallel()
+	ev := probe.ResultEvent{
+		Result:   probe.Result{ProbeID: "p1", Kind: "dns", Error: "no such host"},
+		Breaches: []probe.Breach{{ProbeID: "p1", Severity: "critical", Field: "success"}},
+	}
+	got := probeanomaly.Detections(ev)
+	if len(got) != 1 || got[0].Evidence["error"] != "no such host" {
+		t.Fatalf("want error captured in evidence, got %+v", got)
+	}
+}

--- a/internal/probe/anomaly/producer.go
+++ b/internal/probe/anomaly/producer.go
@@ -1,0 +1,222 @@
+package probeanomaly
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+const (
+	// defaultFlushInterval is how often the maintenance tick batches recurrence
+	// writes and ages out recovered probes.
+	defaultFlushInterval = 30 * time.Second
+	// defaultResolveWindow is how long a probe must go without re-breaching before
+	// its anomaly is considered resolved. It MUST exceed any probe's interval so a
+	// still-failing probe (which re-breaches every interval, refreshing lastSeen)
+	// stays active; a recovered probe resolves once silent this long (ADR-0025:
+	// push-model resolution = TTL-on-silence).
+	defaultResolveWindow = 15 * time.Minute
+)
+
+// Producer is the long-lived active-monitoring anomaly source (ADR-0025). It
+// subscribes to the probe engine's ResultEvent channel, maps threshold breaches
+// onto anomaly detections, and persists them through a Coordinator under
+// source=probe (write-through on a material change, batched recurrence on a
+// periodic Flush, resolve-on-Prune when a probe goes silent). It implements
+// engine.Engine so the lifecycle registry drives Start/Stop alongside the probe
+// engine itself.
+type Producer struct {
+	events <-chan probe.ResultEvent
+	coord  *anomaly.Coordinator
+	logger *slog.Logger
+
+	flushInterval time.Duration
+	resolveWindow time.Duration
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// Option configures a Producer.
+type Option func(*config)
+
+type config struct {
+	flushInterval time.Duration
+	resolveWindow time.Duration
+	logger        *slog.Logger
+}
+
+// WithFlushInterval sets the maintenance cadence (Flush + Prune). Non-positive
+// values are ignored.
+func WithFlushInterval(d time.Duration) Option {
+	return func(c *config) {
+		if d > 0 {
+			c.flushInterval = d
+		}
+	}
+}
+
+// WithResolveWindow sets the silence window after which a non-re-breaching probe
+// is resolved. Non-positive values are ignored.
+func WithResolveWindow(d time.Duration) Option {
+	return func(c *config) {
+		if d > 0 {
+			c.resolveWindow = d
+		}
+	}
+}
+
+// WithLogger sets the logger for persistence diagnostics. Defaults to
+// [slog.Default].
+func WithLogger(l *slog.Logger) Option {
+	return func(c *config) {
+		if l != nil {
+			c.logger = l
+		}
+	}
+}
+
+// New builds a probe anomaly producer over the probe engine's event channel
+// (from Engine.Subscribe) and the unified anomaly store. It errors only if the
+// probe anomaly catalog is malformed — a programming error surfaced at startup,
+// never at runtime.
+func New(events <-chan probe.ResultEvent, store anomaly.Store, opts ...Option) (*Producer, error) {
+	cfg := config{flushInterval: defaultFlushInterval, resolveWindow: defaultResolveWindow}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	cat, err := Catalog()
+	if err != nil {
+		return nil, err
+	}
+	logger := cfg.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	engine := anomaly.NewEngine(cat)
+	coord := anomaly.NewCoordinator(engine, store, anomaly.SourceProbe)
+	return &Producer{
+		events:        events,
+		coord:         coord,
+		logger:        logger,
+		flushInterval: cfg.flushInterval,
+		resolveWindow: cfg.resolveWindow,
+	}, nil
+}
+
+// Name implements engine.Engine.
+func (*Producer) Name() string { return "probe-anomaly" }
+
+// Start loads active instances from the store (so a restart keeps coalescing onto
+// persisted anomalies) and launches the consume + maintenance goroutines. It is
+// idempotent: a second call while running is a no-op.
+func (p *Producer) Start(ctx context.Context) error {
+	p.mu.Lock()
+	if p.cancel != nil {
+		p.mu.Unlock()
+		return nil
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	p.cancel = cancel
+	p.mu.Unlock()
+
+	// Load-on-start (ADR-0021). Best-effort — a store error degrades to a
+	// cold-start, not a failed Start.
+	if n, err := p.coord.Load(ctx); err != nil {
+		p.logger.WarnContext(ctx, "probe anomaly load-on-start failed", "error", err)
+	} else if n > 0 {
+		p.logger.InfoContext(ctx, "restored persisted probe anomalies", "count", n)
+	}
+
+	p.wg.Add(1)
+	go p.consume(loopCtx)
+	p.wg.Add(1)
+	go p.maintain(loopCtx)
+	return nil
+}
+
+// Stop cancels the goroutines, waits for them to drain, and performs a final
+// Flush so the last recurrence batch is durable. Safe to call repeatedly and
+// safe when never started.
+func (p *Producer) Stop(ctx context.Context) error {
+	p.mu.Lock()
+	cancel := p.cancel
+	p.cancel = nil
+	p.mu.Unlock()
+	if cancel == nil {
+		return nil
+	}
+	cancel()
+	p.wg.Wait()
+	if err := p.coord.Flush(ctx); err != nil {
+		p.logger.WarnContext(ctx, "probe anomaly final flush failed", "error", err)
+	}
+	return nil
+}
+
+// consume drains the probe event channel, folding each ResultEvent's breaches
+// into the engine. It exits on context cancellation or a closed channel.
+func (p *Producer) consume(ctx context.Context) {
+	defer p.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case re, ok := <-p.events:
+			if !ok {
+				return
+			}
+			p.observe(ctx, re, time.Now().UTC())
+		}
+	}
+}
+
+// observe folds one event's detections into the coordinator at time at. Store
+// errors are logged, not fatal — the in-memory engine stays authoritative and
+// the next Flush re-persists. Separated from consume so it is unit-testable
+// without the goroutine.
+func (p *Producer) observe(ctx context.Context, re probe.ResultEvent, at time.Time) {
+	for _, d := range Detections(re) {
+		if err := p.coord.Observe(ctx, d, at); err != nil {
+			p.logger.WarnContext(ctx, "probe anomaly persist (observe) failed",
+				"defKey", d.DefKey, "probeID", d.Subject.ID, "error", err)
+		}
+	}
+}
+
+// maintain batches recurrence writes and ages out recovered probes on a fixed
+// tick. It exits on context cancellation.
+func (p *Producer) maintain(ctx context.Context) {
+	defer p.wg.Done()
+	ticker := time.NewTicker(p.flushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.flushAndPrune(ctx, time.Now().UTC())
+		}
+	}
+}
+
+// flushAndPrune persists pending recurrence updates and resolves probes that have
+// not re-breached within the resolve window (cutoff = now − resolveWindow).
+// Separated from maintain so it is unit-testable without the goroutine.
+func (p *Producer) flushAndPrune(ctx context.Context, now time.Time) {
+	if err := p.coord.Flush(ctx); err != nil {
+		p.logger.WarnContext(ctx, "probe anomaly persist (flush) failed", "error", err)
+	}
+	if _, err := p.coord.Prune(ctx, now.Add(-p.resolveWindow)); err != nil {
+		p.logger.WarnContext(ctx, "probe anomaly persist (prune) failed", "error", err)
+	}
+}
+
+// Anomalies returns the current probe anomaly stream, most urgent first — the
+// in-memory projection (the persisted view is read via the store).
+func (p *Producer) Anomalies() []anomaly.Anomaly { return p.coord.Engine().Snapshot() }

--- a/internal/probe/anomaly/producer_internal_test.go
+++ b/internal/probe/anomaly/producer_internal_test.go
@@ -1,0 +1,163 @@
+package probeanomaly
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// fakeStore records anomaly.Store calls for assertion.
+type fakeStore struct {
+	mu       sync.Mutex
+	upserts  int
+	rows     []anomaly.Record
+	resolved []string
+}
+
+func (f *fakeStore) Upsert(_ context.Context, recs []anomaly.Record) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.upserts++
+	f.rows = append(f.rows, recs...)
+	return nil
+}
+
+func (f *fakeStore) MarkResolved(_ context.Context, ids []string, _ time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resolved = append(f.resolved, ids...)
+	return nil
+}
+
+func (f *fakeStore) LoadActive(_ context.Context) ([]anomaly.Record, error) { return nil, nil }
+
+func (f *fakeStore) snapshot() (int, []anomaly.Record, []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	rows := append([]anomaly.Record(nil), f.rows...)
+	res := append([]string(nil), f.resolved...)
+	return f.upserts, rows, res
+}
+
+func latencyEvent(probeID string) probe.ResultEvent {
+	return probe.ResultEvent{
+		Result: probe.Result{ProbeID: probeID, Kind: "http"},
+		Breaches: []probe.Breach{
+			{
+				ProbeID:   probeID,
+				Severity:  "warning",
+				Field:     "latency_ms",
+				Threshold: 100.0,
+				Actual:    200.0,
+			},
+		},
+	}
+}
+
+func TestObservePersistsThroughCoordinator(t *testing.T) {
+	t.Parallel()
+	fs := &fakeStore{}
+	p, err := New(nil, fs)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.observe(context.Background(), latencyEvent("p1"), time.Unix(1000, 0).UTC())
+
+	upserts, rows, _ := fs.snapshot()
+	if upserts != 1 || len(rows) != 1 {
+		t.Fatalf(
+			"want one write-through upsert of one row, got %d upserts / %d rows",
+			upserts,
+			len(rows),
+		)
+	}
+	got := rows[0]
+	if got.Source != anomaly.SourceProbe {
+		t.Errorf("source = %q, want probe", got.Source)
+	}
+	if got.Anomaly.DefKey != DefHighLatency || got.Anomaly.Subject.ID != "p1" {
+		t.Errorf(
+			"record = def %q subject %q, want high-latency/p1",
+			got.Anomaly.DefKey,
+			got.Anomaly.Subject.ID,
+		)
+	}
+	wantID := anomaly.RecordID(
+		DefHighLatency,
+		anomaly.SubjectRef{Kind: anomaly.SubjectProbe, ID: "p1"},
+	)
+	if got.ID != wantID {
+		t.Errorf("record id = %q, want %q", got.ID, wantID)
+	}
+}
+
+func TestFlushAndPruneResolvesAfterSilence(t *testing.T) {
+	t.Parallel()
+	fs := &fakeStore{}
+	p, err := New(nil, fs, WithResolveWindow(10*time.Minute))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t0 := time.Unix(2000, 0).UTC()
+	p.observe(context.Background(), latencyEvent("p1"), t0)
+
+	// Within the window: not yet resolved.
+	p.flushAndPrune(context.Background(), t0.Add(5*time.Minute))
+	if _, _, res := fs.snapshot(); len(res) != 0 {
+		t.Fatalf("must not resolve within the window, got %v", res)
+	}
+
+	// Past the window with no re-breach: the probe is considered recovered.
+	p.flushAndPrune(context.Background(), t0.Add(11*time.Minute))
+	_, _, res := fs.snapshot()
+	wantID := anomaly.RecordID(
+		DefHighLatency,
+		anomaly.SubjectRef{Kind: anomaly.SubjectProbe, ID: "p1"},
+	)
+	if len(res) != 1 || res[0] != wantID {
+		t.Fatalf("want %q resolved after silence, got %v", wantID, res)
+	}
+}
+
+func TestStartStopIsIdempotentAndDrains(t *testing.T) {
+	t.Parallel()
+	fs := &fakeStore{}
+	events := make(chan probe.ResultEvent, 4)
+	p, err := New(events, fs, WithFlushInterval(5*time.Millisecond), WithResolveWindow(time.Hour))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx := context.Background()
+	if err = p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Second Start is a no-op.
+	if err = p.Start(ctx); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+
+	events <- latencyEvent("p1")
+	// Wait for the consume goroutine to persist it.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if upserts, _, _ := fs.snapshot(); upserts > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("event was not consumed within 2s")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if err = p.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	// Second Stop is safe.
+	if err = p.Stop(ctx); err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Slice B of ADR-0025: give the probe engine's idle `ResultEvent` channel its first consumer. A long-lived **producer** maps probe threshold breaches onto anomaly detections and persists them under `source=probe` — so the `/telemetry/health-checks/anomalies` endpoint (repointed to `source=probe` in #1634) now has real data behind it.

## How

New package `internal/probe/anomaly` (`probeanomaly`):

- **Catalog** — `probe-unreachable`, `probe-high-latency`, `probe-threshold-breach` (generic fallback so a new checker-specific field is surfaced, not dropped). `CategoryNetHealth`, original copy.
- **`Detections(ResultEvent)`** — one detection per `Breach`: `Field`→defKey, `Severity`→severity, subject = `SubjectProbe` keyed by `ProbeID`, evidence = field/threshold/actual/kind/error. A clean run yields none.
- **`Producer`** (an `engine.Engine`) — subscribes to `probe.Engine.Subscribe()`, Observes breaches through an `anomaly.Coordinator(source=probe)` (write-through on material change), and runs a maintenance tick that `Flush`es recurrence and `Prune`s recovered probes after a **silence window** (push-model resolution = TTL-on-silence, per the ADR). Load-on-start; idempotent Start/Stop; final Flush on Stop.

Composition root: `initProbeEngine` subscribes the producer **at construction** (so it can't miss early events) and registers it as a lifecycle engine, gated `TierFree` alongside probe.

## Resolution model (design note)

Wi-Fi is pull/snapshot (prune anything absent from the re-evaluation). Probe is **push/event**: a recovered probe simply stops breaching, so the producer resolves on a periodic `Prune(now − resolveWindow)`. `resolveWindow` (default 15m) must exceed a probe's interval so a still-failing probe (re-breaching each interval) stays active. Interval-aware resolution + an explicit clean-result fast-path are noted ADR refinements.

## Tests / gates

- `internal/probe/anomaly`: Breach→Detection mapping (latency/success/unknown-field/clean/error-evidence), write-through persist, resolve-after-silence, and an idempotent **Start/Stop drain** — all **race-tested** (`go test -race`).
- `internal/api` run alone (touched `server.go`/`server_engine_tiers.go`): green.
- `golangci-lint --new-from-rev=origin/main` 0 issues · gofmt clean · gitleaks clean · `check-route-policy.sh` + `check-output-escaping.sh` pass. No migration.

Follows #1634 (ADR-0025 + taxonomy). Next: catalog growth (cert/dns/bgp fields as checkers add threshold shapes) + the health-check transport/table deletion track + ph5 severity ladder.