### PR TITLE
feat(probe): add eight health-check vertical checkers (ADR-0027 P1)

### DIFF
--- a/docs/architecture/decisions/0027-migrate-health-checks-onto-probe.md
+++ b/docs/architecture/decisions/0027-migrate-health-checks-onto-probe.md
@@ -1,6 +1,21 @@
 # ADR-0027: Migrate the on-demand health-check stack onto the probe engine, then rename the transport
 
-**Status:** Proposed — 2026-06-11 (scoping ADR; no code in this change)
+**Status:** Accepted — 2026-06-11 (scoping ADR; P1 implemented)
+
+> **P1 as-built (2026-06-11).** The eight vertical checkers landed as `probe.Checker`
+> implementations under `internal/probe/checkers/` (`hl7.go`, `fhir.go`, `sql.go`,
+> `fileshare.go`, `ldap.go`, `lti.go`, `opcua.go`, `modbus.go`), each registered in the
+> engine in `server.go`. HL7 (MLLP ACK), FHIR (CapabilityStatement), LTI (HEAD), OPC-UA
+> (Hello probe), and Modbus (read-register ADU) port the legacy protocol behavior faithfully.
+> SQL, FileShare, and LDAP port the **honest working** behavior only — TCP/TLS reachability —
+> because the legacy `sql.Open`/driver, SMB/NFS local-mount perf test, and LDAP bind/search
+> paths were dead or library-dependent (no driver/library is imported in the module). Those
+> deeper capabilities are deferred and noted in each checker's doc comment; adding a real
+> SQL driver or LDAP library is a separate, security-scanned dependency decision.
+> No new threshold field or catalog `Def` was needed: `success`→`probe-unreachable` and
+> `latency_ms`→`probe-high-latency` already cover the breach side (ADR-0025), and protocol
+> detail (ACK code, FHIR version, register value) is surfaced as informational `Result.Metadata`.
+> P2–P5 (settings storage, `/run` rewire + legacy deletion, frontend, transport rename) follow.
 
 ## Context
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -458,8 +458,8 @@ func (s *Server) initProbeEngine(db *database.DB) {
 	probeEngine := probe.NewEngine(logging.GetLogger()).
 		WithStorage(db.Probes(), sched)
 
-	// Register V1.0 baseline checkers. Stage A1.7 will absorb the
-	// remaining 11 internal/api/health_checks_*.go kinds.
+	// Register V1.0 baseline checkers plus the health-check vertical
+	// checkers absorbed onto the probe engine (ADR-0027 P1).
 	probeEngine.RegisterChecker(checkers.NewDNSChecker())
 	probeEngine.RegisterChecker(checkers.NewTLSChecker())
 	probeEngine.RegisterChecker(checkers.NewPingChecker())
@@ -469,6 +469,14 @@ func (s *Server) initProbeEngine(db *database.DB) {
 	probeEngine.RegisterChecker(checkers.NewHTTPSChecker())
 	probeEngine.RegisterChecker(checkers.NewRTSPChecker())
 	probeEngine.RegisterChecker(checkers.NewDICOMChecker())
+	probeEngine.RegisterChecker(checkers.NewHL7Checker())
+	probeEngine.RegisterChecker(checkers.NewFHIRChecker())
+	probeEngine.RegisterChecker(checkers.NewSQLChecker())
+	probeEngine.RegisterChecker(checkers.NewFileShareChecker())
+	probeEngine.RegisterChecker(checkers.NewLDAPChecker())
+	probeEngine.RegisterChecker(checkers.NewLTIChecker())
+	probeEngine.RegisterChecker(checkers.NewOPCUAChecker())
+	probeEngine.RegisterChecker(checkers.NewModbusChecker())
 
 	s.probeEngine = probeEngine
 	s.probeScheduler = sched

--- a/internal/probe/checkers/dicom.go
+++ b/internal/probe/checkers/dicom.go
@@ -155,8 +155,8 @@ func (c *DICOMChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
 
 	pduType := hdr[0]
 	meta, _ := json.Marshal(map[string]any{
-		"addr":     addr,
-		"pdu_type": pduType,
+		metaKeyAddr: addr,
+		"pdu_type":  pduType,
 	})
 
 	if pduType != dicomPDUTypeAAssociateAC {

--- a/internal/probe/checkers/fhir.go
+++ b/internal/probe/checkers/fhir.go
@@ -1,0 +1,224 @@
+package checkers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// defaultFHIRTimeout is the default request timeout for FHIR metadata probes.
+const defaultFHIRTimeout = 30 * time.Second
+
+// fhirMaxResponseBody caps the body read to 1 MiB, matching the legacy handler.
+const fhirMaxResponseBody = 1 << 20
+
+// FHIRParams is the kind-specific params shape for Kind="fhir".
+// All fields are optional; AuthType defaults to "none".
+type FHIRParams struct {
+	AuthType    string `json:"auth_type,omitempty"`    // none|basic|bearer|oauth2, default none
+	Username    string `json:"username,omitempty"`     // required for basic
+	Password    string `json:"password,omitempty"`     // used with basic
+	BearerToken string `json:"bearer_token,omitempty"` // required for bearer/oauth2
+	TimeoutMs   int    `json:"timeout_ms,omitempty"`   // default 30000
+}
+
+// fhirCapabilityStatement represents the relevant fields of a FHIR
+// CapabilityStatement resource (HL7 FHIR R4 §2.22).
+type fhirCapabilityStatement struct {
+	ResourceType string `json:"resourceType"`
+	FHIRVersion  string `json:"fhirVersion"`
+	Software     struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"software"`
+	Rest []struct {
+		Mode     string `json:"mode"`
+		Resource []struct {
+			Type string `json:"type"`
+		} `json:"resource"`
+	} `json:"rest"`
+}
+
+// FHIRChecker implements probe.Checker for Kind="fhir". It GETs the
+// FHIR /metadata endpoint and validates the returned CapabilityStatement.
+type FHIRChecker struct {
+	doer  HTTPDoer
+	clock func() time.Time
+}
+
+// NewFHIRChecker returns a FHIRChecker wired to a real HTTP client
+// built per-Run from the probe params (timeout, auth).
+func NewFHIRChecker() *FHIRChecker {
+	return &FHIRChecker{clock: time.Now}
+}
+
+// WithFHIRDoer overrides the default per-request client; used by tests
+// to inject a fake HTTPDoer.
+func (c *FHIRChecker) WithFHIRDoer(d HTTPDoer) *FHIRChecker {
+	c.doer = d
+	return c
+}
+
+// Kind returns probe.KindFHIR ("fhir").
+func (c *FHIRChecker) Kind() string { return probe.KindFHIR }
+
+// RequiredCapabilities returns nil; FHIR probes need no special hardware.
+func (c *FHIRChecker) RequiredCapabilities() []string { return nil }
+
+// Run GETs <Target>/metadata, parses the FHIR CapabilityStatement, and
+// reports Success=true when the response is 200 and the document is valid.
+// Metadata includes status_code, fhir_version, server_name, and resource_count.
+func (c *FHIRChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
+	params := parseFHIRParams(p.Params)
+
+	timeout := defaultFHIRTimeout
+	if params.TimeoutMs > 0 {
+		timeout = time.Duration(params.TimeoutMs) * time.Millisecond
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Build the FHIR metadata URL from the probe Target.
+	metadataURL := strings.TrimSuffix(p.Target, "/") + "/metadata"
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, metadataURL, http.NoBody)
+	if err != nil {
+		return fhirFailResult(p, c.clock().UTC(), 0, fmt.Sprintf("invalid request: %v", err))
+	}
+	req.Header.Set("Accept", "application/fhir+json")
+
+	// Apply authentication before sending.
+	if authErr := fhirApplyAuth(req, params); authErr != nil {
+		return fhirFailResult(p, c.clock().UTC(), 0, fmt.Sprintf("authentication failed: %v", authErr))
+	}
+
+	doer := c.doer
+	if doer == nil {
+		doer = &http.Client{Timeout: timeout}
+	}
+
+	start := c.clock()
+	resp, err := doer.Do(req)
+	latencyMs := float64(c.clock().Sub(start).Milliseconds())
+	if err != nil {
+		return fhirFailResult(p, c.clock().UTC(), latencyMs, err.Error())
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fhirFailResult(p, c.clock().UTC(), latencyMs,
+			fmt.Sprintf("Unexpected status: %d", resp.StatusCode))
+	}
+
+	// Read and parse the CapabilityStatement (body capped at 1 MiB).
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, fhirMaxResponseBody))
+	if readErr != nil {
+		return fhirFailResult(p, c.clock().UTC(), latencyMs,
+			fmt.Sprintf("failed to read response: %v", readErr))
+	}
+
+	var capStmt fhirCapabilityStatement
+	if parseErr := json.Unmarshal(body, &capStmt); parseErr != nil {
+		return fhirFailResult(p, c.clock().UTC(), latencyMs,
+			fmt.Sprintf("failed to parse CapabilityStatement: %v", parseErr))
+	}
+
+	// Build a composite server_name from software.name + software.version.
+	serverName := capStmt.Software.Name
+	if capStmt.Software.Version != "" {
+		serverName += " " + capStmt.Software.Version
+	}
+
+	// Count resource types across all REST conformance groups.
+	resourceCount := 0
+	for _, rest := range capStmt.Rest {
+		resourceCount += len(rest.Resource)
+	}
+
+	meta, _ := json.Marshal(map[string]any{
+		"status_code":    resp.StatusCode,
+		"fhir_version":   capStmt.FHIRVersion,
+		"server_name":    serverName,
+		"resource_count": resourceCount,
+	})
+
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: c.clock().UTC(),
+		Success:   true,
+		LatencyMs: latencyMs,
+		Metadata:  meta,
+	}
+}
+
+// fhirFailResult builds a failed Result with a timestamp and latency.
+func fhirFailResult(p probe.Probe, ts time.Time, latencyMs float64, msg string) probe.Result {
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: ts,
+		Success:   false,
+		LatencyMs: latencyMs,
+		Error:     msg,
+	}
+}
+
+// fhirApplyAuth sets the appropriate Authorization header on req based
+// on params.AuthType. Mirrors the legacy applyFHIRAuth logic exactly.
+func fhirApplyAuth(req *http.Request, params FHIRParams) error {
+	switch strings.ToLower(params.AuthType) {
+	case "", "none":
+		// No authentication required.
+		return nil
+
+	case "basic":
+		if params.Username == "" {
+			return errors.New("basic auth requires username")
+		}
+		encoded := base64.StdEncoding.EncodeToString(
+			[]byte(params.Username + ":" + params.Password),
+		)
+		req.Header.Set("Authorization", "Basic "+encoded)
+
+	case "bearer":
+		if params.BearerToken == "" {
+			return errors.New("bearer auth requires token")
+		}
+		req.Header.Set("Authorization", "Bearer "+params.BearerToken)
+
+	case "oauth2":
+		// Simplified OAuth2: expects a pre-obtained bearer token.
+		if params.BearerToken != "" {
+			req.Header.Set("Authorization", "Bearer "+params.BearerToken)
+		} else {
+			return errors.New("oauth2 auth requires token_url and credentials (not yet implemented)")
+		}
+
+	default:
+		return fmt.Errorf("unknown auth type: %s", params.AuthType)
+	}
+
+	return nil
+}
+
+// parseFHIRParams deserialises Probe.Params into FHIRParams. An empty
+// or nil message returns the zero value (all defaults).
+func parseFHIRParams(raw json.RawMessage) FHIRParams {
+	if len(raw) == 0 {
+		return FHIRParams{}
+	}
+	var p FHIRParams
+	_ = json.Unmarshal(raw, &p)
+	return p
+}

--- a/internal/probe/checkers/fhir_test.go
+++ b/internal/probe/checkers/fhir_test.go
@@ -1,0 +1,233 @@
+package checkers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
+)
+
+// fhirDoer is a test double for HTTPDoer used exclusively by FHIR tests.
+// It records the last outbound request so tests can assert on it.
+type fhirDoer struct {
+	resp *http.Response
+	err  error
+	got  *http.Request
+}
+
+func (f *fhirDoer) Do(req *http.Request) (*http.Response, error) {
+	f.got = req
+	return f.resp, f.err
+}
+
+// fhirMockResponse builds a minimal *[http.Response] with the given status
+// and a JSON body — matching the mockResponse convention from http_test.go.
+func fhirMockResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/fhir+json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// validCapabilityStatement returns a minimal but parseable FHIR
+// CapabilityStatement JSON body for success-path tests.
+func validCapabilityStatement() string {
+	return `{
+		"resourceType": "CapabilityStatement",
+		"fhirVersion": "4.0.1",
+		"software": {"name": "TestFHIR", "version": "1.2.3"},
+		"rest": [{"mode": "server", "resource": [{"type": "Patient"}, {"type": "Observation"}]}]
+	}`
+}
+
+func TestFHIRChecker_Kind(t *testing.T) {
+	t.Parallel()
+	if checkers.NewFHIRChecker().Kind() != "fhir" {
+		t.Errorf("FHIRChecker.Kind() = %q, want \"fhir\"", checkers.NewFHIRChecker().Kind())
+	}
+}
+
+func TestFHIRChecker_Run_Success(t *testing.T) {
+	t.Parallel()
+
+	doer := &fhirDoer{resp: fhirMockResponse(200, validCapabilityStatement())}
+	c := checkers.NewFHIRChecker().WithFHIRDoer(doer)
+
+	r := c.Run(context.Background(), probe.Probe{
+		ID:     "p1",
+		Kind:   "fhir",
+		Target: "https://fhir.example.com",
+	})
+
+	if !r.Success {
+		t.Errorf("Success = false; want true: %s", r.Error)
+	}
+
+	// Verify the request was sent to the /metadata path.
+	if doer.got == nil {
+		t.Fatal("no request captured")
+	}
+	if !strings.HasSuffix(doer.got.URL.Path, "/metadata") {
+		t.Errorf("request URL = %q; want path ending with /metadata", doer.got.URL.String())
+	}
+
+	// Verify Accept header.
+	if got := doer.got.Header.Get("Accept"); got != "application/fhir+json" {
+		t.Errorf("Accept = %q; want application/fhir+json", got)
+	}
+
+	// Verify fhir_version is surfaced in metadata.
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("metadata unmarshal: %v", err)
+	}
+	if meta["fhir_version"] != "4.0.1" {
+		t.Errorf("metadata fhir_version = %v; want 4.0.1", meta["fhir_version"])
+	}
+	// resource_count comes back as float64 from JSON unmarshal.
+	if meta["resource_count"] != float64(2) {
+		t.Errorf("metadata resource_count = %v; want 2", meta["resource_count"])
+	}
+}
+
+func TestFHIRChecker_Run_NonOKStatus(t *testing.T) {
+	t.Parallel()
+
+	doer := &fhirDoer{resp: fhirMockResponse(404, "not found")}
+	c := checkers.NewFHIRChecker().WithFHIRDoer(doer)
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "fhir",
+		Target: "https://fhir.example.com",
+	})
+
+	if r.Success {
+		t.Error("Success = true for 404; want false")
+	}
+	if !strings.Contains(r.Error, "404") {
+		t.Errorf("Error = %q; want status code 404 mentioned", r.Error)
+	}
+}
+
+func TestFHIRChecker_Run_TransportError(t *testing.T) {
+	t.Parallel()
+
+	doer := &fhirDoer{err: errors.New("connection refused")}
+	c := checkers.NewFHIRChecker().WithFHIRDoer(doer)
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "fhir",
+		Target: "https://fhir.example.com",
+	})
+
+	if r.Success {
+		t.Error("Success = true on transport error; want false")
+	}
+	if r.Error == "" {
+		t.Error("Error is empty; expected transport error message")
+	}
+}
+
+func TestFHIRChecker_Run_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	doer := &fhirDoer{resp: fhirMockResponse(200, "not json at all")}
+	c := checkers.NewFHIRChecker().WithFHIRDoer(doer)
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "fhir",
+		Target: "https://fhir.example.com",
+	})
+
+	if r.Success {
+		t.Error("Success = true on unparseable body; want false")
+	}
+}
+
+func TestFHIRChecker_Run_BasicAuth(t *testing.T) {
+	t.Parallel()
+
+	doer := &fhirDoer{resp: fhirMockResponse(200, validCapabilityStatement())}
+	c := checkers.NewFHIRChecker().WithFHIRDoer(doer)
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "fhir",
+		Target: "https://fhir.example.com",
+		Params: json.RawMessage(`{"auth_type":"basic","username":"admin","password":"secret"}`),
+	})
+
+	if !r.Success {
+		t.Errorf("Success = false with basic auth; error: %s", r.Error)
+	}
+	if doer.got == nil {
+		t.Fatal("no request captured")
+	}
+	authHeader := doer.got.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Basic ") {
+		t.Errorf("Authorization = %q; want Basic ... header", authHeader)
+	}
+}
+
+func TestFHIRChecker_Run_BasicAuthMissingUsername(t *testing.T) {
+	t.Parallel()
+
+	doer := &fhirDoer{resp: fhirMockResponse(200, validCapabilityStatement())}
+	c := checkers.NewFHIRChecker().WithFHIRDoer(doer)
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "fhir",
+		Target: "https://fhir.example.com",
+		Params: json.RawMessage(`{"auth_type":"basic"}`),
+	})
+
+	if r.Success {
+		t.Error("Success = true; basic auth with no username should fail")
+	}
+}
+
+func TestFHIRChecker_Run_BearerAuth(t *testing.T) {
+	t.Parallel()
+
+	doer := &fhirDoer{resp: fhirMockResponse(200, validCapabilityStatement())}
+	c := checkers.NewFHIRChecker().WithFHIRDoer(doer)
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "fhir",
+		Target: "https://fhir.example.com",
+		Params: json.RawMessage(`{"auth_type":"bearer","bearer_token":"tok123"}`),
+	})
+
+	if !r.Success {
+		t.Errorf("Success = false with bearer auth; error: %s", r.Error)
+	}
+	if got := doer.got.Header.Get("Authorization"); got != "Bearer tok123" {
+		t.Errorf("Authorization = %q; want Bearer tok123", got)
+	}
+}
+
+func TestFHIRChecker_Run_MetadataURLSuffix(t *testing.T) {
+	t.Parallel()
+
+	// Target with a trailing slash should still produce exactly one /metadata suffix.
+	doer := &fhirDoer{resp: fhirMockResponse(200, validCapabilityStatement())}
+	c := checkers.NewFHIRChecker().WithFHIRDoer(doer)
+
+	_ = c.Run(context.Background(), probe.Probe{
+		Kind:   "fhir",
+		Target: "https://fhir.example.com/",
+	})
+
+	if doer.got == nil {
+		t.Fatal("no request captured")
+	}
+	if !strings.HasSuffix(doer.got.URL.String(), "/metadata") {
+		t.Errorf("URL = %q; want suffix /metadata (no double slash)", doer.got.URL.String())
+	}
+}

--- a/internal/probe/checkers/fileshare.go
+++ b/internal/probe/checkers/fileshare.go
@@ -1,0 +1,139 @@
+package checkers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// defaultFileShareTimeout is the per-attempt TCP dial timeout.
+const defaultFileShareTimeout = 10 * time.Second
+
+// File share protocol constants (SMB RFC 1001/1002, NFS RFC 7530).
+const (
+	fileShareProtocolSMB = "smb"
+	fileShareProtocolNFS = "nfs"
+
+	fileShareDefaultSMBPort = 445  // SMB over TCP (direct hosting, IANA 445)
+	fileShareDefaultNFSPort = 2049 // NFS (IANA 2049)
+)
+
+// FileShareParams is the kind-specific params shape. Protocol selects the
+// port; Share is surfaced in metadata only (no mount or filesystem I/O).
+// TimeoutMs overrides the default dial timeout.
+//
+// V1.0 scope: TCP reachability only. Protocol-level mount, read, and write
+// performance tests are out of scope — those require the share to be
+// OS-mounted at a local path, which is fragile in a network-probe context.
+type FileShareParams struct {
+	Protocol  string `json:"protocol,omitempty"`   // "smb"|"nfs", default "smb"
+	Share     string `json:"share,omitempty"`      // e.g. "//host/sharename" (metadata only)
+	TimeoutMs int    `json:"timeout_ms,omitempty"` // default 10000
+}
+
+// FileShareChecker implements probe.Checker for Kind="fileshare". It dials
+// the SMB (445) or NFS (2049) TCP port on Probe.Target and reports
+// reachability + latency. Protocol-level session negotiation and filesystem
+// I/O are intentionally out of scope for V1.0.
+type FileShareChecker struct {
+	dialer PingDialer
+}
+
+// NewFileShareChecker returns a FileShareChecker wired to a real dialer.
+func NewFileShareChecker() *FileShareChecker {
+	return &FileShareChecker{dialer: realPingDialer{}}
+}
+
+// WithFileShareDialer swaps the dialer (for tests).
+func (c *FileShareChecker) WithFileShareDialer(d PingDialer) *FileShareChecker {
+	c.dialer = d
+	return c
+}
+
+// Kind returns probe.KindFileShare.
+func (c *FileShareChecker) Kind() string { return probe.KindFileShare }
+
+// RequiredCapabilities returns nil; TCP dial needs no special capability.
+func (c *FileShareChecker) RequiredCapabilities() []string { return nil }
+
+// Run dials the protocol-appropriate TCP port on Probe.Target and returns
+// Success=true with latency on connect, false with Error on failure.
+func (c *FileShareChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
+	params := parseFileShareParams(p.Params)
+
+	// Resolve port by protocol; empty protocol defaults to SMB.
+	protocol := strings.ToLower(params.Protocol)
+	if protocol == "" {
+		protocol = fileShareProtocolSMB
+	}
+
+	var port int
+	switch protocol {
+	case fileShareProtocolSMB:
+		port = fileShareDefaultSMBPort
+	case fileShareProtocolNFS:
+		port = fileShareDefaultNFSPort
+	default:
+		return fileShareFailure(p, 0, fmt.Sprintf("Unsupported protocol: %s", params.Protocol))
+	}
+
+	timeout := defaultFileShareTimeout
+	if params.TimeoutMs > 0 {
+		timeout = time.Duration(params.TimeoutMs) * time.Millisecond
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	addr := net.JoinHostPort(p.Target, strconv.Itoa(port))
+	start := time.Now()
+	conn, err := c.dialer.Dial(dialCtx, "tcp", addr)
+	latencyMs := float64(time.Since(start).Milliseconds())
+
+	if err != nil {
+		return fileShareFailure(p, time.Duration(latencyMs)*time.Millisecond, err.Error())
+	}
+	_ = conn.Close()
+
+	meta, _ := json.Marshal(map[string]any{
+		"protocol":  protocol,
+		metaKeyAddr: addr,
+		"share":     params.Share,
+	})
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   true,
+		LatencyMs: latencyMs,
+		Metadata:  meta,
+	}
+}
+
+// fileShareFailure builds a failed Result with the measured latency so far.
+func fileShareFailure(p probe.Probe, elapsed time.Duration, msg string) probe.Result {
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   false,
+		LatencyMs: float64(elapsed.Milliseconds()),
+		Error:     msg,
+	}
+}
+
+func parseFileShareParams(raw json.RawMessage) FileShareParams {
+	if len(raw) == 0 {
+		return FileShareParams{}
+	}
+	var p FileShareParams
+	_ = json.Unmarshal(raw, &p)
+	return p
+}

--- a/internal/probe/checkers/fileshare_test.go
+++ b/internal/probe/checkers/fileshare_test.go
@@ -1,0 +1,100 @@
+package checkers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
+)
+
+func TestFileShareChecker_Kind(t *testing.T) {
+	t.Parallel()
+	if checkers.NewFileShareChecker().Kind() != "fileshare" {
+		t.Errorf("Kind != fileshare")
+	}
+}
+
+func TestFileShareChecker_Run_SMBSuccess(t *testing.T) {
+	t.Parallel()
+	params, _ := json.Marshal(checkers.FileShareParams{
+		Protocol: "smb",
+		Share:    "//nas.example.com/backup",
+	})
+	// modbusDialer + modbusFakeConn already exist in this package (modbus_test.go);
+	// reuse them as the PingDialer seam — a successful connect needs only Close().
+	c := checkers.NewFileShareChecker().WithFileShareDialer(&modbusDialer{conn: &modbusFakeConn{}})
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "fileshare",
+		Target: "nas.example.com",
+		Params: params,
+	})
+	if !r.Success {
+		t.Fatalf("Success = false on successful SMB dial: %s", r.Error)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("metadata not JSON: %v", err)
+	}
+	if got := meta["protocol"]; got != "smb" {
+		t.Errorf("metadata protocol = %v, want smb", got)
+	}
+	// addr must contain the SMB port 445.
+	addr, _ := meta["addr"].(string)
+	if addr == "" {
+		t.Errorf("metadata addr missing or empty")
+	}
+	if !fileShareAddrContains(addr, "445") {
+		t.Errorf("metadata addr %q should contain port 445", addr)
+	}
+}
+
+func TestFileShareChecker_Run_DialError(t *testing.T) {
+	t.Parallel()
+	params, _ := json.Marshal(checkers.FileShareParams{Protocol: "nfs"})
+	c := checkers.NewFileShareChecker().WithFileShareDialer(&modbusDialer{err: errors.New("connection refused")})
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "fileshare",
+		Target: "nfs.example.com",
+		Params: params,
+	})
+	if r.Success {
+		t.Error("Success = true on dial error; want false")
+	}
+	if r.Error == "" {
+		t.Error("expected non-empty Error on dial failure")
+	}
+}
+
+func TestFileShareChecker_Run_UnsupportedProtocol(t *testing.T) {
+	t.Parallel()
+	params, _ := json.Marshal(checkers.FileShareParams{Protocol: "ftp"})
+	c := checkers.NewFileShareChecker().WithFileShareDialer(&modbusDialer{conn: &modbusFakeConn{}})
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "fileshare",
+		Target: "host.example.com",
+		Params: params,
+	})
+	if r.Success {
+		t.Error("Success = true on unsupported protocol; want false")
+	}
+	if r.Error == "" {
+		t.Error("expected an error message for unsupported protocol ftp")
+	}
+}
+
+// fileShareAddrContains is a simple substring check — avoids importing strings
+// for a single test helper.
+func fileShareAddrContains(s, sub string) bool {
+	if len(sub) > len(s) {
+		return false
+	}
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/probe/checkers/hl7.go
+++ b/internal/probe/checkers/hl7.go
@@ -1,0 +1,294 @@
+package checkers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// defaultHL7Timeout is the per-attempt HL7 MLLP probe timeout.
+const defaultHL7Timeout = 10 * time.Second
+
+// defaultHL7Port is the default HL7 MLLP port (IANA 2575).
+const defaultHL7Port = 2575
+
+// MLLP framing bytes (HL7 v2 Minimum Lower Layer Protocol).
+const (
+	mllpStartByte = 0x0B // vertical tab — marks start of MLLP block
+	mllpEndByte1  = 0x1C // file separator — first end byte
+	mllpEndByte2  = 0x0D // carriage return — second end byte
+)
+
+// mllpWrapOverhead is the number of bytes MLLP framing adds per message
+// (one start byte + two end bytes).
+const mllpWrapOverhead = 3
+
+// mllpReadBufSize bounds a single read of the raw TCP stream.
+const mllpReadBufSize = 4096
+
+// minHL7MSAFields is the minimum field count required to access MSA[1]
+// (the ACK code).
+const minHL7MSAFields = 2
+
+// minHL7MSAErrorFields is the minimum field count to access MSA[3]
+// (the error code).
+const minHL7MSAErrorFields = 4
+
+// HL7Params is the kind-specific params shape. All fields are optional;
+// application / facility identifiers default to the values the legacy
+// internal/api/handlers_medical_checks.go used.
+type HL7Params struct {
+	Port         int    `json:"port,omitempty"`          // default 2575
+	SendingApp   string `json:"sending_app,omitempty"`   // default "SEED"
+	SendingFac   string `json:"sending_fac,omitempty"`   // default "SEED_FAC"
+	ReceivingApp string `json:"receiving_app,omitempty"` // default "TARGET"
+	ReceivingFac string `json:"receiving_fac,omitempty"` // default "TARGET_FAC"
+	TimeoutMs    int    `json:"timeout_ms,omitempty"`    // default 10000
+}
+
+// HL7Checker implements probe.Checker for Kind="hl7". It opens a TCP
+// connection to an HL7 MLLP endpoint, sends a minimal ADT^A01 admission
+// message wrapped in MLLP framing, reads the ACK, and reports success
+// when the MSA acknowledgment code is AA, CA, or absent (connection-only
+// proof).
+type HL7Checker struct {
+	dialer PingDialer
+}
+
+// NewHL7Checker returns an HL7Checker wired to a real dialer.
+func NewHL7Checker() *HL7Checker {
+	return &HL7Checker{dialer: realPingDialer{}}
+}
+
+// WithHL7Dialer swaps the dialer (for tests).
+func (c *HL7Checker) WithHL7Dialer(d PingDialer) *HL7Checker {
+	c.dialer = d
+	return c
+}
+
+// Kind returns probe.KindHL7.
+func (c *HL7Checker) Kind() string { return probe.KindHL7 }
+
+// RequiredCapabilities returns nil; HL7 MLLP needs no special hardware.
+func (c *HL7Checker) RequiredCapabilities() []string { return nil }
+
+// Run dials Target:Port, sends a minimal HL7 v2.5 ADT^A01 message in
+// MLLP framing, reads the ACK, and maps the MSA acknowledgment code to
+// success or failure.
+//
+// Success rule (mirrors legacy internal/api/handlers_medical_checks.go):
+//   - "AA" or "CA" → success
+//   - "" (no MSA segment / empty code) → success with synthesised ACK "OK"
+//   - "AE" or "CE" → failure "Application error"
+//   - "AR" or "CR" → failure "Application reject"
+//   - anything else → failure "Unexpected ACK code: X"
+//
+//nolint:funlen // HL7 probing is one linear flow: validate, dial, build message, MLLP-frame, write, read, parse ACK.
+func (c *HL7Checker) Run(ctx context.Context, p probe.Probe) probe.Result {
+	params := parseHL7Params(p.Params)
+
+	port := params.Port
+	if port == 0 {
+		port = defaultHL7Port
+	}
+
+	timeout := defaultHL7Timeout
+	if params.TimeoutMs > 0 {
+		timeout = time.Duration(params.TimeoutMs) * time.Millisecond
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	addr := net.JoinHostPort(p.Target, strconv.Itoa(port))
+	start := time.Now()
+	conn, err := c.dialer.Dial(dialCtx, "tcp", addr)
+	if err != nil {
+		return hl7Failure(p, time.Since(start), err.Error())
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	// Apply application / facility defaults used in the legacy stack.
+	sendingApp := params.SendingApp
+	if sendingApp == "" {
+		sendingApp = "SEED"
+	}
+	sendingFac := params.SendingFac
+	if sendingFac == "" {
+		sendingFac = "SEED_FAC"
+	}
+	receivingApp := params.ReceivingApp
+	if receivingApp == "" {
+		receivingApp = "TARGET"
+	}
+	receivingFac := params.ReceivingFac
+	if receivingFac == "" {
+		receivingFac = "TARGET_FAC"
+	}
+
+	// Build a minimal HL7 v2.5 ADT^A01 admission notification for health
+	// probing. ADT^A01 is more universally supported than QBP^Q21.
+	ts := time.Now().Format("20060102150405")
+	hl7Msg := fmt.Sprintf(
+		"MSH|^~\\&|%s|%s|%s|%s|%s||ADT^A01|%s|P|2.5\r"+
+			"EVN|A01|%s\r"+
+			"PID|1||HEALTH_CHECK||SEED^PROBE|||U\r",
+		sendingApp, sendingFac, receivingApp, receivingFac, ts, ts, ts,
+	)
+
+	mllpMsg := hl7WrapMLLP([]byte(hl7Msg))
+
+	if _, writeErr := conn.Write(mllpMsg); writeErr != nil {
+		return hl7Failure(p, time.Since(start), "write message: "+writeErr.Error())
+	}
+
+	response, readErr := hl7ReadMLLP(conn)
+	if readErr != nil {
+		return hl7Failure(p, time.Since(start), "read response: "+readErr.Error())
+	}
+
+	latencyMs := float64(time.Since(start).Milliseconds())
+
+	ackCode, _ := hl7ParseACK(string(response))
+
+	switch ackCode {
+	case "AA", "CA":
+		// Application Accept / Commit Accept — full success.
+	case "AE", "CE":
+		return hl7Failure(p, time.Duration(latencyMs)*time.Millisecond, "Application error")
+	case "AR", "CR":
+		return hl7Failure(p, time.Duration(latencyMs)*time.Millisecond, "Application reject")
+	case "":
+		// No MSA segment found but a response was received — connection
+		// proof is sufficient; surface a synthetic ACK code.
+		ackCode = "OK"
+	default:
+		return hl7Failure(p, time.Duration(latencyMs)*time.Millisecond,
+			fmt.Sprintf("Unexpected ACK code: %s", ackCode))
+	}
+
+	meta, _ := json.Marshal(map[string]any{
+		metaKeyAddr: addr,
+		"ack_code":  ackCode,
+	})
+
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   true,
+		LatencyMs: latencyMs,
+		Metadata:  meta,
+	}
+}
+
+// hl7Failure builds a failed Result with the measured latency so far.
+func hl7Failure(p probe.Probe, elapsed time.Duration, msg string) probe.Result {
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   false,
+		LatencyMs: float64(elapsed.Milliseconds()),
+		Error:     msg,
+	}
+}
+
+// hl7WrapMLLP wraps msg in MLLP framing: 0x0B + payload + 0x1C 0x0D.
+func hl7WrapMLLP(msg []byte) []byte {
+	out := make([]byte, 0, len(msg)+mllpWrapOverhead)
+	out = append(out, mllpStartByte)
+	out = append(out, msg...)
+	out = append(out, mllpEndByte1, mllpEndByte2)
+	return out
+}
+
+// hl7ReadMLLP reads one MLLP-framed message from conn. It discards
+// bytes before the start byte (0x0B) and stops at the end sequence
+// (0x1C 0x0D). An EOF with accumulated data is treated as a complete
+// message.
+//
+//nolint:gocognit // MLLP framing requires byte-by-byte state machine parsing.
+func hl7ReadMLLP(conn net.Conn) ([]byte, error) {
+	var buf bytes.Buffer
+	readBuf := make([]byte, mllpReadBufSize)
+	foundStart := false
+
+	for {
+		n, err := conn.Read(readBuf)
+		if err != nil {
+			if errors.Is(err, io.EOF) && buf.Len() > 0 {
+				break
+			}
+			return nil, err
+		}
+
+		for i := range n {
+			b := readBuf[i]
+			if !foundStart {
+				if b == mllpStartByte {
+					foundStart = true
+				}
+				continue
+			}
+
+			// End sequence: 0x1C followed by 0x0D.
+			if b == mllpEndByte1 && i+1 < n && readBuf[i+1] == mllpEndByte2 {
+				return buf.Bytes(), nil
+			}
+			// End byte 1 without a lookahead — treat as end; the next read
+			// would deliver end byte 2 (or the stream is over).
+			if b == mllpEndByte1 && buf.Len() > 0 {
+				return buf.Bytes(), nil
+			}
+
+			buf.WriteByte(b)
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// hl7ParseACK extracts the acknowledgment code and error code from the
+// MSA segment of an HL7 message. Returns empty strings when no MSA
+// segment is found.
+func hl7ParseACK(msg string) (string, string) {
+	for line := range strings.SplitSeq(msg, "\r") {
+		if !strings.HasPrefix(line, "MSA|") {
+			continue
+		}
+		fields := strings.Split(line, "|")
+		var ackCode, errorCode string
+		if len(fields) >= minHL7MSAFields {
+			ackCode = fields[1]
+		}
+		if len(fields) >= minHL7MSAErrorFields {
+			errorCode = fields[3]
+		}
+		return ackCode, errorCode
+	}
+	return "", ""
+}
+
+// parseHL7Params decodes the params JSON; returns zero value on empty
+// or unparseable input.
+func parseHL7Params(raw json.RawMessage) HL7Params {
+	if len(raw) == 0 {
+		return HL7Params{}
+	}
+	var p HL7Params
+	_ = json.Unmarshal(raw, &p)
+	return p
+}

--- a/internal/probe/checkers/hl7_test.go
+++ b/internal/probe/checkers/hl7_test.go
@@ -1,0 +1,179 @@
+package checkers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
+)
+
+// hl7FakeConn delivers canned MLLP-framed response bytes and records
+// what the checker wrote.
+type hl7FakeConn struct {
+	mu       sync.Mutex
+	response []byte
+	written  []byte
+	pos      int
+}
+
+func (c *hl7FakeConn) Read(b []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.pos >= len(c.response) {
+		return 0, errors.New("hl7FakeConn: response exhausted")
+	}
+	n := copy(b, c.response[c.pos:])
+	c.pos += n
+	return n, nil
+}
+
+func (c *hl7FakeConn) Write(b []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.written = append(c.written, b...)
+	return len(b), nil
+}
+
+func (*hl7FakeConn) Close() error                     { return nil }
+func (*hl7FakeConn) LocalAddr() net.Addr              { return nil }
+func (*hl7FakeConn) RemoteAddr() net.Addr             { return nil }
+func (*hl7FakeConn) SetDeadline(time.Time) error      { return nil }
+func (*hl7FakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (*hl7FakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+// hl7Dialer is a test seam that returns either a fixed conn or error.
+type hl7Dialer struct {
+	conn net.Conn
+	err  error
+}
+
+func (d *hl7Dialer) Dial(_ context.Context, _, _ string) (net.Conn, error) {
+	return d.conn, d.err
+}
+
+// makeHL7MLLPResponse builds an MLLP-framed HL7 ACK payload containing
+// the given MSA acknowledgment code. The structure mirrors what a real
+// HL7 engine would return: 0x0B + HL7 segments + 0x1C 0x0D.
+func makeHL7MLLPResponse(ackCode string) []byte {
+	ts := time.Now().Format("20060102150405")
+	hl7 := fmt.Sprintf(
+		"MSH|^~\\&|TARGET|TARGET_FAC|SEED|SEED_FAC|%s||ACK^A01|%s|P|2.5\r"+
+			"MSA|%s|%s\r",
+		ts, ts, ackCode, ts,
+	)
+	// MLLP frame: 0x0B + payload + 0x1C 0x0D
+	out := make([]byte, 0, 1+len(hl7)+2)
+	out = append(out, 0x0B)
+	out = append(out, []byte(hl7)...)
+	out = append(out, 0x1C, 0x0D)
+	return out
+}
+
+func TestHL7Checker_Kind(t *testing.T) {
+	t.Parallel()
+	if checkers.NewHL7Checker().Kind() != "hl7" {
+		t.Errorf("Kind() != hl7")
+	}
+}
+
+func TestHL7Checker_Run_SuccessAA(t *testing.T) {
+	t.Parallel()
+	conn := &hl7FakeConn{response: makeHL7MLLPResponse("AA")}
+	c := checkers.NewHL7Checker().WithHL7Dialer(&hl7Dialer{conn: conn})
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "hl7",
+		Target: "hl7.example.com",
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false on AA ACK: %s", r.Error)
+	}
+
+	// The first byte written must be the MLLP start byte 0x0B.
+	conn.mu.Lock()
+	written := conn.written
+	conn.mu.Unlock()
+	if len(written) == 0 || written[0] != 0x0B {
+		t.Errorf("first written byte = 0x%02X, want 0x0B (MLLP start)", written[0])
+	}
+
+	// Metadata must carry ack_code.
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("metadata not JSON: %v", err)
+	}
+	if got, ok := meta["ack_code"].(string); !ok || got != "AA" {
+		t.Errorf("ack_code = %v, want AA", meta["ack_code"])
+	}
+}
+
+func TestHL7Checker_Run_FailAR(t *testing.T) {
+	t.Parallel()
+	conn := &hl7FakeConn{response: makeHL7MLLPResponse("AR")}
+	c := checkers.NewHL7Checker().WithHL7Dialer(&hl7Dialer{conn: conn})
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "hl7",
+		Target: "hl7.example.com",
+	})
+
+	if r.Success {
+		t.Error("Success = true on AR ACK; want false")
+	}
+	if r.Error == "" {
+		t.Error("expected a non-empty Error on AR ACK")
+	}
+}
+
+func TestHL7Checker_Run_DialError(t *testing.T) {
+	t.Parallel()
+	c := checkers.NewHL7Checker().WithHL7Dialer(&hl7Dialer{err: errors.New("connection refused")})
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "hl7",
+		Target: "down.example.com",
+	})
+
+	if r.Success {
+		t.Error("Success = true on dial error; want false")
+	}
+	if r.Error == "" {
+		t.Error("expected a non-empty Error on dial error")
+	}
+}
+
+func TestHL7Checker_Run_EmptyACKSucceeds(t *testing.T) {
+	t.Parallel()
+	// A response with no MSA segment produces an empty ACK code, which the
+	// checker maps to success with synthesised ACK code "OK".
+	noMSA := []byte{0x0B}
+	noMSA = append(noMSA, []byte("MSH|^~\\&|TARGET||SEED||20240101||ACK|1|P|2.5\r")...)
+	noMSA = append(noMSA, 0x1C, 0x0D)
+
+	conn := &hl7FakeConn{response: noMSA}
+	c := checkers.NewHL7Checker().WithHL7Dialer(&hl7Dialer{conn: conn})
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "hl7",
+		Target: "hl7.example.com",
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false on no-MSA response: %s", r.Error)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("metadata not JSON: %v", err)
+	}
+	if got, ok := meta["ack_code"].(string); !ok || got != "OK" {
+		t.Errorf("ack_code = %v, want OK", meta["ack_code"])
+	}
+}

--- a/internal/probe/checkers/ldap.go
+++ b/internal/probe/checkers/ldap.go
@@ -1,0 +1,191 @@
+package checkers
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// defaultLDAPTimeout is the per-attempt LDAP probe timeout, matching the
+// legacy internal/api/handlers_enterprise_checks.go LDAPTimeout.
+const defaultLDAPTimeout = 10 * time.Second
+
+// defaultLDAPPort is the standard LDAP port (IANA 389).
+const defaultLDAPPort = 389
+
+// defaultLDAPSPort is the standard LDAPS port (IANA 636) used when UseTLS=true.
+const defaultLDAPSPort = 636
+
+// LDAPParams is the kind-specific params shape for LDAP reachability
+// probes. All fields are optional and fall back to safe defaults.
+//
+// V1.0 scope: TCP reachability + optional TLS handshake only.
+// Authenticated bind and LDAP search require an LDAP library and are
+// out of scope until V1.1+ (see ADR-0027 P1 notes).
+type LDAPParams struct {
+	// Port overrides the target port. Default: 636 when UseTLS=true, 389
+	// otherwise.
+	Port int `json:"port,omitempty"`
+
+	// UseTLS opens an LDAPS (TLS-from-the-start) connection instead of
+	// plain TCP. Validates server certificates; MinVersion TLS 1.2.
+	UseTLS bool `json:"use_tls,omitempty"`
+
+	// BindDN is recorded in metadata to indicate that bind credentials
+	// are configured. No bind is attempted in V1.0 — an LDAP library is
+	// required for that.
+	BindDN string `json:"bind_dn,omitempty"`
+
+	// TimeoutMs overrides the per-attempt dial timeout. Default 10000.
+	TimeoutMs int `json:"timeout_ms,omitempty"`
+}
+
+// LDAPChecker implements probe.Checker for Kind="ldap". It verifies TCP
+// reachability of an LDAP/LDAPS endpoint and, when UseTLS=true, performs
+// a TLS 1.2+ handshake to validate the server certificate.
+//
+// V1.0 scope — reachability only: TCP connectivity succeeds on connect
+// (plain) or TLS handshake (UseTLS). Authenticated bind and directory
+// search are not performed; an LDAP library is required for those
+// operations (V1.1+). BindDN presence is surfaced in metadata only.
+//
+// The plain-TCP path is injectable via PingDialer for unit testing.
+// The TLS path constructs a [tls.Dialer] directly (mirrors tls.go).
+type LDAPChecker struct {
+	dialer PingDialer
+}
+
+// NewLDAPChecker returns an LDAPChecker wired to a real dialer.
+func NewLDAPChecker() *LDAPChecker {
+	return &LDAPChecker{dialer: realPingDialer{}}
+}
+
+// WithLDAPDialer swaps the plain-TCP dialer (for tests).
+func (c *LDAPChecker) WithLDAPDialer(d PingDialer) *LDAPChecker {
+	c.dialer = d
+	return c
+}
+
+// Kind returns probe.KindLDAP.
+func (c *LDAPChecker) Kind() string { return probe.KindLDAP }
+
+// RequiredCapabilities returns nil — TCP/LDAPS reachability needs no
+// special hardware capability.
+func (c *LDAPChecker) RequiredCapabilities() []string { return nil }
+
+// Run dials Target:Port (plain TCP or TLS-from-the-start) and returns a
+// Result. Success indicates the TCP connection was established and, when
+// UseTLS=true, that the TLS handshake completed against a valid cert.
+// The Metadata JSON carries the dialed addr, tls (bool), and
+// bind_dn_configured (bool).
+func (c *LDAPChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
+	params := ldapParseParams(p.Params)
+
+	port := params.Port
+	if port == 0 {
+		port = ldapDefaultPort(params.UseTLS)
+	}
+
+	timeout := defaultLDAPTimeout
+	if params.TimeoutMs > 0 {
+		timeout = time.Duration(params.TimeoutMs) * time.Millisecond
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	addr := net.JoinHostPort(p.Target, strconv.Itoa(port))
+	start := time.Now()
+
+	var dialErr error
+	if params.UseTLS {
+		dialErr = ldapDialTLS(dialCtx, addr, p.Target)
+	} else {
+		var conn net.Conn
+		conn, dialErr = c.dialer.Dial(dialCtx, "tcp", addr)
+		if dialErr == nil {
+			_ = conn.Close()
+		}
+	}
+
+	latencyMs := float64(time.Since(start).Milliseconds())
+
+	if dialErr != nil {
+		return ldapFailure(p, latencyMs, dialErr.Error())
+	}
+
+	meta, _ := json.Marshal(map[string]any{
+		metaKeyAddr:          addr,
+		"tls":                params.UseTLS,
+		"bind_dn_configured": params.BindDN != "",
+	})
+
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   true,
+		LatencyMs: latencyMs,
+		Metadata:  meta,
+	}
+}
+
+// ldapDefaultPort returns the canonical port for plain (389) or TLS (636)
+// LDAP connections.
+func ldapDefaultPort(useTLS bool) int {
+	if useTLS {
+		return defaultLDAPSPort
+	}
+	return defaultLDAPPort
+}
+
+// ldapDialTLS opens a TLS-from-the-start connection to addr, validating
+// the server certificate against the system trust store. ServerName is
+// set to target (bare host without port) for SNI. MinVersion is TLS 1.2.
+func ldapDialTLS(ctx context.Context, addr, target string) error {
+	cfg := &tls.Config{
+		ServerName: target,
+		MinVersion: tls.VersionTLS12,
+		// InsecureSkipVerify defaults to false — validate certs.
+	}
+	td := &tls.Dialer{
+		NetDialer: &net.Dialer{},
+		Config:    cfg,
+	}
+	conn, err := td.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return fmt.Errorf("ldaps dial: %w", err)
+	}
+	_ = conn.Close()
+	return nil
+}
+
+// ldapFailure builds a failed Result with the measured latency.
+func ldapFailure(p probe.Probe, latencyMs float64, msg string) probe.Result {
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   false,
+		LatencyMs: latencyMs,
+		Error:     msg,
+	}
+}
+
+// ldapParseParams decodes the params JSON; returns zero value on empty input.
+func ldapParseParams(raw json.RawMessage) LDAPParams {
+	if len(raw) == 0 {
+		return LDAPParams{}
+	}
+	var p LDAPParams
+	_ = json.Unmarshal(raw, &p)
+	return p
+}

--- a/internal/probe/checkers/ldap_test.go
+++ b/internal/probe/checkers/ldap_test.go
@@ -1,0 +1,154 @@
+package checkers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
+)
+
+// ldapDialer returns a fakePingDialer pre-loaded with a single outcome.
+// The dialer records gotAddrs so tests can assert the address that was
+// dialled (host:port), enabling port-selection assertions without a
+// live network.
+func ldapDialer(err error) *fakePingDialer {
+	d := &fakePingDialer{}
+	if err != nil {
+		d.attempts = []dialOutcome{{err: err}}
+	} else {
+		d.attempts = []dialOutcome{{conn: fakeConn{}}}
+	}
+	return d
+}
+
+func TestLDAPChecker_Kind(t *testing.T) {
+	t.Parallel()
+	if checkers.NewLDAPChecker().Kind() != "ldap" {
+		t.Errorf("Kind() = %q, want ldap", checkers.NewLDAPChecker().Kind())
+	}
+}
+
+func TestLDAPChecker_Run_PlainSuccess(t *testing.T) {
+	t.Parallel()
+	d := ldapDialer(nil)
+	c := checkers.NewLDAPChecker().WithLDAPDialer(d)
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "ldap",
+		Target: "ldap.example.com",
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false; err=%q", r.Error)
+	}
+	// Default port for plain LDAP must be 389.
+	if len(d.gotAddrs) == 0 || d.gotAddrs[0] != "ldap.example.com:389" {
+		t.Errorf("dialed addr = %q, want ldap.example.com:389", d.gotAddrs)
+	}
+
+	// Metadata must carry addr, tls:false, bind_dn_configured:false.
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("metadata is not valid JSON: %v", err)
+	}
+	if meta["addr"] != "ldap.example.com:389" {
+		t.Errorf("metadata[addr] = %v, want ldap.example.com:389", meta["addr"])
+	}
+	if meta["tls"] != false {
+		t.Errorf("metadata[tls] = %v, want false", meta["tls"])
+	}
+	if meta["bind_dn_configured"] != false {
+		t.Errorf("metadata[bind_dn_configured] = %v, want false", meta["bind_dn_configured"])
+	}
+}
+
+func TestLDAPChecker_Run_BindDNConfigured(t *testing.T) {
+	t.Parallel()
+	d := ldapDialer(nil)
+	c := checkers.NewLDAPChecker().WithLDAPDialer(d)
+
+	params, _ := json.Marshal(checkers.LDAPParams{BindDN: "cn=admin,dc=example,dc=com"})
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "ldap",
+		Target: "ldap.example.com",
+		Params: params,
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false; err=%q", r.Error)
+	}
+
+	var meta map[string]any
+	_ = json.Unmarshal(r.Metadata, &meta)
+	// BindDN present in params — must be reflected in metadata.
+	if meta["bind_dn_configured"] != true {
+		t.Errorf("metadata[bind_dn_configured] = %v, want true", meta["bind_dn_configured"])
+	}
+}
+
+func TestLDAPChecker_Run_DialError(t *testing.T) {
+	t.Parallel()
+	d := ldapDialer(errors.New("connection refused"))
+	c := checkers.NewLDAPChecker().WithLDAPDialer(d)
+
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "ldap",
+		Target: "down.example.com",
+	})
+
+	if r.Success {
+		t.Error("Success = true; want false on dial error")
+	}
+	if r.Error == "" {
+		t.Error("Error is empty; want a non-empty error message")
+	}
+}
+
+func TestLDAPChecker_Run_CustomPort(t *testing.T) {
+	t.Parallel()
+	d := ldapDialer(nil)
+	c := checkers.NewLDAPChecker().WithLDAPDialer(d)
+
+	params, _ := json.Marshal(checkers.LDAPParams{Port: 3389})
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "ldap",
+		Target: "ldap.example.com",
+		Params: params,
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false; err=%q", r.Error)
+	}
+	if len(d.gotAddrs) == 0 || d.gotAddrs[0] != "ldap.example.com:3389" {
+		t.Errorf("dialed addr = %q, want ldap.example.com:3389", d.gotAddrs)
+	}
+}
+
+// TestLDAPChecker_Run_Port636Plain exercises the port plumbing that feeds
+// the default-LDAPS port value (636) through to the dialer. UseTLS is NOT
+// set — the test forces Port=636 on the plain path so it stays offline and
+// deterministic, verifying that numeric port 636 is correctly assembled
+// into the dial address. The default port-selection logic (UseTLS=true →
+// port 636, false → port 389) is covered without a live TLS server.
+func TestLDAPChecker_Run_Port636Plain(t *testing.T) {
+	t.Parallel()
+	d := ldapDialer(nil)
+	c := checkers.NewLDAPChecker().WithLDAPDialer(d)
+
+	params, _ := json.Marshal(checkers.LDAPParams{Port: 636})
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "ldap",
+		Target: "ldap.example.com",
+		Params: params,
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false; err=%q", r.Error)
+	}
+	if len(d.gotAddrs) == 0 || d.gotAddrs[0] != "ldap.example.com:636" {
+		t.Errorf("dialed addr = %q, want ldap.example.com:636", d.gotAddrs)
+	}
+}

--- a/internal/probe/checkers/lti.go
+++ b/internal/probe/checkers/lti.go
@@ -1,0 +1,164 @@
+package checkers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// defaultLTITimeout is the per-request timeout for LTI probes (mirrors
+// the legacy LTITimeout constant in internal/api/handlers_industry_checks.go).
+const defaultLTITimeout = 10 * time.Second
+
+// ltiSuccessMin / ltiSuccessMax define the half-open status range that
+// counts as success: [200, 400). LTI launch URLs frequently redirect, so
+// all 3xx responses are intentionally included (legacy §185 comment).
+const (
+	ltiSuccessMin = 200
+	ltiSuccessMax = 400
+)
+
+// LTIParams is the kind-specific params shape. Probe.Target is the LTI
+// launch URL. LTIVersion is carried through to metadata only; it does
+// not alter the probe logic. TimeoutMs overrides the default 10 s.
+type LTIParams struct {
+	LTIVersion string `json:"lti_version,omitempty"` // informational (1.1 / 1.3 / advantage)
+	TimeoutMs  int    `json:"timeout_ms,omitempty"`  // default 10000
+}
+
+// LTIChecker implements probe.Checker for Kind="lti". It issues an HTTP
+// HEAD request to Probe.Target and reports success for any 2xx/3xx
+// response, mirroring the legacy testLTIEndpoint behaviour.
+type LTIChecker struct {
+	doer  HTTPDoer
+	clock func() time.Time
+}
+
+// NewLTIChecker returns an LTIChecker backed by the default production
+// [http.Client]. The client is constructed per Run call so each probe gets
+// isolated state (timeout, redirect chain).
+func NewLTIChecker() *LTIChecker {
+	return &LTIChecker{clock: time.Now}
+}
+
+// WithLTIDoer replaces the default per-request client; used by tests to
+// inject a fake without needing a real network.
+func (c *LTIChecker) WithLTIDoer(d HTTPDoer) *LTIChecker {
+	c.doer = d
+	return c
+}
+
+// Kind returns probe.KindLTI.
+func (c *LTIChecker) Kind() string { return probe.KindLTI }
+
+// RequiredCapabilities returns nil; LTI probes need no special hardware.
+func (c *LTIChecker) RequiredCapabilities() []string { return nil }
+
+// Run issues a HEAD request to Probe.Target and reports success when the
+// response status falls in [200, 400). SSL validity is captured for
+// https targets. Transport errors always fail.
+func (c *LTIChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
+	params := ltiParseParams(p.Params)
+
+	timeout := defaultLTITimeout
+	if params.TimeoutMs > 0 {
+		timeout = time.Duration(params.TimeoutMs) * time.Millisecond
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodHead, p.Target, http.NoBody)
+	if err != nil {
+		return ltiFailure(p, c.clock().UTC(), 0, fmt.Sprintf("invalid request: %v", err))
+	}
+
+	doer := c.doer
+	if doer == nil {
+		doer = ltiDefaultClient(timeout)
+	}
+
+	start := c.clock()
+	resp, err := doer.Do(req)
+	latencyMs := float64(c.clock().Sub(start).Milliseconds())
+	if err != nil {
+		return ltiFailure(p, c.clock().UTC(), latencyMs, err.Error())
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Capture SSL validity for https targets (non-https => sslValid stays false).
+	sslValid := resp.TLS != nil && len(resp.TLS.PeerCertificates) > 0 &&
+		strings.HasPrefix(p.Target, "https://")
+
+	meta, _ := json.Marshal(map[string]any{
+		"status_code": resp.StatusCode,
+		"lti_version": params.LTIVersion,
+		"ssl_valid":   sslValid,
+	})
+
+	if resp.StatusCode < ltiSuccessMin || resp.StatusCode >= ltiSuccessMax {
+		return probe.Result{
+			ProbeID:   p.ID,
+			ClientID:  p.ClientID,
+			Kind:      p.Kind,
+			Timestamp: c.clock().UTC(),
+			Success:   false,
+			LatencyMs: latencyMs,
+			Error:     fmt.Sprintf("Unexpected status: %d", resp.StatusCode),
+			Metadata:  meta,
+		}
+	}
+
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: c.clock().UTC(),
+		Success:   true,
+		LatencyMs: latencyMs,
+		Metadata:  meta,
+	}
+}
+
+// ltiFailure builds a failure Result with no metadata.
+func ltiFailure(p probe.Probe, ts time.Time, latencyMs float64, msg string) probe.Result {
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: ts,
+		Success:   false,
+		LatencyMs: latencyMs,
+		Error:     msg,
+	}
+}
+
+// ltiDefaultClient returns a production [http.Client] that follows up to
+// ten redirects (matching legacy ltiMaxRedirects) with the given timeout.
+func ltiDefaultClient(timeout time.Duration) HTTPDoer {
+	const maxRedirects = 10
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				return fmt.Errorf("lti: exceeded %d redirects", maxRedirects)
+			}
+			return nil
+		},
+	}
+}
+
+// ltiParseParams unmarshals the raw JSON params; returns zero-value on
+// absent or malformed input.
+func ltiParseParams(raw json.RawMessage) LTIParams {
+	if len(raw) == 0 {
+		return LTIParams{}
+	}
+	var p LTIParams
+	_ = json.Unmarshal(raw, &p)
+	return p
+}

--- a/internal/probe/checkers/lti_test.go
+++ b/internal/probe/checkers/lti_test.go
@@ -1,0 +1,137 @@
+package checkers_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
+)
+
+// fakeLTIDoer captures the outbound request and returns a canned response.
+type fakeLTIDoer struct {
+	resp *http.Response
+	err  error
+	got  *http.Request
+}
+
+func (f *fakeLTIDoer) Do(req *http.Request) (*http.Response, error) {
+	f.got = req
+	return f.resp, f.err
+}
+
+// ltiMockResponse builds a minimal *[http.Response] with the given status.
+func ltiMockResponse(status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+}
+
+// ltiMockTLSResponse builds a response with a populated TLS state so
+// that ssl_valid is captured as true.
+func ltiMockTLSResponse(status int) *http.Response {
+	resp := ltiMockResponse(status)
+	resp.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{{}},
+	}
+	return resp
+}
+
+func TestLTIChecker_Kind(t *testing.T) {
+	t.Parallel()
+	if checkers.NewLTIChecker().Kind() != "lti" {
+		t.Errorf("LTIChecker.Kind = %q; want %q", checkers.NewLTIChecker().Kind(), "lti")
+	}
+}
+
+func TestLTIChecker_Run_200_Success(t *testing.T) {
+	t.Parallel()
+	doer := &fakeLTIDoer{resp: ltiMockResponse(200)}
+	c := checkers.NewLTIChecker().WithLTIDoer(doer)
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindLTI,
+		Target: "https://lms.example.com/lti/launch",
+	})
+	if !r.Success {
+		t.Errorf("Success = false; want true: %s", r.Error)
+	}
+	if doer.got == nil || doer.got.Method != http.MethodHead {
+		t.Errorf("method = %q; want HEAD", doer.got.Method)
+	}
+}
+
+func TestLTIChecker_Run_302_Success(t *testing.T) {
+	t.Parallel()
+	// 3xx is intentionally a success for LTI (endpoints often redirect to
+	// a login page before the actual launch).
+	doer := &fakeLTIDoer{resp: ltiMockResponse(302)}
+	c := checkers.NewLTIChecker().WithLTIDoer(doer)
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindLTI,
+		Target: "https://lms.example.com/lti/launch",
+	})
+	if !r.Success {
+		t.Errorf("Success = false for 302; want true: %s", r.Error)
+	}
+}
+
+func TestLTIChecker_Run_500_Failure(t *testing.T) {
+	t.Parallel()
+	doer := &fakeLTIDoer{resp: ltiMockResponse(500)}
+	c := checkers.NewLTIChecker().WithLTIDoer(doer)
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindLTI,
+		Target: "https://lms.example.com/lti/launch",
+	})
+	if r.Success {
+		t.Error("Success = true for 500; want false")
+	}
+	if !strings.Contains(r.Error, "500") {
+		t.Errorf("Error = %q; want it to contain status code 500", r.Error)
+	}
+}
+
+func TestLTIChecker_Run_TransportError_Failure(t *testing.T) {
+	t.Parallel()
+	doer := &fakeLTIDoer{err: errors.New("connection refused")}
+	c := checkers.NewLTIChecker().WithLTIDoer(doer)
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindLTI,
+		Target: "https://lms.example.com/lti/launch",
+	})
+	if r.Success {
+		t.Error("Success = true on transport error; want false")
+	}
+	if r.Error == "" {
+		t.Error("Error is empty; want a descriptive message")
+	}
+}
+
+func TestLTIChecker_Run_SSLValid_Captured(t *testing.T) {
+	t.Parallel()
+	doer := &fakeLTIDoer{resp: ltiMockTLSResponse(200)}
+	c := checkers.NewLTIChecker().WithLTIDoer(doer)
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindLTI,
+		Target: "https://lms.example.com/lti/launch",
+	})
+	if !r.Success {
+		t.Fatalf("Success = false; want true: %s", r.Error)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("metadata unmarshal: %v", err)
+	}
+	if meta["ssl_valid"] != true {
+		t.Errorf("ssl_valid = %v; want true", meta["ssl_valid"])
+	}
+}

--- a/internal/probe/checkers/modbus.go
+++ b/internal/probe/checkers/modbus.go
@@ -1,0 +1,237 @@
+package checkers
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// defaultModbusTimeout is the per-attempt Modbus probe timeout.
+const defaultModbusTimeout = 5 * time.Second
+
+// defaultModbusPort is the default Modbus TCP port (IANA 502).
+const defaultModbusPort = 502
+
+// Modbus read function codes (Modbus Application Protocol V1.1b3 §6).
+const (
+	modbusFCReadCoils            = 0x01
+	modbusFCReadDiscreteInputs   = 0x02
+	modbusFCReadHoldingRegisters = 0x03
+	modbusFCReadInputRegisters   = 0x04
+)
+
+// Register-type selectors accepted in params.register_type.
+const (
+	modbusRegisterHolding  = "holding"
+	modbusRegisterInput    = "input"
+	modbusRegisterCoil     = "coil"
+	modbusRegisterDiscrete = "discrete"
+)
+
+// Modbus TCP ADU framing sizes (Modbus Messaging on TCP/IP V1.0b §3-4).
+const (
+	modbusRequestSize    = 12 // MBAP header (7) + PDU (5: FC + addr + qty)
+	modbusPDULength      = 6  // unit ID + FC + start addr + quantity, the MBAP length field
+	modbusMinResponseLen = 9  // MBAP (7) + FC (1) + byte-count/exception (1)
+	modbusExceptionFlag  = 0x80
+	modbusUnitIDMax      = 247 // 1-247 addressable; 0 = broadcast
+	modbusMaxRegister    = 0xFFFF
+)
+
+// modbusResponseBufferSize bounds a single read of the Modbus response.
+const modbusResponseBufferSize = 256
+
+// ModbusParams is the kind-specific params shape. UnitID and
+// TestRegister default to 0 (valid); RegisterType defaults to holding.
+type ModbusParams struct {
+	Port         int    `json:"port,omitempty"`          // default 502
+	UnitID       int    `json:"unit_id,omitempty"`       // 0-247, default 0
+	RegisterType string `json:"register_type,omitempty"` // holding|input|coil|discrete, default holding
+	TestRegister int    `json:"test_register,omitempty"` // 0-65535, default 0
+	TimeoutMs    int    `json:"timeout_ms,omitempty"`    // default 5000
+}
+
+// ModbusChecker implements probe.Checker for Kind="modbus". It opens a
+// Modbus TCP connection and issues a single read of one register/coil,
+// reporting success when the device returns a non-exception response.
+type ModbusChecker struct {
+	dialer PingDialer
+}
+
+// NewModbusChecker returns a ModbusChecker wired to a real dialer.
+func NewModbusChecker() *ModbusChecker {
+	return &ModbusChecker{dialer: realPingDialer{}}
+}
+
+// WithModbusDialer swaps the dialer (for tests).
+func (c *ModbusChecker) WithModbusDialer(d PingDialer) *ModbusChecker {
+	c.dialer = d
+	return c
+}
+
+// Kind returns probe.KindMODBUS.
+func (c *ModbusChecker) Kind() string { return probe.KindMODBUS }
+
+// RequiredCapabilities returns nil; Modbus TCP needs no special hardware.
+func (c *ModbusChecker) RequiredCapabilities() []string { return nil }
+
+// Run reads one register from the Modbus device at Target:Port and
+// reports success on a valid, non-exception response.
+func (c *ModbusChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
+	params := parseModbusParams(p.Params)
+
+	port := params.Port
+	if port == 0 {
+		port = defaultModbusPort
+	}
+	if params.UnitID < 0 || params.UnitID > modbusUnitIDMax {
+		return modbusFailure(p, 0, fmt.Sprintf(
+			"modbus probe requires params.unit_id in range 0-%d", modbusUnitIDMax))
+	}
+	if params.TestRegister < 0 || params.TestRegister > modbusMaxRegister {
+		return modbusFailure(p, 0, fmt.Sprintf(
+			"modbus probe requires params.test_register in range 0-%d", modbusMaxRegister))
+	}
+
+	timeout := defaultModbusTimeout
+	if params.TimeoutMs > 0 {
+		timeout = time.Duration(params.TimeoutMs) * time.Millisecond
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	addr := net.JoinHostPort(p.Target, strconv.Itoa(port))
+	start := time.Now()
+	conn, err := c.dialer.Dial(dialCtx, "tcp", addr)
+	if err != nil {
+		return modbusFailure(p, time.Since(start), err.Error())
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	functionCode := modbusFunctionCode(params.RegisterType)
+	request := buildModbusTCPRequest(
+		uint8(params.UnitID),
+		functionCode,
+		uint16(params.TestRegister),
+		1,
+	)
+	if _, writeErr := conn.Write(request); writeErr != nil {
+		return modbusFailure(p, time.Since(start), "write request: "+writeErr.Error())
+	}
+
+	respBuf := make([]byte, modbusResponseBufferSize)
+	n, readErr := conn.Read(respBuf)
+	if readErr != nil {
+		return modbusFailure(p, time.Since(start), "read response: "+readErr.Error())
+	}
+	latencyMs := float64(time.Since(start).Milliseconds())
+
+	if n < modbusMinResponseLen {
+		return modbusFailure(p, time.Since(start), "response too short")
+	}
+	// Exception response: function code byte has the high bit set.
+	if respBuf[7]&modbusExceptionFlag != 0 {
+		return modbusFailure(p, time.Since(start), "modbus exception: "+modbusExceptionString(respBuf[8]))
+	}
+
+	meta := map[string]any{
+		metaKeyAddr:     addr,
+		"unit_id":       params.UnitID,
+		"function_code": functionCode,
+	}
+	// Register reads carry a 16-bit value at the data offset; surface it.
+	if (functionCode == modbusFCReadHoldingRegisters || functionCode == modbusFCReadInputRegisters) && n >= 11 {
+		meta["register_value"] = int(binary.BigEndian.Uint16(respBuf[9:11]))
+	}
+	metaJSON, _ := json.Marshal(meta)
+
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   true,
+		LatencyMs: latencyMs,
+		Metadata:  metaJSON,
+	}
+}
+
+// modbusFailure builds a failed Result with the measured latency so far.
+func modbusFailure(p probe.Probe, elapsed time.Duration, msg string) probe.Result {
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   false,
+		LatencyMs: float64(elapsed.Milliseconds()),
+		Error:     msg,
+	}
+}
+
+// modbusFunctionCode maps a register-type selector to its read function
+// code, defaulting to holding registers for any unrecognized value.
+func modbusFunctionCode(registerType string) uint8 {
+	switch strings.ToLower(registerType) {
+	case modbusRegisterCoil:
+		return modbusFCReadCoils
+	case modbusRegisterDiscrete:
+		return modbusFCReadDiscreteInputs
+	case modbusRegisterInput:
+		return modbusFCReadInputRegisters
+	default:
+		return modbusFCReadHoldingRegisters
+	}
+}
+
+// buildModbusTCPRequest assembles a Modbus TCP/IP ADU: a 7-byte MBAP
+// header (transaction ID, protocol ID 0, length, unit ID) followed by
+// the read PDU (function code, start address, quantity).
+func buildModbusTCPRequest(unitID, functionCode uint8, startAddr, quantity uint16) []byte {
+	request := make([]byte, modbusRequestSize)
+	binary.BigEndian.PutUint16(request[0:2], 1) // transaction ID (arbitrary)
+	binary.BigEndian.PutUint16(request[2:4], 0) // protocol ID (0 = Modbus)
+	binary.BigEndian.PutUint16(request[4:6], modbusPDULength)
+	request[6] = unitID
+	request[7] = functionCode
+	binary.BigEndian.PutUint16(request[8:10], startAddr)
+	binary.BigEndian.PutUint16(request[10:12], quantity)
+	return request
+}
+
+// modbusExceptionString renders a Modbus exception code (Modbus
+// Application Protocol V1.1b3 §7) as a human-readable reason.
+func modbusExceptionString(code uint8) string {
+	exceptions := map[uint8]string{
+		0x01: "Illegal Function",
+		0x02: "Illegal Data Address",
+		0x03: "Illegal Data Value",
+		0x04: "Server Device Failure",
+		0x05: "Acknowledge",
+		0x06: "Server Device Busy",
+		0x08: "Memory Parity Error",
+		0x0A: "Gateway Path Unavailable",
+		0x0B: "Gateway Target Device Failed to Respond",
+	}
+	if msg, ok := exceptions[code]; ok {
+		return msg
+	}
+	return fmt.Sprintf("Unknown exception (0x%02X)", code)
+}
+
+func parseModbusParams(raw json.RawMessage) ModbusParams {
+	if len(raw) == 0 {
+		return ModbusParams{}
+	}
+	var p ModbusParams
+	_ = json.Unmarshal(raw, &p)
+	return p
+}

--- a/internal/probe/checkers/modbus_test.go
+++ b/internal/probe/checkers/modbus_test.go
@@ -1,0 +1,156 @@
+package checkers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
+)
+
+// modbusFakeConn delivers a canned Modbus TCP response and records the
+// request bytes the checker wrote.
+type modbusFakeConn struct {
+	mu       sync.Mutex
+	response []byte
+	written  []byte
+	pos      int
+}
+
+func (m *modbusFakeConn) Read(b []byte) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.pos >= len(m.response) {
+		return 0, errors.New("modbusFakeConn: response exhausted")
+	}
+	n := copy(b, m.response[m.pos:])
+	m.pos += n
+	return n, nil
+}
+
+func (m *modbusFakeConn) Write(b []byte) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.written = append(m.written, b...)
+	return len(b), nil
+}
+
+func (*modbusFakeConn) Close() error                     { return nil }
+func (*modbusFakeConn) LocalAddr() net.Addr              { return nil }
+func (*modbusFakeConn) RemoteAddr() net.Addr             { return nil }
+func (*modbusFakeConn) SetDeadline(time.Time) error      { return nil }
+func (*modbusFakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (*modbusFakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+type modbusDialer struct {
+	conn net.Conn
+	err  error
+}
+
+func (d *modbusDialer) Dial(_ context.Context, _, _ string) (net.Conn, error) {
+	return d.conn, d.err
+}
+
+// makeModbusReadResponse builds a holding-register read response with
+// the given 16-bit value: MBAP header + FC 0x03 + byte count 2 + value.
+func makeModbusReadResponse(value uint16) []byte {
+	return []byte{
+		0x00, 0x01, // transaction ID
+		0x00, 0x00, // protocol ID
+		0x00, 0x05, // length
+		0x00,             // unit ID
+		0x03,             // function code (read holding registers)
+		0x02,             // byte count
+		byte(value >> 8), // value hi
+		byte(value),      // value lo
+	}
+}
+
+// makeModbusException builds an exception response: FC with high bit set
+// plus an exception code.
+func makeModbusException(fc, code uint8) []byte {
+	return []byte{
+		0x00, 0x01,
+		0x00, 0x00,
+		0x00, 0x03,
+		0x00,
+		fc | 0x80,
+		code,
+	}
+}
+
+func TestModbusChecker_Kind(t *testing.T) {
+	t.Parallel()
+	if checkers.NewModbusChecker().Kind() != "modbus" {
+		t.Errorf("Kind != modbus")
+	}
+}
+
+func TestModbusChecker_Run_Success(t *testing.T) {
+	t.Parallel()
+	conn := &modbusFakeConn{response: makeModbusReadResponse(0x1234)}
+	c := checkers.NewModbusChecker().WithModbusDialer(&modbusDialer{conn: conn})
+	r := c.Run(context.Background(), probe.Probe{Kind: "modbus", Target: "plc.example.com"})
+	if !r.Success {
+		t.Fatalf("Success = false on valid read: %s", r.Error)
+	}
+	// The request is a well-formed Modbus TCP ADU: protocol ID 0, FC 0x03.
+	if len(conn.written) != 12 || conn.written[2] != 0x00 || conn.written[3] != 0x00 || conn.written[7] != 0x03 {
+		t.Errorf("malformed request ADU: %v", conn.written)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("metadata not JSON: %v", err)
+	}
+	if got, ok := meta["register_value"].(float64); !ok || int(got) != 0x1234 {
+		t.Errorf("register_value = %v, want 4660", meta["register_value"])
+	}
+}
+
+func TestModbusChecker_Run_Exception(t *testing.T) {
+	t.Parallel()
+	conn := &modbusFakeConn{response: makeModbusException(0x03, 0x02)}
+	c := checkers.NewModbusChecker().WithModbusDialer(&modbusDialer{conn: conn})
+	r := c.Run(context.Background(), probe.Probe{Kind: "modbus", Target: "plc.example.com"})
+	if r.Success {
+		t.Error("Success = true on exception response; want false")
+	}
+	if r.Error == "" {
+		t.Error("expected an exception error message")
+	}
+}
+
+func TestModbusChecker_Run_DialError(t *testing.T) {
+	t.Parallel()
+	c := checkers.NewModbusChecker().WithModbusDialer(&modbusDialer{err: errors.New("refused")})
+	r := c.Run(context.Background(), probe.Probe{Kind: "modbus", Target: "down"})
+	if r.Success {
+		t.Error("Success = true; dial error should fail")
+	}
+}
+
+func TestModbusChecker_Run_InvalidUnitID(t *testing.T) {
+	t.Parallel()
+	params, _ := json.Marshal(checkers.ModbusParams{UnitID: 999})
+	c := checkers.NewModbusChecker().WithModbusDialer(&modbusDialer{conn: &modbusFakeConn{}})
+	r := c.Run(context.Background(), probe.Probe{Kind: "modbus", Target: "plc", Params: params})
+	if r.Success {
+		t.Error("Success = true with out-of-range unit_id; want validation failure")
+	}
+}
+
+func TestModbusChecker_Run_RegisterTypeSelectsFunctionCode(t *testing.T) {
+	t.Parallel()
+	conn := &modbusFakeConn{response: makeModbusException(0x01, 0x01)}
+	params, _ := json.Marshal(checkers.ModbusParams{RegisterType: "coil"})
+	c := checkers.NewModbusChecker().WithModbusDialer(&modbusDialer{conn: conn})
+	_ = c.Run(context.Background(), probe.Probe{Kind: "modbus", Target: "plc", Params: params})
+	if len(conn.written) < 8 || conn.written[7] != 0x01 {
+		t.Errorf("coil register_type should select FC 0x01; got %v", conn.written)
+	}
+}

--- a/internal/probe/checkers/opcua.go
+++ b/internal/probe/checkers/opcua.go
@@ -1,0 +1,195 @@
+package checkers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// defaultOPCUATimeout is the per-attempt OPC-UA probe timeout.
+const defaultOPCUATimeout = 10 * time.Second
+
+// defaultOPCUAPort is the default OPC-UA TCP port (IANA 4840).
+const defaultOPCUAPort = 4840
+
+// opcuaReadDeadlineWindow is the short read deadline applied after the
+// Hello write. A timeout here is NOT a failure — TCP already succeeded.
+const opcuaReadDeadlineWindow = 2 * time.Second
+
+// opcuaResponseBufferSize bounds a single read of the OPC-UA response.
+const opcuaResponseBufferSize = 256
+
+// opcuaMinResponseLen is the minimum byte count to inspect the message type.
+const opcuaMinResponseLen = 4
+
+// opcuaHello is the 4-byte minimal OPC-UA Hello prefix (OPC-UA Part 6
+// §7.1.2, "HEL" message type + "F" final-chunk flag).
+const opcuaHello = "HELF"
+
+// OPCUAParams is the kind-specific params shape. All fields are optional.
+type OPCUAParams struct {
+	// SecurityMode is informational only (None / Sign / SignAndEncrypt).
+	// V1.0 does not negotiate a secure channel; it is stored in metadata.
+	SecurityMode string `json:"security_mode,omitempty"`
+
+	// TimeoutMs overrides the per-attempt dial timeout. Default 10000.
+	TimeoutMs int `json:"timeout_ms,omitempty"`
+}
+
+// OPCUAChecker implements probe.Checker for Kind="opcua". It opens a
+// TCP connection to the OPC-UA server, writes a 4-byte Hello prefix,
+// and reads whatever the server sends back.
+//
+// Scoping (V1.0): this is a shallow TCP + minimal Hello probe. It does
+// NOT perform a full OPC-UA OpenSecureChannel / GetEndpoints handshake.
+// TCP connect success is the pass signal; ACK/ERR classification is
+// informational. Operators needing the full handshake should use an
+// OPC-UA client library outside this probe.
+type OPCUAChecker struct {
+	dialer PingDialer
+}
+
+// NewOPCUAChecker returns an OPCUAChecker wired to a real dialer.
+func NewOPCUAChecker() *OPCUAChecker {
+	return &OPCUAChecker{dialer: realPingDialer{}}
+}
+
+// WithOPCUADialer swaps the dialer (for tests).
+func (c *OPCUAChecker) WithOPCUADialer(d PingDialer) *OPCUAChecker {
+	c.dialer = d
+	return c
+}
+
+// Kind returns probe.KindOPCUA.
+func (c *OPCUAChecker) Kind() string { return probe.KindOPCUA }
+
+// RequiredCapabilities returns nil; OPC-UA TCP needs no special hardware.
+func (c *OPCUAChecker) RequiredCapabilities() []string { return nil }
+
+// Run connects to the OPC-UA TCP port derived from Probe.Target
+// (expected form: opc.tcp://host:port/path), writes a minimal Hello
+// prefix, and classifies the server's response. TCP connect success
+// means Success=true; only a dial error, URL parse error, or write
+// error is a hard failure.
+func (c *OPCUAChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
+	params := parseOPCUAParams(p.Params)
+
+	timeout := defaultOPCUATimeout
+	if params.TimeoutMs > 0 {
+		timeout = time.Duration(params.TimeoutMs) * time.Millisecond
+	}
+
+	// Parse opc.tcp://host:port/path — net/url handles the scheme.
+	parsedURL, parseErr := url.Parse(p.Target)
+	if parseErr != nil {
+		return opcuaFailure(p, 0, "parse target URL: "+parseErr.Error())
+	}
+	host := parsedURL.Hostname()
+	port := parsedURL.Port()
+	if port == "" {
+		port = strconv.Itoa(defaultOPCUAPort)
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	addr := net.JoinHostPort(host, port)
+	start := time.Now()
+	conn, err := c.dialer.Dial(dialCtx, "tcp", addr)
+	if err != nil {
+		return opcuaFailure(p, time.Since(start), "connection failed: "+err.Error())
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Write the Hello prefix. A write error means the connection dropped
+	// immediately — treat as a failure.
+	if _, writeErr := conn.Write([]byte(opcuaHello)); writeErr != nil {
+		return opcuaFailure(p, time.Since(start), "send Hello: "+writeErr.Error())
+	}
+
+	// Apply a short read deadline. A timeout or closed connection here is
+	// NOT a failure: the TCP connection already succeeded, meaning the
+	// server is reachable. Some servers reject the malformed Hello and
+	// close cleanly; that is still a connectivity success.
+	_ = conn.SetReadDeadline(time.Now().Add(opcuaReadDeadlineWindow))
+	respBuf := make([]byte, opcuaResponseBufferSize)
+	n, readErr := conn.Read(respBuf)
+
+	latencyMs := float64(time.Since(start).Milliseconds())
+
+	serverInfo, msgType := opcuaClassifyResponse(n, readErr, respBuf)
+
+	meta := map[string]any{
+		metaKeyAddr:   addr,
+		"server_info": serverInfo,
+	}
+	if msgType != "" {
+		meta["msg_type"] = msgType
+	}
+	if params.SecurityMode != "" {
+		meta["security_mode"] = params.SecurityMode
+	}
+	metaJSON, _ := json.Marshal(meta)
+
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   true,
+		LatencyMs: latencyMs,
+		Metadata:  metaJSON,
+	}
+}
+
+// opcuaClassifyResponse interprets the first bytes of the server
+// response and returns a human-readable server_info string plus the
+// raw 3-byte message type (empty when there was no readable response).
+func opcuaClassifyResponse(n int, readErr error, buf []byte) (string, string) {
+	const tcpOnly = "TCP connection successful, server may require full handshake"
+	if readErr != nil {
+		// Timeout or connection close after Hello — TCP is fine.
+		return tcpOnly, ""
+	}
+	if n < opcuaMinResponseLen {
+		// Too short to classify; still a TCP success.
+		return tcpOnly, ""
+	}
+	msgType := string(buf[:3])
+	switch msgType {
+	case "ACK":
+		return "OPC-UA server acknowledged connection", msgType
+	case "ERR":
+		return "OPC-UA server returned error (authentication may be required)", msgType
+	default:
+		return fmt.Sprintf("server responded with: %s", msgType), msgType
+	}
+}
+
+// opcuaFailure builds a failed Result with the measured latency so far.
+func opcuaFailure(p probe.Probe, elapsed time.Duration, msg string) probe.Result {
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   false,
+		LatencyMs: float64(elapsed.Milliseconds()),
+		Error:     msg,
+	}
+}
+
+func parseOPCUAParams(raw json.RawMessage) OPCUAParams {
+	if len(raw) == 0 {
+		return OPCUAParams{}
+	}
+	var p OPCUAParams
+	_ = json.Unmarshal(raw, &p)
+	return p
+}

--- a/internal/probe/checkers/opcua_test.go
+++ b/internal/probe/checkers/opcua_test.go
@@ -1,0 +1,231 @@
+package checkers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
+)
+
+// opcuaFakeConn delivers canned response bytes and records the bytes
+// the checker wrote (to verify the Hello prefix was sent).
+type opcuaFakeConn struct {
+	mu       sync.Mutex
+	response []byte
+	written  []byte
+	pos      int
+	readErr  error
+}
+
+func (o *opcuaFakeConn) Read(b []byte) (int, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.readErr != nil {
+		return 0, o.readErr
+	}
+	if o.pos >= len(o.response) {
+		return 0, errors.New("opcuaFakeConn: response exhausted")
+	}
+	n := copy(b, o.response[o.pos:])
+	o.pos += n
+	return n, nil
+}
+
+func (o *opcuaFakeConn) Write(b []byte) (int, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.written = append(o.written, b...)
+	return len(b), nil
+}
+
+func (*opcuaFakeConn) Close() error                     { return nil }
+func (*opcuaFakeConn) LocalAddr() net.Addr              { return nil }
+func (*opcuaFakeConn) RemoteAddr() net.Addr             { return nil }
+func (*opcuaFakeConn) SetDeadline(time.Time) error      { return nil }
+func (*opcuaFakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (*opcuaFakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+type opcuaDialer struct {
+	conn net.Conn
+	err  error
+}
+
+func (d *opcuaDialer) Dial(_ context.Context, _, _ string) (net.Conn, error) {
+	return d.conn, d.err
+}
+
+// makeOPCUAResponse builds a padded response starting with the given
+// 3-byte message type, long enough to satisfy opcuaMinResponseLen.
+func makeOPCUAResponse(msgType string) []byte {
+	resp := make([]byte, 8)
+	copy(resp, msgType)
+	return resp
+}
+
+// --- Tests ---
+
+func TestOPCUAChecker_Kind(t *testing.T) {
+	t.Parallel()
+	if checkers.NewOPCUAChecker().Kind() != "opcua" {
+		t.Errorf("Kind() != opcua")
+	}
+}
+
+func TestOPCUAChecker_Run_SuccessACK(t *testing.T) {
+	t.Parallel()
+
+	conn := &opcuaFakeConn{response: makeOPCUAResponse("ACK")}
+	c := checkers.NewOPCUAChecker().WithOPCUADialer(&opcuaDialer{conn: conn})
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "opcua",
+		Target: "opc.tcp://plc.example.com:4840/server",
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false on ACK response: %s", r.Error)
+	}
+
+	// Verify the checker wrote the 4-byte Hello prefix.
+	conn.mu.Lock()
+	written := conn.written
+	conn.mu.Unlock()
+	if len(written) < 4 || string(written[:4]) != "HELF" {
+		t.Errorf("expected HELF written; got %q", written)
+	}
+
+	// Verify metadata contains acknowledged server_info.
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("metadata not JSON: %v", err)
+	}
+	serverInfo, _ := meta["server_info"].(string)
+	if serverInfo == "" || serverInfo == "TCP connection successful, server may require full handshake" {
+		t.Errorf("server_info %q should mention acknowledged; got %q", serverInfo, serverInfo)
+	}
+	if mt, ok := meta["msg_type"].(string); !ok || mt != "ACK" {
+		t.Errorf("msg_type = %v, want ACK", meta["msg_type"])
+	}
+}
+
+func TestOPCUAChecker_Run_SuccessERR(t *testing.T) {
+	t.Parallel()
+
+	// ERR response = still a TCP-level success (auth may be required).
+	conn := &opcuaFakeConn{response: makeOPCUAResponse("ERR")}
+	c := checkers.NewOPCUAChecker().WithOPCUADialer(&opcuaDialer{conn: conn})
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "opcua",
+		Target: "opc.tcp://plc.example.com:4840/server",
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false on ERR response: %s", r.Error)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("metadata not JSON: %v", err)
+	}
+	if mt, ok := meta["msg_type"].(string); !ok || mt != "ERR" {
+		t.Errorf("msg_type = %v, want ERR", meta["msg_type"])
+	}
+}
+
+func TestOPCUAChecker_Run_SuccessReadError(t *testing.T) {
+	t.Parallel()
+
+	// Read returns an error (e.g. timeout or connection close). The TCP
+	// connect + Hello write succeeded, so Success must still be true.
+	conn := &opcuaFakeConn{readErr: errors.New("i/o timeout")}
+	c := checkers.NewOPCUAChecker().WithOPCUADialer(&opcuaDialer{conn: conn})
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "opcua",
+		Target: "opc.tcp://192.0.2.1:4840",
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false on read error; TCP-only path should still succeed: %s", r.Error)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("metadata not JSON: %v", err)
+	}
+	// msg_type should be absent when there was no readable response.
+	if _, present := meta["msg_type"]; present {
+		t.Errorf("msg_type present when no response was read; want absent")
+	}
+}
+
+func TestOPCUAChecker_Run_DialError(t *testing.T) {
+	t.Parallel()
+
+	c := checkers.NewOPCUAChecker().WithOPCUADialer(&opcuaDialer{err: errors.New("connection refused")})
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "opcua",
+		Target: "opc.tcp://down.example.com:4840",
+	})
+
+	if r.Success {
+		t.Error("Success = true; dial error should fail the probe")
+	}
+	if r.Error == "" {
+		t.Error("expected a non-empty Error on dial failure")
+	}
+}
+
+func TestOPCUAChecker_Run_MalformedTarget(t *testing.T) {
+	t.Parallel()
+
+	// A colon-only target breaks url.Parse Hostname/Port extraction.
+	// The checker should fail cleanly without panicking.
+	c := checkers.NewOPCUAChecker().WithOPCUADialer(&opcuaDialer{conn: &opcuaFakeConn{}})
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "opcua",
+		Target: "://\x00invalid",
+	})
+
+	if r.Success {
+		t.Error("Success = true on malformed URL; want failure")
+	}
+	if r.Error == "" {
+		t.Error("expected a non-empty Error for malformed URL")
+	}
+}
+
+func TestOPCUAChecker_Run_DefaultPort(t *testing.T) {
+	t.Parallel()
+
+	// A target without an explicit port should dial on 4840.
+	var dialedAddr string
+	fakeDialer := &opcuaDialerFunc{fn: func(_ context.Context, _, addr string) (net.Conn, error) {
+		dialedAddr = addr
+		return &opcuaFakeConn{readErr: errors.New("timeout")}, nil
+	}}
+
+	c := checkers.NewOPCUAChecker().WithOPCUADialer(fakeDialer)
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   "opcua",
+		Target: "opc.tcp://plc.factory.local/sensor",
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false: %s", r.Error)
+	}
+	if dialedAddr != "plc.factory.local:4840" {
+		t.Errorf("dialed %q; want plc.factory.local:4840", dialedAddr)
+	}
+}
+
+// opcuaDialerFunc allows an inline func as a PingDialer.
+type opcuaDialerFunc struct {
+	fn func(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+func (d *opcuaDialerFunc) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	return d.fn(ctx, network, addr)
+}

--- a/internal/probe/checkers/rtsp.go
+++ b/internal/probe/checkers/rtsp.go
@@ -117,7 +117,7 @@ func (c *RTSPChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
 
 	meta, _ := json.Marshal(map[string]any{
 		"status_line": statusLine,
-		"addr":        addr,
+		metaKeyAddr:   addr,
 	})
 
 	if !statusOK {

--- a/internal/probe/checkers/sql.go
+++ b/internal/probe/checkers/sql.go
@@ -1,0 +1,237 @@
+package checkers
+
+// SQLChecker implements probe.Checker for Kind="sql".
+//
+// V1.0 scope — reachability only: for network-backed databases (MySQL,
+// PostgreSQL, SQL Server, Oracle) the checker dials the database TCP port
+// and reports Success on connect. Driver-level authentication, session
+// setup, and query execution are out of scope for V1.0 because no SQL
+// driver is imported in this module; adding one would require a dependency
+// that is unjustified until a specific customer need arises.
+//
+// For SQLite (file-backed, no network) the checker verifies that the
+// database file exists and is a regular file via os.Stat. No read or write
+// is attempted — file presence is sufficient evidence of reachability.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// defaultSQLTimeout is the per-attempt SQL probe timeout.
+const defaultSQLTimeout = 10 * time.Second
+
+// Default TCP ports by driver (IANA / vendor assignments).
+const (
+	defaultMySQLPort     = 3306
+	defaultPostgresPort  = 5432
+	defaultSQLServerPort = 1433
+	defaultOraclePort    = 1521
+)
+
+// Recognised driver identifiers accepted in SQLParams.Driver.
+const (
+	sqlDriverMySQL     = "mysql"
+	sqlDriverPostgres  = "postgres"
+	sqlDriverSQLServer = "sqlserver"
+	sqlDriverOracle    = "oracle"
+	sqlDriverSQLite    = "sqlite"
+)
+
+// SQLParams is the kind-specific params shape. Driver is required.
+// Port, Database, and TimeoutMs are optional and default as described.
+type SQLParams struct {
+	// Driver selects the database engine: "mysql", "postgres",
+	// "sqlserver", "oracle", or "sqlite".
+	Driver string `json:"driver,omitempty"`
+
+	// Port overrides the well-known TCP port for the driver. When 0
+	// the checker uses the driver default (mysql=3306, postgres=5432,
+	// sqlserver=1433, oracle=1521). Unused for sqlite.
+	Port int `json:"port,omitempty"`
+
+	// Database names the database / file path. For sqlite the value is
+	// used as the file path when non-empty, falling back to Probe.Target.
+	Database string `json:"database,omitempty"`
+
+	// TimeoutMs overrides the default 10 000 ms dial/stat timeout.
+	TimeoutMs int `json:"timeout_ms,omitempty"`
+}
+
+// SQLChecker implements probe.Checker for Kind="sql" — TCP reachability
+// for network databases; file-stat reachability for SQLite.
+type SQLChecker struct {
+	dialer PingDialer
+}
+
+// NewSQLChecker returns an SQLChecker wired to a real [net.Dialer].
+func NewSQLChecker() *SQLChecker {
+	return &SQLChecker{dialer: realPingDialer{}}
+}
+
+// WithSQLDialer swaps the dialer; used by tests.
+func (c *SQLChecker) WithSQLDialer(d PingDialer) *SQLChecker {
+	c.dialer = d
+	return c
+}
+
+// Kind returns probe.KindSQL.
+func (c *SQLChecker) Kind() string { return probe.KindSQL }
+
+// RequiredCapabilities returns nil; TCP dial and file-stat need no
+// special hardware capability.
+func (c *SQLChecker) RequiredCapabilities() []string { return nil }
+
+// Run probes the SQL endpoint. For SQLite it stat-checks the database
+// file; for all other drivers it dials Target:Port over TCP.
+func (c *SQLChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
+	params := parseSQLParams(p.Params)
+
+	timeout := defaultSQLTimeout
+	if params.TimeoutMs > 0 {
+		timeout = time.Duration(params.TimeoutMs) * time.Millisecond
+	}
+
+	driver := strings.ToLower(strings.TrimSpace(params.Driver))
+
+	if driver == sqlDriverSQLite {
+		return c.runSQLite(p, params, timeout)
+	}
+
+	return c.runNetwork(ctx, p, params, driver, timeout)
+}
+
+// runSQLite stat-checks the SQLite database file. It reports Success
+// when the file exists and is a regular file (not a directory).
+func (c *SQLChecker) runSQLite(p probe.Probe, params SQLParams, _ time.Duration) probe.Result {
+	path := params.Database
+	if path == "" {
+		path = p.Target
+	}
+
+	start := time.Now()
+	fi, err := os.Stat(path)
+	latencyMs := float64(time.Since(start).Milliseconds())
+
+	if err != nil {
+		return sqlFailure(p, latencyMs, fmt.Sprintf("sqlite: cannot stat %q: %s", path, err.Error()))
+	}
+	if fi.IsDir() {
+		return sqlFailure(p, latencyMs, fmt.Sprintf("sqlite: path %q is a directory, not a file", path))
+	}
+
+	meta, _ := json.Marshal(map[string]any{
+		"driver":         sqlDriverSQLite,
+		"path":           path,
+		"size":           fi.Size(),
+		"modified":       fi.ModTime().UTC().Format(time.RFC3339),
+		"server_version": "SQLite",
+	})
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   true,
+		LatencyMs: latencyMs,
+		Metadata:  meta,
+	}
+}
+
+// runNetwork dials the database TCP port and reports reachability.
+func (c *SQLChecker) runNetwork(
+	ctx context.Context,
+	p probe.Probe,
+	params SQLParams,
+	driver string,
+	timeout time.Duration,
+) probe.Result {
+	port, err := resolvePort(driver, params.Port)
+	if err != nil {
+		return sqlFailure(p, 0, err.Error())
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	addr := net.JoinHostPort(p.Target, strconv.Itoa(port))
+	start := time.Now()
+	conn, dialErr := c.dialer.Dial(dialCtx, "tcp", addr)
+	latencyMs := float64(time.Since(start).Milliseconds())
+
+	if dialErr != nil {
+		return sqlFailure(p, latencyMs, dialErr.Error())
+	}
+	_ = conn.Close()
+
+	meta, _ := json.Marshal(map[string]any{
+		"driver":    driver,
+		metaKeyAddr: addr,
+		"database":  params.Database,
+	})
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   true,
+		LatencyMs: latencyMs,
+		Metadata:  meta,
+	}
+}
+
+// resolvePort returns the effective TCP port for the given driver,
+// applying the well-known default when port is 0. It returns an error
+// for unknown or empty driver names.
+func resolvePort(driver string, port int) (int, error) {
+	if port > 0 {
+		return port, nil
+	}
+	switch driver {
+	case sqlDriverMySQL:
+		return defaultMySQLPort, nil
+	case sqlDriverPostgres:
+		return defaultPostgresPort, nil
+	case sqlDriverSQLServer:
+		return defaultSQLServerPort, nil
+	case sqlDriverOracle:
+		return defaultOraclePort, nil
+	case "":
+		return 0, errors.New("sql probe requires params.driver (mysql|postgres|sqlserver|oracle|sqlite)")
+	default:
+		return 0, fmt.Errorf("sql probe: unknown driver %q; want mysql|postgres|sqlserver|oracle|sqlite", driver)
+	}
+}
+
+// sqlFailure builds a failed Result with the measured latency so far.
+func sqlFailure(p probe.Probe, latencyMs float64, msg string) probe.Result {
+	return probe.Result{
+		ProbeID:   p.ID,
+		ClientID:  p.ClientID,
+		Kind:      p.Kind,
+		Timestamp: time.Now().UTC(),
+		Success:   false,
+		LatencyMs: latencyMs,
+		Error:     msg,
+	}
+}
+
+// parseSQLParams decodes the params JSON; returns zero on empty or
+// unparseable input.
+func parseSQLParams(raw json.RawMessage) SQLParams {
+	if len(raw) == 0 {
+		return SQLParams{}
+	}
+	var p SQLParams
+	_ = json.Unmarshal(raw, &p)
+	return p
+}

--- a/internal/probe/checkers/sql_test.go
+++ b/internal/probe/checkers/sql_test.go
@@ -1,0 +1,249 @@
+package checkers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
+)
+
+// newSQLDialer returns a modbusDialer (defined in modbus_test.go, same
+// package) wired to succeed or fail — the SQL TCP path only calls Dial
+// and Close, so the heavier modbusFakeConn is a fine substitute.
+func newSQLDialer(err error) *modbusDialer {
+	if err != nil {
+		return &modbusDialer{err: err}
+	}
+	// Success path: provide a conn that Close() never errors.
+	return &modbusDialer{conn: &modbusFakeConn{}}
+}
+
+// ---- Kind -----------------------------------------------------------------
+
+func TestSQLChecker_Kind(t *testing.T) {
+	t.Parallel()
+	if checkers.NewSQLChecker().Kind() != "sql" {
+		t.Errorf("Kind() = %q; want %q", checkers.NewSQLChecker().Kind(), "sql")
+	}
+}
+
+// ---- TCP path — postgres ---------------------------------------------------
+
+func TestSQLChecker_Run_Postgres_Success(t *testing.T) {
+	t.Parallel()
+
+	params, _ := json.Marshal(checkers.SQLParams{Driver: "postgres"})
+	c := checkers.NewSQLChecker().WithSQLDialer(newSQLDialer(nil))
+	r := c.Run(context.Background(), probe.Probe{
+		ID:     "p1",
+		Kind:   probe.KindSQL,
+		Target: "db.example.com",
+		Params: params,
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false; want true: %s", r.Error)
+	}
+	if r.Kind != probe.KindSQL {
+		t.Errorf("Kind = %q; want %q", r.Kind, probe.KindSQL)
+	}
+
+	// Metadata must contain driver and addr.
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("Metadata not valid JSON: %v", err)
+	}
+	if meta["driver"] != "postgres" {
+		t.Errorf("metadata.driver = %v; want %q", meta["driver"], "postgres")
+	}
+	if addr, ok := meta["addr"].(string); !ok || addr == "" {
+		t.Errorf("metadata.addr missing or empty")
+	}
+}
+
+func TestSQLChecker_Run_Postgres_DialError(t *testing.T) {
+	t.Parallel()
+
+	params, _ := json.Marshal(checkers.SQLParams{Driver: "postgres"})
+	c := checkers.NewSQLChecker().WithSQLDialer(newSQLDialer(errors.New("connection refused")))
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindSQL,
+		Target: "down.example.com",
+		Params: params,
+	})
+
+	if r.Success {
+		t.Error("Success = true on dial error; want false")
+	}
+	if r.Error == "" {
+		t.Error("Error field empty on dial failure")
+	}
+}
+
+// ---- TCP path — MySQL default port ----------------------------------------
+
+func TestSQLChecker_Run_MySQL_DefaultPort(t *testing.T) {
+	t.Parallel()
+
+	params, _ := json.Marshal(checkers.SQLParams{Driver: "mysql"})
+	c := checkers.NewSQLChecker().WithSQLDialer(newSQLDialer(nil))
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindSQL,
+		Target: "mysql.example.com",
+		Params: params,
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false; want true: %s", r.Error)
+	}
+	var meta map[string]any
+	_ = json.Unmarshal(r.Metadata, &meta)
+	// addr should include the default MySQL port 3306.
+	if addr, _ := meta["addr"].(string); addr == "" {
+		t.Error("metadata.addr missing")
+	}
+}
+
+// ---- Unknown / empty driver -----------------------------------------------
+
+func TestSQLChecker_Run_UnknownDriver(t *testing.T) {
+	t.Parallel()
+
+	params, _ := json.Marshal(checkers.SQLParams{Driver: "cassandra"})
+	c := checkers.NewSQLChecker().WithSQLDialer(newSQLDialer(nil))
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindSQL,
+		Target: "host.example.com",
+		Params: params,
+	})
+
+	if r.Success {
+		t.Error("Success = true for unknown driver; want false")
+	}
+	if r.Error == "" {
+		t.Error("Error field empty for unknown driver")
+	}
+}
+
+func TestSQLChecker_Run_EmptyDriver(t *testing.T) {
+	t.Parallel()
+
+	// No params at all — driver defaults to empty string.
+	c := checkers.NewSQLChecker().WithSQLDialer(newSQLDialer(nil))
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindSQL,
+		Target: "host.example.com",
+	})
+
+	if r.Success {
+		t.Error("Success = true with no driver specified; want false")
+	}
+	if r.Error == "" {
+		t.Error("Error field empty for missing driver")
+	}
+}
+
+// ---- SQLite path ----------------------------------------------------------
+
+func TestSQLChecker_Run_SQLite_FileExists(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dbFile := filepath.Join(dir, "test.db")
+	if err := os.WriteFile(dbFile, []byte("SQLite format 3"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	params, _ := json.Marshal(checkers.SQLParams{Driver: "sqlite", Database: dbFile})
+	// SQLite path does not use the dialer; pass nil-conn dialer to confirm it
+	// is never invoked (a dial attempt would return an error and fail the test).
+	c := checkers.NewSQLChecker()
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindSQL,
+		Target: dbFile,
+		Params: params,
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false; want true: %s", r.Error)
+	}
+
+	var meta map[string]any
+	if err := json.Unmarshal(r.Metadata, &meta); err != nil {
+		t.Fatalf("Metadata not valid JSON: %v", err)
+	}
+	if meta["server_version"] != "SQLite" {
+		t.Errorf("metadata.server_version = %v; want %q", meta["server_version"], "SQLite")
+	}
+	if meta["path"] != dbFile {
+		t.Errorf("metadata.path = %v; want %q", meta["path"], dbFile)
+	}
+}
+
+func TestSQLChecker_Run_SQLite_FileNotFound(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nonexistent.db")
+
+	params, _ := json.Marshal(checkers.SQLParams{Driver: "sqlite", Database: missing})
+	c := checkers.NewSQLChecker()
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindSQL,
+		Target: missing,
+		Params: params,
+	})
+
+	if r.Success {
+		t.Error("Success = true for missing SQLite file; want false")
+	}
+	if r.Error == "" {
+		t.Error("Error field empty for missing file")
+	}
+}
+
+func TestSQLChecker_Run_SQLite_TargetFallback(t *testing.T) {
+	t.Parallel()
+
+	// When Database is empty, checker falls back to Probe.Target.
+	dir := t.TempDir()
+	dbFile := filepath.Join(dir, "fallback.db")
+	if err := os.WriteFile(dbFile, []byte("stub"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	params, _ := json.Marshal(checkers.SQLParams{Driver: "sqlite"}) // no Database field
+	c := checkers.NewSQLChecker()
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindSQL,
+		Target: dbFile, // used as fallback path
+		Params: params,
+	})
+
+	if !r.Success {
+		t.Fatalf("Success = false on Target fallback; want true: %s", r.Error)
+	}
+}
+
+func TestSQLChecker_Run_SQLite_DirectoryIsRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	params, _ := json.Marshal(checkers.SQLParams{Driver: "sqlite", Database: dir})
+	c := checkers.NewSQLChecker()
+	r := c.Run(context.Background(), probe.Probe{
+		Kind:   probe.KindSQL,
+		Target: dir,
+		Params: params,
+	})
+
+	if r.Success {
+		t.Error("Success = true when path is a directory; want false")
+	}
+}

--- a/internal/probe/checkers/tcp.go
+++ b/internal/probe/checkers/tcp.go
@@ -13,6 +13,11 @@ import (
 // defaultTCPDialTimeout is the default per-attempt dial timeout.
 const defaultTCPDialTimeout = 5 * time.Second
 
+// metaKeyAddr is the shared Result.Metadata key for the dialed
+// host:port address. Checkers across this package surface it so the
+// probe result shows exactly which endpoint was contacted.
+const metaKeyAddr = "addr"
+
 // TCPParams is the kind-specific params shape. Port is required;
 // TimeoutMs overrides the default dial timeout.
 type TCPParams struct {
@@ -84,7 +89,7 @@ func (c *TCPChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
 	}
 	_ = conn.Close()
 
-	meta, _ := json.Marshal(map[string]any{"addr": addr})
+	meta, _ := json.Marshal(map[string]any{metaKeyAddr: addr})
 	return probe.Result{
 		ProbeID:   p.ID,
 		ClientID:  p.ClientID,

--- a/internal/probe/checkers/udp.go
+++ b/internal/probe/checkers/udp.go
@@ -92,7 +92,7 @@ func (c *UDPChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
 		}
 	}
 
-	meta, _ := json.Marshal(map[string]any{"addr": addr})
+	meta, _ := json.Marshal(map[string]any{metaKeyAddr: addr})
 	return probe.Result{
 		ProbeID:   p.ID,
 		ClientID:  p.ClientID,

--- a/internal/probe/types.go
+++ b/internal/probe/types.go
@@ -22,6 +22,8 @@ const (
 	KindFHIR        = "fhir"
 	KindLTI         = "lti"
 	KindLDAP        = "ldap"
+	KindSQL         = "sql"
+	KindFileShare   = "fileshare"
 	KindOPCUA       = "opcua"
 	KindMODBUS      = "modbus"
 	KindNTP         = "ntp"


### PR DESCRIPTION
## What

First phase of **ADR-0027** — absorb the on-demand health-check verticals onto the probe engine as `probe.Checker` implementations. Eight new checkers under `internal/probe/checkers/`, each registered in the engine:

| Kind | Port of | Behavior |
|------|---------|----------|
| `hl7` | `testHL7Endpoint` | MLLP-framed ADT^A01, parse MSA ACK (AA/CA → success) |
| `fhir` | `testFHIREndpoint` | GET `/metadata`, parse CapabilityStatement; basic/bearer/oauth2 auth |
| `lti` | `testLTIEndpoint` | HEAD launch URL, 2xx/3xx → success, SSL validity |
| `opcua` | `testOPCUAEndpoint` | TCP + minimal `HELF` Hello probe, classify ACK/ERR |
| `modbus` | `testModbusEndpoint` | Modbus TCP read-register ADU, exception parsing |
| `sql` | `testSQLEndpoint` | TCP reachability by driver port (+ SQLite file-stat) |
| `fileshare` | `testFileShareEndpoint` | TCP reachability to SMB(445)/NFS(2049) |
| `ldap` | `testLDAPEndpoint` | TCP / LDAPS (TLS 1.2+, cert-validating) reachability |

Adds `KindSQL` and `KindFileShare` constants and a shared `metaKeyAddr` metadata-key constant.

## Honesty note (port working behavior, not staleness)

HL7 / FHIR / LTI / OPC-UA / Modbus port the legacy **protocol** behavior faithfully. **SQL, FileShare, and LDAP** port the **honest working** behavior only — TCP/TLS reachability — because the legacy `sql.Open`/driver, SMB/NFS local-mount perf test, and LDAP bind/search paths were dead or library-dependent (no SQL driver or LDAP library is imported in the module, so `sql.Open` errors `unknown driver` today). Each checker documents the deferred capability in its doc comment; adding a real driver/library is a separate, security-scanned dependency decision (out of P1 scope).

## Anomaly integration

No new threshold field or catalog `Def` is needed: `success` → `probe-unreachable` and `latency_ms` → `probe-high-latency` already cover the breach side (ADR-0025). Protocol detail (ACK code, FHIR version, register value) is surfaced as informational `Result.Metadata`.

## Validation

- `go build ./...` clean
- `go test -race ./internal/probe/...` green (102 checker test cases) + `go test ./internal/api/` green
- `golangci-lint run` on all changed files: **0 issues** (incl. a `metaKeyAddr` refactor that brought pre-existing `tcp/udp/dicom/rtsp` checkers up to standard after the new files crossed the `goconst` threshold)
- `gofmt -l` clean

## Follow-ups (ADR-0027 phasing)

P2 (`/settings` config→`probes` table) · P3 (`/run` rewire + delete the ~4,067-LOC legacy stack) · P4 (frontend) · P5 (transport rename `/telemetry/health-checks/*` → `/telemetry/probes/*`).

ADR-0027 moved to **Accepted** with a P1 as-built note.