### PR TITLE
feat(anomaly): add error severity to the four-level ladder (ADR-0021 ph5)

### DIFF
--- a/docs/architecture/decisions/0021-persist-and-converge-anomaly-engine.md
+++ b/docs/architecture/decisions/0021-persist-and-converge-anomaly-engine.md
@@ -220,4 +220,21 @@ so no frontend type migration was required. No migration → no schema-golden ch
   the engine — a decision the probe-vs-jobs ADR must make first. The endpoint is correctly plumbed and
   lights up the moment a real source=health producer persists. The **health catalog `Def`s**
   (latency_spike/availability_dip/error_spike/…) land with that producer, since they are only exercised
-  once detections flow.
+  once detections flow. (The probe-vs-jobs decision was subsequently made in
+  [ADR-0025](0025-probe-is-the-active-monitoring-anomaly-source.md): `internal/probe` is the producer,
+  `source=health`→`source=probe`; the dormant health-check stack was deleted in
+  [ADR-0026](0026-delete-dead-health-check-read-path.md).)
+
+**Phase 5 (as-built) — the four-level severity ladder, live.** The `Info → Warning → Error → Critical`
+ladder anticipated in phase 1 is now realized: `anomaly.SeverityError` (`"error"`) joins the enum
+between `Warning` and `Critical`, with a matching `rankError` so ordering/coalescing is `info < warning
+< error < critical`, and the engine's recurrence escalation (`effectiveSeverityOf`) bumps one level per
+step through the full ladder (`warning → error → critical`, capped at critical). This aligns `anomaly`
+with the fleet alert vocabulary (`database.AlertSeverity*` already carried all four). As predicted, the
+persistence layer needed **no schema change** — `severity` is stored verbatim (the migration's only
+constraint is `<> ''`), so no migration and no schema-golden change. The frontend severity map
+(`ui/.../wifi/severity.ts`) gains an `error` badge on the existing `severity-high` design token (the
+orange slot between warning-yellow and critical-red; critical keeps `status-error` red), and
+`WiFiAnomaliesCard` treats `error` as an elevated card status alongside `critical`. **Catalog growth is
+separate:** existing `Def` defaults are unchanged; assigning `Error` to specific failure modes is
+per-def authoring that lands with each source's catalog work, not in this mechanism slice.

--- a/internal/anomaly/anomaly.go
+++ b/internal/anomaly/anomaly.go
@@ -9,7 +9,8 @@ package anomaly
 import "time"
 
 // Severity is the anomaly urgency, aligned with the fleet alert vocabulary
-// (internal/database AlertSeverity*). info < warning < critical.
+// (internal/database AlertSeverity*, which carries the same four levels).
+// info < warning < error < critical.
 type Severity string
 
 const (
@@ -17,6 +18,9 @@ const (
 	SeverityInfo Severity = "info"
 	// SeverityWarning is a degradation or risk that should be addressed.
 	SeverityWarning Severity = "warning"
+	// SeverityError is an error-level fault — more urgent than a warning but not
+	// yet an active outage/exposure.
+	SeverityError Severity = "error"
 	// SeverityCritical is an active problem or security exposure.
 	SeverityCritical Severity = "critical"
 )
@@ -27,6 +31,7 @@ const (
 	rankNone = iota
 	rankInfo
 	rankWarning
+	rankError
 	rankCritical
 )
 
@@ -35,6 +40,8 @@ func (s Severity) rank() int {
 	switch s {
 	case SeverityCritical:
 		return rankCritical
+	case SeverityError:
+		return rankError
 	case SeverityWarning:
 		return rankWarning
 	case SeverityInfo:

--- a/internal/anomaly/coordinator_test.go
+++ b/internal/anomaly/coordinator_test.go
@@ -152,8 +152,8 @@ func TestCoordinatorWritesThroughOnEscalation(t *testing.T) {
 	if store.upserts != 2 {
 		t.Fatalf("escalation crossing should write through: upsert calls = %d, want 2", store.upserts)
 	}
-	if store.rows["open-ssid|bssid|aa"].Anomaly.Severity != anomaly.SeverityCritical {
-		t.Errorf("persisted severity = %q, want critical (escalated)",
+	if store.rows["open-ssid|bssid|aa"].Anomaly.Severity != anomaly.SeverityError {
+		t.Errorf("persisted severity = %q, want error (one bump up the ladder from warning)",
 			store.rows["open-ssid|bssid|aa"].Anomaly.Severity)
 	}
 }

--- a/internal/anomaly/engine.go
+++ b/internal/anomaly/engine.go
@@ -190,6 +190,8 @@ func (e *Engine) effectiveSeverityOf(base Severity, count int) Severity {
 	case SeverityInfo:
 		return SeverityWarning
 	case SeverityWarning:
+		return SeverityError
+	case SeverityError:
 		return SeverityCritical
 	case SeverityCritical:
 		return SeverityCritical

--- a/internal/anomaly/engine_test.go
+++ b/internal/anomaly/engine_test.go
@@ -136,8 +136,35 @@ func TestSeverityEscalationOnRecurrence(t *testing.T) {
 		t.Fatalf("before threshold: severity = %q, want warning", got)
 	}
 	must(t, e.Observe(det, at)) // count now 3 == threshold
-	if got := e.Snapshot()[0].Severity; got != anomaly.SeverityCritical {
-		t.Errorf("after threshold: severity = %q, want critical (escalated)", got)
+	if got := e.Snapshot()[0].Severity; got != anomaly.SeverityError {
+		t.Errorf("after threshold: severity = %q, want error (one bump up the ladder)", got)
+	}
+}
+
+// TestSeverityLadderEscalation exercises the full info→warning→error→critical
+// ladder (ADR-0021 ph5): each recurrence past the threshold bumps the base one
+// level, and critical is the cap.
+func TestSeverityLadderEscalation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		base anomaly.Severity
+		want anomaly.Severity
+	}{
+		{"info escalates to warning", anomaly.SeverityInfo, anomaly.SeverityWarning},
+		{"warning escalates to error", anomaly.SeverityWarning, anomaly.SeverityError},
+		{"error escalates to critical", anomaly.SeverityError, anomaly.SeverityCritical},
+		{"critical is the cap", anomaly.SeverityCritical, anomaly.SeverityCritical},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := anomaly.NewEngine(testCatalog(t), anomaly.WithEscalateAfter(2))
+			// open-ssid exists in the test catalog; override its base severity.
+			det := anomaly.Detection{DefKey: "open-ssid", Subject: bssid("aa"), Severity: tc.base}
+			must(t, e.Observe(det, time.Unix(0, 0)))
+			must(t, e.Observe(det, time.Unix(0, 0))) // count == threshold → escalate
+			if got := e.Snapshot()[0].Severity; got != tc.want {
+				t.Errorf("base %q escalated to %q, want %q", tc.base, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/anomaly/severity_internal_test.go
+++ b/internal/anomaly/severity_internal_test.go
@@ -1,0 +1,30 @@
+package anomaly
+
+import "testing"
+
+// TestSeverityRankOrdering pins the ladder ordering info < warning < error <
+// critical (ADR-0021 ph5) and that an unknown severity ranks below all of them.
+func TestSeverityRankOrdering(t *testing.T) {
+	ordered := []Severity{SeverityInfo, SeverityWarning, SeverityError, SeverityCritical}
+	for i := 1; i < len(ordered); i++ {
+		if ordered[i-1].rank() >= ordered[i].rank() {
+			t.Errorf("rank(%q)=%d should be < rank(%q)=%d",
+				ordered[i-1], ordered[i-1].rank(), ordered[i], ordered[i].rank())
+		}
+	}
+	if (Severity("nope")).rank() != rankNone {
+		t.Errorf("unknown severity rank = %d, want rankNone(%d)", Severity("nope").rank(), rankNone)
+	}
+}
+
+// TestSeverityValid confirms every ladder level is valid and an unknown one is not.
+func TestSeverityValid(t *testing.T) {
+	for _, s := range []Severity{SeverityInfo, SeverityWarning, SeverityError, SeverityCritical} {
+		if !s.valid() {
+			t.Errorf("%q should be valid", s)
+		}
+	}
+	if (Severity("nope")).valid() {
+		t.Error(`"nope" should be invalid`)
+	}
+}

--- a/ui/src/components/wifi/WiFiAnomaliesCard.tsx
+++ b/ui/src/components/wifi/WiFiAnomaliesCard.tsx
@@ -4,9 +4,11 @@ import { Card } from '../ui/card';
 import type { Status } from '../ui/statusConfig';
 import { WiFiAnomalyStream } from './WiFiAnomalyStream';
 
-// cardStatus reflects the most urgent anomaly severity in the card header.
+// cardStatus reflects the most urgent anomaly severity in the card header. The
+// Status vocabulary tops out at 'error', so both critical and error anomalies
+// map to it (the per-row badge in severity.ts keeps them visually distinct).
 function cardStatus(anomalies: Anomaly[]): Status {
-  if (anomalies.some((a) => a.severity === 'critical')) {
+  if (anomalies.some((a) => a.severity === 'critical' || a.severity === 'error')) {
     return 'error';
   }
   if (anomalies.some((a) => a.severity === 'warning')) {

--- a/ui/src/components/wifi/WiFiAnomalyStream.test.tsx
+++ b/ui/src/components/wifi/WiFiAnomalyStream.test.tsx
@@ -33,19 +33,21 @@ describe('WiFiAnomalyStream', () => {
     expect(screen.getByText('00:11:22:33:44:55')).toBeInTheDocument();
   });
 
-  it('orders critical before warning before info', () => {
+  it('orders critical before error before warning before info', () => {
     render(
       <WiFiAnomalyStream
         anomalies={[
           anomaly({ defKey: 'a', severity: 'info', title: 'Info one' }),
           anomaly({ defKey: 'b', severity: 'critical', title: 'Critical one' }),
           anomaly({ defKey: 'c', severity: 'warning', title: 'Warning one' }),
+          anomaly({ defKey: 'd', severity: 'error', title: 'Error one' }),
         ]}
       />,
     );
     const titles = screen.getAllByTestId('wifi-anomaly-row').map((r) => r.textContent ?? '');
     expect(titles[0]).toContain('Critical one');
-    expect(titles[1]).toContain('Warning one');
-    expect(titles[2]).toContain('Info one');
+    expect(titles[1]).toContain('Error one');
+    expect(titles[2]).toContain('Warning one');
+    expect(titles[3]).toContain('Info one');
   });
 });

--- a/ui/src/components/wifi/severity.test.ts
+++ b/ui/src/components/wifi/severity.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { severityStyle } from './severity';
+
+describe('severityStyle', () => {
+  it('ranks the ladder info < warning < error < critical', () => {
+    expect(severityStyle('info').rank).toBe(1);
+    expect(severityStyle('warning').rank).toBe(2);
+    expect(severityStyle('error').rank).toBe(3);
+    expect(severityStyle('critical').rank).toBe(4);
+  });
+
+  it('gives error the orange severity-high token, distinct from critical red', () => {
+    expect(severityStyle('error').badge).toContain('severity-high');
+    expect(severityStyle('critical').badge).toContain('status-error');
+    expect(severityStyle('error').badge).not.toEqual(severityStyle('critical').badge);
+  });
+
+  it('falls back for an unknown severity', () => {
+    const fb = severityStyle('nope');
+    expect(fb.rank).toBe(0);
+    expect(fb.badge).toContain('surface-sunken');
+  });
+});

--- a/ui/src/components/wifi/severity.ts
+++ b/ui/src/components/wifi/severity.ts
@@ -1,6 +1,7 @@
-// Maps anomaly severities (info < warning < critical) to design-token classes.
-// Token-only — no raw colours — so the design-token CI gate stays green and the
-// badges are theme-aware.
+// Maps anomaly severities (info < warning < error < critical) to design-token
+// classes. Token-only — no raw colours — so the design-token CI gate stays green
+// and the badges are theme-aware. `error` uses severity-high (the orange slot
+// between warning-yellow and critical-red); critical keeps status-error red.
 
 export interface SeverityStyle {
   /** Tailwind classes for a severity pill (token colours only). */
@@ -10,12 +11,16 @@ export interface SeverityStyle {
 }
 
 const styles: Record<string, SeverityStyle> = {
-  critical: { badge: 'bg-status-error/10 text-status-error', rank: 3 },
+  critical: { badge: 'bg-status-error/10 text-status-error', rank: 4 },
+  error: { badge: 'bg-severity-high/10 text-severity-high', rank: 3 },
   warning: { badge: 'bg-status-warning/10 text-status-warning', rank: 2 },
   info: { badge: 'bg-status-info/10 text-status-info', rank: 1 },
 };
 
-const fallback: SeverityStyle = { badge: 'bg-surface-sunken text-text-secondary', rank: 0 };
+const fallback: SeverityStyle = {
+  badge: 'bg-surface-sunken text-text-secondary',
+  rank: 0,
+};
 
 /** severityStyle returns the token classes + rank for a severity string. */
 export function severityStyle(severity: string): SeverityStyle {


### PR DESCRIPTION
Realizes the Info -> Warning -> Error -> Critical ladder anticipated in
ADR-0021 phase 1. anomaly.SeverityError ("error") slots between Warning
and Critical with a matching rankError, so ordering/coalescing is
info < warning < error < critical, and the engine's recurrence escalation
(effectiveSeverityOf) now bumps one level per step through the full ladder
(warning -> error -> critical, capped at critical).

This aligns anomaly with the fleet alert vocabulary (database.AlertSeverity*
already carried all four levels). Persistence is unchanged: severity is
stored verbatim (the anomalies migration only constrains it <> ''), so no
migration and no schema-golden change.

Frontend: severity.ts gains an `error` badge on the existing severity-high
design token (the orange slot between warning-yellow and critical-red;
critical keeps status-error red), and WiFiAnomaliesCard treats error as an
elevated card status alongside critical.

Catalog growth is separate: existing Def defaults are unchanged; assigning
Error to specific failure modes is per-def authoring for each source's
catalog work, not this mechanism slice.

Tests: rank ordering + validity (internal); full ladder escalation incl.
error->critical and the critical cap (engine); coordinator write-through on
the warning->error crossing; frontend severityStyle map + stream ordering.
