### PR TITLE
feat(anomaly): daily-rollup census of the anomaly store (ADR-0028)

### DIFF
--- a/docs/architecture/decisions/0028-anomaly-daily-rollups.md
+++ b/docs/architecture/decisions/0028-anomaly-daily-rollups.md
@@ -1,11 +1,11 @@
 # ADR-0028: Daily rollups for the anomaly store (census of mutable instances, not a RollupSource)
 
-**Status:** Proposed — 2026-06-11 · design-only (no code in this ADR) · realizes the deferred
-"daily rollups" clause of [ADR-0021](0021-persist-and-converge-anomaly-engine.md) §"Owner decisions"
-and its "Phase 2 as-built" re-sequencing note. Builds on
-[ADR-0006](0006-migrations-sql-goose-strict.md) (goose/STRICT migrations),
-[ADR-0010](0010-identifier-casing-conventions.md) (casing). Owner sign-off needed on the two
-decision points flagged **[OWNER]** below before implementation.
+**Status:** Accepted — 2026-06-11 · realizes the deferred "daily rollups" clause of
+[ADR-0021](0021-persist-and-converge-anomaly-engine.md) §"Owner decisions" and its "Phase 2
+as-built" re-sequencing note. Builds on [ADR-0006](0006-migrations-sql-goose-strict.md)
+(goose/STRICT migrations), [ADR-0010](0010-identifier-casing-conventions.md) (casing). Both
+**[OWNER]** decision points below were resolved on 2026-06-11 (cumulative snapshot; reuse the probe
+DailyDays horizon) and the census shipped — see "As-built" at the end.
 
 ## Context
 
@@ -112,15 +112,15 @@ The live row carries only a **cumulative** `count`, so a faithful "occurrences o
 prior day's cumulative. V1.0 stores `count_cumulative` and derives per-day deltas by differencing
 consecutive day rows for the same (def, subject) at query time. This is the same honesty trade-off
 the probe daily rollup already documents (its `AVG(avg_latency_ms)` caveat) — exact intra-day
-recurrence counting would require snapshotting at each day boundary and is deferred. **[OWNER]**
-confirm census-with-cumulative is acceptable vs. carrying a true per-day delta column.
+recurrence counting would require snapshotting at each day boundary and is deferred.
 
-## [OWNER] decision points
+## [OWNER] decision points — RESOLVED 2026-06-11
 
-1. **Census vs. true per-day delta** (§5): ship the simpler cumulative-snapshot census in V1.0, or
-   pay for a per-day-delta column now?
-2. **`DailyDays` horizon for anomaly rollups**: reuse the probe tier horizons verbatim (Pro 730d), or
-   a distinct anomaly horizon? Default proposal: reuse, one policy to reason about.
+1. **Census vs. true per-day delta** (§5): **cumulative-snapshot census** chosen for V1.0. Stores
+   `count_cumulative`; per-day deltas are derived by differencing consecutive day rows at query time.
+   A true per-day-delta column is deferred until exact intra-day analytics are a requirement.
+2. **`DailyDays` horizon for anomaly rollups**: **reuse the probe tier horizons verbatim** (Pro 730d,
+   Free/Starter 0). One policy to reason about; exposed via `retention.HorizonsFor(tier).DailyDays`.
 
 ## Consequences
 
@@ -148,3 +148,33 @@ confirm census-with-cumulative is acceptable vs. carrying a true per-day delta c
   exact intra-day recurrence analytics become a requirement.
 - **No rollups, rely on TTL only.** Rejected: violates the locked ADR-0021 decision and loses all
   history older than 90 days — the appliance could not answer "was this site flapping last quarter?"
+
+## As-built — 2026-06-11
+
+Shipped exactly as decided, both owner decisions resolved (cumulative snapshot; reuse horizon):
+
+- **Schema:** migration `00008_anomaly_rollups_daily.sql` — STRICT `anomaly_rollups_daily`, PK
+  `(day_bucket, def_key, subject_kind, subject_id)`, indexes on `day_bucket` and
+  `(subject_kind, subject_id)`; columns per §4 (`max_severity` = the live row's current escalated
+  severity, `count_cumulative` per §5). Schema golden regenerated.
+- **Census query** (`AnomalyRepository.CensusThrough`): `INSERT OR REPLACE … SELECT FROM anomalies
+  WHERE date(first_seen) <= :day AND :day <= date(COALESCE(resolved_at, last_seen))` — the §1
+  intersection. The rollup table's own `MAX(day_bucket)` is the high-water mark, so a pass after
+  downtime catches up every missed day through today (§3) with **no separate marker**; an empty table
+  censuses today only. Re-census is idempotent (REPLACE).
+- **One ordered pass** (§2): folded into `database.RunCleanup` — census runs **first** (before
+  `cleanupResolvedAnomalies` TTL-purges resolved rows), then `PurgeRollupsDailyOlderThan` bounds the
+  rollup table. Gated on `RetentionPolicy.AnomalyRollupDailyDays`: Pro censuses + retains 730d;
+  Free/Starter (0) skip the census and purge in full. The api maintenance goroutine
+  (`server_shutdown.go`) sets the horizon per tick from `retention.HorizonsFor(tier).DailyDays`, so an
+  in-place upgrade takes effect on the next pass — same tier-awareness as the retention engine.
+- **Callsite guard** (§3): `TestRunCleanupCensusesResolvedRowBeforePurge` asserts a row resolved
+  within the census window survives in the rollups after its live row is purged in the same
+  `RunCleanup` — the "0 callers" gap is structurally impossible to reintroduce silently. Plus unit
+  coverage for the intersection predicate, catch-up, idempotent re-census, bucket-cutoff purge, and
+  the Free-tier skip.
+- **V1.0 boundary:** the catch-up only reaches back to the last censused day, so the very first census
+  pass ever (empty table) records today only — a cold-start with no prior history, by definition
+  lossless. Per-day occurrence counts are derived by differencing `count_cumulative` at query time
+  (§5); no consumer read API yet (the future trend/correlation surface plugs into this table when a
+  consumer needs it).

--- a/internal/api/server_shutdown.go
+++ b/internal/api/server_shutdown.go
@@ -13,6 +13,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/netif"
+	"github.com/MustardSeedNetworks/seed/internal/timeseries/retention"
 )
 
 // getClientIP extracts the client IP from a request, considering trusted proxies.
@@ -231,6 +232,11 @@ func (s *Server) startMaintenance(retentionDays int) {
 			if retentionDays <= 0 || s.db() == nil {
 				continue
 			}
+			// Resolve the anomaly daily-rollup horizon per tick so an in-place
+			// license upgrade takes effect on the next pass (ADR-0028 §4 reuses the
+			// probe DailyDays horizon, same as the retention engine).
+			tier := licenseTierAdapter{lm: s.licenseMgr}.GetTier()
+			policy.AnomalyRollupDailyDays = retention.HorizonsFor(tier).DailyDays
 			result, err := s.db().RunCleanup(context.Background(), policy)
 			if err != nil {
 				logging.GetLogger().Error("Data retention cleanup failed", "error", err)

--- a/internal/database/export_test.go
+++ b/internal/database/export_test.go
@@ -23,6 +23,51 @@ func ExportMigrationsCount() int {
 	return count
 }
 
+// RollupDailyRow is one decoded anomaly_rollups_daily row, for testing the
+// census output without exposing a production read API before a consumer needs
+// one (ADR-0028).
+type RollupDailyRow struct {
+	DayBucket   string
+	DefKey      string
+	Source      string
+	Category    string
+	SubjectKind string
+	SubjectID   string
+	MaxSeverity string
+	CountCumul  int64
+	IsResolved  bool
+	ResolvedAt  string
+}
+
+// ExportRollupDailyRows returns every anomaly_rollups_daily row ordered by
+// (day_bucket, def_key, subject_id), for testing.
+func (db *DB) ExportRollupDailyRows(ctx context.Context) ([]RollupDailyRow, error) {
+	rows, err := db.Query(ctx, `
+		SELECT day_bucket, def_key, source, category, subject_kind, subject_id,
+		       max_severity, count_cumulative, is_resolved, COALESCE(resolved_at, '')
+		FROM anomaly_rollups_daily
+		ORDER BY day_bucket, def_key, subject_id
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []RollupDailyRow
+	for rows.Next() {
+		var r RollupDailyRow
+		var resolved int
+		if scanErr := rows.Scan(&r.DayBucket, &r.DefKey, &r.Source, &r.Category,
+			&r.SubjectKind, &r.SubjectID, &r.MaxSeverity, &r.CountCumul,
+			&resolved, &r.ResolvedAt); scanErr != nil {
+			return nil, scanErr
+		}
+		r.IsResolved = resolved != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 // DeleteAuditLogsOlderThan exports deleteAuditLogsOlderThan for testing.
 func (db *DB) DeleteAuditLogsOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
 	return db.deleteAuditLogsOlderThan(ctx, cutoff)

--- a/internal/database/migrations/00008_anomaly_rollups_daily.sql
+++ b/internal/database/migrations/00008_anomaly_rollups_daily.sql
@@ -1,0 +1,47 @@
+-- 00008_anomaly_rollups_daily.sql — daily census rollup of the anomaly store
+-- (ADR-0028). Realizes the deferred "daily rollups" clause of ADR-0021's locked
+-- retention model (TTL + daily rollups). The `anomalies` table (00006) is
+-- coalesced — one mutable row per (def, subject) carrying a cumulative count and
+-- lifecycle — so it has NO per-occurrence event log to GROUP BY. The only
+-- faithful daily artifact is therefore a CENSUS: each UTC day, one row per
+-- (def, subject) whose lifecycle intersects that day, snapshotting the facts the
+-- live row still holds. This long-term trend survives the 90-day TTL purge of
+-- resolved anomalies (ADR-0021 / migration 00006), with bounded appliance growth
+-- via the DailyDays tier horizon (purged in the same RunCleanup pass that writes
+-- the census — census first, purge second).
+--
+-- NOT a timeseries RollupSource: there is no immutable raw stream, no hourly
+-- tier, and the Phase-2 TTL cleanup already owns deletion of resolved rows
+-- (ADR-0028 "Alternatives considered"). One daily table, one INSERT OR REPLACE.
+--
+-- Per-day occurrence counting (ADR-0028 §5, V1.0): count_cumulative stores the
+-- live row's cumulative count at census time; exact per-day deltas are derived by
+-- differencing consecutive day rows for the same (def, subject) at query time.
+--
+-- Regenerate the gate golden after edits:
+--   UPDATE_SCHEMA_GOLDEN=1 go test ./internal/database/ -run TestSchemaSnapshot
+
+-- +goose Up
+CREATE TABLE anomaly_rollups_daily (
+	day_bucket       TEXT    NOT NULL,                      -- YYYY-MM-DD UTC (retention.dayFormat)
+	def_key          TEXT    NOT NULL CHECK (def_key <> ''),
+	source           TEXT    NOT NULL CHECK (source <> ''), -- wifi|wired|snmp|bluetooth|health|security|autotest
+	category         TEXT    NOT NULL CHECK (category <> ''),
+	subject_kind     TEXT    NOT NULL CHECK (subject_kind <> ''),
+	subject_id       TEXT    NOT NULL,
+	max_severity     TEXT    NOT NULL CHECK (max_severity <> ''), -- highest severity held as of the census
+	count_cumulative INTEGER NOT NULL CHECK (count_cumulative >= 0),
+	first_seen       TEXT    NOT NULL,                       -- RFC3339, carried from the live row
+	last_seen        TEXT    NOT NULL,                       -- RFC3339, carried from the live row
+	is_resolved      INTEGER NOT NULL DEFAULT 0 CHECK (is_resolved IN (0, 1)),
+	resolved_at      TEXT,                                   -- RFC3339, NULL while active
+	PRIMARY KEY (day_bucket, def_key, subject_kind, subject_id) -- idempotent re-census
+) STRICT;
+
+-- Purge + day-range queries scan by bucket; cross-source correlation (the point
+-- of the subject taxonomy) scans by subject.
+CREATE INDEX idx_anomaly_rollups_daily_bucket ON anomaly_rollups_daily(day_bucket);
+CREATE INDEX idx_anomaly_rollups_daily_subject ON anomaly_rollups_daily(subject_kind, subject_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS anomaly_rollups_daily;

--- a/internal/database/repository_anomalies.go
+++ b/internal/database/repository_anomalies.go
@@ -134,6 +134,97 @@ func (r *AnomalyRepository) DeleteResolvedOlderThan(ctx context.Context, cutoff 
 	return affected, nil
 }
 
+// truncToUTCDay returns t collapsed to UTC midnight, the canonical day boundary
+// for census buckets.
+func truncToUTCDay(t time.Time) time.Time {
+	y, m, d := t.UTC().Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+// anomalyDayFormat is the YYYY-MM-DD UTC form stored in
+// anomaly_rollups_daily.day_bucket. It matches internal/timeseries/retention's
+// dayFormat so anomaly and probe rollups bucket identically.
+const anomalyDayFormat = "2006-01-02"
+
+// censusDaySQL writes one anomaly_rollups_daily row per (def, subject) whose
+// lifecycle intersects the given UTC day (ADR-0028 §1): the day falls in
+// [date(first_seen), date(coalesce(resolved_at, last_seen))]. coalesce folds the
+// resolution day in for resolved rows (resolved_at >= last_seen) and uses
+// last_seen for active rows (resolved_at NULL). INSERT OR REPLACE on the PK
+// (day_bucket, def_key, subject_kind, subject_id) makes a re-census idempotent —
+// it refreshes the snapshot to the latest cumulative count / severity. The live
+// `severity` is taken as max_severity: the coalescing engine escalates-only
+// within a live instance, so the current value is the highest the (def, subject)
+// has held (ADR-0028 §4).
+const censusDaySQL = `
+	INSERT OR REPLACE INTO anomaly_rollups_daily
+	  (day_bucket, def_key, source, category, subject_kind, subject_id,
+	   max_severity, count_cumulative, first_seen, last_seen, is_resolved, resolved_at)
+	SELECT
+	  ?, def_key, source, category, subject_kind, subject_id,
+	  severity, count, first_seen, last_seen, is_resolved, resolved_at
+	FROM anomalies
+	WHERE date(first_seen) <= ?
+	  AND ? <= date(COALESCE(resolved_at, last_seen))`
+
+// CensusThrough writes the daily census for every UTC day from the last censused
+// day through today inclusive (ADR-0028 §1/§3), so a server that missed day
+// boundaries during downtime catches up on its next maintenance pass. The
+// rollup table is its own high-water mark — MAX(day_bucket) — so no separate
+// marker is needed; an empty table censuses today only. Re-censusing the
+// high-water day is harmless (idempotent) and captures late-in-day updates.
+// Returns the number of rows written across all censused days. Call BEFORE the
+// resolved-anomaly TTL purge so a resolution-day row is captured before its live
+// row is deleted (ADR-0028 §2: census first, purge second).
+func (r *AnomalyRepository) CensusThrough(ctx context.Context, today time.Time) (int64, error) {
+	today = truncToUTCDay(today)
+
+	var highWater sql.NullString
+	if err := r.db.QueryRow(ctx,
+		`SELECT MAX(day_bucket) FROM anomaly_rollups_daily`,
+	).Scan(&highWater); err != nil {
+		return 0, fmt.Errorf("anomaly rollup high-water: %w", err)
+	}
+
+	start := today
+	if highWater.Valid {
+		if hw, err := time.Parse(anomalyDayFormat, highWater.String); err == nil && hw.Before(today) {
+			start = truncToUTCDay(hw)
+		}
+	}
+
+	var written int64
+	for day := start; !day.After(today); day = day.AddDate(0, 0, 1) {
+		bucket := day.Format(anomalyDayFormat)
+		res, err := r.db.Exec(ctx, censusDaySQL, bucket, bucket, bucket)
+		if err != nil {
+			return written, fmt.Errorf("census anomalies for %s: %w", bucket, err)
+		}
+		if n, raErr := res.RowsAffected(); raErr == nil {
+			written += n
+		}
+	}
+	return written, nil
+}
+
+// PurgeRollupsDailyOlderThan removes census rows whose day_bucket predates cutoff,
+// bounding the rollup table by the DailyDays tier horizon (ADR-0028 §4, mirroring
+// probe_rollups_daily). Returns the number of rows removed.
+func (r *AnomalyRepository) PurgeRollupsDailyOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	result, err := r.db.Exec(ctx,
+		`DELETE FROM anomaly_rollups_daily WHERE day_bucket < ?`,
+		cutoff.UTC().Format(anomalyDayFormat),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("purge anomaly rollups daily: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("purge anomaly rollups daily rows affected: %w", err)
+	}
+	return affected, nil
+}
+
 // LoadActive returns every unresolved instance, ordered by id for determinism,
 // so the engine can be repopulated on start.
 func (r *AnomalyRepository) LoadActive(ctx context.Context) ([]anomaly.Record, error) {

--- a/internal/database/repository_anomalies_test.go
+++ b/internal/database/repository_anomalies_test.go
@@ -332,3 +332,296 @@ func TestActiveBySourceFiltersAndExcludesResolved(t *testing.T) {
 		t.Fatalf("want the single wifi anomaly intact, got %+v", wifi)
 	}
 }
+
+// recordSpanning builds a record whose lifecycle covers [first, last] with a
+// known cumulative count, for exercising the daily census intersection (ADR-0028).
+func recordSpanning(id string, first, last time.Time, count int) anomaly.Record {
+	rec := sampleRecord(id)
+	rec.Anomaly.FirstSeen = first
+	rec.Anomaly.LastSeen = last
+	rec.Anomaly.Count = count
+	return rec
+}
+
+func dayKey(t time.Time) string { return t.UTC().Format("2006-01-02") }
+
+// TestCensusThroughCurrentDayActive censuses an empty table for today and asserts
+// one row per active anomaly intersecting today, carrying the live row's facts.
+func TestCensusThroughCurrentDayActive(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupAnomalyDB(t)
+	repo := db.Anomalies()
+	now := time.Now().UTC()
+
+	if err := repo.Upsert(ctx, []anomaly.Record{
+		recordSpanning("open-ssid|bssid|aa:bb", now.AddDate(0, 0, -2), now, 3),
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	written, err := repo.CensusThrough(ctx, now)
+	if err != nil {
+		t.Fatalf("CensusThrough: %v", err)
+	}
+	if written != 1 {
+		t.Fatalf("written = %d, want 1", written)
+	}
+
+	rows, err := db.ExportRollupDailyRows(ctx)
+	if err != nil {
+		t.Fatalf("ExportRollupDailyRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rollup rows = %d, want 1 (%+v)", len(rows), rows)
+	}
+	r := rows[0]
+	if r.DayBucket != dayKey(now) {
+		t.Errorf("day_bucket = %q, want %q", r.DayBucket, dayKey(now))
+	}
+	if r.CountCumul != 3 || r.MaxSeverity != "warning" || r.Source != "wifi" || r.IsResolved {
+		t.Errorf("row = %+v, want count=3 sev=warning source=wifi active", r)
+	}
+}
+
+// TestCensusThroughExcludesNonIntersectingDay proves the intersection predicate:
+// an anomaly whose whole lifecycle predates today is not in today's census.
+func TestCensusThroughExcludesNonIntersectingDay(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupAnomalyDB(t)
+	repo := db.Anomalies()
+	now := time.Now().UTC()
+
+	old := now.AddDate(0, 0, -5)
+	if err := repo.Upsert(ctx, []anomaly.Record{recordSpanning("old|bssid|aa:bb", old, old, 1)}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if err := repo.MarkResolved(ctx, []string{"old|bssid|aa:bb"}, old); err != nil {
+		t.Fatalf("MarkResolved: %v", err)
+	}
+
+	written, err := repo.CensusThrough(ctx, now)
+	if err != nil {
+		t.Fatalf("CensusThrough: %v", err)
+	}
+	if written != 0 {
+		t.Fatalf("written = %d, want 0 (lifecycle predates today)", written)
+	}
+}
+
+// TestCensusThroughCatchUp proves the rollup table's MAX(day_bucket) acts as the
+// high-water mark: after a census at an earlier day, a later census fills every
+// missed day through today (the downtime catch-up, ADR-0028 §3).
+func TestCensusThroughCatchUp(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupAnomalyDB(t)
+	repo := db.Anomalies()
+	now := time.Now().UTC()
+
+	// An anomaly active across the whole window.
+	if err := repo.Upsert(ctx, []anomaly.Record{
+		recordSpanning("flap|bssid|aa:bb", now.AddDate(0, 0, -10), now, 9),
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Establish the high-water two days back.
+	if _, err := repo.CensusThrough(ctx, now.AddDate(0, 0, -2)); err != nil {
+		t.Fatalf("CensusThrough(now-2d): %v", err)
+	}
+	// Catch up to today: re-census now-2d plus now-1d and now.
+	if _, err := repo.CensusThrough(ctx, now); err != nil {
+		t.Fatalf("CensusThrough(now): %v", err)
+	}
+
+	rows, err := db.ExportRollupDailyRows(ctx)
+	if err != nil {
+		t.Fatalf("ExportRollupDailyRows: %v", err)
+	}
+	want := map[string]bool{
+		dayKey(now.AddDate(0, 0, -2)): true,
+		dayKey(now.AddDate(0, 0, -1)): true,
+		dayKey(now):                   true,
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("rollup rows = %d, want %d (%+v)", len(rows), len(want), rows)
+	}
+	for _, r := range rows {
+		if !want[r.DayBucket] {
+			t.Errorf("unexpected day_bucket %q", r.DayBucket)
+		}
+	}
+}
+
+// TestCensusThroughIdempotentReflectsLatestCount re-censuses the same day after
+// the live count advances and asserts the row is replaced, not duplicated.
+func TestCensusThroughIdempotentReflectsLatestCount(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupAnomalyDB(t)
+	repo := db.Anomalies()
+	now := time.Now().UTC()
+
+	id := "open-ssid|bssid|aa:bb"
+	if err := repo.Upsert(ctx, []anomaly.Record{recordSpanning(id, now.AddDate(0, 0, -1), now, 3)}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if _, err := repo.CensusThrough(ctx, now); err != nil {
+		t.Fatalf("first CensusThrough: %v", err)
+	}
+	// The anomaly recurs; cumulative count advances.
+	if err := repo.Upsert(ctx, []anomaly.Record{recordSpanning(id, now.AddDate(0, 0, -1), now, 7)}); err != nil {
+		t.Fatalf("second Upsert: %v", err)
+	}
+	if _, err := repo.CensusThrough(ctx, now); err != nil {
+		t.Fatalf("second CensusThrough: %v", err)
+	}
+
+	rows, err := db.ExportRollupDailyRows(ctx)
+	if err != nil {
+		t.Fatalf("ExportRollupDailyRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rollup rows = %d, want 1 (idempotent replace)", len(rows))
+	}
+	if rows[0].CountCumul != 7 {
+		t.Errorf("count_cumulative = %d, want 7 (latest snapshot)", rows[0].CountCumul)
+	}
+}
+
+// TestPurgeRollupsDailyOlderThan asserts the bucket-cutoff boundary: a same-day
+// rollup survives a cutoff at today, and is removed once the cutoff passes it.
+func TestPurgeRollupsDailyOlderThan(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupAnomalyDB(t)
+	repo := db.Anomalies()
+	now := time.Now().UTC()
+
+	if err := repo.Upsert(ctx, []anomaly.Record{recordSpanning("open-ssid|bssid|aa:bb", now, now, 1)}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if _, err := repo.CensusThrough(ctx, now); err != nil {
+		t.Fatalf("CensusThrough: %v", err)
+	}
+
+	// Cutoff at today: today's bucket is not strictly older, so it survives.
+	deleted, err := repo.PurgeRollupsDailyOlderThan(ctx, now)
+	if err != nil {
+		t.Fatalf("PurgeRollupsDailyOlderThan(now): %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 (today's bucket survives)", deleted)
+	}
+
+	// Cutoff tomorrow: today's bucket is now older and is removed.
+	deleted, err = repo.PurgeRollupsDailyOlderThan(ctx, now.AddDate(0, 0, 1))
+	if err != nil {
+		t.Fatalf("PurgeRollupsDailyOlderThan(now+1d): %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+}
+
+// TestRunCleanupCensusesResolvedRowBeforePurge is the ADR-0028 §3 callsite guard:
+// RunCleanup must census the live anomaly table BEFORE the resolved-anomaly TTL
+// purge, so a row resolved within the census window is preserved in the rollups
+// even as its live row is deleted in the same pass. The CreateDailyRollup "0
+// callers" gap must be impossible to reintroduce.
+func TestRunCleanupCensusesResolvedRowBeforePurge(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupAnomalyDB(t)
+	repo := db.Anomalies()
+	now := time.Now().UTC()
+
+	// A: resolved two days ago (lifecycle ends now-2d). B: still active.
+	resolvedDay := now.AddDate(0, 0, -2)
+	if err := repo.Upsert(ctx, []anomaly.Record{
+		recordSpanning("A|bssid|aa:bb", now.AddDate(0, 0, -5), resolvedDay, 4),
+		recordForSource("B|bssid|cc:dd", anomaly.SourceWiFi),
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	// Keep B's lifecycle current so it intersects every catch-up day.
+	bSpan := recordSpanning("B|bssid|cc:dd", now.AddDate(0, 0, -5), now, 2)
+	if err := repo.Upsert(ctx, []anomaly.Record{bSpan}); err != nil {
+		t.Fatalf("Upsert B span: %v", err)
+	}
+	if err := repo.MarkResolved(ctx, []string{"A|bssid|aa:bb"}, resolvedDay); err != nil {
+		t.Fatalf("MarkResolved A: %v", err)
+	}
+	// Prior census established the high-water at now-3d, so the catch-up covers
+	// A's resolution day (now-2d).
+	if _, err := repo.CensusThrough(ctx, now.AddDate(0, 0, -3)); err != nil {
+		t.Fatalf("seed high-water: %v", err)
+	}
+
+	result, err := db.RunCleanup(ctx, database.RetentionPolicy{
+		AnomalyResolvedDays:    1,   // cutoff now-1d → A (resolved now-2d) is purged
+		AnomalyRollupDailyDays: 730, // Pro: census + retain
+	})
+	if err != nil {
+		t.Fatalf("RunCleanup: %v", err)
+	}
+	if result.AnomaliesResolvedDeleted != 1 {
+		t.Errorf("AnomaliesResolvedDeleted = %d, want 1 (A purged)", result.AnomaliesResolvedDeleted)
+	}
+	if result.AnomalyRollupsCensused == 0 {
+		t.Error("AnomalyRollupsCensused = 0, want > 0 (census ran inside RunCleanup)")
+	}
+
+	// A is gone from the live table...
+	active, err := repo.LoadActive(ctx)
+	if err != nil {
+		t.Fatalf("LoadActive: %v", err)
+	}
+	if len(active) != 1 || active[0].ID != "B|bssid|cc:dd" {
+		t.Fatalf("active = %+v, want only B", active)
+	}
+
+	// ...but its resolution-day census survived (captured before the purge).
+	rows, err := db.ExportRollupDailyRows(ctx)
+	if err != nil {
+		t.Fatalf("ExportRollupDailyRows: %v", err)
+	}
+	var foundA bool
+	for _, r := range rows {
+		if r.DefKey == "open-ssid" && r.SubjectID == "aa:bb" && r.DayBucket == dayKey(resolvedDay) {
+			foundA = true
+			if !r.IsResolved {
+				t.Errorf("A's census row is_resolved = false, want true")
+			}
+		}
+	}
+	if !foundA {
+		t.Errorf("A's resolution-day census (%s) missing — census did not run before purge; rows=%+v",
+			dayKey(resolvedDay), rows)
+	}
+}
+
+// TestRunCleanupSkipsCensusOnFreeTier asserts no census is written when the
+// DailyDays horizon is zero (Free/Starter).
+func TestRunCleanupSkipsCensusOnFreeTier(t *testing.T) {
+	t.Parallel()
+	db, ctx := setupAnomalyDB(t)
+	repo := db.Anomalies()
+	now := time.Now().UTC()
+
+	active := recordSpanning("open-ssid|bssid|aa:bb", now.AddDate(0, 0, -1), now, 3)
+	if err := repo.Upsert(ctx, []anomaly.Record{active}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	result, err := db.RunCleanup(ctx, database.RetentionPolicy{AnomalyRollupDailyDays: 0})
+	if err != nil {
+		t.Fatalf("RunCleanup: %v", err)
+	}
+	if result.AnomalyRollupsCensused != 0 {
+		t.Errorf("AnomalyRollupsCensused = %d, want 0 (Free tier)", result.AnomalyRollupsCensused)
+	}
+	rows, err := db.ExportRollupDailyRows(ctx)
+	if err != nil {
+		t.Fatalf("ExportRollupDailyRows: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("rollup rows = %d, want 0 (no census on Free)", len(rows))
+	}
+}

--- a/internal/database/retention.go
+++ b/internal/database/retention.go
@@ -77,6 +77,14 @@ type RetentionPolicy struct {
 	// AnomalyResolvedDays is how many days to keep RESOLVED anomalies (0 =
 	// forever). Active anomalies are never aged out (ADR-0021).
 	AnomalyResolvedDays int
+
+	// AnomalyRollupDailyDays is how many days to keep daily anomaly census
+	// rollups, and the gate for writing them (ADR-0028 §4). It reuses the probe
+	// DailyDays tier horizon (Pro 730, Free/Starter 0). When > 0 the maintenance
+	// pass censuses the live anomaly table (census first) and purges census rows
+	// older than this window; when 0 (Free/Starter) no census is written and any
+	// existing rollups are purged in full, mirroring probe_rollups_daily.
+	AnomalyRollupDailyDays int
 }
 
 // DefaultRetentionPolicy returns the default retention policy.
@@ -103,6 +111,8 @@ type CleanupResult struct {
 	DNSResultsDeleted        int64
 	GatewayResultsDeleted    int64
 	AnomaliesResolvedDeleted int64
+	AnomalyRollupsCensused   int64
+	AnomalyRollupsDeleted    int64
 	Duration                 time.Duration
 }
 
@@ -137,6 +147,15 @@ func (db *DB) RunCleanup(ctx context.Context, policy RetentionPolicy) (*CleanupR
 	result := &CleanupResult{}
 	now := time.Now().UTC()
 
+	// Anomaly daily-rollup census (ADR-0028) runs FIRST so a resolution-day row
+	// is captured before cleanupResolvedAnomalies (below) can TTL-delete its live
+	// row — census first, purge second. Gated on the DailyDays horizon: Pro
+	// censuses + retains; Free/Starter (0) skip the census and purge any existing
+	// rollups in full.
+	if err := db.runAnomalyRollups(ctx, policy, now, result); err != nil {
+		return nil, err
+	}
+
 	tasks := []cleanupTask{
 		{policy.MetricsDays, db.cleanupMetrics, "metrics"},
 		{policy.AlertsDays, db.cleanupAlerts, "alerts"},
@@ -168,6 +187,31 @@ func (db *DB) RunCleanup(ctx context.Context, policy RetentionPolicy) (*CleanupR
 	result.Duration = time.Since(start)
 
 	return result, nil
+}
+
+// runAnomalyRollups writes the daily census and purges aged census rows in one
+// step (ADR-0028). It is invoked at the top of RunCleanup so the census reads
+// resolved rows before they are TTL-purged. When AnomalyRollupDailyDays is 0
+// (Free/Starter) no census is written; any existing rollups are purged in full
+// (cutoff = now), mirroring probe_rollups_daily on those tiers.
+func (db *DB) runAnomalyRollups(
+	ctx context.Context, policy RetentionPolicy, now time.Time, result *CleanupResult,
+) error {
+	if policy.AnomalyRollupDailyDays > 0 {
+		censused, err := db.Anomalies().CensusThrough(ctx, now)
+		if err != nil {
+			return fmt.Errorf("anomaly rollup census: %w", err)
+		}
+		result.AnomalyRollupsCensused = censused
+	}
+
+	cutoff := now.AddDate(0, 0, -policy.AnomalyRollupDailyDays)
+	deleted, err := db.Anomalies().PurgeRollupsDailyOlderThan(ctx, cutoff)
+	if err != nil {
+		return fmt.Errorf("anomaly rollup purge: %w", err)
+	}
+	result.AnomalyRollupsDeleted = deleted
+	return nil
 }
 
 // cleanupMetrics wraps the Metrics().DeleteOlderThan call to match cleanupFunc signature.

--- a/internal/database/testdata/schema.sql
+++ b/internal/database/testdata/schema.sql
@@ -41,6 +41,12 @@ CREATE INDEX idx_anomalies_source ON anomalies(source);
 -- index: idx_anomalies_subject
 CREATE INDEX idx_anomalies_subject ON anomalies(subject_kind, subject_id);
 
+-- index: idx_anomaly_rollups_daily_bucket
+CREATE INDEX idx_anomaly_rollups_daily_bucket ON anomaly_rollups_daily(day_bucket);
+
+-- index: idx_anomaly_rollups_daily_subject
+CREATE INDEX idx_anomaly_rollups_daily_subject ON anomaly_rollups_daily(subject_kind, subject_id);
+
 -- index: idx_api_tokens_active
 CREATE INDEX idx_api_tokens_active ON api_tokens(revoked_at);
 
@@ -716,6 +722,23 @@ CREATE TABLE anomalies (
 	is_resolved     INTEGER NOT NULL DEFAULT 0 CHECK (is_resolved IN (0, 1)),
 	acknowledged_by TEXT,
 	acknowledged_at TEXT
+) STRICT;
+
+-- table: anomaly_rollups_daily
+CREATE TABLE anomaly_rollups_daily (
+	day_bucket       TEXT    NOT NULL,                      -- YYYY-MM-DD UTC (retention.dayFormat)
+	def_key          TEXT    NOT NULL CHECK (def_key <> ''),
+	source           TEXT    NOT NULL CHECK (source <> ''), -- wifi|wired|snmp|bluetooth|health|security|autotest
+	category         TEXT    NOT NULL CHECK (category <> ''),
+	subject_kind     TEXT    NOT NULL CHECK (subject_kind <> ''),
+	subject_id       TEXT    NOT NULL,
+	max_severity     TEXT    NOT NULL CHECK (max_severity <> ''), -- highest severity held as of the census
+	count_cumulative INTEGER NOT NULL CHECK (count_cumulative >= 0),
+	first_seen       TEXT    NOT NULL,                       -- RFC3339, carried from the live row
+	last_seen        TEXT    NOT NULL,                       -- RFC3339, carried from the live row
+	is_resolved      INTEGER NOT NULL DEFAULT 0 CHECK (is_resolved IN (0, 1)),
+	resolved_at      TEXT,                                   -- RFC3339, NULL while active
+	PRIMARY KEY (day_bucket, def_key, subject_kind, subject_id) -- idempotent re-census
 ) STRICT;
 
 -- table: api_tokens

--- a/internal/timeseries/retention/engine.go
+++ b/internal/timeseries/retention/engine.go
@@ -29,6 +29,12 @@ const initialPassDelay = 60 * time.Second
 // architecture locks 7 days across all tiers.
 const rawRetentionDays = 7
 
+// HorizonsFor exposes the per-tier retention horizons to callers
+// outside this package (e.g. the anomaly daily-rollup census, which
+// reuses the DailyDays horizon verbatim — ADR-0028 §4). It is a thin
+// exported wrapper over the same locked policy the engine applies.
+func HorizonsFor(t license.Tier) TierHorizons { return tierHorizons(t) }
+
 // tierHorizons returns the (raw, hourly, daily) day-count tuple for
 // a given license tier. Lock the architecture's locked-decision:
 // Free retains raw-7d only; Starter adds hourly-30d; Pro adds


### PR DESCRIPTION
## What

Implements **ADR-0028** — the daily-rollup **census** of the `anomalies` store, realizing the deferred "TTL + daily rollups" clause of ADR-0021's locked retention model. The `anomalies` table is coalesced (one mutable row per def+subject with a running count + lifecycle), so it has no per-occurrence event log to `GROUP BY`. The only faithful daily artifact is a **census**: each UTC day, one row per anomaly whose lifecycle intersects that day, snapshotting the live row's facts so long-term trend survives the 90-day TTL purge of resolved rows.

## How

- **Migration** `00008_anomaly_rollups_daily.sql` — STRICT table, PK `(day_bucket, def_key, subject_kind, subject_id)`, indexes on `day_bucket` and `(subject_kind, subject_id)`. Schema golden regenerated.
- **`AnomalyRepository.CensusThrough`** — `INSERT OR REPLACE … SELECT FROM anomalies WHERE date(first_seen) <= :day AND :day <= date(COALESCE(resolved_at, last_seen))`. The rollup table's own `MAX(day_bucket)` is the high-water mark → a pass after downtime catches up every missed day through today with **no separate marker**; empty table censuses today only; re-census is idempotent.
- **`PurgeRollupsDailyOlderThan`** — bounds the table by the `DailyDays` tier horizon.
- **One ordered owner** — folded into `database.RunCleanup`: census runs **first** (before the resolved-anomaly TTL purge), then the rollup purge. Gated on `RetentionPolicy.AnomalyRollupDailyDays` (Pro 730d; Free/Starter skip census, purge in full). The api maintenance goroutine sets the horizon per tick via `retention.HorizonsFor(tier)` — tier-aware like the retention engine.

## Owner decisions (resolved 2026-06-11)

1. **Cumulative snapshot** (not a per-day delta column) — per-day deltas derived by differencing at query time.
2. **Reuse the probe `DailyDays` horizon** verbatim (Pro 730d, Free/Starter 0).

## Tests / evidence

- `TestRunCleanupCensusesResolvedRowBeforePurge` — the ADR §3 callsite guard: a row resolved within the census window survives in the rollups after its live row is purged in the **same** `RunCleanup` pass (the `CreateDailyRollup` "0 callers" gap cannot reappear).
- Unit coverage: intersection predicate, downtime catch-up, idempotent re-census, bucket-cutoff purge, Free-tier skip.
- `go build ./...` clean · `go test ./internal/database/ ./internal/timeseries/... ./internal/api/` green · isolated `golangci-lint --new-from-rev=origin/main` 0 issues · output-escaping + route-policy + filename-policy gates pass · schema golden regenerated.

## Scope

No frontend, no new routes, no new i18n. No consumer read API yet — the future trend/correlation surface plugs into this table when a consumer needs it. Independent of the larger anomaly **coordinator merge** (#5), which will be scoped separately as ADR-0029.