### PR TITLE
fix(probe): seed factory health-check targets on first run

### DIFF
--- a/docs/architecture/decisions/0027-migrate-health-checks-onto-probe.md
+++ b/docs/architecture/decisions/0027-migrate-health-checks-onto-probe.md
@@ -92,6 +92,17 @@
 > the probes table via a thin best-effort hydrate snapshot; P3 deletes that. No schema
 > migration was needed. (Landed in #1642.)
 
+> **First-run seeding follow-up (2026-06-11).** Making the `probes` table the store of
+> record left a gap P2 did not close: nothing populated it on a fresh install, so the
+> health-check card came up empty out-of-box (the pre-ADR-0027 `/run` path read factory
+> defaults straight from `config.HealthChecks`; that fallback is gone). Fixed by seeding
+> `config.DefaultConfig().HealthChecks` through the same `healthCheckProbesFromConfig` +
+> `ReplaceProbesByKinds` used by the settings save, run once at server init
+> (`seedDefaultHealthCheckProbes`) and gated by a persistent `settings` marker
+> (`health_checks.seeded`) so deleting every probe does not re-seed on the next restart.
+> An install that already holds health-check probes (the upgrade path, marker absent) is
+> marked seeded and left untouched.
+
 > **P1 as-built (2026-06-11).** The eight vertical checkers landed as `probe.Checker`
 > implementations under `internal/probe/checkers/` (`hl7.go`, `fhir.go`, `sql.go`,
 > `fileshare.go`, `ldap.go`, `lti.go`, `opcua.go`, `modbus.go`), each registered in the

--- a/internal/api/healthcheckmapping.go
+++ b/internal/api/healthcheckmapping.go
@@ -40,6 +40,22 @@ func healthCheckKinds() []string {
 	}
 }
 
+// countHealthCheckProbes returns the total number of probes across the
+// health-check kinds for the default client. Used by the first-run seed to
+// detect an install that already holds a configured set (the upgrade path)
+// so the factory defaults never overwrite it.
+func countHealthCheckProbes(ctx context.Context, repo *database.ProbeRepository) (int, error) {
+	total := 0
+	for _, kind := range healthCheckKinds() {
+		n, err := repo.CountProbes(ctx, database.DefaultClientID, kind)
+		if err != nil {
+			return 0, fmt.Errorf("count %s probes: %w", kind, err)
+		}
+		total += n
+	}
+	return total, nil
+}
+
 // endpointToProbe builds a probe row from an endpoint: the endpoint is
 // marshaled wholesale into params_json (Name/Target/Enabled are also
 // authoritative columns, so the duplicate keys in params are harmless

--- a/internal/api/healthcheckseed.go
+++ b/internal/api/healthcheckseed.go
@@ -1,0 +1,74 @@
+package api
+
+// healthcheckseed.go restores the pre-ADR-0027 out-of-box behavior: a fresh
+// install ships with the factory health-check targets visible. Since P2 the
+// probes table is the store of record (see healthcheckmapping.go), and the
+// only writer is the settings-PUT path — so nothing populated it on first
+// run and the health-check card came up empty. This seeds the factory
+// defaults once, gated by a persistent marker so an operator who later
+// deletes every probe stays empty across restarts.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+// settingKeyHealthChecksSeeded marks that the factory health-check probes
+// have been seeded. Its presence — not the probe count — is the gate, so
+// deleting every health-check probe does not trigger a re-seed.
+const settingKeyHealthChecksSeeded = "health_checks.seeded"
+
+// seedDefaultHealthCheckProbes seeds the factory health-check targets into
+// the probes table on a genuine first run. It is a no-op once the seed
+// marker is set, and it never overwrites an install that already holds
+// health-check probes (the upgrade path, where the marker predates this
+// code). The factory set comes from config.DefaultConfig().HealthChecks and
+// is mapped through the same healthCheckProbesFromConfig used by the
+// settings-PUT save, so the two paths can never diverge.
+func (s *Server) seedDefaultHealthCheckProbes(ctx context.Context, db *database.DB) error {
+	settings := db.Settings()
+
+	marker, err := settings.GetValue(ctx, settingKeyHealthChecksSeeded)
+	if err != nil {
+		return fmt.Errorf("read health-check seed marker: %w", err)
+	}
+	if marker != "" {
+		return nil // already seeded — honor an operator's later delete-all.
+	}
+
+	// Upgrade guard: an install that already configured health-check probes
+	// (saved before this seeding existed, so no marker) must keep its set.
+	// Mark it seeded and leave the probes untouched.
+	existing, err := countHealthCheckProbes(ctx, db.Probes())
+	if err != nil {
+		return fmt.Errorf("count existing health-check probes: %w", err)
+	}
+	if existing > 0 {
+		return s.markHealthChecksSeeded(ctx, settings)
+	}
+
+	hc := config.DefaultConfig().HealthChecks
+	probes, err := healthCheckProbesFromConfig(&hc)
+	if err != nil {
+		return fmt.Errorf("build default health-check probes: %w", err)
+	}
+	if err = db.Probes().ReplaceProbesByKinds(
+		ctx, database.DefaultClientID, healthCheckKinds(), probes,
+	); err != nil {
+		return fmt.Errorf("seed default health-check probes: %w", err)
+	}
+	return s.markHealthChecksSeeded(ctx, settings)
+}
+
+// markHealthChecksSeeded records the seed marker with a UTC timestamp value.
+// The value is informational; only its presence gates re-seeding.
+func (s *Server) markHealthChecksSeeded(ctx context.Context, settings *database.SettingsRepository) error {
+	if err := settings.Set(ctx, settingKeyHealthChecksSeeded, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("set health-check seed marker: %w", err)
+	}
+	return nil
+}

--- a/internal/api/healthcheckseed_internal_test.go
+++ b/internal/api/healthcheckseed_internal_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// TestSeedDefaultHealthCheckProbes_FreshInstall verifies that a genuine
+// first run seeds the factory health-check targets into the probes table,
+// restoring the pre-ADR-0027 out-of-box behavior (a non-empty health-check
+// card). Before this seed, getHealthChecksSettings read an empty probes
+// table because nothing populated it outside the settings-PUT path.
+func TestSeedDefaultHealthCheckProbes_FreshInstall(t *testing.T) {
+	db := newTestDB(t)
+	s := &Server{config: &config.Config{}, dbConn: db}
+	ctx := context.Background()
+
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+
+	// The factory ping targets are now persisted as probe rows.
+	pings, err := db.Probes().ListProbes(ctx, database.DefaultClientID, probe.KindPing)
+	require.NoError(t, err)
+	hosts := map[string]bool{}
+	for _, p := range pings {
+		hosts[p.Target] = true
+	}
+	require.True(t, hosts["8.8.8.8"], "factory Google DNS ping target should be seeded")
+	require.True(t, hosts["1.1.1.1"], "factory Cloudflare ping target should be seeded")
+
+	// The GET handler now reconstructs a non-empty endpoint set.
+	gw := httptest.NewRecorder()
+	gr := httptest.NewRequest(http.MethodGet, "/x", http.NoBody)
+	s.getHealthChecksSettings(gw, gr)
+	require.Equal(t, http.StatusOK, gw.Code, "GET body: %s", gw.Body.String())
+	require.Greater(t, len(gw.Body.String()), 2, "settings response must not be empty")
+}
+
+// TestSeedDefaultHealthCheckProbes_Idempotent verifies that seeding twice
+// does not duplicate the factory set: the persistent marker short-circuits
+// the second call.
+func TestSeedDefaultHealthCheckProbes_Idempotent(t *testing.T) {
+	db := newTestDB(t)
+	s := &Server{config: &config.Config{}, dbConn: db}
+	ctx := context.Background()
+
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+	first, err := db.Probes().CountProbes(ctx, database.DefaultClientID, probe.KindPing)
+	require.NoError(t, err)
+	require.Equal(t, 2, first, "factory set has two ping targets")
+
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+	second, err := db.Probes().CountProbes(ctx, database.DefaultClientID, probe.KindPing)
+	require.NoError(t, err)
+	require.Equal(t, first, second, "second seed must not duplicate the factory set")
+}
+
+// TestSeedDefaultHealthCheckProbes_NoReseedAfterDeleteAll verifies the
+// persistent-marker contract: once seeded, an operator who deletes every
+// health-check probe stays empty across restarts rather than having the
+// factory set silently reappear.
+func TestSeedDefaultHealthCheckProbes_NoReseedAfterDeleteAll(t *testing.T) {
+	db := newTestDB(t)
+	s := &Server{config: &config.Config{}, dbConn: db}
+	ctx := context.Background()
+
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+
+	// Operator clears the whole health-check set (settings save with no targets).
+	require.NoError(t, db.Probes().ReplaceProbesByKinds(
+		ctx, database.DefaultClientID, healthCheckKinds(), nil,
+	))
+
+	// A subsequent boot must NOT re-seed.
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+	count, err := db.Probes().CountProbes(ctx, database.DefaultClientID, probe.KindPing)
+	require.NoError(t, err)
+	require.Equal(t, 0, count, "deleting all probes must not trigger a re-seed")
+}
+
+// TestSeedDefaultHealthCheckProbes_PreservesExistingProbes verifies the
+// upgrade guard: an install that already holds health-check probes (saved
+// before this seeding existed, so the marker is absent) is left untouched —
+// the operator's set is never overwritten with factory defaults.
+func TestSeedDefaultHealthCheckProbes_PreservesExistingProbes(t *testing.T) {
+	db := newTestDB(t)
+	s := &Server{config: &config.Config{}, dbConn: db}
+	ctx := context.Background()
+
+	// Pre-existing operator-configured set, no seed marker.
+	custom := TestsSettingsResponse{
+		PingTargets: []PingTargetResponse{{Name: "lab", Host: "10.0.0.1", Enabled: true}},
+	}
+	require.True(t, s.saveHealthCheckProbes(
+		httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPut, "/x", http.NoBody),
+		&custom,
+	))
+
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+
+	pings, err := db.Probes().ListProbes(ctx, database.DefaultClientID, probe.KindPing)
+	require.NoError(t, err)
+	require.Len(t, pings, 1, "existing set must not be replaced by the factory defaults")
+	require.Equal(t, "10.0.0.1", pings[0].Target)
+}

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -111,6 +111,15 @@ func (s *Server) initDatabaseServices(cfg *config.Config, db *database.DB) {
 		}
 	}
 
+	// Seed the factory health-check targets on first run (ADR-0027 follow-up).
+	// The probes table is the store of record since P2; without this a fresh
+	// install comes up with an empty health-check card. Gated by a persistent
+	// marker, so a later delete-all is not re-seeded. Non-fatal: a failure
+	// degrades to the empty card rather than aborting startup.
+	if err := s.seedDefaultHealthCheckProbes(context.Background(), db); err != nil {
+		logging.GetLogger().Error("Failed to seed default health-check probes", "error", err)
+	}
+
 	// Initialize MIB database for SNMP OID resolution
 	s.initMibDatabase(db)
 


### PR DESCRIPTION
## Problem

ADR-0027 P2 (#1642) made the `probes` table the store of record for the fourteen health-check kinds. `getHealthChecksSettings` reads endpoints via `loadHealthCheckEndpoints` → `ProbeRepository.ListProbes`. But the **only** writer is the settings-PUT path (`saveHealthCheckProbes`). Nothing populated the table on a fresh install, so the health-check card came up **empty out-of-box** — a regression from the pre-ADR-0027 `/run` path, which read factory defaults straight from `config.HealthChecks` (that fallback was deleted in P3/P4).

## Fix

Seed `config.DefaultConfig().HealthChecks` into the probes table once at server init, reusing the **same** `healthCheckProbesFromConfig` + `ReplaceProbesByKinds` the settings save uses — so the seed and save paths can't diverge, and `defaultHealthChecksConfig()` stays the single source of truth.

- `seedDefaultHealthCheckProbes` (new `internal/api/healthcheckseed.go`) runs from `initDatabaseServices`, right after the admin-user migration.
- **Gated by a persistent marker** (`settings` kv key `health_checks.seeded`), not the probe count — so an operator who deletes every health-check probe stays empty across restarts rather than having the factory set silently reappear.
- **Upgrade guard:** an install that already holds health-check probes (marker absent because this seeding is new) is marked seeded and left untouched — factory defaults never overwrite a configured set.
- **Non-fatal:** a seed failure logs and degrades to the empty card rather than aborting startup.

The `HealthChecksConfig` type was **not** split — its endpoint lists still legitimately back `/api/settings/defaults`.

## Mechanism choice

Boot-time seed + marker, not a goose data-migration: `healthCheckProbesFromConfig` lives in `internal/api`, so a migration in `internal/database` can't reuse it (import cycle) and would have to re-encode all fourteen factory lists as raw SQL. The marker also handles the delete-all case a migration can't.

## Tests (TDD)

`internal/api/healthcheckseed_internal_test.go`:
- `FreshInstall` — factory ping targets (8.8.8.8, 1.1.1.1) seeded; GET returns non-empty.
- `Idempotent` — second seed does not duplicate.
- `NoReseedAfterDeleteAll` — delete-all then boot stays empty (marker gate).
- `PreservesExistingProbes` — pre-existing set with no marker is not overwritten.

## Gate

`go build ./...`, `go vet`, `go test ./internal/api/... ./internal/database/...`, `gofmt -l`, `golangci-lint run internal/api/...` (0 issues), `scripts/check-json-casing.sh` — all clean.