### PR TITLE
feat(probe): detect TLS certificate expiry as a probe anomaly

### DIFF
--- a/docs/architecture/decisions/0025-probe-is-the-active-monitoring-anomaly-source.md
+++ b/docs/architecture/decisions/0025-probe-is-the-active-monitoring-anomaly-source.md
@@ -74,6 +74,25 @@ pattern the Wi-Fi visibility producer uses, applied to a push channel rather tha
   threshold shapes). `Breach.Field` selects the `defKey`; `Breach.Severity` overrides the catalog
   default; `Field`/`Threshold`/`Actual`/`Kind`/`Target` become the detection evidence.
 
+**As-built (2026-06-11) — cert-expiry is the first kind-specific threshold beyond latency/success.**
+Catalog growth must ship *with* a real breach-emission path (defs matching emitted breaches, not
+speculative stubs). The probe engine previously emitted only `success` (bool) and `latency_ms` (float)
+breaches; the TLS checker computed certificate days-remaining into `Result.Metadata.days_remaining` but
+never threshold-evaluated it. This slice closes that gap end-to-end:
+- `genericThreshold` gains `cert_days_remaining` (int) in the per-probe `Warning`/`Critical` JSON,
+  evaluated centrally in `evaluateThresholds` like `latency_ms` — but **inverted**: a breach fires when
+  remaining days fall *below* the bound (fewer is worse; a negative value is an already-expired cert).
+- The actual value is read from `Result.Metadata.days_remaining` via a pointer field, so "absent"
+  (a non-TLS probe) is distinct from a real zero/negative — the gate **auto-scopes** to cert-bearing
+  probes without the engine knowing about TLS. The JSON field name is the only coupling (the contract
+  with the checker's `TLSCertInfo`), kept in the shared `probe` package.
+- New `DefCertExpiry` (`probe-cert-expiry`, cites RFC 5280 §4.1.2.5) + a `defKeyForField` case for
+  `cert_days_remaining`. The generic `DefThresholdBreach` stays as the fallback for still-unmapped
+  fields (e.g. a future BGP state field). Severity stays **warning/critical** from the two thresholds —
+  cert-expiry is naturally two-tier, so `SeverityError` is not shoehorned in here (it remains for
+  genuinely error-tier defs as the catalog grows). DNS-failure and BGP defs remain deferred: no checker
+  emits a kind-specific breach for them yet.
+
 ### 3. Resolution is push-model TTL-on-silence
 
 Unlike the Wi-Fi producer, which re-snapshots the full live set each evaluation and prunes anything

--- a/internal/probe/anomaly/catalog.go
+++ b/internal/probe/anomaly/catalog.go
@@ -17,8 +17,12 @@ const (
 	DefUnreachable = "probe-unreachable"
 	// DefHighLatency is a latency threshold breach (Breach.Field == "latency_ms").
 	DefHighLatency = "probe-high-latency"
+	// DefCertExpiry is a certificate nearing or past expiry (Breach.Field ==
+	// "cert_days_remaining"): a TLS-family probe's leaf certificate has fewer days
+	// left than the configured warning/critical bound.
+	DefCertExpiry = "probe-cert-expiry"
 	// DefThresholdBreach is the generic fallback for any other breached field a
-	// checker reports (cert days-remaining, BGP state, …) before that field has a
+	// checker reports (e.g. a future BGP state field) before that field has a
 	// dedicated def. It keeps a breach from being silently dropped.
 	DefThresholdBreach = "probe-threshold-breach"
 )
@@ -65,13 +69,31 @@ func Defs() []anomaly.Def {
 				"correlate with other probes sharing the path.",
 		},
 		{
+			ID:              DefCertExpiry,
+			Category:        anomaly.CategoryNetHealth,
+			DefaultSeverity: anomaly.SeverityWarning,
+			Standards:       []string{"RFC 5280 §4.1.2.5"},
+			Title:           "TLS certificate nearing expiry",
+			Description: "A TLS probe's leaf certificate has fewer days remaining than its " +
+				"configured warning or critical bound (a negative value means the certificate " +
+				"has already expired). The handshake still succeeds, so the target is reachable, " +
+				"but the certificate needs renewal.",
+			Impact: "Once the certificate expires, clients that validate it will refuse the " +
+				"connection, causing an outage of the service this probe checks. Renewing late " +
+				"risks the gap between expiry and replacement.",
+			Recommendation: "Renew or rotate the certificate before it expires. Confirm the " +
+				"automated renewal pipeline (for example ACME) is healthy, and check the " +
+				"certificate's issuer and chain in the anomaly evidence.",
+		},
+		{
 			ID:              DefThresholdBreach,
 			Category:        anomaly.CategoryNetHealth,
 			DefaultSeverity: anomaly.SeverityWarning,
 			Title:           "Monitored target threshold breach",
 			Description: "A scheduled probe reported a value outside its configured " +
-				"threshold for a check-specific field (for example a certificate's remaining " +
-				"days, or a protocol-state field). The exact field is in the anomaly evidence.",
+				"threshold for a check-specific field (for example a protocol-state field) " +
+				"that does not yet have a dedicated anomaly type. The exact field is in the " +
+				"anomaly evidence.",
 			Impact: "A monitored condition has crossed the operator's defined bound and " +
 				"needs attention before it escalates to an outage.",
 			Recommendation: "Read the breached field, threshold, and actual value in the " +

--- a/internal/probe/anomaly/detect.go
+++ b/internal/probe/anomaly/detect.go
@@ -37,6 +37,8 @@ func defKeyForField(field string) string {
 		return DefUnreachable
 	case "latency_ms":
 		return DefHighLatency
+	case "cert_days_remaining":
+		return DefCertExpiry
 	default:
 		return DefThresholdBreach
 	}

--- a/internal/probe/anomaly/detect_test.go
+++ b/internal/probe/anomaly/detect_test.go
@@ -19,6 +19,7 @@ func TestCatalogBuildsAndCoversMappedDefs(t *testing.T) {
 	for _, id := range []string{
 		probeanomaly.DefUnreachable,
 		probeanomaly.DefHighLatency,
+		probeanomaly.DefCertExpiry,
 		probeanomaly.DefThresholdBreach,
 	} {
 		if _, ok := cat.Lookup(id); !ok {
@@ -70,20 +71,36 @@ func TestDetectionsMapsBreaches(t *testing.T) {
 			wantDef: probeanomaly.DefUnreachable, wantSev: anomaly.SeverityCritical, wantSubID: "p2",
 		},
 		{
-			name: "unknown field -> generic threshold breach",
+			name: "cert days-remaining breach -> cert-expiry",
 			event: probe.ResultEvent{
 				Result: probe.Result{ProbeID: "p3", Kind: "tls"},
 				Breaches: []probe.Breach{
 					{
 						ProbeID:   "p3",
-						Severity:  "warning",
+						Severity:  "critical",
 						Field:     "cert_days_remaining",
-						Threshold: 14,
+						Threshold: 7,
 						Actual:    3,
 					},
 				},
 			},
-			wantDef: probeanomaly.DefThresholdBreach, wantSev: anomaly.SeverityWarning, wantSubID: "p3",
+			wantDef: probeanomaly.DefCertExpiry, wantSev: anomaly.SeverityCritical, wantSubID: "p3",
+		},
+		{
+			name: "still-unmapped field -> generic threshold breach",
+			event: probe.ResultEvent{
+				Result: probe.Result{ProbeID: "p4", Kind: "bgp"},
+				Breaches: []probe.Breach{
+					{
+						ProbeID:   "p4",
+						Severity:  "warning",
+						Field:     "bgp_state",
+						Threshold: "established",
+						Actual:    "idle",
+					},
+				},
+			},
+			wantDef: probeanomaly.DefThresholdBreach, wantSev: anomaly.SeverityWarning, wantSubID: "p4",
 		},
 	}
 

--- a/internal/probe/engine.go
+++ b/internal/probe/engine.go
@@ -181,60 +181,93 @@ func (e *Engine) emit(re ResultEvent) {
 
 // evaluateThresholds compares a Result against the Warning and
 // Critical threshold JSON on the Probe. Returns one Breach per
-// violated rule. V1.0 supports latency_ms thresholds; kind-specific
-// thresholds (cert days_remaining, BGP state, etc.) are added per-
-// checker in A1.4+ via custom JSON shapes the Checker reads
-// directly from p.Critical / p.Warning before returning Result.
+// violated rule. Two metrics are gated centrally today: latency_ms
+// (breach when actual EXCEEDS the bound — higher is worse) and
+// cert_days_remaining (breach when actual falls BELOW the bound —
+// fewer days is worse). The cert metric is read from
+// Result.Metadata.days_remaining, which only TLS-family checkers
+// publish, so it auto-scopes to cert-bearing probes. Further
+// kind-specific metrics (BGP state, etc.) add a field to
+// genericThreshold and a gate here as their checkers expose them.
 func evaluateThresholds(p Probe, r Result) []Breach {
 	var breaches []Breach
-	if warn := parseGenericThreshold(p.Warning); warn != nil {
-		if warn.LatencyMs > 0 && r.LatencyMs > warn.LatencyMs {
-			breaches = append(breaches, Breach{
-				ProbeID:   p.ID,
-				ClientID:  p.ClientID,
-				Severity:  "warning",
-				Field:     "latency_ms",
-				Threshold: warn.LatencyMs,
-				Actual:    r.LatencyMs,
-				Timestamp: r.Timestamp,
-			})
+	warn := parseGenericThreshold(p.Warning)
+	crit := parseGenericThreshold(p.Critical)
+
+	// latency_ms: breach when the measured value exceeds the bound.
+	if warn != nil && warn.LatencyMs > 0 && r.LatencyMs > warn.LatencyMs {
+		breaches = append(breaches, breachOf(p, r, "warning", "latency_ms", warn.LatencyMs, r.LatencyMs))
+	}
+	if crit != nil && crit.LatencyMs > 0 && r.LatencyMs > crit.LatencyMs {
+		breaches = append(breaches, breachOf(p, r, "critical", "latency_ms", crit.LatencyMs, r.LatencyMs))
+	}
+
+	// cert_days_remaining: breach when the certificate's remaining days
+	// fall below the bound (inverted from latency). Only evaluated when the
+	// probe published days_remaining in its metadata — a non-TLS probe has
+	// none and skips the gate.
+	if days, ok := certDaysRemaining(r); ok {
+		if warn != nil && warn.CertDaysRemaining > 0 && days < warn.CertDaysRemaining {
+			breaches = append(breaches, breachOf(p, r, "warning", "cert_days_remaining", warn.CertDaysRemaining, days))
+		}
+		if crit != nil && crit.CertDaysRemaining > 0 && days < crit.CertDaysRemaining {
+			breaches = append(breaches, breachOf(p, r, "critical", "cert_days_remaining", crit.CertDaysRemaining, days))
 		}
 	}
-	if crit := parseGenericThreshold(p.Critical); crit != nil {
-		if crit.LatencyMs > 0 && r.LatencyMs > crit.LatencyMs {
-			breaches = append(breaches, Breach{
-				ProbeID:   p.ID,
-				ClientID:  p.ClientID,
-				Severity:  "critical",
-				Field:     "latency_ms",
-				Threshold: crit.LatencyMs,
-				Actual:    r.LatencyMs,
-				Timestamp: r.Timestamp,
-			})
-		}
-	}
+
 	// Success=false always breaches at critical when no other
 	// threshold matched. Lets every probe at minimum surface "this
 	// failed" to the alerts pipeline.
 	if !r.Success && len(breaches) == 0 {
-		breaches = append(breaches, Breach{
-			ProbeID:   p.ID,
-			ClientID:  p.ClientID,
-			Severity:  "critical",
-			Field:     "success",
-			Threshold: true,
-			Actual:    false,
-			Timestamp: r.Timestamp,
-		})
+		breaches = append(breaches, breachOf(p, r, "critical", "success", true, false))
 	}
 	return breaches
 }
 
-// genericThreshold is the V1.0 base threshold shape. Checkers that
-// need kind-specific fields (e.g. cert_days_remaining for TLS)
-// embed this and add their own.
+// breachOf builds a Breach for a violated threshold, stamping the probe/client
+// identity and result timestamp shared by every breach. Threshold and actual are
+// any so each metric supplies its own value type (float latency, int days, bool
+// success).
+func breachOf(p Probe, r Result, severity, field string, threshold, actual any) Breach {
+	return Breach{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Severity:  severity,
+		Field:     field,
+		Threshold: threshold,
+		Actual:    actual,
+		Timestamp: r.Timestamp,
+	}
+}
+
+// genericThreshold is the threshold shape parsed from a probe's Warning/Critical
+// JSON. Each field is one centrally-gated metric (see evaluateThresholds); a
+// zero value means that metric is unconfigured for this probe.
 type genericThreshold struct {
-	LatencyMs float64 `json:"latency_ms,omitempty"`
+	LatencyMs         float64 `json:"latency_ms,omitempty"`
+	CertDaysRemaining int     `json:"cert_days_remaining,omitempty"`
+}
+
+// certMetadata is the slice of a TLS-family probe's Result.Metadata the cert
+// gate reads. The JSON field name is the contract with the TLS checker's
+// TLSCertInfo (internal/probe/checkers); a pointer distinguishes "absent" (a
+// non-TLS probe) from a real zero/negative days-remaining (an expired cert).
+type certMetadata struct {
+	DaysRemaining *int `json:"days_remaining"`
+}
+
+// certDaysRemaining extracts the certificate days-remaining a TLS-family probe
+// publishes in Result.Metadata. The bool is false when the field is absent, so a
+// probe that does not report a certificate skips the cert gate entirely.
+func certDaysRemaining(r Result) (int, bool) {
+	if len(r.Metadata) == 0 {
+		return 0, false
+	}
+	var m certMetadata
+	if err := json.Unmarshal(r.Metadata, &m); err != nil || m.DaysRemaining == nil {
+		return 0, false
+	}
+	return *m.DaysRemaining, true
 }
 
 // parseGenericThreshold decodes a threshold JSON blob into the

--- a/internal/probe/engine_test.go
+++ b/internal/probe/engine_test.go
@@ -176,6 +176,126 @@ func TestEngine_Thresholds_CriticalLatency(t *testing.T) {
 	}
 }
 
+// TestEngine_Thresholds_CertExpiry covers the certificate days-remaining gate.
+// Unlike latency (breach when actual exceeds the bound), cert-expiry breaches
+// when the remaining days fall BELOW the bound — fewer days is worse. The actual
+// value is read from Result.Metadata.days_remaining, which only TLS-family
+// checkers publish, so a probe without that metadata skips the gate entirely.
+func TestEngine_Thresholds_CertExpiry(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		metadata     string // Result.Metadata JSON ("" = none, e.g. a non-TLS probe)
+		warning      string // Probe.Warning JSON
+		critical     string // Probe.Critical JSON
+		wantBreaches int
+		wantSevs     []string // severities expected, any order
+	}{
+		{
+			name:         "below warning fires warning",
+			metadata:     `{"days_remaining": 20}`,
+			warning:      `{"cert_days_remaining": 30}`,
+			wantBreaches: 1,
+			wantSevs:     []string{"warning"},
+		},
+		{
+			name:         "below both fires warning and critical",
+			metadata:     `{"days_remaining": 3}`,
+			warning:      `{"cert_days_remaining": 30}`,
+			critical:     `{"cert_days_remaining": 7}`,
+			wantBreaches: 2,
+			wantSevs:     []string{"warning", "critical"},
+		},
+		{
+			name:         "expired cert (negative days) fires critical",
+			metadata:     `{"days_remaining": -5}`,
+			critical:     `{"cert_days_remaining": 7}`,
+			wantBreaches: 1,
+			wantSevs:     []string{"critical"},
+		},
+		{
+			name:         "healthy cert above threshold does not breach",
+			metadata:     `{"days_remaining": 90}`,
+			warning:      `{"cert_days_remaining": 30}`,
+			wantBreaches: 0,
+		},
+		{
+			name:         "no cert metadata skips the gate",
+			metadata:     "",
+			warning:      `{"cert_days_remaining": 30}`,
+			wantBreaches: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			e := probe.NewEngine(silentLogger())
+			e.RegisterChecker(&fakeChecker{
+				kind: "tls",
+				result: probe.Result{
+					Success:  true, // a TLS handshake to an expiring cert still succeeds
+					Metadata: rawOrNil(tc.metadata),
+				},
+			})
+			sub := e.Subscribe()
+
+			p := probe.Probe{
+				ID:       "p-1",
+				Kind:     "tls",
+				Warning:  rawOrNil(tc.warning),
+				Critical: rawOrNil(tc.critical),
+			}
+			e.RunDefinition(context.Background(), p)
+
+			evt := waitForEvent(t, sub)
+			if len(evt.Breaches) != tc.wantBreaches {
+				t.Fatalf("got %d breaches, want %d: %+v", len(evt.Breaches), tc.wantBreaches, evt.Breaches)
+			}
+			gotSevs := certBreachSeverities(t, evt.Breaches)
+			for _, want := range tc.wantSevs {
+				if !gotSevs[want] {
+					t.Errorf("missing %q breach; got %v", want, gotSevs)
+				}
+			}
+		})
+	}
+}
+
+// waitForEvent reads one ResultEvent from sub or fails after a timeout.
+func waitForEvent(t *testing.T, sub <-chan probe.ResultEvent) probe.ResultEvent {
+	t.Helper()
+	select {
+	case evt := <-sub:
+		return evt
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+		return probe.ResultEvent{}
+	}
+}
+
+// certBreachSeverities asserts every breach is on the cert field and returns the
+// set of severities seen, so a test can check which thresholds fired.
+func certBreachSeverities(t *testing.T, breaches []probe.Breach) map[string]bool {
+	t.Helper()
+	sevs := map[string]bool{}
+	for _, b := range breaches {
+		if b.Field != "cert_days_remaining" {
+			t.Errorf("Breach.Field = %q, want %q", b.Field, "cert_days_remaining")
+		}
+		sevs[b.Severity] = true
+	}
+	return sevs
+}
+
+// rawOrNil returns nil for an empty string so a test case can express "no JSON
+// configured" distinctly from an empty object.
+func rawOrNil(s string) json.RawMessage {
+	if s == "" {
+		return nil
+	}
+	return json.RawMessage(s)
+}
+
 func TestEngine_FailedProbe_AlwaysBreaches(t *testing.T) {
 	t.Parallel()
 	e := probe.NewEngine(silentLogger())


### PR DESCRIPTION
## What

First **kind-specific probe threshold beyond latency/success** — and the template for catalog growth (a def ships *with* a real breach-emission path, not as a speculative stub). Implements loose-end #2 from the unified anomaly platform (`~/.claude/plans/unified-anomaly-platform.md`), reframed by the audit that found the probe engine emitted only `success`+`latency_ms` breaches.

The TLS checker already computed certificate days-remaining into `Result.Metadata.days_remaining` but **never threshold-evaluated it** — so a cert nearing or past expiry surfaced no anomaly. This closes that gap end-to-end.

## Design (architecture-consistent)

- Threshold evaluation stays **centralized** in `engine.evaluateThresholds` — checkers still only return `Result`, never construct `Breach`es (unchanged contract).
- `genericThreshold` gains `cert_days_remaining` (int) in the per-probe `Warning`/`Critical` JSON, gated like `latency_ms` but **inverted**: a breach fires when remaining days fall *below* the bound (fewer is worse; a negative value = already-expired cert).
- The actual value is read from `Result.Metadata.days_remaining` via a **pointer** field, so "absent" (a non-TLS probe) is distinct from a real zero/negative — the gate **auto-scopes** to cert-bearing probes without the engine knowing about TLS. The JSON field name is the only coupling (contract with the checker's `TLSCertInfo`), kept in the shared `probe` package.
- Extracted `breachOf` to DRY the five breach-construction sites.
- New `DefCertExpiry` (`probe-cert-expiry`, cites **RFC 5280 §4.1.2.5**) + a `defKeyForField` case for `cert_days_remaining`. `DefThresholdBreach` stays the fallback for still-unmapped fields (e.g. a future BGP state field).

## Design note on severity

Cert-expiry severity stays **warning/critical** from the two thresholds — it's naturally two-tier (approaching vs imminent/expired), so `SeverityError` is **not shoehorned** in here. It remains for genuinely error-tier defs as the catalog grows. DNS-failure and BGP defs stay deferred: no checker emits a kind-specific breach for them yet (authoring them now would be the unfed-stub anti-pattern).

## Tests (TDD, RED→GREEN)

- `TestEngine_Thresholds_CertExpiry` (table-driven): below-warning fires warning; below-both fires warning+critical; expired (negative days) fires critical; healthy cert no breach; **no cert metadata skips the gate** (non-TLS probe).
- `detect_test.go`: `cert_days_remaining` → `DefCertExpiry`; added a still-unmapped-field (`bgp_state`) → `DefThresholdBreach` case to keep the fallback covered; `DefCertExpiry` added to catalog-coverage assertion.

## Gates

- `go build ./...` ✅
- `go test -race -count=1 ./internal/probe/ ./internal/probe/anomaly/` ✅
- `golangci-lint run --new-from-rev=origin/main ./internal/probe/...` → 0 issues ✅
- gofmt + gitleaks clean ✅
- No migration, no API routes, no frontend (verified: no `ui/src` references the threshold fields; no golden enumerates the catalog).

ADR-0025 §2 updated to as-built.