### PR TITLE
feat(probe): probes table is store-of-record for health-check settings (ADR-0027 P2)

### DIFF
--- a/docs/schemas/api/config.schema.json
+++ b/docs/schemas/api/config.schema.json
@@ -533,9 +533,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -544,8 +541,7 @@
         "name",
         "base_url",
         "auth_type",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "FileShareEndpoint": {
@@ -585,9 +581,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -597,8 +590,7 @@
         "protocol",
         "host",
         "share",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "FingerprintingConfig": {
@@ -685,9 +677,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -700,8 +689,7 @@
         "sending_facility",
         "receiving_app",
         "receiving_facility",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "HTTPEndpoint": {
@@ -1033,9 +1021,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -1047,8 +1032,7 @@
         "use_tls",
         "start_tls",
         "base_dn",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "LTIEndpoint": {
@@ -1079,9 +1063,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -1089,8 +1070,7 @@
       "required": [
         "name",
         "launch_url",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "LinkConfig": {
@@ -1182,9 +1162,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -1195,8 +1172,7 @@
         "port",
         "unit_id",
         "test_register",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "NetworkDiscoveryConfig": {
@@ -1292,9 +1268,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -1302,8 +1275,7 @@
       "required": [
         "name",
         "endpoint_url",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "PassiveProtocolConfig": {
@@ -1529,9 +1501,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -1542,8 +1511,7 @@
         "host",
         "port",
         "database",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "SSOConfig": {

--- a/docs/schemas/api/fhir-endpoint-response.schema.json
+++ b/docs/schemas/api/fhir-endpoint-response.schema.json
@@ -16,9 +16,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -27,8 +24,7 @@
         "name",
         "baseUrl",
         "authType",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     }
   },

--- a/docs/schemas/api/file-share-endpoint-response.schema.json
+++ b/docs/schemas/api/file-share-endpoint-response.schema.json
@@ -31,9 +31,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -43,8 +40,7 @@
         "protocol",
         "host",
         "share",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     }
   },

--- a/docs/schemas/api/hl7-endpoint-response.schema.json
+++ b/docs/schemas/api/hl7-endpoint-response.schema.json
@@ -28,9 +28,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -43,8 +40,7 @@
         "sendingFacility",
         "receivingApp",
         "receivingFacility",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     }
   },

--- a/docs/schemas/api/ldap-endpoint-response.schema.json
+++ b/docs/schemas/api/ldap-endpoint-response.schema.json
@@ -28,9 +28,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -42,8 +39,7 @@
         "useTls",
         "startTls",
         "baseDn",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     }
   },

--- a/docs/schemas/api/lti-endpoint-response.schema.json
+++ b/docs/schemas/api/lti-endpoint-response.schema.json
@@ -16,9 +16,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -26,8 +23,7 @@
       "required": [
         "name",
         "launchUrl",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     }
   },

--- a/docs/schemas/api/modbus-endpoint-response.schema.json
+++ b/docs/schemas/api/modbus-endpoint-response.schema.json
@@ -25,9 +25,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -38,8 +35,7 @@
         "port",
         "unitId",
         "testRegister",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     }
   },

--- a/docs/schemas/api/opcua-endpoint-response.schema.json
+++ b/docs/schemas/api/opcua-endpoint-response.schema.json
@@ -19,9 +19,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -29,8 +26,7 @@
       "required": [
         "name",
         "endpointUrl",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     }
   },

--- a/docs/schemas/api/sql-endpoint-response.schema.json
+++ b/docs/schemas/api/sql-endpoint-response.schema.json
@@ -25,9 +25,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -38,8 +35,7 @@
         "host",
         "port",
         "database",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     }
   },

--- a/docs/schemas/api/tests-settings-response.schema.json
+++ b/docs/schemas/api/tests-settings-response.schema.json
@@ -64,9 +64,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -75,8 +72,7 @@
         "name",
         "baseUrl",
         "authType",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "FileShareEndpointResponse": {
@@ -107,9 +103,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -119,8 +112,7 @@
         "protocol",
         "host",
         "share",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "HL7EndpointResponse": {
@@ -148,9 +140,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -163,8 +152,7 @@
         "sendingFacility",
         "receivingApp",
         "receivingFacility",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "HTTPEndpointResponse": {
@@ -243,9 +231,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -257,8 +242,7 @@
         "useTls",
         "startTls",
         "baseDn",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "LTIEndpointResponse": {
@@ -274,9 +258,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -284,8 +265,7 @@
       "required": [
         "name",
         "launchUrl",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "ModbusEndpointResponse": {
@@ -310,9 +290,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -323,8 +300,7 @@
         "port",
         "unitId",
         "testRegister",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "OPCUAEndpointResponse": {
@@ -343,9 +319,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -353,8 +326,7 @@
       "required": [
         "name",
         "endpointUrl",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "PingTargetResponse": {
@@ -419,9 +391,6 @@
         },
         "enabled": {
           "type": "boolean"
-        },
-        "criticality": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -432,8 +401,7 @@
         "host",
         "port",
         "database",
-        "enabled",
-        "criticality"
+        "enabled"
       ]
     },
     "SpeedtestSettingsResponse": {

--- a/internal/api/endpoints_integration_test.go
+++ b/internal/api/endpoints_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	api "github.com/MustardSeedNetworks/seed/internal/api"
+	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/netif"
 	"github.com/MustardSeedNetworks/seed/internal/testutil"
 )
@@ -425,8 +426,16 @@ func TestTestsSettingsEndpoints(t *testing.T) {
 		t.Fatalf("Failed to save test config: %v", err)
 	}
 
+	// The health-checks settings endpoint is store-of-record backed by the
+	// probes table (ADR-0027 P2), so the server needs a real database.
+	db, err := database.Open(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("Failed to open test database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
 	netMgr, _ := netif.NewManager("")
-	server := api.NewServer(cfg, configPath, "", netMgr, false, nil, nil, nil)
+	server := api.NewServer(cfg, configPath, "", netMgr, false, nil, db, nil)
 	defer server.Close()
 
 	ts := httptest.NewServer(server.Mux())
@@ -449,8 +458,12 @@ func TestTestsSettingsEndpoints(t *testing.T) {
 		}
 	})
 
-	t.Run("UpdateHealthChecksSettings", func(t *testing.T) {
-		// Issue #605 fixed: config.Save() deadlock resolved by unlocking before Save()
+	t.Run("UpdateHealthChecksSettingsIsWriteGated", func(t *testing.T) {
+		// The settings PUT persists to the probes table (ADR-0027 P2) and is a
+		// mutating route, so it must enforce the operator write gate. An
+		// unauthenticated request is rejected. The happy-path persistence
+		// round-trip is covered by the handler-level internal test
+		// (TestHealthChecksSettingsRoundTrip).
 		settings := api.TestsSettingsResponse{
 			DNSHostname: "example.com",
 			DNSServers:  []api.DNSServerResponse{{Address: "8.8.8.8", Enabled: true}},
@@ -472,8 +485,8 @@ func TestTestsSettingsEndpoints(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		if resp.StatusCode != http.StatusOK {
-			t.Errorf("Expected status 200, got %d", resp.StatusCode)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("Expected status 401 (write-gated), got %d", resp.StatusCode)
 		}
 	})
 }

--- a/internal/api/handlers_health_checks.go
+++ b/internal/api/handlers_health_checks.go
@@ -6,6 +6,7 @@ package api
 // rtsp, dicom). DNS, Speedtest, and iPerf handlers live in separate files.
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
@@ -195,6 +196,12 @@ func (s *Server) handleHealthChecks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The probes table is the store of record for health-check targets
+	// (ADR-0027 P2). Hydrate the in-memory config snapshot from it so the
+	// run*Tests helpers below see the current set. P3 rewires /run onto
+	// Engine.RunNow and deletes these helpers along with this hydration.
+	s.hydrateHealthCheckTargets(r.Context())
+
 	result := CustomTestsResult{
 		PingResults:  s.runPingTests(),
 		TCPResults:   s.runTCPTests(r.Context()),
@@ -223,6 +230,35 @@ func (s *Server) handleHealthChecks(w http.ResponseWriter, r *http.Request) {
 		len(s.config.HealthChecks.ModbusEndpoints) > 0
 
 	sendJSONResponse(w, logger, http.StatusOK, result)
+}
+
+// hydrateHealthCheckTargets refreshes the in-memory config's health-check
+// endpoint lists from the probes table (the store of record, ADR-0027 P2),
+// leaving the performance toggles untouched. Best-effort: a load failure is
+// logged and the previous in-memory snapshot is left in place. P3 removes
+// this once /run dispatches through Engine.RunNow directly.
+func (s *Server) hydrateHealthCheckTargets(ctx context.Context) {
+	hc, err := loadHealthCheckEndpoints(ctx, s.db().Probes())
+	if err != nil {
+		logging.FromContext(ctx).WarnContext(ctx, "Failed to hydrate health-check targets from probes", "error", err)
+		return
+	}
+	s.config.Lock()
+	defer s.config.Unlock()
+	s.config.HealthChecks.PingTargets = hc.PingTargets
+	s.config.HealthChecks.TCPPorts = hc.TCPPorts
+	s.config.HealthChecks.UDPPorts = hc.UDPPorts
+	s.config.HealthChecks.HTTPEndpoints = hc.HTTPEndpoints
+	s.config.HealthChecks.RTSPEndpoints = hc.RTSPEndpoints
+	s.config.HealthChecks.DICOMEndpoints = hc.DICOMEndpoints
+	s.config.HealthChecks.HL7Endpoints = hc.HL7Endpoints
+	s.config.HealthChecks.FHIREndpoints = hc.FHIREndpoints
+	s.config.HealthChecks.SQLEndpoints = hc.SQLEndpoints
+	s.config.HealthChecks.FileShareEndpoints = hc.FileShareEndpoints
+	s.config.HealthChecks.LDAPEndpoints = hc.LDAPEndpoints
+	s.config.HealthChecks.LTIEndpoints = hc.LTIEndpoints
+	s.config.HealthChecks.OPCUAEndpoints = hc.OPCUAEndpoints
+	s.config.HealthChecks.ModbusEndpoints = hc.ModbusEndpoints
 }
 
 // getTestStatus returns status based on latency and thresholds.

--- a/internal/api/handlers_health_checks_settings.go
+++ b/internal/api/handlers_health_checks_settings.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/dns"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
@@ -45,37 +46,37 @@ func (s *Server) buildDNSServersResponse() []DNSServerResponse {
 	return resp
 }
 
-// buildPingTargetsResponse converts config ping targets to response format.
-func (s *Server) buildPingTargetsResponse() []PingTargetResponse {
-	resp := make([]PingTargetResponse, 0, len(s.config.HealthChecks.PingTargets))
-	for _, p := range s.config.HealthChecks.PingTargets {
+// buildPingTargetsResponse converts ping targets to response format.
+func buildPingTargetsResponse(eps []config.PingTarget) []PingTargetResponse {
+	resp := make([]PingTargetResponse, 0, len(eps))
+	for _, p := range eps {
 		resp = append(resp, PingTargetResponse{Name: p.Name, Host: p.Host, Enabled: p.Enabled})
 	}
 	return resp
 }
 
-// buildTCPPortsResponse converts config TCP ports to response format.
-func (s *Server) buildTCPPortsResponse() []TCPPortResponse {
-	resp := make([]TCPPortResponse, 0, len(s.config.HealthChecks.TCPPorts))
-	for _, t := range s.config.HealthChecks.TCPPorts {
+// buildTCPPortsResponse converts TCP ports to response format.
+func buildTCPPortsResponse(eps []config.TCPPortTest) []TCPPortResponse {
+	resp := make([]TCPPortResponse, 0, len(eps))
+	for _, t := range eps {
 		resp = append(resp, TCPPortResponse{Name: t.Name, Host: t.Host, Port: t.Port, Enabled: t.Enabled})
 	}
 	return resp
 }
 
-// buildUDPPortsResponse converts config UDP ports to response format.
-func (s *Server) buildUDPPortsResponse() []UDPPortResponse {
-	resp := make([]UDPPortResponse, 0, len(s.config.HealthChecks.UDPPorts))
-	for _, u := range s.config.HealthChecks.UDPPorts {
+// buildUDPPortsResponse converts UDP ports to response format.
+func buildUDPPortsResponse(eps []config.UDPPortTest) []UDPPortResponse {
+	resp := make([]UDPPortResponse, 0, len(eps))
+	for _, u := range eps {
 		resp = append(resp, UDPPortResponse{Name: u.Name, Host: u.Host, Port: u.Port, Enabled: u.Enabled})
 	}
 	return resp
 }
 
-// buildHTTPEndpointsResponse converts config HTTP endpoints to response format.
-func (s *Server) buildHTTPEndpointsResponse() []HTTPEndpointResponse {
-	resp := make([]HTTPEndpointResponse, 0, len(s.config.HealthChecks.HTTPEndpoints))
-	for _, h := range s.config.HealthChecks.HTTPEndpoints {
+// buildHTTPEndpointsResponse converts HTTP endpoints to response format.
+func buildHTTPEndpointsResponse(eps []config.HTTPEndpoint) []HTTPEndpointResponse {
+	resp := make([]HTTPEndpointResponse, 0, len(eps))
+	for _, h := range eps {
 		resp = append(resp, HTTPEndpointResponse{
 			Name:                 h.Name,
 			URL:                  h.URL,
@@ -91,19 +92,19 @@ func (s *Server) buildHTTPEndpointsResponse() []HTTPEndpointResponse {
 	return resp
 }
 
-// buildRTSPEndpointsResponse converts config RTSP endpoints to response format.
-func (s *Server) buildRTSPEndpointsResponse() []RTSPEndpointResponse {
-	resp := make([]RTSPEndpointResponse, 0, len(s.config.HealthChecks.RTSPEndpoints))
-	for _, r := range s.config.HealthChecks.RTSPEndpoints {
+// buildRTSPEndpointsResponse converts RTSP endpoints to response format.
+func buildRTSPEndpointsResponse(eps []config.RTSPEndpoint) []RTSPEndpointResponse {
+	resp := make([]RTSPEndpointResponse, 0, len(eps))
+	for _, r := range eps {
 		resp = append(resp, RTSPEndpointResponse{Name: r.Name, URL: r.URL, Enabled: r.Enabled})
 	}
 	return resp
 }
 
-// buildDICOMEndpointsResponse converts config DICOM endpoints to response format.
-func (s *Server) buildDICOMEndpointsResponse() []DICOMEndpointResponse {
-	resp := make([]DICOMEndpointResponse, 0, len(s.config.HealthChecks.DICOMEndpoints))
-	for _, d := range s.config.HealthChecks.DICOMEndpoints {
+// buildDICOMEndpointsResponse converts DICOM endpoints to response format.
+func buildDICOMEndpointsResponse(eps []config.DICOMEndpoint) []DICOMEndpointResponse {
+	resp := make([]DICOMEndpointResponse, 0, len(eps))
+	for _, d := range eps {
 		resp = append(resp, DICOMEndpointResponse{
 			Name: d.Name, Host: d.Host, Port: d.Port,
 			CalledAE: d.CalledAE, CallingAE: d.CallingAE, Enabled: d.Enabled,
@@ -112,127 +113,142 @@ func (s *Server) buildDICOMEndpointsResponse() []DICOMEndpointResponse {
 	return resp
 }
 
-// buildHL7EndpointsResponse converts config HL7 endpoints to response format.
-func (s *Server) buildHL7EndpointsResponse() []HL7EndpointResponse {
-	resp := make([]HL7EndpointResponse, 0, len(s.config.HealthChecks.HL7Endpoints))
-	for _, h := range s.config.HealthChecks.HL7Endpoints {
+// buildHL7EndpointsResponse converts HL7 endpoints to response format.
+func buildHL7EndpointsResponse(eps []config.HL7Endpoint) []HL7EndpointResponse {
+	resp := make([]HL7EndpointResponse, 0, len(eps))
+	for _, h := range eps {
 		resp = append(resp, HL7EndpointResponse{
 			Name: h.Name, Host: h.Host, Port: h.Port,
 			SendingApp: h.SendingApp, SendingFac: h.SendingFac,
 			ReceivingApp: h.ReceivingApp, ReceivingFac: h.ReceivingFac,
-			Enabled: h.Enabled, Criticality: h.Criticality,
+			Enabled: h.Enabled,
 		})
 	}
 	return resp
 }
 
-// buildFHIREndpointsResponse converts config FHIR endpoints to response format.
-func (s *Server) buildFHIREndpointsResponse() []FHIREndpointResponse {
-	resp := make([]FHIREndpointResponse, 0, len(s.config.HealthChecks.FHIREndpoints))
-	for _, f := range s.config.HealthChecks.FHIREndpoints {
+// buildFHIREndpointsResponse converts FHIR endpoints to response format.
+func buildFHIREndpointsResponse(eps []config.FHIREndpoint) []FHIREndpointResponse {
+	resp := make([]FHIREndpointResponse, 0, len(eps))
+	for _, f := range eps {
 		resp = append(resp, FHIREndpointResponse{
 			Name: f.Name, BaseURL: f.BaseURL, AuthType: f.AuthType,
-			Enabled: f.Enabled, Criticality: f.Criticality,
+			Enabled: f.Enabled,
 		})
 	}
 	return resp
 }
 
-// buildSQLEndpointsResponse converts config SQL endpoints to response format.
-func (s *Server) buildSQLEndpointsResponse() []SQLEndpointResponse {
-	resp := make([]SQLEndpointResponse, 0, len(s.config.HealthChecks.SQLEndpoints))
-	for _, sq := range s.config.HealthChecks.SQLEndpoints {
+// buildSQLEndpointsResponse converts SQL endpoints to response format.
+func buildSQLEndpointsResponse(eps []config.SQLEndpoint) []SQLEndpointResponse {
+	resp := make([]SQLEndpointResponse, 0, len(eps))
+	for _, sq := range eps {
 		resp = append(resp, SQLEndpointResponse{
 			Name: sq.Name, Driver: sq.Driver, Host: sq.Host, Port: sq.Port,
 			Database: sq.Database, SSLMode: sq.SSLMode,
-			Enabled: sq.Enabled, Criticality: sq.Criticality,
+			Enabled: sq.Enabled,
 		})
 	}
 	return resp
 }
 
-// buildFileShareEndpointsResponse converts config file share endpoints to response format.
-func (s *Server) buildFileShareEndpointsResponse() []FileShareEndpointResponse {
-	resp := make([]FileShareEndpointResponse, 0, len(s.config.HealthChecks.FileShareEndpoints))
-	for _, fs := range s.config.HealthChecks.FileShareEndpoints {
+// buildFileShareEndpointsResponse converts file share endpoints to response format.
+func buildFileShareEndpointsResponse(eps []config.FileShareEndpoint) []FileShareEndpointResponse {
+	resp := make([]FileShareEndpointResponse, 0, len(eps))
+	for _, fs := range eps {
 		resp = append(resp, FileShareEndpointResponse{
 			Name: fs.Name, Protocol: fs.Protocol, Host: fs.Host, Share: fs.Share, Path: fs.Path,
 			TestReadPerformance: fs.TestReadPerformance, TestWritePerformance: fs.TestWritePerformance,
-			TestFileSizeMB: fs.TestFileSizeMB, Enabled: fs.Enabled, Criticality: fs.Criticality,
+			TestFileSizeMB: fs.TestFileSizeMB, Enabled: fs.Enabled,
 		})
 	}
 	return resp
 }
 
-// buildLDAPEndpointsResponse converts config LDAP endpoints to response format.
-func (s *Server) buildLDAPEndpointsResponse() []LDAPEndpointResponse {
-	resp := make([]LDAPEndpointResponse, 0, len(s.config.HealthChecks.LDAPEndpoints))
-	for _, l := range s.config.HealthChecks.LDAPEndpoints {
+// buildLDAPEndpointsResponse converts LDAP endpoints to response format.
+func buildLDAPEndpointsResponse(eps []config.LDAPEndpoint) []LDAPEndpointResponse {
+	resp := make([]LDAPEndpointResponse, 0, len(eps))
+	for _, l := range eps {
 		resp = append(resp, LDAPEndpointResponse{
 			Name: l.Name, Host: l.Host, Port: l.Port, UseTLS: l.UseTLS, StartTLS: l.StartTLS,
-			BaseDN: l.BaseDN, SearchFilter: l.SearchFilter, Enabled: l.Enabled, Criticality: l.Criticality,
+			BaseDN: l.BaseDN, SearchFilter: l.SearchFilter, Enabled: l.Enabled,
 		})
 	}
 	return resp
 }
 
-// buildLTIEndpointsResponse converts config LTI endpoints to response format.
-func (s *Server) buildLTIEndpointsResponse() []LTIEndpointResponse {
-	resp := make([]LTIEndpointResponse, 0, len(s.config.HealthChecks.LTIEndpoints))
-	for _, lt := range s.config.HealthChecks.LTIEndpoints {
+// buildLTIEndpointsResponse converts LTI endpoints to response format.
+func buildLTIEndpointsResponse(eps []config.LTIEndpoint) []LTIEndpointResponse {
+	resp := make([]LTIEndpointResponse, 0, len(eps))
+	for _, lt := range eps {
 		resp = append(resp, LTIEndpointResponse{
 			Name: lt.Name, LaunchURL: lt.LaunchURL, LTIVersion: lt.LTIVersion,
-			Enabled: lt.Enabled, Criticality: lt.Criticality,
+			Enabled: lt.Enabled,
 		})
 	}
 	return resp
 }
 
-// buildOPCUAEndpointsResponse converts config OPC-UA endpoints to response format.
-func (s *Server) buildOPCUAEndpointsResponse() []OPCUAEndpointResponse {
-	resp := make([]OPCUAEndpointResponse, 0, len(s.config.HealthChecks.OPCUAEndpoints))
-	for _, opc := range s.config.HealthChecks.OPCUAEndpoints {
+// buildOPCUAEndpointsResponse converts OPC-UA endpoints to response format.
+func buildOPCUAEndpointsResponse(eps []config.OPCUAEndpoint) []OPCUAEndpointResponse {
+	resp := make([]OPCUAEndpointResponse, 0, len(eps))
+	for _, opc := range eps {
 		resp = append(resp, OPCUAEndpointResponse{
 			Name: opc.Name, EndpointURL: opc.EndpointURL,
 			SecurityMode: opc.SecurityMode, SecurityPolicy: opc.SecurityPolicy,
-			Enabled: opc.Enabled, Criticality: opc.Criticality,
+			Enabled: opc.Enabled,
 		})
 	}
 	return resp
 }
 
-// buildModbusEndpointsResponse converts config Modbus endpoints to response format.
-func (s *Server) buildModbusEndpointsResponse() []ModbusEndpointResponse {
-	resp := make([]ModbusEndpointResponse, 0, len(s.config.HealthChecks.ModbusEndpoints))
-	for _, mb := range s.config.HealthChecks.ModbusEndpoints {
+// buildModbusEndpointsResponse converts Modbus endpoints to response format.
+func buildModbusEndpointsResponse(eps []config.ModbusEndpoint) []ModbusEndpointResponse {
+	resp := make([]ModbusEndpointResponse, 0, len(eps))
+	for _, mb := range eps {
 		resp = append(resp, ModbusEndpointResponse{
 			Name: mb.Name, Host: mb.Host, Port: mb.Port, UnitID: mb.UnitID,
 			TestRegister: mb.TestRegister, RegisterType: mb.RegisterType,
-			Enabled: mb.Enabled, Criticality: mb.Criticality,
+			Enabled: mb.Enabled,
 		})
 	}
 	return resp
 }
 
+// getHealthChecksSettings returns the check-target configuration. The
+// health-check endpoint lists are sourced from the probes table (the
+// store of record since ADR-0027 P2); the DNS, performance, and
+// speedtest/iperf toggles remain config-file backed.
 func (s *Server) getHealthChecksSettings(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
+
+	hc, err := loadHealthCheckEndpoints(r.Context(), s.db().Probes())
+	if err != nil {
+		logger.ErrorContext(r.Context(), "Failed to load health-check probes", "error", err)
+		sendErrorResponseWithDetails(
+			w, logger, http.StatusInternalServerError, ErrCodeInternal,
+			i18n.FromRequest(r).T("errors.settings.loadFailed"), "",
+		)
+		return
+	}
+
 	resp := TestsSettingsResponse{
 		DNSHostname:        s.config.DNS.TestHostname,
 		DNSServers:         s.buildDNSServersResponse(),
-		PingTargets:        s.buildPingTargetsResponse(),
-		TCPPorts:           s.buildTCPPortsResponse(),
-		UDPPorts:           s.buildUDPPortsResponse(),
-		HTTPEndpoints:      s.buildHTTPEndpointsResponse(),
-		RTSPEndpoints:      s.buildRTSPEndpointsResponse(),
-		DICOMEndpoints:     s.buildDICOMEndpointsResponse(),
-		HL7Endpoints:       s.buildHL7EndpointsResponse(),
-		FHIREndpoints:      s.buildFHIREndpointsResponse(),
-		SQLEndpoints:       s.buildSQLEndpointsResponse(),
-		FileShareEndpoints: s.buildFileShareEndpointsResponse(),
-		LDAPEndpoints:      s.buildLDAPEndpointsResponse(),
-		LTIEndpoints:       s.buildLTIEndpointsResponse(),
-		OPCUAEndpoints:     s.buildOPCUAEndpointsResponse(),
-		ModbusEndpoints:    s.buildModbusEndpointsResponse(),
+		PingTargets:        buildPingTargetsResponse(hc.PingTargets),
+		TCPPorts:           buildTCPPortsResponse(hc.TCPPorts),
+		UDPPorts:           buildUDPPortsResponse(hc.UDPPorts),
+		HTTPEndpoints:      buildHTTPEndpointsResponse(hc.HTTPEndpoints),
+		RTSPEndpoints:      buildRTSPEndpointsResponse(hc.RTSPEndpoints),
+		DICOMEndpoints:     buildDICOMEndpointsResponse(hc.DICOMEndpoints),
+		HL7Endpoints:       buildHL7EndpointsResponse(hc.HL7Endpoints),
+		FHIREndpoints:      buildFHIREndpointsResponse(hc.FHIREndpoints),
+		SQLEndpoints:       buildSQLEndpointsResponse(hc.SQLEndpoints),
+		FileShareEndpoints: buildFileShareEndpointsResponse(hc.FileShareEndpoints),
+		LDAPEndpoints:      buildLDAPEndpointsResponse(hc.LDAPEndpoints),
+		LTIEndpoints:       buildLTIEndpointsResponse(hc.LTIEndpoints),
+		OPCUAEndpoints:     buildOPCUAEndpointsResponse(hc.OPCUAEndpoints),
+		ModbusEndpoints:    buildModbusEndpointsResponse(hc.ModbusEndpoints),
 		RunPerformance:     s.config.HealthChecks.RunPerformance,
 		RunSpeedtest:       s.config.HealthChecks.RunSpeedtest,
 		RunIperf:           s.config.HealthChecks.RunIperf,
@@ -276,70 +292,132 @@ func (s *Server) applyDNSSettings(req *TestsSettingsResponse) {
 	}
 }
 
-// applyTestTargets applies test target configuration from request.
-func (s *Server) applyTestTargets(req *TestsSettingsResponse) {
-	s.config.HealthChecks.PingTargets = make([]config.PingTarget, 0, len(req.PingTargets))
+// requestEndpointTargets builds a HealthChecksConfig from the request's
+// endpoint lists, covering all fourteen health-check kinds. This is the
+// inverse of the build*Response helpers; the resulting config is flattened
+// into probe rows by healthCheckProbesFromConfig for persistence in the
+// probes table (ADR-0027 P2). Only the fields the settings DTO carries are
+// mapped; credential-bearing fields not yet exposed by the settings UI
+// (FHIR/SQL/LDAP/OPC-UA/LTI secrets) are out of scope until the P4 frontend
+// rework surfaces them.
+//
+//nolint:funlen // A flat fan over the fourteen endpoint lists; one block each.
+func requestEndpointTargets(req *TestsSettingsResponse) config.HealthChecksConfig {
+	var hc config.HealthChecksConfig
+
+	hc.PingTargets = make([]config.PingTarget, 0, len(req.PingTargets))
 	for _, p := range req.PingTargets {
-		s.config.HealthChecks.PingTargets = append(
-			s.config.HealthChecks.PingTargets,
-			config.PingTarget{Name: p.Name, Host: p.Host, Enabled: p.Enabled},
-		)
+		hc.PingTargets = append(hc.PingTargets,
+			config.PingTarget{Name: p.Name, Host: p.Host, Enabled: p.Enabled})
 	}
 
-	s.config.HealthChecks.TCPPorts = make([]config.TCPPortTest, 0, len(req.TCPPorts))
+	hc.TCPPorts = make([]config.TCPPortTest, 0, len(req.TCPPorts))
 	for _, t := range req.TCPPorts {
-		s.config.HealthChecks.TCPPorts = append(
-			s.config.HealthChecks.TCPPorts,
-			config.TCPPortTest{Name: t.Name, Host: t.Host, Port: t.Port, Enabled: t.Enabled},
-		)
+		hc.TCPPorts = append(hc.TCPPorts,
+			config.TCPPortTest{Name: t.Name, Host: t.Host, Port: t.Port, Enabled: t.Enabled})
 	}
 
-	s.config.HealthChecks.UDPPorts = make([]config.UDPPortTest, 0, len(req.UDPPorts))
+	hc.UDPPorts = make([]config.UDPPortTest, 0, len(req.UDPPorts))
 	for _, u := range req.UDPPorts {
-		s.config.HealthChecks.UDPPorts = append(
-			s.config.HealthChecks.UDPPorts,
-			config.UDPPortTest{Name: u.Name, Host: u.Host, Port: u.Port, Enabled: u.Enabled},
-		)
+		hc.UDPPorts = append(hc.UDPPorts,
+			config.UDPPortTest{Name: u.Name, Host: u.Host, Port: u.Port, Enabled: u.Enabled})
 	}
 
-	s.config.HealthChecks.HTTPEndpoints = make([]config.HTTPEndpoint, 0, len(req.HTTPEndpoints))
+	hc.HTTPEndpoints = make([]config.HTTPEndpoint, 0, len(req.HTTPEndpoints))
 	for _, h := range req.HTTPEndpoints {
-		s.config.HealthChecks.HTTPEndpoints = append(
-			s.config.HealthChecks.HTTPEndpoints,
-			config.HTTPEndpoint{
-				Name:                 h.Name,
-				URL:                  h.URL,
-				ExpectedStatus:       h.ExpectedStatus,
-				Enabled:              h.Enabled,
-				BodyMatch:            h.BodyMatch,
-				BodyMatchIsRegex:     h.BodyMatchIsRegex,
-				CheckSecurityHeaders: h.CheckSecurityHeaders,
-				FollowRedirects:      h.FollowRedirects,
-				MaxRedirects:         h.MaxRedirects,
-			},
-		)
+		hc.HTTPEndpoints = append(hc.HTTPEndpoints, config.HTTPEndpoint{
+			Name:                 h.Name,
+			URL:                  h.URL,
+			ExpectedStatus:       h.ExpectedStatus,
+			Enabled:              h.Enabled,
+			BodyMatch:            h.BodyMatch,
+			BodyMatchIsRegex:     h.BodyMatchIsRegex,
+			CheckSecurityHeaders: h.CheckSecurityHeaders,
+			FollowRedirects:      h.FollowRedirects,
+			MaxRedirects:         h.MaxRedirects,
+		})
 	}
 
-	// RTSP endpoints (Issue #778)
-	s.config.HealthChecks.RTSPEndpoints = make([]config.RTSPEndpoint, 0, len(req.RTSPEndpoints))
+	hc.RTSPEndpoints = make([]config.RTSPEndpoint, 0, len(req.RTSPEndpoints))
 	for _, r := range req.RTSPEndpoints {
-		s.config.HealthChecks.RTSPEndpoints = append(
-			s.config.HealthChecks.RTSPEndpoints,
-			config.RTSPEndpoint{Name: r.Name, URL: r.URL, Enabled: r.Enabled},
-		)
+		hc.RTSPEndpoints = append(hc.RTSPEndpoints,
+			config.RTSPEndpoint{Name: r.Name, URL: r.URL, Enabled: r.Enabled})
 	}
 
-	// DICOM endpoints (Issue #777)
-	s.config.HealthChecks.DICOMEndpoints = make([]config.DICOMEndpoint, 0, len(req.DICOMEndpoints))
+	hc.DICOMEndpoints = make([]config.DICOMEndpoint, 0, len(req.DICOMEndpoints))
 	for _, d := range req.DICOMEndpoints {
-		s.config.HealthChecks.DICOMEndpoints = append(
-			s.config.HealthChecks.DICOMEndpoints,
-			config.DICOMEndpoint{
-				Name: d.Name, Host: d.Host, Port: d.Port,
-				CalledAE: d.CalledAE, CallingAE: d.CallingAE, Enabled: d.Enabled,
-			},
-		)
+		hc.DICOMEndpoints = append(hc.DICOMEndpoints, config.DICOMEndpoint{
+			Name: d.Name, Host: d.Host, Port: d.Port,
+			CalledAE: d.CalledAE, CallingAE: d.CallingAE, Enabled: d.Enabled,
+		})
 	}
+
+	hc.HL7Endpoints = make([]config.HL7Endpoint, 0, len(req.HL7Endpoints))
+	for _, h := range req.HL7Endpoints {
+		hc.HL7Endpoints = append(hc.HL7Endpoints, config.HL7Endpoint{
+			Name: h.Name, Host: h.Host, Port: h.Port,
+			SendingApp: h.SendingApp, SendingFac: h.SendingFac,
+			ReceivingApp: h.ReceivingApp, ReceivingFac: h.ReceivingFac,
+			Enabled: h.Enabled,
+		})
+	}
+
+	hc.FHIREndpoints = make([]config.FHIREndpoint, 0, len(req.FHIREndpoints))
+	for _, f := range req.FHIREndpoints {
+		hc.FHIREndpoints = append(hc.FHIREndpoints, config.FHIREndpoint{
+			Name: f.Name, BaseURL: f.BaseURL, AuthType: f.AuthType, Enabled: f.Enabled,
+		})
+	}
+
+	hc.SQLEndpoints = make([]config.SQLEndpoint, 0, len(req.SQLEndpoints))
+	for _, sq := range req.SQLEndpoints {
+		hc.SQLEndpoints = append(hc.SQLEndpoints, config.SQLEndpoint{
+			Name: sq.Name, Driver: sq.Driver, Host: sq.Host, Port: sq.Port,
+			Database: sq.Database, SSLMode: sq.SSLMode, Enabled: sq.Enabled,
+		})
+	}
+
+	hc.FileShareEndpoints = make([]config.FileShareEndpoint, 0, len(req.FileShareEndpoints))
+	for _, fs := range req.FileShareEndpoints {
+		hc.FileShareEndpoints = append(hc.FileShareEndpoints, config.FileShareEndpoint{
+			Name: fs.Name, Protocol: fs.Protocol, Host: fs.Host, Share: fs.Share, Path: fs.Path,
+			TestReadPerformance: fs.TestReadPerformance, TestWritePerformance: fs.TestWritePerformance,
+			TestFileSizeMB: fs.TestFileSizeMB, Enabled: fs.Enabled,
+		})
+	}
+
+	hc.LDAPEndpoints = make([]config.LDAPEndpoint, 0, len(req.LDAPEndpoints))
+	for _, l := range req.LDAPEndpoints {
+		hc.LDAPEndpoints = append(hc.LDAPEndpoints, config.LDAPEndpoint{
+			Name: l.Name, Host: l.Host, Port: l.Port, UseTLS: l.UseTLS, StartTLS: l.StartTLS,
+			BaseDN: l.BaseDN, SearchFilter: l.SearchFilter, Enabled: l.Enabled,
+		})
+	}
+
+	hc.LTIEndpoints = make([]config.LTIEndpoint, 0, len(req.LTIEndpoints))
+	for _, lt := range req.LTIEndpoints {
+		hc.LTIEndpoints = append(hc.LTIEndpoints, config.LTIEndpoint{
+			Name: lt.Name, LaunchURL: lt.LaunchURL, LTIVersion: lt.LTIVersion, Enabled: lt.Enabled,
+		})
+	}
+
+	hc.OPCUAEndpoints = make([]config.OPCUAEndpoint, 0, len(req.OPCUAEndpoints))
+	for _, opc := range req.OPCUAEndpoints {
+		hc.OPCUAEndpoints = append(hc.OPCUAEndpoints, config.OPCUAEndpoint{
+			Name: opc.Name, EndpointURL: opc.EndpointURL,
+			SecurityMode: opc.SecurityMode, SecurityPolicy: opc.SecurityPolicy, Enabled: opc.Enabled,
+		})
+	}
+
+	hc.ModbusEndpoints = make([]config.ModbusEndpoint, 0, len(req.ModbusEndpoints))
+	for _, mb := range req.ModbusEndpoints {
+		hc.ModbusEndpoints = append(hc.ModbusEndpoints, config.ModbusEndpoint{
+			Name: mb.Name, Host: mb.Host, Port: mb.Port, UnitID: mb.UnitID,
+			TestRegister: mb.TestRegister, RegisterType: mb.RegisterType, Enabled: mb.Enabled,
+		})
+	}
+
+	return hc
 }
 
 // applyPerformanceSettings applies performance test configuration from request.
@@ -367,10 +445,16 @@ func (s *Server) updateHealthChecksSettings(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Lock config for write access (unlock before Save to avoid deadlock)
+	// The endpoint targets are the store-of-record in the probes table
+	// (ADR-0027 P2); the DNS, performance, and speedtest/iperf toggles
+	// remain config-file backed.
+	if !s.saveHealthCheckProbes(w, r, &req) {
+		return
+	}
+
+	// Lock config for write access (unlock before Save to avoid deadlock).
 	s.config.Lock()
 	s.applyDNSSettings(&req)
-	s.applyTestTargets(&req)
 	s.applyPerformanceSettings(&req)
 	s.config.Unlock()
 
@@ -391,6 +475,47 @@ func (s *Server) updateHealthChecksSettings(w http.ResponseWriter, r *http.Reque
 		Status:  statusSuccess,
 		Message: "Health checks settings updated",
 	})
+}
+
+// saveHealthCheckProbes persists the request's endpoint targets to the
+// probes table (replacing the existing health-check-kind probes) and
+// reschedules the running probe engine so the change takes effect without
+// a restart. Returns false (after writing an error response) on failure.
+func (s *Server) saveHealthCheckProbes(w http.ResponseWriter, r *http.Request, req *TestsSettingsResponse) bool {
+	logger := logging.FromContext(r.Context())
+	localizer := i18n.FromRequest(r)
+
+	hc := requestEndpointTargets(req)
+	probes, err := healthCheckProbesFromConfig(&hc)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "Failed to map health-check endpoints to probes", "error", err)
+		sendErrorResponseWithDetails(
+			w, logger, http.StatusInternalServerError, ErrCodeInternal,
+			localizer.T("errors.settings.saveFailed"), "",
+		)
+		return false
+	}
+
+	if dbErr := s.db().Probes().ReplaceProbesByKinds(
+		r.Context(), database.DefaultClientID, healthCheckKinds(), probes,
+	); dbErr != nil {
+		logger.ErrorContext(r.Context(), "Failed to persist health-check probes", "error", dbErr)
+		sendErrorResponseWithDetails(
+			w, logger, http.StatusInternalServerError, ErrCodeInternal,
+			localizer.T("errors.settings.saveFailed"), "",
+		)
+		return false
+	}
+
+	// Best-effort reschedule: persistence already succeeded, so a
+	// reschedule failure is logged but not surfaced — the new set takes
+	// effect on the next engine start regardless.
+	if s.probeEngine != nil {
+		if rErr := s.probeEngine.Reschedule(r.Context()); rErr != nil {
+			logger.WarnContext(r.Context(), "Failed to reschedule probe engine after settings save", "error", rErr)
+		}
+	}
+	return true
 }
 
 // statusResponse is the JSON body returned by simple ack-style endpoints.

--- a/internal/api/handlers_health_checks_settings_internal_test.go
+++ b/internal/api/handlers_health_checks_settings_internal_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+// TestHealthChecksSettingsRoundTrip exercises the ADR-0027 P2 store-of-record
+// move: saving health-check settings persists the endpoint targets to the
+// probes table, and reading them back reconstructs the same endpoints —
+// including a vertical kind (HL7) that the pre-P2 save path silently dropped.
+func TestHealthChecksSettingsRoundTrip(t *testing.T) {
+	db := newTestDB(t)
+	s := &Server{config: &config.Config{}, dbConn: db}
+
+	req := TestsSettingsResponse{
+		PingTargets: []PingTargetResponse{
+			{Name: "Google DNS", Host: "8.8.8.8", Enabled: true},
+		},
+		HL7Endpoints: []HL7EndpointResponse{
+			{Name: "Lab MLLP", Host: "hl7.example", Port: 2575, SendingApp: "SEED", Enabled: true},
+		},
+	}
+
+	// Save via the persistence path used by the PUT handler.
+	body, _ := json.Marshal(req)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/x", bytes.NewReader(body))
+	require.True(t, s.saveHealthCheckProbes(w, r, &req),
+		"saveHealthCheckProbes should succeed; got %d %s", w.Code, w.Body.String())
+
+	// The probes table now holds exactly the two endpoints, as their kinds.
+	probes, err := db.Probes().ListProbes(r.Context(), database.DefaultClientID, "")
+	require.NoError(t, err)
+	kinds := map[string]string{}
+	for _, p := range probes {
+		kinds[p.Kind] = p.Target
+	}
+	require.Equal(t, "8.8.8.8", kinds["ping"])
+	require.Equal(t, "hl7.example", kinds["hl7"], "vertical HL7 endpoint must be persisted (pre-P2 dropped it)")
+
+	// Read back through the GET handler.
+	gw := httptest.NewRecorder()
+	gr := httptest.NewRequest(http.MethodGet, "/x", http.NoBody)
+	s.getHealthChecksSettings(gw, gr)
+	require.Equal(t, http.StatusOK, gw.Code, "GET body: %s", gw.Body.String())
+
+	var got TestsSettingsResponse
+	require.NoError(t, json.Unmarshal(gw.Body.Bytes(), &got))
+	require.Len(t, got.PingTargets, 1)
+	require.Equal(t, "8.8.8.8", got.PingTargets[0].Host)
+	require.True(t, got.PingTargets[0].Enabled)
+	require.Len(t, got.HL7Endpoints, 1)
+	require.Equal(t, "hl7.example", got.HL7Endpoints[0].Host)
+	require.Equal(t, "SEED", got.HL7Endpoints[0].SendingApp, "vertical-specific params round-trip through params_json")
+}
+
+// TestSaveHealthCheckProbesReplacesPriorSet verifies that a second save
+// replaces the prior health-check probes rather than appending.
+func TestSaveHealthCheckProbesReplacesPriorSet(t *testing.T) {
+	db := newTestDB(t)
+	s := &Server{config: &config.Config{}, dbConn: db}
+
+	first := TestsSettingsResponse{
+		PingTargets: []PingTargetResponse{
+			{Name: "a", Host: "1.1.1.1", Enabled: true},
+			{Name: "b", Host: "2.2.2.2", Enabled: true},
+		},
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/x", http.NoBody)
+	require.True(t, s.saveHealthCheckProbes(w, r, &first))
+
+	second := TestsSettingsResponse{
+		PingTargets: []PingTargetResponse{{Name: "c", Host: "3.3.3.3", Enabled: true}},
+	}
+	require.True(t, s.saveHealthCheckProbes(httptest.NewRecorder(), r, &second))
+
+	count, err := db.Probes().CountProbes(r.Context(), database.DefaultClientID, "ping")
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "second save should replace, not append")
+}

--- a/internal/api/handlers_health_checks_settings_types.go
+++ b/internal/api/handlers_health_checks_settings_types.go
@@ -99,28 +99,25 @@ type HL7EndpointResponse struct {
 	ReceivingApp string `json:"receivingApp"`
 	ReceivingFac string `json:"receivingFacility"`
 	Enabled      bool   `json:"enabled"`
-	Criticality  int    `json:"criticality"`
 }
 
 // FHIREndpointResponse contains a FHIR R4 endpoint configuration (Health Checks 100x).
 type FHIREndpointResponse struct {
-	Name        string `json:"name"`
-	BaseURL     string `json:"baseUrl"`
-	AuthType    string `json:"authType"`
-	Enabled     bool   `json:"enabled"`
-	Criticality int    `json:"criticality"`
+	Name     string `json:"name"`
+	BaseURL  string `json:"baseUrl"`
+	AuthType string `json:"authType"`
+	Enabled  bool   `json:"enabled"`
 }
 
 // SQLEndpointResponse contains a SQL database endpoint configuration (Health Checks 100x).
 type SQLEndpointResponse struct {
-	Name        string `json:"name"`
-	Driver      string `json:"driver"`
-	Host        string `json:"host"`
-	Port        int    `json:"port"`
-	Database    string `json:"database"`
-	SSLMode     string `json:"sslMode,omitempty"`
-	Enabled     bool   `json:"enabled"`
-	Criticality int    `json:"criticality"`
+	Name     string `json:"name"`
+	Driver   string `json:"driver"`
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	Database string `json:"database"`
+	SSLMode  string `json:"sslMode,omitempty"`
+	Enabled  bool   `json:"enabled"`
 }
 
 // FileShareEndpointResponse contains a file share endpoint configuration (Health Checks 100x).
@@ -134,7 +131,6 @@ type FileShareEndpointResponse struct {
 	TestWritePerformance bool   `json:"testWritePerformance,omitempty"`
 	TestFileSizeMB       int    `json:"testFileSizeMb,omitempty"`
 	Enabled              bool   `json:"enabled"`
-	Criticality          int    `json:"criticality"`
 }
 
 // LDAPEndpointResponse contains an LDAP/AD endpoint configuration (Health Checks 100x).
@@ -147,16 +143,14 @@ type LDAPEndpointResponse struct {
 	BaseDN       string `json:"baseDn"`
 	SearchFilter string `json:"searchFilter,omitempty"`
 	Enabled      bool   `json:"enabled"`
-	Criticality  int    `json:"criticality"`
 }
 
 // LTIEndpointResponse contains an LTI/LMS endpoint configuration (Health Checks 100x - Education).
 type LTIEndpointResponse struct {
-	Name        string `json:"name"`
-	LaunchURL   string `json:"launchUrl"`
-	LTIVersion  string `json:"ltiVersion,omitempty"`
-	Enabled     bool   `json:"enabled"`
-	Criticality int    `json:"criticality"`
+	Name       string `json:"name"`
+	LaunchURL  string `json:"launchUrl"`
+	LTIVersion string `json:"ltiVersion,omitempty"`
+	Enabled    bool   `json:"enabled"`
 }
 
 // OPCUAEndpointResponse contains an OPC-UA endpoint configuration (Health Checks 100x - Manufacturing).
@@ -166,7 +160,6 @@ type OPCUAEndpointResponse struct {
 	SecurityMode   string `json:"securityMode,omitempty"`
 	SecurityPolicy string `json:"securityPolicy,omitempty"`
 	Enabled        bool   `json:"enabled"`
-	Criticality    int    `json:"criticality"`
 }
 
 // ModbusEndpointResponse contains a Modbus TCP endpoint configuration (Health Checks 100x - Manufacturing).
@@ -178,7 +171,6 @@ type ModbusEndpointResponse struct {
 	TestRegister int    `json:"testRegister"`
 	RegisterType string `json:"registerType,omitempty"`
 	Enabled      bool   `json:"enabled"`
-	Criticality  int    `json:"criticality"`
 }
 
 // SpeedtestSettingsResponse contains speedtest configuration options.

--- a/internal/api/healthcheckmapping.go
+++ b/internal/api/healthcheckmapping.go
@@ -1,0 +1,462 @@
+package api
+
+// healthcheckmapping.go converts between the health-check endpoint
+// configuration shapes (config.*Endpoint) and probe.Probe definitions
+// persisted in the probes table (ADR-0027 P2). The probes table is the
+// store of record for the fourteen health-check kinds; the legacy
+// config.HealthChecks endpoint lists are migrated onto it here.
+//
+// Each probe row keeps the endpoint's identity in dedicated columns —
+// DisplayName (Name), Target (the host or URL), and Enabled — and stores
+// the full endpoint JSON in params_json. The per-kind Checker
+// (internal/probe/checkers) unmarshals the subset of params it needs and
+// ignores the rest, while settings reads the whole endpoint back. The
+// JSON key namespaces are kept aligned so one params blob serves both.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// defaultHealthCheckIntervalSeconds is the scheduling interval assigned
+// to migrated health-check probes. Endpoints carried no interval; the
+// engine schedules each probe at this cadence.
+const defaultHealthCheckIntervalSeconds = 60
+
+// healthCheckKinds lists the probe kinds owned by the health-check
+// settings surface. Used to scope the replace-by-kind save so the
+// migration never touches probes of other kinds.
+func healthCheckKinds() []string {
+	return []string{
+		probe.KindPing, probe.KindTCP, probe.KindUDP, probe.KindHTTP,
+		probe.KindRTSP, probe.KindDICOM, probe.KindHL7, probe.KindFHIR,
+		probe.KindSQL, probe.KindFileShare, probe.KindLDAP, probe.KindLTI,
+		probe.KindOPCUA, probe.KindMODBUS,
+	}
+}
+
+// endpointToProbe builds a probe row from an endpoint: the endpoint is
+// marshaled wholesale into params_json (Name/Target/Enabled are also
+// authoritative columns, so the duplicate keys in params are harmless
+// and the columns win on read). ID and ClientID are left empty for
+// CreateProbe to fill (uuid + default client).
+func endpointToProbe(kind, name, target string, enabled bool, endpoint any) (*database.Probe, error) {
+	pj, err := json.Marshal(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s endpoint params: %w", kind, err)
+	}
+	return &database.Probe{
+		Kind:            kind,
+		DisplayName:     name,
+		Target:          target,
+		ParamsJSON:      string(pj),
+		IntervalSeconds: defaultHealthCheckIntervalSeconds,
+		Enabled:         enabled,
+	}, nil
+}
+
+// endpointFromProbe unmarshals a probe's params_json into the endpoint
+// type T. The caller overwrites the identity fields (Name/Target/Enabled)
+// from the authoritative columns afterwards.
+func endpointFromProbe[T any](p *database.Probe) (T, error) {
+	var e T
+	if p.ParamsJSON == "" {
+		return e, nil
+	}
+	if err := json.Unmarshal([]byte(p.ParamsJSON), &e); err != nil {
+		return e, fmt.Errorf("unmarshal %s probe params: %w", p.Kind, err)
+	}
+	return e, nil
+}
+
+// --- per-kind forward mappings (config endpoint -> probe row) ---
+
+func pingTargetToProbe(e config.PingTarget) (*database.Probe, error) {
+	return endpointToProbe(probe.KindPing, e.Name, e.Host, e.Enabled, e)
+}
+
+func tcpPortToProbe(e config.TCPPortTest) (*database.Probe, error) {
+	return endpointToProbe(probe.KindTCP, e.Name, e.Host, e.Enabled, e)
+}
+
+func udpPortToProbe(e config.UDPPortTest) (*database.Probe, error) {
+	return endpointToProbe(probe.KindUDP, e.Name, e.Host, e.Enabled, e)
+}
+
+func httpEndpointToProbe(e config.HTTPEndpoint) (*database.Probe, error) {
+	return endpointToProbe(probe.KindHTTP, e.Name, e.URL, e.Enabled, e)
+}
+
+func rtspEndpointToProbe(e config.RTSPEndpoint) (*database.Probe, error) {
+	return endpointToProbe(probe.KindRTSP, e.Name, e.URL, e.Enabled, e)
+}
+
+func dicomEndpointToProbe(e config.DICOMEndpoint) (*database.Probe, error) {
+	return endpointToProbe(probe.KindDICOM, e.Name, e.Host, e.Enabled, e)
+}
+
+func hl7EndpointToProbe(e config.HL7Endpoint) (*database.Probe, error) {
+	return endpointToProbe(probe.KindHL7, e.Name, e.Host, e.Enabled, e)
+}
+
+func fhirEndpointToProbe(e config.FHIREndpoint) (*database.Probe, error) {
+	return endpointToProbe(probe.KindFHIR, e.Name, e.BaseURL, e.Enabled, e)
+}
+
+func sqlEndpointToProbe(e config.SQLEndpoint) (*database.Probe, error) {
+	return endpointToProbe(probe.KindSQL, e.Name, e.Host, e.Enabled, e)
+}
+
+func fileShareEndpointToProbe(e config.FileShareEndpoint) (*database.Probe, error) {
+	return endpointToProbe(probe.KindFileShare, e.Name, e.Host, e.Enabled, e)
+}
+
+func ldapEndpointToProbe(e config.LDAPEndpoint) (*database.Probe, error) {
+	return endpointToProbe(probe.KindLDAP, e.Name, e.Host, e.Enabled, e)
+}
+
+func ltiEndpointToProbe(e config.LTIEndpoint) (*database.Probe, error) {
+	return endpointToProbe(probe.KindLTI, e.Name, e.LaunchURL, e.Enabled, e)
+}
+
+func opcuaEndpointToProbe(e config.OPCUAEndpoint) (*database.Probe, error) {
+	return endpointToProbe(probe.KindOPCUA, e.Name, e.EndpointURL, e.Enabled, e)
+}
+
+func modbusEndpointToProbe(e config.ModbusEndpoint) (*database.Probe, error) {
+	return endpointToProbe(probe.KindMODBUS, e.Name, e.Host, e.Enabled, e)
+}
+
+// --- per-kind reverse mappings (probe row -> config endpoint) ---
+
+func probeToPingTarget(p *database.Probe) (config.PingTarget, error) {
+	e, err := endpointFromProbe[config.PingTarget](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.Host, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToTCPPort(p *database.Probe) (config.TCPPortTest, error) {
+	e, err := endpointFromProbe[config.TCPPortTest](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.Host, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToUDPPort(p *database.Probe) (config.UDPPortTest, error) {
+	e, err := endpointFromProbe[config.UDPPortTest](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.Host, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToHTTPEndpoint(p *database.Probe) (config.HTTPEndpoint, error) {
+	e, err := endpointFromProbe[config.HTTPEndpoint](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.URL, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToRTSPEndpoint(p *database.Probe) (config.RTSPEndpoint, error) {
+	e, err := endpointFromProbe[config.RTSPEndpoint](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.URL, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToDICOMEndpoint(p *database.Probe) (config.DICOMEndpoint, error) {
+	e, err := endpointFromProbe[config.DICOMEndpoint](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.Host, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToHL7Endpoint(p *database.Probe) (config.HL7Endpoint, error) {
+	e, err := endpointFromProbe[config.HL7Endpoint](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.Host, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToFHIREndpoint(p *database.Probe) (config.FHIREndpoint, error) {
+	e, err := endpointFromProbe[config.FHIREndpoint](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.BaseURL, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToSQLEndpoint(p *database.Probe) (config.SQLEndpoint, error) {
+	e, err := endpointFromProbe[config.SQLEndpoint](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.Host, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToFileShareEndpoint(p *database.Probe) (config.FileShareEndpoint, error) {
+	e, err := endpointFromProbe[config.FileShareEndpoint](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.Host, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToLDAPEndpoint(p *database.Probe) (config.LDAPEndpoint, error) {
+	e, err := endpointFromProbe[config.LDAPEndpoint](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.Host, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToLTIEndpoint(p *database.Probe) (config.LTIEndpoint, error) {
+	e, err := endpointFromProbe[config.LTIEndpoint](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.LaunchURL, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToOPCUAEndpoint(p *database.Probe) (config.OPCUAEndpoint, error) {
+	e, err := endpointFromProbe[config.OPCUAEndpoint](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.EndpointURL, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+func probeToModbusEndpoint(p *database.Probe) (config.ModbusEndpoint, error) {
+	e, err := endpointFromProbe[config.ModbusEndpoint](p)
+	if err != nil {
+		return e, err
+	}
+	e.Name, e.Host, e.Enabled = p.DisplayName, p.Target, p.Enabled
+	return e, nil
+}
+
+// loadHealthCheckEndpoints reads the health-check probe definitions from
+// the probes table and assembles them into the endpoint lists of a
+// HealthChecksConfig. Only the endpoint lists are populated; the
+// performance/discovery toggles live in the config file and are not
+// sourced here. A malformed params row is skipped with the error
+// returned so the caller can log it without dropping the whole set.
+func loadHealthCheckEndpoints(ctx context.Context, repo *database.ProbeRepository) (config.HealthChecksConfig, error) {
+	var hc config.HealthChecksConfig
+	probes, err := repo.ListProbes(ctx, database.DefaultClientID, "")
+	if err != nil {
+		return hc, fmt.Errorf("list health-check probes: %w", err)
+	}
+	for _, p := range probes {
+		if err = appendProbeToConfig(&hc, p); err != nil {
+			return hc, err
+		}
+	}
+	return hc, nil
+}
+
+// appendProbeToConfig maps one probe row onto its endpoint list in hc.
+// Probes of non-health-check kinds are ignored.
+//
+//nolint:gocognit,cyclop,funlen // A flat dispatch over the fourteen probe kinds; one case each.
+func appendProbeToConfig(hc *config.HealthChecksConfig, p *database.Probe) error {
+	switch p.Kind {
+	case probe.KindPing:
+		e, err := probeToPingTarget(p)
+		if err != nil {
+			return err
+		}
+		hc.PingTargets = append(hc.PingTargets, e)
+	case probe.KindTCP:
+		e, err := probeToTCPPort(p)
+		if err != nil {
+			return err
+		}
+		hc.TCPPorts = append(hc.TCPPorts, e)
+	case probe.KindUDP:
+		e, err := probeToUDPPort(p)
+		if err != nil {
+			return err
+		}
+		hc.UDPPorts = append(hc.UDPPorts, e)
+	case probe.KindHTTP:
+		e, err := probeToHTTPEndpoint(p)
+		if err != nil {
+			return err
+		}
+		hc.HTTPEndpoints = append(hc.HTTPEndpoints, e)
+	case probe.KindRTSP:
+		e, err := probeToRTSPEndpoint(p)
+		if err != nil {
+			return err
+		}
+		hc.RTSPEndpoints = append(hc.RTSPEndpoints, e)
+	case probe.KindDICOM:
+		e, err := probeToDICOMEndpoint(p)
+		if err != nil {
+			return err
+		}
+		hc.DICOMEndpoints = append(hc.DICOMEndpoints, e)
+	case probe.KindHL7:
+		e, err := probeToHL7Endpoint(p)
+		if err != nil {
+			return err
+		}
+		hc.HL7Endpoints = append(hc.HL7Endpoints, e)
+	case probe.KindFHIR:
+		e, err := probeToFHIREndpoint(p)
+		if err != nil {
+			return err
+		}
+		hc.FHIREndpoints = append(hc.FHIREndpoints, e)
+	case probe.KindSQL:
+		e, err := probeToSQLEndpoint(p)
+		if err != nil {
+			return err
+		}
+		hc.SQLEndpoints = append(hc.SQLEndpoints, e)
+	case probe.KindFileShare:
+		e, err := probeToFileShareEndpoint(p)
+		if err != nil {
+			return err
+		}
+		hc.FileShareEndpoints = append(hc.FileShareEndpoints, e)
+	case probe.KindLDAP:
+		e, err := probeToLDAPEndpoint(p)
+		if err != nil {
+			return err
+		}
+		hc.LDAPEndpoints = append(hc.LDAPEndpoints, e)
+	case probe.KindLTI:
+		e, err := probeToLTIEndpoint(p)
+		if err != nil {
+			return err
+		}
+		hc.LTIEndpoints = append(hc.LTIEndpoints, e)
+	case probe.KindOPCUA:
+		e, err := probeToOPCUAEndpoint(p)
+		if err != nil {
+			return err
+		}
+		hc.OPCUAEndpoints = append(hc.OPCUAEndpoints, e)
+	case probe.KindMODBUS:
+		e, err := probeToModbusEndpoint(p)
+		if err != nil {
+			return err
+		}
+		hc.ModbusEndpoints = append(hc.ModbusEndpoints, e)
+	}
+	return nil
+}
+
+// healthCheckProbesFromConfig flattens the endpoint lists of a
+// HealthChecksConfig into the probe rows to persist. Order follows
+// healthCheckKinds; a marshal failure aborts the whole set.
+//
+//nolint:gocognit,cyclop // A flat fan over the fourteen endpoint lists; one block each.
+func healthCheckProbesFromConfig(hc *config.HealthChecksConfig) ([]*database.Probe, error) {
+	var out []*database.Probe
+	add := func(p *database.Probe, err error) error {
+		if err != nil {
+			return err
+		}
+		out = append(out, p)
+		return nil
+	}
+	for _, e := range hc.PingTargets {
+		if err := add(pingTargetToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.TCPPorts {
+		if err := add(tcpPortToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.UDPPorts {
+		if err := add(udpPortToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.HTTPEndpoints {
+		if err := add(httpEndpointToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.RTSPEndpoints {
+		if err := add(rtspEndpointToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.DICOMEndpoints {
+		if err := add(dicomEndpointToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.HL7Endpoints {
+		if err := add(hl7EndpointToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.FHIREndpoints {
+		if err := add(fhirEndpointToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.SQLEndpoints {
+		if err := add(sqlEndpointToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.FileShareEndpoints {
+		if err := add(fileShareEndpointToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.LDAPEndpoints {
+		if err := add(ldapEndpointToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.LTIEndpoints {
+		if err := add(ltiEndpointToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.OPCUAEndpoints {
+		if err := add(opcuaEndpointToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range hc.ModbusEndpoints {
+		if err := add(modbusEndpointToProbe(e)); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}

--- a/internal/api/healthcheckmapping_internal_test.go
+++ b/internal/api/healthcheckmapping_internal_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// TestHL7EndpointRoundTrip verifies a full HL7 endpoint survives the
+// config -> probe -> config conversion unchanged, and that params_json
+// uses the checker-aligned key (sending_facility) so the HL7 checker can
+// read the facility fields back.
+func TestHL7EndpointRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := config.HL7Endpoint{
+		Name: "Lab interface", Host: "hl7.example.com", Port: 2575,
+		SendingApp: "SEED", SendingFac: "MAIN", ReceivingApp: "EPIC",
+		ReceivingFac: "WARD", Enabled: true,
+	}
+	p, err := hl7EndpointToProbe(in)
+	if err != nil {
+		t.Fatalf("hl7EndpointToProbe: %v", err)
+	}
+	if p.Kind != probe.KindHL7 || p.Target != in.Host || p.DisplayName != in.Name || !p.Enabled {
+		t.Errorf(
+			"probe columns wrong: kind=%s target=%s name=%s enabled=%v",
+			p.Kind,
+			p.Target,
+			p.DisplayName,
+			p.Enabled,
+		)
+	}
+	if !strings.Contains(p.ParamsJSON, `"sending_facility":"MAIN"`) {
+		t.Errorf("params_json should carry checker-aligned key sending_facility; got %s", p.ParamsJSON)
+	}
+	out, err := probeToHL7Endpoint(p)
+	if err != nil {
+		t.Fatalf("probeToHL7Endpoint: %v", err)
+	}
+	if out != in {
+		t.Errorf("round trip mismatch:\n in=%+v\nout=%+v", in, out)
+	}
+}
+
+// TestFHIREndpointPreservesSettingsOnlyFields verifies that fields the
+// checker never reads (ClientSecret, TokenURL) still round-trip, since
+// params_json stores the whole endpoint.
+func TestFHIREndpointPreservesSettingsOnlyFields(t *testing.T) {
+	t.Parallel()
+	in := config.FHIREndpoint{
+		Name: "EHR", BaseURL: "https://fhir.example.com/r4", AuthType: "oauth2",
+		BearerToken: "tok", ClientID: "cid", ClientSecret: "secret",
+		TokenURL: "https://auth.example.com/token", Enabled: true,
+	}
+	p, err := fhirEndpointToProbe(in)
+	if err != nil {
+		t.Fatalf("fhirEndpointToProbe: %v", err)
+	}
+	if p.Target != in.BaseURL {
+		t.Errorf("target should be base URL; got %s", p.Target)
+	}
+	out, err := probeToFHIREndpoint(p)
+	if err != nil {
+		t.Fatalf("probeToFHIREndpoint: %v", err)
+	}
+	if out != in {
+		t.Errorf("settings-only fields lost:\n in=%+v\nout=%+v", in, out)
+	}
+}
+
+// TestHealthCheckProbesFromConfigAndBack verifies the bulk flatten +
+// per-kind reassembly preserves a multi-kind set.
+func TestHealthCheckProbesFromConfigAndBack(t *testing.T) {
+	t.Parallel()
+	hc := config.HealthChecksConfig{
+		PingTargets: []config.PingTarget{{Name: "gw", Host: "192.0.2.1", Enabled: true}},
+		ModbusEndpoints: []config.ModbusEndpoint{
+			{
+				Name:         "plc",
+				Host:         "10.0.0.5",
+				Port:         502,
+				UnitID:       3,
+				TestRegister: 40001,
+				RegisterType: "holding",
+				Enabled:      true,
+			},
+		},
+	}
+	probes, err := healthCheckProbesFromConfig(&hc)
+	if err != nil {
+		t.Fatalf("healthCheckProbesFromConfig: %v", err)
+	}
+	if len(probes) != 2 {
+		t.Fatalf("expected 2 probes, got %d", len(probes))
+	}
+	var got config.HealthChecksConfig
+	for _, p := range probes {
+		if err = appendProbeToConfig(&got, p); err != nil {
+			t.Fatalf("appendProbeToConfig: %v", err)
+		}
+	}
+	if len(got.PingTargets) != 1 || got.PingTargets[0] != hc.PingTargets[0] {
+		t.Errorf("ping round trip mismatch: %+v", got.PingTargets)
+	}
+	if len(got.ModbusEndpoints) != 1 || got.ModbusEndpoints[0] != hc.ModbusEndpoints[0] {
+		t.Errorf("modbus round trip mismatch: %+v", got.ModbusEndpoints)
+	}
+}
+
+// TestNonHealthCheckKindIgnored verifies appendProbeToConfig drops a
+// probe of an unrelated kind rather than misfiling it.
+func TestNonHealthCheckKindIgnored(t *testing.T) {
+	t.Parallel()
+	var hc config.HealthChecksConfig
+	params, _ := json.Marshal(map[string]any{"x": 1})
+	dnsProbe := &database.Probe{Kind: "dns", Target: "8.8.8.8", ParamsJSON: string(params)}
+	if err := appendProbeToConfig(&hc, dnsProbe); err != nil {
+		t.Fatalf("appendProbeToConfig: %v", err)
+	}
+	if len(hc.PingTargets)+len(hc.HTTPEndpoints)+len(hc.ModbusEndpoints) != 0 {
+		t.Error("a non-health-check kind should not be filed into any endpoint list")
+	}
+}

--- a/internal/config/config_types_health.go
+++ b/internal/config/config_types_health.go
@@ -94,7 +94,6 @@ type HL7Endpoint struct {
 	ReceivingApp string `json:"receiving_app"`      // Receiving application name
 	ReceivingFac string `json:"receiving_facility"` // Receiving facility name
 	Enabled      bool   `json:"enabled"`
-	Criticality  int    `json:"criticality"` // 1-10 scale for health scoring
 }
 
 // FHIREndpoint represents a custom FHIR R4 endpoint test (Health Checks 100x).
@@ -109,22 +108,20 @@ type FHIREndpoint struct {
 	ClientSecret string `json:"client_secret,omitempty"`
 	TokenURL     string `json:"token_url,omitempty"` // OAuth2 token endpoint
 	Enabled      bool   `json:"enabled"`
-	Criticality  int    `json:"criticality"` // 1-10 scale for health scoring
 }
 
 // SQLEndpoint represents a custom SQL database test (Health Checks 100x).
 type SQLEndpoint struct {
-	Name        string `json:"name"`
-	Driver      string `json:"driver"` // "mysql", "postgres", "sqlserver", "oracle", "sqlite"
-	Host        string `json:"host"`
-	Port        int    `json:"port"` // Default varies by driver
-	Database    string `json:"database"`
-	Username    string `json:"username,omitempty"`
-	Password    string `json:"password,omitempty"`
-	SSLMode     string `json:"ssl_mode,omitempty"`   // "disable", "require", "verify-ca", "verify-full"
-	TestQuery   string `json:"test_query,omitempty"` // Custom query to execute (default: SELECT 1)
-	Enabled     bool   `json:"enabled"`
-	Criticality int    `json:"criticality"` // 1-10 scale for health scoring
+	Name      string `json:"name"`
+	Driver    string `json:"driver"` // "mysql", "postgres", "sqlserver", "oracle", "sqlite"
+	Host      string `json:"host"`
+	Port      int    `json:"port"` // Default varies by driver
+	Database  string `json:"database"`
+	Username  string `json:"username,omitempty"`
+	Password  string `json:"password,omitempty"`
+	SSLMode   string `json:"ssl_mode,omitempty"`   // "disable", "require", "verify-ca", "verify-full"
+	TestQuery string `json:"test_query,omitempty"` // Custom query to execute (default: SELECT 1)
+	Enabled   bool   `json:"enabled"`
 }
 
 // FileShareEndpoint represents a file share test (SMB/CIFS or NFS) with performance testing.
@@ -142,7 +139,6 @@ type FileShareEndpoint struct {
 	TestWritePerformance bool `json:"test_write_performance,omitempty"` // Write test file to measure speed
 	TestFileSizeMB       int  `json:"test_file_size_mb,omitempty"`      // Size of test file in MB (default: 10)
 	Enabled              bool `json:"enabled"`
-	Criticality          int  `json:"criticality"` // 1-10 scale for health scoring
 }
 
 // LDAPEndpoint represents an LDAP/Active Directory test (Health Checks 100x).
@@ -157,7 +153,6 @@ type LDAPEndpoint struct {
 	BindPassword string `json:"bind_password,omitempty"`
 	SearchFilter string `json:"search_filter,omitempty"` // Test search filter
 	Enabled      bool   `json:"enabled"`
-	Criticality  int    `json:"criticality"` // 1-10 scale for health scoring
 }
 
 // LTIEndpoint represents an LTI/LMS endpoint test (Health Checks 100x - Education).
@@ -171,7 +166,6 @@ type LTIEndpoint struct {
 	DeploymentID   string `json:"deployment_id,omitempty"`   // LTI 1.3 deployment ID
 	PlatformURL    string `json:"platform_url,omitempty"`    // LTI 1.3 platform issuer URL
 	Enabled        bool   `json:"enabled"`
-	Criticality    int    `json:"criticality"` // 1-10 scale for health scoring
 }
 
 // OPCUAEndpoint represents an OPC-UA endpoint test (Health Checks 100x - Manufacturing).
@@ -185,7 +179,6 @@ type OPCUAEndpoint struct {
 	CertPath       string `json:"cert_path,omitempty"` // Client certificate path
 	KeyPath        string `json:"key_path,omitempty"`  // Client private key path
 	Enabled        bool   `json:"enabled"`
-	Criticality    int    `json:"criticality"` // 1-10 scale for health scoring
 }
 
 // ModbusEndpoint represents a Modbus TCP endpoint test (Health Checks 100x - Manufacturing).
@@ -197,7 +190,6 @@ type ModbusEndpoint struct {
 	TestRegister int    `json:"test_register"`           // Register address to read for testing
 	RegisterType string `json:"register_type,omitempty"` // "holding", "input", "coil", "discrete"
 	Enabled      bool   `json:"enabled"`
-	Criticality  int    `json:"criticality"` // 1-10 scale for health scoring
 }
 
 // SpeedtestConfig contains speedtest settings.

--- a/internal/config/schema.json
+++ b/internal/config/schema.json
@@ -1057,12 +1057,6 @@
           "type": "boolean",
           "description": "Enable this test",
           "default": true
-        },
-        "criticality": {
-          "type": "integer",
-          "description": "1-10 scale for health scoring",
-          "minimum": 1,
-          "maximum": 10
         }
       }
     },
@@ -1116,12 +1110,6 @@
           "type": "boolean",
           "description": "Enable this test",
           "default": true
-        },
-        "criticality": {
-          "type": "integer",
-          "description": "1-10 scale for health scoring",
-          "minimum": 1,
-          "maximum": 10
         }
       }
     },
@@ -1173,12 +1161,6 @@
           "type": "boolean",
           "description": "Enable this test",
           "default": true
-        },
-        "criticality": {
-          "type": "integer",
-          "description": "1-10 scale for health scoring",
-          "minimum": 1,
-          "maximum": 10
         }
       }
     },
@@ -1238,12 +1220,6 @@
           "type": "boolean",
           "description": "Enable this test",
           "default": true
-        },
-        "criticality": {
-          "type": "integer",
-          "description": "1-10 scale for health scoring",
-          "minimum": 1,
-          "maximum": 10
         }
       }
     },
@@ -1293,12 +1269,6 @@
           "type": "boolean",
           "description": "Enable this test",
           "default": true
-        },
-        "criticality": {
-          "type": "integer",
-          "description": "1-10 scale for health scoring",
-          "minimum": 1,
-          "maximum": 10
         }
       }
     },
@@ -1347,12 +1317,6 @@
           "type": "boolean",
           "description": "Enable this test",
           "default": true
-        },
-        "criticality": {
-          "type": "integer",
-          "description": "1-10 scale for health scoring",
-          "minimum": 1,
-          "maximum": 10
         }
       }
     },
@@ -1400,12 +1364,6 @@
           "type": "boolean",
           "description": "Enable this test",
           "default": true
-        },
-        "criticality": {
-          "type": "integer",
-          "description": "1-10 scale for health scoring",
-          "minimum": 1,
-          "maximum": 10
         }
       }
     },
@@ -1446,12 +1404,6 @@
           "type": "boolean",
           "description": "Enable this test",
           "default": true
-        },
-        "criticality": {
-          "type": "integer",
-          "description": "1-10 scale for health scoring",
-          "minimum": 1,
-          "maximum": 10
         }
       }
     },

--- a/internal/database/repository_probes.go
+++ b/internal/database/repository_probes.go
@@ -55,6 +55,55 @@ func (r *ProbeRepository) CreateProbe(ctx context.Context, p *Probe) error {
 	return nil
 }
 
+// ReplaceProbesByKinds swaps every probe of the named kinds for clientID
+// with the supplied set, in a single transaction. Probes of other kinds
+// are left untouched. Used by the health-check settings save (ADR-0027
+// P2), where the probes table is the store of record for the fourteen
+// health-check kinds: the operator's edited endpoint set replaces the
+// stored one wholesale, and probes of unrelated kinds (DNS, TLS, …) are
+// preserved. An empty kinds slice is a no-op delete; passing no
+// replacement probes clears the named kinds.
+func (r *ProbeRepository) ReplaceProbesByKinds(
+	ctx context.Context, clientID string, kinds []string, probes []*Probe,
+) error {
+	if clientID == "" {
+		clientID = DefaultClientID
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	return r.db.WithTx(ctx, func(tx *sql.Tx) error {
+		for _, kind := range kinds {
+			if _, err := tx.ExecContext(ctx,
+				`DELETE FROM probes WHERE client_id = ? AND kind = ?`, clientID, kind,
+			); err != nil {
+				return fmt.Errorf("delete %s probes: %w", kind, err)
+			}
+		}
+		for _, p := range probes {
+			if p.ID == "" {
+				p.ID = uuid.New().String()
+			}
+			p.ClientID = clientID
+			p.CreatedAt = time.Now().UTC()
+			p.UpdatedAt = p.CreatedAt
+			_, err := tx.ExecContext(ctx, `
+				INSERT INTO probes (id, client_id, kind, display_name, target, params_json,
+					interval_seconds, enabled, warning_json, critical_json, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			`,
+				p.ID, p.ClientID, p.Kind, p.DisplayName, p.Target,
+				toNullString(p.ParamsJSON),
+				p.IntervalSeconds, boolToInt(p.Enabled),
+				toNullString(p.WarningJSON), toNullString(p.CriticalJSON),
+				now, now,
+			)
+			if err != nil {
+				return fmt.Errorf("insert replacement probe: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
 // GetProbe returns a probe by id.
 func (r *ProbeRepository) GetProbe(ctx context.Context, id string) (*Probe, error) {
 	row := r.db.QueryRow(ctx, `

--- a/internal/database/repository_probes_test.go
+++ b/internal/database/repository_probes_test.go
@@ -1,0 +1,71 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+// TestReplaceProbesByKinds verifies the transactional replace-by-kind
+// used by the health-check settings save (ADR-0027 P2): probes of the
+// named kinds are swapped wholesale while probes of other kinds are
+// left untouched.
+func TestReplaceProbesByKinds(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	repo := db.Probes()
+
+	// Seed: two ping probes (health-check kind) and one dns probe (not a
+	// health-check kind — must survive the replace).
+	seed := []*database.Probe{
+		{Kind: "ping", DisplayName: "a", Target: "a.example", IntervalSeconds: 60, Enabled: true},
+		{Kind: "ping", DisplayName: "b", Target: "b.example", IntervalSeconds: 60, Enabled: false},
+		{Kind: "dns", DisplayName: "dns1", Target: "example.com", IntervalSeconds: 60, Enabled: true},
+	}
+	for _, p := range seed {
+		require.NoError(t, repo.CreateProbe(ctx, p))
+	}
+
+	// Replace all ping + tcp probes with a single new tcp probe.
+	replacement := []*database.Probe{
+		{Kind: "tcp", DisplayName: "c", Target: "c.example", IntervalSeconds: 30, Enabled: true},
+	}
+	err := repo.ReplaceProbesByKinds(ctx, database.DefaultClientID, []string{"ping", "tcp"}, replacement)
+	require.NoError(t, err)
+
+	all, err := repo.ListProbes(ctx, database.DefaultClientID, "")
+	require.NoError(t, err)
+
+	byKind := map[string]int{}
+	for _, p := range all {
+		byKind[p.Kind]++
+		require.NotEmpty(t, p.ID, "replaced probe should have an id assigned")
+		require.Equal(t, database.DefaultClientID, p.ClientID)
+	}
+	require.Equal(t, 0, byKind["ping"], "old ping probes should be deleted")
+	require.Equal(t, 1, byKind["tcp"], "new tcp probe should be inserted")
+	require.Equal(t, 1, byKind["dns"], "dns probe of a non-replaced kind must survive")
+}
+
+// TestReplaceProbesByKindsClearsToEmpty verifies that passing no
+// replacement probes deletes all probes of the named kinds.
+func TestReplaceProbesByKindsClearsToEmpty(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	repo := db.Probes()
+
+	require.NoError(t, repo.CreateProbe(ctx, &database.Probe{
+		Kind: "ping", DisplayName: "a", Target: "a.example", IntervalSeconds: 60, Enabled: true,
+	}))
+
+	require.NoError(t, repo.ReplaceProbesByKinds(ctx, database.DefaultClientID, []string{"ping"}, nil))
+
+	count, err := repo.CountProbes(ctx, database.DefaultClientID, "ping")
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+}

--- a/internal/i18n/locales/en/settings.json
+++ b/internal/i18n/locales/en/settings.json
@@ -223,7 +223,6 @@
     "digestMode": "Digest Mode",
     "digestDescription": "Batch alerts instead of sending immediately",
     "maxSamples": "Rolling window size",
-    "criticality": "Criticality (1-10)",
     "sqlEndpoints": "SQL Database Endpoints",
     "sqlDescription": "Test database connectivity (PostgreSQL, MySQL, SQL Server, Oracle)",
     "database": "Database",

--- a/internal/i18n/locales/es/settings.json
+++ b/internal/i18n/locales/es/settings.json
@@ -223,7 +223,6 @@
     "digestMode": "Modo resumen",
     "digestDescription": "Agrupar alertas en lugar de enviar inmediatamente",
     "maxSamples": "Tamaño de ventana móvil",
-    "criticality": "Criticidad (1-10)",
     "sqlEndpoints": "Endpoints de base de datos SQL",
     "sqlDescription": "Probar conectividad de base de datos (PostgreSQL, MySQL, SQL Server, Oracle)",
     "database": "Base de datos",

--- a/internal/probe/checkers/hl7.go
+++ b/internal/probe/checkers/hl7.go
@@ -47,12 +47,12 @@ const minHL7MSAErrorFields = 4
 // application / facility identifiers default to the values the legacy
 // internal/api/handlers_medical_checks.go used.
 type HL7Params struct {
-	Port         int    `json:"port,omitempty"`          // default 2575
-	SendingApp   string `json:"sending_app,omitempty"`   // default "SEED"
-	SendingFac   string `json:"sending_fac,omitempty"`   // default "SEED_FAC"
-	ReceivingApp string `json:"receiving_app,omitempty"` // default "TARGET"
-	ReceivingFac string `json:"receiving_fac,omitempty"` // default "TARGET_FAC"
-	TimeoutMs    int    `json:"timeout_ms,omitempty"`    // default 10000
+	Port         int    `json:"port,omitempty"`               // default 2575
+	SendingApp   string `json:"sending_app,omitempty"`        // default "SEED"
+	SendingFac   string `json:"sending_facility,omitempty"`   // default "SEED_FAC"
+	ReceivingApp string `json:"receiving_app,omitempty"`      // default "TARGET"
+	ReceivingFac string `json:"receiving_facility,omitempty"` // default "TARGET_FAC"
+	TimeoutMs    int    `json:"timeout_ms,omitempty"`         // default 10000
 }
 
 // HL7Checker implements probe.Checker for Kind="hl7". It opens a TCP

--- a/internal/probe/lifecycle.go
+++ b/internal/probe/lifecycle.go
@@ -69,18 +69,8 @@ func (e *Engine) Start(ctx context.Context) error {
 		return err
 	}
 
-	probes, err := storage.ListProbes(ctx, "", "")
-	if err != nil {
-		return fmt.Errorf("load probes: %w", err)
-	}
-
-	for _, p := range probes {
-		if !p.Enabled {
-			continue
-		}
-		job := &probeJob{engine: e, probeID: p.ID, interval: time.Duration(p.IntervalSeconds) * time.Second}
-		sched.Register(job)
-		e.jobIDs = append(e.jobIDs, job.ID())
+	if err = e.loadAndRegisterProbes(ctx, storage, sched); err != nil {
+		return err
 	}
 
 	sched.Start(ctx)
@@ -116,6 +106,57 @@ func (e *Engine) Stop(ctx context.Context) error {
 	sched.Stop()
 	e.started = false
 	e.logger.InfoContext(ctx, "probe engine stopped")
+	return nil
+}
+
+// Reschedule re-reads probe definitions from storage and rebuilds the
+// scheduler's job set, so changes made after Start — a settings save
+// that adds, removes, enables, or disables probes — take effect on the
+// running engine without a restart. It is a no-op if the engine has not
+// been started (Start will pick up the current definitions). Safe for
+// concurrent use with Start/Stop; all serialize on runMu.
+func (e *Engine) Reschedule(ctx context.Context) error {
+	e.runMu.Lock()
+	defer e.runMu.Unlock()
+
+	if !e.started {
+		return nil
+	}
+
+	storage, sched, err := e.requireStorage()
+	if err != nil {
+		return err
+	}
+
+	for _, id := range e.jobIDs {
+		sched.Unregister(id)
+	}
+	e.jobIDs = nil
+
+	if err = e.loadAndRegisterProbes(ctx, storage, sched); err != nil {
+		return err
+	}
+
+	e.logger.InfoContext(ctx, "probe engine rescheduled", "probes_scheduled", len(e.jobIDs))
+	return nil
+}
+
+// loadAndRegisterProbes lists the enabled probes from storage and
+// registers a scheduler job for each, recording the job IDs on the
+// engine. Callers must hold runMu. Shared by Start and Reschedule.
+func (e *Engine) loadAndRegisterProbes(ctx context.Context, storage probeStorage, sched probeScheduler) error {
+	probes, err := storage.ListProbes(ctx, "", "")
+	if err != nil {
+		return fmt.Errorf("load probes: %w", err)
+	}
+	for _, p := range probes {
+		if !p.Enabled {
+			continue
+		}
+		job := &probeJob{engine: e, probeID: p.ID, interval: time.Duration(p.IntervalSeconds) * time.Second}
+		sched.Register(job)
+		e.jobIDs = append(e.jobIDs, job.ID())
+	}
 	return nil
 }
 

--- a/ui/src/components/settings/sections/HealthChecksSettings.tsx
+++ b/ui/src/components/settings/sections/HealthChecksSettings.tsx
@@ -484,33 +484,6 @@ export const HealthChecksSettings: React.NamedExoticComponent<HealthChecksSettin
                     'bg-surface-raised',
                   )}
                 />
-                {/* Criticality Slider */}
-                <div className={cn('flex items-center', spacing.gap.compact)}>
-                  <label
-                    htmlFor={`http-criticality-${endpoint.id}`}
-                    className="caption text-text-muted w-28"
-                  >
-                    {t('health.criticality')}
-                  </label>
-                  <input
-                    id={`http-criticality-${endpoint.id}`}
-                    type="range"
-                    min={1}
-                    max={10}
-                    value={endpoint.criticality ?? 5}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void =>
-                      updateHttpEndpoint(
-                        endpoint.id ?? '',
-                        'criticality',
-                        Number.parseInt(e.target.value, 10),
-                      )
-                    }
-                    className="flex-1 h-2 bg-surface-raised rounded-lg appearance-none cursor-pointer accent-brand-primary"
-                  />
-                  <span className="caption text-text-muted w-6 text-center">
-                    {endpoint.criticality ?? 5}
-                  </span>
-                </div>
               </div>
             ))}
           </div>

--- a/ui/src/components/settings/sections/HealthChecksSettingsEnterprise.tsx
+++ b/ui/src/components/settings/sections/HealthChecksSettingsEnterprise.tsx
@@ -36,7 +36,6 @@ export function HealthChecksSettingsEnterprise({
     database: '',
     username: '',
     enabled: true,
-    criticality: 7,
   }));
 
   const {
@@ -49,7 +48,6 @@ export function HealthChecksSettingsEnterprise({
     host: '',
     sharePath: '',
     enabled: true,
-    criticality: 5,
   }));
 
   const {
@@ -63,7 +61,6 @@ export function HealthChecksSettingsEnterprise({
     useTls: false,
     baseDn: '',
     enabled: true,
-    criticality: 7,
   }));
 
   return (

--- a/ui/src/components/settings/sections/HealthChecksSettingsSpecialty.tsx
+++ b/ui/src/components/settings/sections/HealthChecksSettingsSpecialty.tsx
@@ -32,7 +32,6 @@ export function HealthChecksSettingsSpecialty({
     name: '',
     url: 'rtsp://',
     enabled: true,
-    criticality: 5,
   }));
 
   const {
@@ -45,7 +44,6 @@ export function HealthChecksSettingsSpecialty({
     port: 104,
     aeTitle: '',
     enabled: true,
-    criticality: 8,
   }));
 
   const {
@@ -61,7 +59,6 @@ export function HealthChecksSettingsSpecialty({
     receivingApp: '',
     receivingFacility: '',
     enabled: true,
-    criticality: 9,
   }));
 
   const {
@@ -73,7 +70,6 @@ export function HealthChecksSettingsSpecialty({
     baseUrl: 'https://',
     authType: 'none' as const,
     enabled: true,
-    criticality: 8,
   }));
 
   const {
@@ -85,7 +81,6 @@ export function HealthChecksSettingsSpecialty({
     launchUrl: 'https://',
     consumerKey: '',
     enabled: true,
-    criticality: 6,
   }));
 
   const {
@@ -97,7 +92,6 @@ export function HealthChecksSettingsSpecialty({
     endpointUrl: 'opc.tcp://',
     securityMode: 'None' as const,
     enabled: true,
-    criticality: 8,
   }));
 
   const {
@@ -111,7 +105,6 @@ export function HealthChecksSettingsSpecialty({
     unitId: 1,
     testRegister: 0,
     enabled: true,
-    criticality: 8,
   }));
 
   return (

--- a/ui/src/types/generated/config.ts
+++ b/ui/src/types/generated/config.ts
@@ -212,7 +212,6 @@ export interface HL7Endpoint {
   receiving_app: string;
   receiving_facility: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface FHIREndpoint {
   name: string;
@@ -225,7 +224,6 @@ export interface FHIREndpoint {
   client_secret?: string;
   token_url?: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface SQLEndpoint {
   name: string;
@@ -238,7 +236,6 @@ export interface SQLEndpoint {
   ssl_mode?: string;
   test_query?: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface FileShareEndpoint {
   name: string;
@@ -253,7 +250,6 @@ export interface FileShareEndpoint {
   test_write_performance?: boolean;
   test_file_size_mb?: number;
   enabled: boolean;
-  criticality: number;
 }
 export interface LDAPEndpoint {
   name: string;
@@ -266,7 +262,6 @@ export interface LDAPEndpoint {
   bind_password?: string;
   search_filter?: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface LTIEndpoint {
   name: string;
@@ -278,7 +273,6 @@ export interface LTIEndpoint {
   deployment_id?: string;
   platform_url?: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface OPCUAEndpoint {
   name: string;
@@ -290,7 +284,6 @@ export interface OPCUAEndpoint {
   cert_path?: string;
   key_path?: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface ModbusEndpoint {
   name: string;
@@ -300,7 +293,6 @@ export interface ModbusEndpoint {
   test_register: number;
   register_type?: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface SpeedtestConfig {
   server_id: string;

--- a/ui/src/types/generated/fhir-endpoint-response.ts
+++ b/ui/src/types/generated/fhir-endpoint-response.ts
@@ -10,5 +10,4 @@ export interface FHIREndpointResponse {
   baseUrl: string;
   authType: string;
   enabled: boolean;
-  criticality: number;
 }

--- a/ui/src/types/generated/file-share-endpoint-response.ts
+++ b/ui/src/types/generated/file-share-endpoint-response.ts
@@ -15,5 +15,4 @@ export interface FileShareEndpointResponse {
   testWritePerformance?: boolean;
   testFileSizeMb?: number;
   enabled: boolean;
-  criticality: number;
 }

--- a/ui/src/types/generated/hl7-endpoint-response.ts
+++ b/ui/src/types/generated/hl7-endpoint-response.ts
@@ -14,5 +14,4 @@ export interface HL7EndpointResponse {
   receivingApp: string;
   receivingFacility: string;
   enabled: boolean;
-  criticality: number;
 }

--- a/ui/src/types/generated/ldap-endpoint-response.ts
+++ b/ui/src/types/generated/ldap-endpoint-response.ts
@@ -14,5 +14,4 @@ export interface LDAPEndpointResponse {
   baseDn: string;
   searchFilter?: string;
   enabled: boolean;
-  criticality: number;
 }

--- a/ui/src/types/generated/lti-endpoint-response.ts
+++ b/ui/src/types/generated/lti-endpoint-response.ts
@@ -10,5 +10,4 @@ export interface LTIEndpointResponse {
   launchUrl: string;
   ltiVersion?: string;
   enabled: boolean;
-  criticality: number;
 }

--- a/ui/src/types/generated/modbus-endpoint-response.ts
+++ b/ui/src/types/generated/modbus-endpoint-response.ts
@@ -13,5 +13,4 @@ export interface ModbusEndpointResponse {
   testRegister: number;
   registerType?: string;
   enabled: boolean;
-  criticality: number;
 }

--- a/ui/src/types/generated/opcua-endpoint-response.ts
+++ b/ui/src/types/generated/opcua-endpoint-response.ts
@@ -11,5 +11,4 @@ export interface OPCUAEndpointResponse {
   securityMode?: string;
   securityPolicy?: string;
   enabled: boolean;
-  criticality: number;
 }

--- a/ui/src/types/generated/sql-endpoint-response.ts
+++ b/ui/src/types/generated/sql-endpoint-response.ts
@@ -13,5 +13,4 @@ export interface SQLEndpointResponse {
   database: string;
   sslMode?: string;
   enabled: boolean;
-  criticality: number;
 }

--- a/ui/src/types/generated/tests-settings-response.ts
+++ b/ui/src/types/generated/tests-settings-response.ts
@@ -83,14 +83,12 @@ export interface HL7EndpointResponse {
   receivingApp: string;
   receivingFacility: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface FHIREndpointResponse {
   name: string;
   baseUrl: string;
   authType: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface SQLEndpointResponse {
   name: string;
@@ -100,7 +98,6 @@ export interface SQLEndpointResponse {
   database: string;
   sslMode?: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface FileShareEndpointResponse {
   name: string;
@@ -112,7 +109,6 @@ export interface FileShareEndpointResponse {
   testWritePerformance?: boolean;
   testFileSizeMb?: number;
   enabled: boolean;
-  criticality: number;
 }
 export interface LDAPEndpointResponse {
   name: string;
@@ -123,14 +119,12 @@ export interface LDAPEndpointResponse {
   baseDn: string;
   searchFilter?: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface LTIEndpointResponse {
   name: string;
   launchUrl: string;
   ltiVersion?: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface OPCUAEndpointResponse {
   name: string;
@@ -138,7 +132,6 @@ export interface OPCUAEndpointResponse {
   securityMode?: string;
   securityPolicy?: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface ModbusEndpointResponse {
   name: string;
@@ -148,7 +141,6 @@ export interface ModbusEndpointResponse {
   testRegister: number;
   registerType?: string;
   enabled: boolean;
-  criticality: number;
 }
 export interface SpeedtestSettingsResponse {
   serverId: string;

--- a/ui/src/types/settings.ts
+++ b/ui/src/types/settings.ts
@@ -97,7 +97,6 @@ export interface PingTarget {
   host: string;
   enabled: boolean;
   count?: number;
-  criticality?: number; // 1-10 scale for health scoring
 }
 
 export interface DnsServer {
@@ -112,7 +111,6 @@ export interface TcpPort {
   host: string;
   port: number;
   enabled: boolean;
-  criticality?: number; // 1-10 scale for health scoring
 }
 
 export interface UdpPort {
@@ -121,7 +119,6 @@ export interface UdpPort {
   host: string;
   port: number;
   enabled: boolean;
-  criticality?: number; // 1-10 scale for health scoring
 }
 
 export interface HttpEndpoint {
@@ -130,7 +127,6 @@ export interface HttpEndpoint {
   url: string;
   expectedStatus: number;
   enabled: boolean;
-  criticality?: number; // 1-10 scale for health scoring
 }
 
 // ============================================================================
@@ -143,7 +139,6 @@ export interface RtspEndpoint {
   name: string;
   url: string; // rtsp://host:554/path
   enabled: boolean;
-  criticality?: number;
 }
 
 /** DICOM medical imaging endpoint */
@@ -154,7 +149,6 @@ export interface DicomEndpoint {
   port: number; // Default: 104
   aeTitle: string; // Application Entity Title
   enabled: boolean;
-  criticality?: number;
 }
 
 /** SQL database endpoint */
@@ -167,7 +161,6 @@ export interface SqlEndpoint {
   database: string;
   username: string;
   enabled: boolean;
-  criticality?: number;
 }
 
 /** File share endpoint (SMB/NFS) */
@@ -178,7 +171,6 @@ export interface FileShareEndpoint {
   host: string;
   sharePath: string;
   enabled: boolean;
-  criticality?: number;
 }
 
 /** LDAP/Active Directory endpoint */
@@ -190,7 +182,6 @@ export interface LdapEndpoint {
   useTls: boolean;
   baseDn: string;
   enabled: boolean;
-  criticality?: number;
 }
 
 /** HL7 MLLP medical messaging endpoint */
@@ -204,7 +195,6 @@ export interface Hl7Endpoint {
   receivingApp: string;
   receivingFacility: string;
   enabled: boolean;
-  criticality?: number;
 }
 
 /** FHIR R4 healthcare API endpoint */
@@ -214,7 +204,6 @@ export interface FhirEndpoint {
   baseUrl: string;
   authType: 'none' | 'basic' | 'oauth2';
   enabled: boolean;
-  criticality?: number;
 }
 
 /** LTI/LMS education endpoint */
@@ -224,7 +213,6 @@ export interface LtiEndpoint {
   launchUrl: string;
   consumerKey: string;
   enabled: boolean;
-  criticality?: number;
 }
 
 /** OPC-UA industrial endpoint */
@@ -234,7 +222,6 @@ export interface OpcuaEndpoint {
   endpointUrl: string; // opc.tcp://host:4840
   securityMode: 'None' | 'Sign' | 'SignAndEncrypt';
   enabled: boolean;
-  criticality?: number;
 }
 
 /** Modbus TCP industrial endpoint */
@@ -246,7 +233,6 @@ export interface ModbusEndpoint {
   unitId: number;
   testRegister: number;
   enabled: boolean;
-  criticality?: number;
 }
 
 export interface TestsSettings {


### PR DESCRIPTION
## ADR-0027 P2 — health-check `/settings` storage migration

Moves the `/telemetry/health-checks/settings` endpoint off the config file and onto the `probes` table for all fourteen health-check kinds, so configured targets are **continuously monitored** (feeding the unified anomaly store) instead of only checked on demand. Stacked on P1 (#1641, merged).

### What changed
- **`ProbeRepository.ReplaceProbesByKinds`** — transactional delete-then-insert scoped to the health-check kinds; DNS/TLS/HTTPS probes are left untouched.
- **GET** sources endpoints via `loadHealthCheckEndpoints` (probes → config shape). **PUT** flattens the request via `requestEndpointTargets` → `healthCheckProbesFromConfig`, persists with `ReplaceProbesByKinds`, then calls `Engine.Reschedule` so the running scheduler updates without a restart. DNS / performance / speedtest toggles stay config-file backed.
- **`internal/api/healthcheckmapping.go`** (from the P2 foundation) maps each `config.*Endpoint` ⇄ `database.Probe` — identity in `display_name`/`target`/`enabled` columns, full endpoint JSON in `params_json`.
- **Latent bug fixed**: the old save path (`applyTestTargets`) silently dropped the eight vertical kinds (HL7/FHIR/SQL/FileShare/LDAP/LTI/OPC-UA/Modbus). They now persist.
- **`criticality` removed outright** — unread since ADR-0026 deleted health scoring — across config types, DTOs, `internal/config/schema.json`, `docs/schemas/api/*`, generated TS, FE types + the settings slider, and i18n (en+es).
- **`/run`** is fed from the probes table via a thin best-effort `hydrateHealthCheckTargets` snapshot into the in-memory config; **P3 deletes** this when `/run` moves onto `Engine.RunNow`.

### Notes / scope
- No schema migration needed — existing `probes` columns suffice.
- Credential-bearing endpoint fields the settings DTO doesn't expose (FHIR/SQL/LDAP/OPC-UA/LTI secrets) stay out of scope until the P4 frontend rework surfaces them.
- The settings PUT remains write-gated (operator+); the integration test asserts the 401 gate, and a new handler-level internal test covers the happy-path persistence round-trip.

### Tests / gates
- `ReplaceProbesByKinds` repo test (replace + preserve-other-kinds + clear-to-empty).
- Mapping round-trip tests (foundation) + handler round-trip & replace internal tests + PUT write-gate assertion.
- `go test ./...` green · golangci-lint (new-from-main) clean · tsc + Biome + 219 vitest green · schema/types drift clean · output-escaping / route-policy / json-casing / i18n parity all green.

ADR-0027 updated with the P2 as-built note. P3–P5 (rewire `/run` + delete legacy stack, frontend rework, transport rename) follow.