### PR TITLE
feat(probe): enrich HTTP/HTTPS checker with per-phase timings + cert summary (ADR-0027 P3a)

### DIFF
--- a/docs/architecture/decisions/0027-migrate-health-checks-onto-probe.md
+++ b/docs/architecture/decisions/0027-migrate-health-checks-onto-probe.md
@@ -1,6 +1,42 @@
 # ADR-0027: Migrate the on-demand health-check stack onto the probe engine, then rename the transport
 
-**Status:** Accepted — 2026-06-11 (scoping ADR; P1 implemented)
+**Status:** Accepted — 2026-06-11 (scoping ADR; P1–P2 implemented, P3a checker-enrichment landed)
+
+> **P3a checker-enrichment as-built (2026-06-11).** A read-only audit before the P3 cutover
+> found that the probe checkers emit thinner `Result.Metadata` than the legacy `/run` surfaced
+> on the health-check card — so rewiring `/run` onto the engine as-is would have **regressed**
+> the rendered diagnostics. (This also corrects the P1 note below: the HTTP checker was *not* a
+> faithful port — it was a status/body-match reachability check.) P3a closes the gap for the
+> dominant case: the HTTP/HTTPS checker now publishes a **per-phase timing breakdown**
+> (`timings_ms`: dns/tcp/tls/ttfb via `httptrace`) and, for HTTPS, a **leaf-cert summary**
+> (`tls`: CN/issuer/not-after/days-remaining/version, reusing the TLS checker's
+> `extractCertInfo` so one cert path serves both kinds). The dedicated `tls` checker already
+> emitted the cert block, and the P1 vertical checkers already emit their key protocol fields
+> (HL7 `ack_code`, FHIR `fhir_version`/`resource_count`, Modbus `register_value`, etc.), so
+> after P3a the probe metadata carries the rich data the card renders. **Deliberate non-ports**
+> (documented, not silent regressions): (a) extended-ping loss/jitter/min/max — a multi-sample
+> *on-demand snapshot* concept that does not belong in a continuously-scheduled probe (the
+> engine samples once per interval; jitter/loss emerge from the time series, or from a future
+> `/run` multi-sample mode, not from N rapid dials baked into the checker); (b) deep vertical
+> fields (SQL driver-version/query timing, LDAP bind/search/entries, OPC-UA session state,
+> FileShare read/write IO) — these need a real driver/library or a stateful protocol session
+> and were already dead/stub in the legacy stack (see the P1 note), so omitting them is honest.
+> Cert *status* (`success`/`warning`/`error`) stays a consumer concern (it needs the config
+> expiry thresholds), derived in the P3/P4 mapping rather than baked into the checker.
+
+> **P2 as-built (2026-06-11).** The `/telemetry/health-checks/settings` endpoint is now
+> store-of-record backed by the `probes` table for all fourteen health-check kinds.
+> `internal/api/healthcheckmapping.go` maps each `config.*Endpoint` ⇄ a `database.Probe`
+> (identity in the `display_name`/`target`/`enabled` columns, the full endpoint JSON in
+> `params_json`). GET reads via `loadHealthCheckEndpoints`; PUT flattens the request via
+> `requestEndpointTargets` → `healthCheckProbesFromConfig` and persists with the transactional
+> `ProbeRepository.ReplaceProbesByKinds` (delete-then-insert scoped to the fourteen kinds, so
+> DNS/TLS/HTTPS probes are untouched), then calls `Engine.Reschedule`. Targets are now
+> continuously monitored rather than on-demand only. The pre-P2 save path silently dropped the
+> eight vertical kinds — they now persist. The unread `criticality` field (dead since ADR-0026
+> deleted health scoring) was **removed outright** rather than given a home. `/run` is fed from
+> the probes table via a thin best-effort hydrate snapshot; P3 deletes that. No schema
+> migration was needed. (Landed in #1642.)
 
 > **P1 as-built (2026-06-11).** The eight vertical checkers landed as `probe.Checker`
 > implementations under `internal/probe/checkers/` (`hl7.go`, `fhir.go`, `sql.go`,
@@ -112,7 +148,7 @@ Each phase is its own PR; the behavioral migration (1–4) **must precede** the 
 | Phase | Scope | Notes |
 |---|---|---|
 | **P1** | Vertical checkers — HL7, FHIR, SQL, FileShare, LDAP, LTI, OPC-UA, Modbus as `probe.Checker`s, registered in the engine. | The bulk of the work; can be split per-kind or batched. Each needs its kind-specific threshold shape (à la cert-expiry). New files are single-word lowercase per the existing `internal/probe/checkers/` convention — `hl7.go`, `fhir.go`, `sql.go`, `fileshare.go`, `ldap.go`, `lti.go`, `opcua.go`, `modbus.go` — **no underscores** (the repo filename policy allows `_` only in `_test.go`). |
-| **P2** | `/settings` storage migration: `config.Config.HealthChecks` target lists → `probes` table; `criticality` → threshold/severity mapping; a goose migration if the `probes` schema needs new columns. | Settling the config→DB move; the scheduler now monitors these targets continuously. |
+| **P2** ✅ | `/settings` storage migration: `config.Config.HealthChecks` target lists → `probes` table; a goose migration if the `probes` schema needs new columns. **As-built: `criticality` was removed outright** (unread since ADR-0026), not mapped; no migration was needed. | Settling the config→DB move; the scheduler now monitors these targets continuously. |
 | **P3** | Rewire `/run` to fan `Engine.RunNow` over the configured probes; **delete** the legacy protocol files + `run*Tests()`/`Run*Checks()` methods + config-file plumbing. | The ~4,067-LOC deletion lands here, once P1 covers every kind. This also retires the underscore-named `internal/api/health_checks_*.go` filenames (a pre-policy legacy naming) — the replacements already live under the no-underscore `internal/probe/checkers/` convention from P1. |
 | **P4** | Frontend rework: `HealthCheckCard` results display reads the new run/probe-result shape; settings panels bind to probe definitions; regenerate `types/generated/config.ts`; rename `HealthCheck*` components/types and the internal `'healthchecks'` / `'healthChecksUpdated'` coordination tokens. | Mostly mechanical but touches ~6 components + ~80 i18n keys (en+es). |
 | **P5** | Transport rename `/telemetry/health-checks/*` → `/telemetry/probes/*` (3 backend literals + `capabilities.txt` golden + integration tests + 4 FE fetch sites + i18n namespace). | Pure rename; rides last so it is never a half-rename. |
@@ -153,5 +189,7 @@ Each phase is its own PR; the behavioral migration (1–4) **must precede** the 
   variant only if real batch sizes demand it (still a probe run-now, not a job).
 - **Per-kind threshold shapes.** Each vertical defines its own breach fields (à la
   `cert_days_remaining`); the exact fields and catalog `Def`s are authored with each checker in P1.
-- **`criticality` mapping.** Whether it becomes a threshold input or an anomaly severity is a per-kind
-  call made in P2.
+- **`criticality` mapping.** ~~Whether it becomes a threshold input or an anomaly severity is a per-kind
+  call made in P2.~~ **Resolved in P2: removed.** Unread since ADR-0026 deleted health scoring; dropped
+  everywhere (no-compat, pre-alpha) rather than invent a new behavior. A future per-kind severity input
+  can be reintroduced deliberately if a real consumer needs it.

--- a/internal/probe/checkers/http.go
+++ b/internal/probe/checkers/http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptrace"
 	"slices"
 	"strings"
 	"time"
@@ -20,6 +21,11 @@ const defaultHTTPTimeout = 10 * time.Second
 // maxResponseBodyBytes caps how much of the response body the
 // checker reads when matching body patterns. 1 MiB is generous.
 const maxResponseBodyBytes = 1 << 20
+
+// microsPerMilli converts microseconds to milliseconds as a float so the
+// per-phase timings keep sub-millisecond precision (localhost handshakes
+// round to zero at whole-millisecond resolution).
+const microsPerMilli = 1000.0
 
 // bodySnippetMaxBytes caps the on-failure body snippet included
 // in the Result.Error field.
@@ -96,7 +102,9 @@ func (c *HTTPChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
 		method = http.MethodGet
 	}
 
-	req, err := http.NewRequestWithContext(reqCtx, method, p.Target, http.NoBody)
+	tr := &httpTrace{}
+	traceCtx := httptrace.WithClientTrace(reqCtx, tr.clientTrace())
+	req, err := http.NewRequestWithContext(traceCtx, method, p.Target, http.NoBody)
 	if err != nil {
 		return c.failResult(p, 0, fmt.Sprintf("invalid request: %v", err))
 	}
@@ -131,11 +139,18 @@ func (c *HTTPChecker) Run(ctx context.Context, p probe.Probe) probe.Result {
 		}
 	}
 
-	meta, _ := json.Marshal(map[string]any{
+	metaMap := map[string]any{
 		"status_code":  resp.StatusCode,
 		"content_type": resp.Header.Get("Content-Type"),
 		"body_match":   params.BodyMatch != "" && bodyOK,
-	})
+	}
+	if timings := tr.timings(start); len(timings) > 0 {
+		metaMap["timings_ms"] = timings
+	}
+	if cert, ok := certInfoFromResponse(resp, req.URL.Hostname()); ok {
+		metaMap["tls"] = cert
+	}
+	meta, _ := json.Marshal(metaMap)
 
 	if !statusOK || !bodyOK {
 		errMsg := fmt.Sprintf("status %d", resp.StatusCode)
@@ -230,4 +245,63 @@ func buildHTTPClient(timeout time.Duration, params HTTPParams) HTTPDoer {
 		}
 	}
 	return client
+}
+
+// httpTrace records the connection-phase timestamps captured by an
+// [httptrace.ClientTrace] during a single request, so the checker can
+// publish a DNS/TCP/TLS/TTFB latency breakdown — the per-phase timing
+// the legacy /run surfaced on the health-check card (ADR-0027 P3a).
+type httpTrace struct {
+	dnsStart, dnsDone   time.Time
+	connStart, connDone time.Time
+	tlsStart, tlsDone   time.Time
+	firstByte           time.Time
+}
+
+// clientTrace returns the trace whose hooks stamp the phase timestamps.
+// Connection reuse means DNS/connect/TLS hooks may not fire; the timings
+// helper emits only the phases that were actually measured.
+func (h *httpTrace) clientTrace() *httptrace.ClientTrace {
+	return &httptrace.ClientTrace{
+		DNSStart:             func(httptrace.DNSStartInfo) { h.dnsStart = time.Now() },
+		DNSDone:              func(httptrace.DNSDoneInfo) { h.dnsDone = time.Now() },
+		ConnectStart:         func(_, _ string) { h.connStart = time.Now() },
+		ConnectDone:          func(_, _ string, _ error) { h.connDone = time.Now() },
+		TLSHandshakeStart:    func() { h.tlsStart = time.Now() },
+		TLSHandshakeDone:     func(tls.ConnectionState, error) { h.tlsDone = time.Now() },
+		GotFirstResponseByte: func() { h.firstByte = time.Now() },
+	}
+}
+
+// timings returns the measured per-phase durations in milliseconds. start
+// is the wall-clock instant the request was dispatched (the TTFB baseline).
+// Phases that did not fire (e.g. TLS on a plain-HTTP request, or any phase
+// on a reused connection) are omitted rather than reported as zero.
+func (h *httpTrace) timings(start time.Time) map[string]float64 {
+	m := map[string]float64{}
+	add := func(key string, from, to time.Time) {
+		if !from.IsZero() && !to.IsZero() && to.After(from) {
+			m[key] = float64(to.Sub(from).Microseconds()) / microsPerMilli
+		}
+	}
+	add("dns", h.dnsStart, h.dnsDone)
+	add("tcp", h.connStart, h.connDone)
+	add("tls", h.tlsStart, h.tlsDone)
+	if !h.firstByte.IsZero() && !start.IsZero() && h.firstByte.After(start) {
+		m["ttfb"] = float64(h.firstByte.Sub(start).Microseconds()) / microsPerMilli
+	}
+	return m
+}
+
+// certInfoFromResponse extracts the leaf-certificate summary from a TLS
+// response, reusing the same shape the TLS checker publishes so a single
+// cert-extraction path serves both kinds. Returns ok=false for plain HTTP.
+func certInfoFromResponse(resp *http.Response, sni string) (TLSCertInfo, bool) {
+	if resp.TLS == nil || len(resp.TLS.PeerCertificates) == 0 {
+		return TLSCertInfo{}, false
+	}
+	return extractCertInfo(TLSConnState{
+		PeerCertificates: resp.TLS.PeerCertificates,
+		Version:          resp.TLS.Version,
+	}, sni), true
 }

--- a/internal/probe/checkers/http_test.go
+++ b/internal/probe/checkers/http_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -140,5 +141,95 @@ func TestHTTPChecker_Run_CustomMethodAndHeaders(t *testing.T) {
 	}
 	if doer.got.Header.Get("X-Probe") != "seed" {
 		t.Errorf("X-Probe header = %q, want seed", doer.got.Header.Get("X-Probe"))
+	}
+}
+
+// httpMeta unmarshals a Result's Metadata into a generic map for assertion.
+func httpMeta(t *testing.T, r probe.Result) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(r.Metadata, &m); err != nil {
+		t.Fatalf("unmarshal metadata %q: %v", r.Metadata, err)
+	}
+	return m
+}
+
+// TestHTTPChecker_Run_CapturesPhaseTimings runs against a real local
+// server so the httptrace hooks fire, and asserts the per-phase timing
+// breakdown lands in Result.Metadata. These are the timings the legacy
+// /run surfaced on the health-check card (ADR-0027 P3a parity).
+func TestHTTPChecker_Run_CapturesPhaseTimings(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r := checkers.NewHTTPChecker().Run(context.Background(), probe.Probe{
+		Kind:   "http",
+		Target: srv.URL,
+	})
+	if !r.Success {
+		t.Fatalf("Success = false; want true: %s", r.Error)
+	}
+	meta := httpMeta(t, r)
+	timings, ok := meta["timings_ms"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata has no timings_ms object: %v", meta)
+	}
+	// TTFB always elapses (the server processes the request); TCP connect
+	// elapses for a fresh connection. DNS/TLS may be ~0 for a plain-HTTP
+	// IP-literal target, so only assert the always-present phases.
+	if ttfb, _ := timings["ttfb"].(float64); ttfb <= 0 {
+		t.Errorf("ttfb timing = %v, want > 0", timings["ttfb"])
+	}
+	if _, present := timings["tcp"]; !present {
+		t.Errorf("timings missing tcp phase: %v", timings)
+	}
+}
+
+// TestHTTPSChecker_Run_CapturesCertInfo runs against a real TLS server
+// and asserts the leaf-cert summary the card renders for HTTPS endpoints
+// (CN, issuer, days-remaining, negotiated version) lands in Metadata.
+func TestHTTPSChecker_Run_CapturesCertInfo(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r := checkers.NewHTTPSChecker().Run(context.Background(), probe.Probe{
+		Kind:   "https",
+		Target: srv.URL,
+		// httptest TLS server presents a self-signed cert; let the probe
+		// inspect it without verification (matches the TLS checker policy).
+		Params: json.RawMessage(`{"insecure_skip_verify":true}`),
+	})
+	if !r.Success {
+		t.Fatalf("Success = false; want true: %s", r.Error)
+	}
+	meta := httpMeta(t, r)
+	cert, ok := meta["tls"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata has no tls cert object: %v", meta)
+	}
+	if cert["tls_version"] == "" || cert["tls_version"] == nil {
+		t.Errorf("tls_version missing: %v", cert)
+	}
+	if _, present := cert["days_remaining"]; !present {
+		t.Errorf("days_remaining missing: %v", cert)
+	}
+}
+
+// TestHTTPChecker_Run_PlainHTTPHasNoCert confirms a plain-HTTP probe
+// emits timings but no tls cert object.
+func TestHTTPChecker_Run_PlainHTTPHasNoCert(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer srv.Close()
+
+	r := checkers.NewHTTPChecker().Run(context.Background(), probe.Probe{Kind: "http", Target: srv.URL})
+	if _, hasTLS := httpMeta(t, r)["tls"]; hasTLS {
+		t.Error("plain-HTTP probe should not carry a tls cert object")
 	}
 }


### PR DESCRIPTION
## ADR-0027 P3a — probe-checker enrichment (parity groundwork before the P3 cutover)

P3 will rewire `/run` onto the probe engine and delete the ~3,500 LOC legacy stack. A read-only audit before that cutover found the probe checkers emit **thinner `Result.Metadata`** than the legacy `/run` surfaced on the health-check card — so rewiring as-is would have **silently regressed** the rendered diagnostics (the AirCheck/EtherScope-competitor surface). This PR closes the gap for the dominant case so P3+P4 can cut over without feature loss.

### What changed
- **HTTP/HTTPS checker** now publishes:
  - `timings_ms` — per-phase breakdown (`dns`/`tcp`/`tls`/`ttfb`) captured via `net/http/httptrace`; phases that don't fire (TLS on plain HTTP, reused connections) are omitted, not reported as zero.
  - `tls` — leaf-cert summary for HTTPS (CN/issuer/not-after/days-remaining/version), reusing the TLS checker's `extractCertInfo` so a single cert-extraction path serves both `tls` and `https` kinds.
- The dedicated `tls` checker already emits the cert block; the P1 vertical checkers already emit their key protocol fields (HL7 `ack_code`, FHIR `fhir_version`/`resource_count`, Modbus `register_value`, …). So after this PR the probe metadata carries the rich data the card renders.

### Deliberate non-ports (documented in ADR-0027, **not** silent regressions)
- **Extended-ping** loss/jitter/min/max — a multi-sample *on-demand snapshot* concept that doesn't fit a continuously-scheduled probe (the engine samples once per interval; jitter/loss belong to the time series, or a future `/run` multi-sample mode, not N rapid dials baked into the checker).
- **Deep vertical fields** (SQL driver-version/query timing, LDAP bind/search/entries, OPC-UA session state, FileShare read/write IO) — need a real driver/library or stateful protocol session and were already dead/stub in the legacy stack.
- **Cert *status*** (success/warning/error) stays a consumer concern — it needs the config expiry thresholds, derived in the P3/P4 mapping, not baked into the checker.

### Docs
- Recovers the **P2 as-built ADR note** that was lost when #1642 squash-merged without the doc re-staged, and **corrects the P1 note's inaccurate "faithful port" claim** for HTTP.

### Tests / gates
- Real `httptest` server + TLS-server cases assert `timings_ms` (ttfb>0, tcp present) and the `tls` cert block (version, days-remaining) land in `Metadata`; a plain-HTTP probe carries no `tls` object.
- `go build ./...` green · probe tests green · golangci-lint (new-from-main) clean · `make fmt-check` clean.

Next: the combined **P3+P4 cutover** (rewire `/run` onto `Engine.RunNow`, map probe `Result`+metadata → the card shape, delete the legacy stack) in one PR so the card is never broken.