### PR TITLE
feat(anomaly): resolve probe anomalies immediately on a clean result

### DIFF
--- a/docs/architecture/decisions/0025-probe-is-the-active-monitoring-anomaly-source.md
+++ b/docs/architecture/decisions/0025-probe-is-the-active-monitoring-anomaly-source.md
@@ -82,8 +82,15 @@ breaches. The producer therefore resolves an instance by **`Prune(cutoff)` on a 
 tick**, where `cutoff = now − resolveWindow`. `resolveWindow` must exceed a probe's interval so a
 still-failing probe (which re-breaches every interval, refreshing `lastSeen`) stays active; a recovered
 probe's anomaly resolves once it has been silent for the window. Interval-aware (per-probe) resolution
-and an explicit "clean result clears this probe's anomalies now" fast-path are noted refinements, not
-required for the first producer.
+is still a noted refinement.
+
+**As-built (2026-06-11):** the explicit "clean result clears this probe's anomalies now" fast-path is
+**implemented**. A `ResultEvent` with zero breaches resolves every active anomaly for that probe
+(`SubjectProbe` keyed by `ProbeID`) immediately, via `Coordinator.ResolveSubject` (which clears all of a
+subject's instances across defs and marks exactly those resolved). The maintenance `Prune` remains the
+backstop for a probe that goes **fully silent** — disabled or deleted — and therefore never emits a clean
+result to trigger the fast-path. So recovery is immediate when the probe reports healthy, and bounded by
+`resolveWindow` when it stops reporting entirely.
 
 ### 4. The health-check stack is legacy to delete, not revive
 
@@ -112,9 +119,10 @@ compat, so the rename is free when it happens).
   was never meant to own, and saddle every probe with a terminal-state lifecycle it does not have.
 - **Per-source anomaly tables / a second engine for probe.** Rejected — ADR-0021's single store and
   source-neutral engine already hold; probe is just another `Source` writing the one schema.
-- **Resolve probe anomalies only by exact recovery signal (clean result).** Deferred, not rejected — a
-  precise fast-path, but TTL-on-silence is simpler, matches the engine's existing `Prune(cutoff)` API,
-  and is correct; the fast-path is an additive refinement.
+- **Resolve probe anomalies only by exact recovery signal (clean result).** Was deferred; **now shipped
+  as an additive fast-path alongside** TTL-on-silence (see §3 as-built). The clean-result signal resolves
+  immediately when a probe reports healthy; TTL-on-silence still backstops a probe that stops reporting
+  entirely. Resolving *only* by clean result remains rejected — a deleted/disabled probe never sends one.
 
 ## Consequences
 

--- a/internal/anomaly/coordinator.go
+++ b/internal/anomaly/coordinator.go
@@ -72,28 +72,42 @@ func (c *Coordinator) Flush(ctx context.Context) error {
 }
 
 // Prune clears instances idle since cutoff and marks exactly those resolved in
-// the store as of cutoff (the idle boundary). Returns the number cleared.
+// the store as of cutoff (the idle boundary). Returns the number cleared. This is
+// the TTL-on-silence resolution path; ResolveSubject is the explicit fast-path.
 func (c *Coordinator) Prune(ctx context.Context, cutoff time.Time) (int, error) {
 	keys := c.engine.pruneKeys(cutoff)
+	return len(keys), c.resolveKeys(ctx, keys, cutoff)
+}
+
+// ResolveSubject clears every live instance for subject (across all defs) and
+// marks exactly those resolved in the store as of `at`. It is the explicit
+// recovery fast-path (ADR-0025 §3): a source that observes a subject return to
+// health resolves its anomalies at once, instead of waiting for Prune's
+// TTL-on-silence. Returns the number cleared; a subject with no active instances
+// is a no-op.
+func (c *Coordinator) ResolveSubject(ctx context.Context, subject SubjectRef, at time.Time) (int, error) {
+	keys := c.engine.clearSubject(subject)
+	return len(keys), c.resolveKeys(ctx, keys, at)
+}
+
+// resolveKeys marks already-cleared instance keys resolved in the store as of
+// `at` and drops any pending dirty marks, so a later Flush cannot resurrect a
+// resolved row. Shared by Prune (idle boundary) and ResolveSubject (explicit
+// recovery). A no-op when keys is empty.
+func (c *Coordinator) resolveKeys(ctx context.Context, keys []instanceKey, at time.Time) error {
 	if len(keys) == 0 {
-		return 0, nil
+		return nil
 	}
 	ids := make([]string, len(keys))
 	for i, k := range keys {
 		ids[i] = k.recordID()
 	}
-	// The pruned instances are gone from the engine; drop any pending dirty
-	// marks so a later Flush does not resurrect a resolved row.
 	c.mu.Lock()
 	for _, k := range keys {
 		delete(c.dirty, k)
 	}
 	c.mu.Unlock()
-
-	if err := c.store.MarkResolved(ctx, ids, cutoff); err != nil {
-		return len(keys), err
-	}
-	return len(keys), nil
+	return c.store.MarkResolved(ctx, ids, at)
 }
 
 // Load seeds the engine from the store's active (unresolved) instances (ADR-0021

--- a/internal/anomaly/coordinator_test.go
+++ b/internal/anomaly/coordinator_test.go
@@ -197,6 +197,87 @@ func TestCoordinatorResolvesOnPrune(t *testing.T) {
 	}
 }
 
+// TestCoordinatorResolveSubject asserts the explicit recovery fast-path clears
+// every live instance for a subject (across all defs) and marks exactly those
+// resolved as of the supplied time, leaving other subjects untouched.
+func TestCoordinatorResolveSubject(t *testing.T) {
+	cat, err := anomaly.NewCatalog(
+		anomaly.Def{
+			ID: "open-ssid", Category: anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityWarning, Title: "Open network",
+			Description: "No encryption.", Recommendation: "Enable WPA2/WPA3.",
+		},
+		anomaly.Def{
+			ID: "weak-cipher", Category: anomaly.CategorySecurity,
+			DefaultSeverity: anomaly.SeverityWarning, Title: "Weak cipher",
+			Description: "Deprecated cipher suite.", Recommendation: "Use AES-CCMP.",
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewCatalog: %v", err)
+	}
+	store := newFakeStore()
+	c := anomaly.NewCoordinator(anomaly.NewEngine(cat), store, anomaly.SourceWiFi)
+	ctx := context.Background()
+	at := time.Unix(1000, 0)
+
+	det := func(def, id string) anomaly.Detection {
+		return anomaly.Detection{DefKey: def, Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: id}}
+	}
+	// Two defs on subject A, one on subject B.
+	for _, d := range []anomaly.Detection{det("open-ssid", "A"), det("weak-cipher", "A"), det("open-ssid", "B")} {
+		if obsErr := c.Observe(ctx, d, at); obsErr != nil {
+			t.Fatalf("Observe %s/%s: %v", d.DefKey, d.Subject.ID, obsErr)
+		}
+	}
+
+	resolveAt := time.Unix(2000, 0)
+	n, err := c.ResolveSubject(ctx, anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: "A"}, resolveAt)
+	if err != nil {
+		t.Fatalf("ResolveSubject: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("ResolveSubject cleared %d, want 2 (both defs on A)", n)
+	}
+	for _, id := range []string{"open-ssid|bssid|A", "weak-cipher|bssid|A"} {
+		if got, ok := store.resolved[id]; !ok {
+			t.Errorf("%s not marked resolved; resolved=%v", id, store.resolved)
+		} else if !got.Equal(resolveAt) {
+			t.Errorf("%s resolved at %v, want %v", id, got, resolveAt)
+		}
+	}
+	if _, live := store.rows["open-ssid|bssid|B"]; !live {
+		t.Errorf("subject B should remain live; rows=%v", store.rows)
+	}
+
+	// A Flush must not resurrect a resolved row.
+	if flushErr := c.Flush(ctx); flushErr != nil {
+		t.Fatalf("Flush: %v", flushErr)
+	}
+	if _, revived := store.rows["open-ssid|bssid|A"]; revived {
+		t.Error("Flush resurrected a resolved instance")
+	}
+}
+
+// TestCoordinatorResolveSubjectUnknownIsNoop asserts resolving a subject with no
+// active instances neither errors nor touches the store.
+func TestCoordinatorResolveSubjectUnknownIsNoop(t *testing.T) {
+	store := newFakeStore()
+	c := newCoord(t, store)
+
+	n, err := c.ResolveSubject(
+		context.Background(),
+		anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: "ghost"},
+		time.Unix(1, 0),
+	)
+	if err != nil {
+		t.Fatalf("ResolveSubject: %v", err)
+	}
+	if n != 0 || len(store.resolved) != 0 {
+		t.Fatalf("unknown subject: cleared=%d resolved=%v, want 0 / empty", n, store.resolved)
+	}
+}
+
 // TestEngineRestoreSeedsActiveInstances asserts Restore repopulates the live set
 // from records (load-on-start) and skips records whose def is uncatalogued.
 func TestEngineRestoreSeedsActiveInstances(t *testing.T) {

--- a/internal/anomaly/engine.go
+++ b/internal/anomaly/engine.go
@@ -221,6 +221,24 @@ func (e *Engine) pruneKeys(cutoff time.Time) []instanceKey {
 	return cleared
 }
 
+// clearSubject removes every live instance for subject (across all defs) and
+// returns their keys, so a source that observes a subject return to health can
+// resolve all of its anomalies at once (the explicit recovery fast-path,
+// ADR-0025 §3). Mirror of pruneKeys, keyed on subject identity rather than idle
+// time.
+func (e *Engine) clearSubject(subject SubjectRef) []instanceKey {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	var cleared []instanceKey
+	for k := range e.active {
+		if k.kind == subject.Kind && k.id == subject.ID {
+			cleared = append(cleared, k)
+			delete(e.active, k)
+		}
+	}
+	return cleared
+}
+
 // project builds the Anomaly view of one tracked instance, merging catalog copy
 // with instance evidence/lifecycle and degrading capability-gated auto
 // follow-ups to prompts. The caller holds e.mu.

--- a/internal/probe/anomaly/producer.go
+++ b/internal/probe/anomaly/producer.go
@@ -180,12 +180,36 @@ func (p *Producer) consume(ctx context.Context) {
 // errors are logged, not fatal — the in-memory engine stays authoritative and
 // the next Flush re-persists. Separated from consume so it is unit-testable
 // without the goroutine.
+//
+// A clean run (no breaches) is the recovery fast-path (ADR-0025 §3): the probe
+// ran and nothing tripped, so any active anomalies for that probe are resolved
+// immediately rather than aging out over the silence window. The maintenance
+// Prune remains the backstop for a probe that goes fully silent (disabled or
+// deleted) and never emits a clean result.
 func (p *Producer) observe(ctx context.Context, re probe.ResultEvent, at time.Time) {
-	for _, d := range Detections(re) {
+	dets := Detections(re)
+	if len(dets) == 0 {
+		p.resolveClean(ctx, re.Result.ProbeID, at)
+		return
+	}
+	for _, d := range dets {
 		if err := p.coord.Observe(ctx, d, at); err != nil {
 			p.logger.WarnContext(ctx, "probe anomaly persist (observe) failed",
 				"defKey", d.DefKey, "probeID", d.Subject.ID, "error", err)
 		}
+	}
+}
+
+// resolveClean resolves every active anomaly for a recovered probe. A blank
+// probe ID (a malformed event) is skipped — there is no subject to key on.
+func (p *Producer) resolveClean(ctx context.Context, probeID string, at time.Time) {
+	if probeID == "" {
+		return
+	}
+	subject := anomaly.SubjectRef{Kind: anomaly.SubjectProbe, ID: probeID}
+	if _, err := p.coord.ResolveSubject(ctx, subject, at); err != nil {
+		p.logger.WarnContext(ctx, "probe anomaly persist (resolve-on-clean) failed",
+			"probeID", probeID, "error", err)
 	}
 }
 

--- a/internal/probe/anomaly/producer_internal_test.go
+++ b/internal/probe/anomaly/producer_internal_test.go
@@ -58,6 +58,56 @@ func latencyEvent(probeID string) probe.ResultEvent {
 	}
 }
 
+// cleanEvent is a successful probe run with no threshold breaches.
+func cleanEvent(probeID string) probe.ResultEvent {
+	return probe.ResultEvent{Result: probe.Result{ProbeID: probeID, Kind: "http", Success: true}}
+}
+
+// TestObserveCleanResultResolvesImmediately asserts the recovery fast-path
+// (ADR-0025 §3): a clean run for a probe with an active anomaly resolves it right
+// away rather than waiting out the silence window.
+func TestObserveCleanResultResolvesImmediately(t *testing.T) {
+	t.Parallel()
+	fs := &fakeStore{}
+	p, err := New(nil, fs, WithResolveWindow(time.Hour))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx := context.Background()
+	t0 := time.Unix(3000, 0).UTC()
+	p.observe(ctx, latencyEvent("p1"), t0) // active anomaly
+
+	// A clean run resolves it immediately — no flushAndPrune / silence wait.
+	p.observe(ctx, cleanEvent("p1"), t0.Add(time.Minute))
+
+	_, _, res := fs.snapshot()
+	wantID := anomaly.RecordID(DefHighLatency, anomaly.SubjectRef{Kind: anomaly.SubjectProbe, ID: "p1"})
+	if len(res) != 1 || res[0] != wantID {
+		t.Fatalf("want %q resolved on clean result, got %v", wantID, res)
+	}
+	if n := p.coord.Engine().Len(); n != 0 {
+		t.Errorf("engine still tracks %d instances after clean result, want 0", n)
+	}
+}
+
+// TestObserveCleanResultNoActiveIsNoop asserts a clean run for a probe with no
+// active anomalies neither writes nor resolves anything.
+func TestObserveCleanResultNoActiveIsNoop(t *testing.T) {
+	t.Parallel()
+	fs := &fakeStore{}
+	p, err := New(nil, fs)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.observe(context.Background(), cleanEvent("ghost"), time.Unix(1, 0).UTC())
+
+	upserts, rows, res := fs.snapshot()
+	if upserts != 0 || len(rows) != 0 || len(res) != 0 {
+		t.Fatalf("clean run with no active anomaly touched the store: upserts=%d rows=%d resolved=%v",
+			upserts, len(rows), res)
+	}
+}
+
 func TestObservePersistsThroughCoordinator(t *testing.T) {
 	t.Parallel()
 	fs := &fakeStore{}


### PR DESCRIPTION
## What

Adds the explicit clean-result recovery fast-path for probe anomalies that ADR-0025 §3 flagged as an additive refinement.

Previously probe anomalies resolved **only** by TTL-on-silence: a recovered probe stops breaching and its anomaly ages out via the maintenance `Prune` after `resolveWindow` (~15m). Now a probe `ResultEvent` with **zero breaches** resolves every active anomaly for that probe (`SubjectProbe` keyed by `ProbeID`) **immediately**.

The maintenance `Prune` stays as the backstop for a probe that goes **fully silent** (disabled/deleted) and never emits a clean result to trigger the fast-path. So recovery is immediate when the probe reports healthy, and bounded by `resolveWindow` when it stops reporting entirely.

## Changes

- `anomaly.Engine.clearSubject` — remove all live instances for a subject across defs, returning their keys (mirror of `pruneKeys`, keyed on subject identity).
- `anomaly.Coordinator.ResolveSubject` — clear a subject's instances and mark exactly those resolved in the store; extracted `resolveKeys` now shared with `Prune` (DRY).
- `probeanomaly.Producer.observe` — a no-breach event resolves the probe subject via the Coordinator; a blank `ProbeID` is skipped.
- ADR-0025 §3 + Alternatives updated to as-built.

## Tests (TDD, RED→GREEN)

- `TestCoordinatorResolveSubject` — clears both defs on a subject, leaves other subjects live, resolves at the supplied time, Flush can't resurrect.
- `TestCoordinatorResolveSubjectUnknownIsNoop` — unknown subject = 0 cleared, store untouched.
- `TestObserveCleanResultResolvesImmediately` — clean run resolves an active anomaly without waiting the window; engine no longer tracks it.
- `TestObserveCleanResultNoActiveIsNoop` — clean run with no active anomaly writes/resolves nothing.

## Gates

- `go build ./internal/...` ✅
- `go test -race -count=1 ./internal/anomaly/ ./internal/probe/anomaly/` ✅
- `golangci-lint run --new-from-rev=origin/main` → 0 issues ✅
- gofmt clean, gitleaks clean ✅
- No migration, no API routes, no frontend touched.