### PR TITLE
refactor(anomaly): source on detection + source-scoped prune (ADR-0029 P1)

### DIFF
--- a/docs/architecture/decisions/0029-converge-anomaly-engines.md
+++ b/docs/architecture/decisions/0029-converge-anomaly-engines.md
@@ -1,0 +1,115 @@
+# ADR-0029: Converge the per-producer anomaly engines into one server-owned engine
+
+**Status:** Accepted — 2026-06-11 · completes the end-state of
+[ADR-0021](0021-persist-and-converge-anomaly-engine.md) ("ONE anomaly engine, ONE SQL database, ONE
+structure, used everywhere"). Builds on [ADR-0025](0025-probe-is-the-active-monitoring-anomaly-source.md)
+(probe is the active-monitoring producer) and the Phase 1–4 persistence/producer work. Sequenced
+after ADR-0028 (daily-rollup census), which is independent of this convergence.
+
+## Context
+
+ADR-0021 locked a single source-neutral `anomaly.Engine` + SQL store, with source as a first-class
+correlation dimension. The Phase 1–4 work shipped the persistence `Coordinator`, the SQL store, and
+**two** long-lived producers — but each owns its *own* engine and Coordinator:
+
+- `internal/wifi/visibility.Service` — engine over the Wi-Fi catalog, `Coordinator(source=wifi)`, a
+  5 s eval loop that observes + flushes + prunes (idle retention 5 m), load-on-start. Owned by
+  `internal/api.BackgroundComponents` (manual Start/Stop).
+- `internal/probe/anomaly.Producer` — engine over the probe catalog, `Coordinator(source=probe)`,
+  event-driven consume + a 30 s maintain loop that flushes + prunes (silence window 15 m),
+  load-on-start. Owned by the engine lifecycle registry (`registerEngineIfLicensed`).
+
+Both write to the **same** `anomalies` table, differentiated by the `source` column, and their
+catalogs are disjoint (Wi-Fi def IDs vs probe def IDs). So the store half of ADR-0021 is converged;
+the **engine half is still scattered into two instances**. This is the remaining de-scatter.
+
+Three facts in the current code shape the design:
+
+1. **Source is a `Coordinator` field, not per-detection.** `NewCoordinator(engine, store, source)`
+   tags every write with one source. A single shared Coordinator therefore cannot serve two sources —
+   source must move onto the `Detection`.
+2. **Resolution windows are genuinely per-source.** Wi-Fi resolves on 5 m of airspace silence; probe
+   on 15 m (must exceed the probe interval, ADR-0025). A single engine pruned with one cutoff would
+   wrongly resolve the other source's instances. `Prune` must become source-scoped.
+3. **Consumers are asymmetric.** `/wifi/anomalies` reads the in-memory `engine.Snapshot`;
+   `/telemetry/probes/anomalies` reads the store via `ActiveBySource(probe)`. With one shared engine
+   holding all sources, the Wi-Fi handler can no longer treat "the engine" as Wi-Fi-only.
+
+## Decision
+
+### 1. One server-owned `anomaly.Coordinator` (single engine, merged catalog, single store)
+
+The server constructs exactly one `Engine` over a **merged catalog** (Wi-Fi defs ∪ probe defs ∪
+future), wrapped in one `Coordinator` over `db.Anomalies()`. The producers no longer own engines or
+Coordinators — they are injected with the shared one. `NewCatalog`'s duplicate-ID rejection becomes
+the fail-fast guard that two domains never ship a colliding def ID.
+
+### 2. `Source` moves onto `Detection`; the Coordinator drops its single-source field
+
+`Detection` gains a `Source`. The **producer stamps it once** at the hand-off to the Coordinator (the
+domain rule code — `wifianomaly.Detector.Detect`, `probeanomaly.Detections` — stays source-agnostic;
+only the one observe site stamps). The engine carries source on the tracked instance and projects it
+into the persisted `Record`; `RecordID` stays `defKey|subjectKind|subjectId` (source-free), which is
+unique because catalog IDs are globally unique across the merged catalog. `instanceKey` is unchanged
+— coalescing is still by (def, subject).
+
+### 3. `Prune` is source-scoped; `ResolveSubject` stays subject-scoped
+
+`Coordinator.Prune(ctx, source, cutoff)` resolves only that source's idle instances, so each producer
+drives its own window (Wi-Fi 5 m, probe 15 m) against the shared engine. `ResolveSubject` (the probe
+clean-result fast-path, ADR-0025 §3) is unchanged — it is keyed by subject, and probe subjects are a
+distinct `SubjectKind`, so there is no cross-source clearing.
+
+### 4. Consumers read the store by source; the in-memory snapshot is internal-only
+
+`/wifi/anomalies` switches to `db.Anomalies().ActiveBySource(SourceWiFi)`, mirroring the probe
+endpoint. The in-memory `Snapshot` remains for diagnostics/status counts but is no longer a consumer
+read path — so a shared engine holding every source never leaks the wrong source to an endpoint.
+
+### 5. Load-on-start happens once, server-owned
+
+The server calls `Coordinator.Load()` once during init (before any producer starts observing), over
+the merged engine. No per-source cross-contamination, because one catalog holds every def — the
+Phase-1 `Restore` "skip orphan defs" guard no longer silently drops the *other* producer's rows. The
+two duplicate load-on-start paths in the producers are removed. A final `Flush` on shutdown stays.
+
+### 6. `troubleshooting.AnalyzeBSSes` stays a transient one-shot — out of scope
+
+The survey analysis path builds a single-use engine, returns a snapshot, and discards it (no
+lifecycle, no persistence). It is intentionally ephemeral and is **not** converged.
+
+## Consequences
+
+- **The ADR-0021 end-state is reached** — one engine, one catalog, one store, one load, one place for
+  cross-source correlation and the ADR-0028 census to build on.
+- **Source becomes a true per-detection fact**, not a coordinator-construction accident — the natural
+  home for it and a prerequisite for any third producer (wired/SNMP/Bluetooth) to share the engine.
+- **Per-source resolution stays correct** — convergence does not flatten the genuinely different
+  silence windows; it scopes them.
+- **The read path is uniform** — both endpoints read the store by source; no in-memory/SQL split.
+- **Cost:** a core type change (`Detection.Source`, source-scoped prune) + producer surgery (strip
+  owned engines) + one consumer repoint. Phased so each PR is independently green.
+
+## Phasing (each its own golden-gated PR)
+
+- **P1 — core plumbing (this PR):** add `Detection.Source`; engine projects source into records and
+  gains source-scoped prune; `Coordinator` drops the source constructor arg, reads source from the
+  detection, and takes `Prune(ctx, source, cutoff)`. The two existing producers stamp their source at
+  the observe site and pass it to Prune. Behavior-preserving — each still owns its Coordinator; this
+  is the type refactor that makes a single shared Coordinator possible.
+- **P2 — single server-owned Coordinator:** merged catalog + one Coordinator built in the server;
+  inject it into both producers (they stop constructing their own engine/Coordinator/load); one
+  server-owned load-on-start + shutdown flush.
+- **P3 — consumers read the store:** `/wifi/anomalies` → `ActiveBySource(wifi)`; remove the dead
+  in-memory read path; goldens/tests updated.
+
+## Alternatives considered
+
+- **Keep two Coordinators sharing one store (status quo).** Rejected: leaves two engines, two catalogs,
+  two loads (with the orphan-def cross-contamination footgun), and no single home for cross-source
+  correlation — i.e. ADR-0021's engine half stays unconverged.
+- **A multi-source "wrapper" Coordinator holding N sub-engines.** Rejected: re-introduces N engines
+  behind one type; the whole point is one coalescing map so a subject seen by two sources can
+  correlate. The merged single catalog is simpler and is what ADR-0021 specified.
+- **Unify the resolution window (one prune cutoff).** Rejected: 5 m vs 15 m are correctness-bearing
+  (probe's must exceed the probe interval); flattening them would mis-resolve one source.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -36,3 +36,4 @@ See the [Re-Architecture Blueprint](../RE_ARCHITECTURE_BLUEPRINT.md) for the ful
 | [0026](0026-delete-dead-health-check-read-path.md) | Delete the dead health-check read path (results/scoring/SLA); keep run/settings/anomalies | Accepted |
 | [0027](0027-migrate-health-checks-onto-probe.md) | Migrate on-demand health-checks onto the probe engine, then rename the transport | Accepted |
 | [0028](0028-anomaly-daily-rollups.md) | Daily rollups for the anomaly store — a daily census of mutable instances, not a RollupSource | Proposed |
+| [0029](0029-converge-anomaly-engines.md) | Converge the per-producer anomaly engines into one server-owned engine | Accepted |

--- a/internal/anomaly/anomaly.go
+++ b/internal/anomaly/anomaly.go
@@ -146,12 +146,17 @@ type SubjectRef struct {
 
 // Detection is what a rule source emits to the engine: which catalog entry
 // fired, about what subject, with the live evidence (measured values). An empty
-// Severity means "use the catalog default".
+// Severity means "use the catalog default". Source identifies the producer; the
+// shared server-owned Coordinator (ADR-0029) tags persisted instances from it, so
+// one engine can coalesce detections from every source while the store stays
+// filterable by producer. The domain rule code leaves it empty; the producer
+// stamps it at the hand-off to the Coordinator.
 type Detection struct {
 	DefKey   string
 	Subject  SubjectRef
 	Severity Severity
 	Evidence map[string]string
+	Source   Source
 }
 
 // key identifies the live instance a detection coalesces into: one per

--- a/internal/anomaly/coordinator.go
+++ b/internal/anomaly/coordinator.go
@@ -17,19 +17,18 @@ import (
 type Coordinator struct {
 	engine *Engine
 	store  Store
-	source Source
 
 	mu    sync.Mutex
 	dirty map[instanceKey]struct{}
 }
 
-// NewCoordinator wraps engine with write-through persistence to store, tagging
-// every persisted instance with source.
-func NewCoordinator(engine *Engine, store Store, source Source) *Coordinator {
+// NewCoordinator wraps engine with write-through persistence to store. Each
+// persisted instance is tagged with the Source carried on its detection
+// (ADR-0029), so one shared Coordinator serves every producer.
+func NewCoordinator(engine *Engine, store Store) *Coordinator {
 	return &Coordinator{
 		engine: engine,
 		store:  store,
-		source: source,
 		dirty:  make(map[instanceKey]struct{}),
 	}
 }
@@ -44,7 +43,7 @@ func (c *Coordinator) Observe(ctx context.Context, d Detection, at time.Time) er
 		return err
 	}
 	if res.material {
-		return c.store.Upsert(ctx, c.records([]instanceKey{res.key}))
+		return c.store.Upsert(ctx, c.engine.recordsForKeys([]instanceKey{res.key}))
 	}
 	c.mu.Lock()
 	c.dirty[res.key] = struct{}{}
@@ -64,18 +63,21 @@ func (c *Coordinator) Flush(ctx context.Context) error {
 	c.dirty = make(map[instanceKey]struct{})
 	c.mu.Unlock()
 
-	recs := c.records(keys)
+	recs := c.engine.recordsForKeys(keys)
 	if len(recs) == 0 {
 		return nil
 	}
 	return c.store.Upsert(ctx, recs)
 }
 
-// Prune clears instances idle since cutoff and marks exactly those resolved in
-// the store as of cutoff (the idle boundary). Returns the number cleared. This is
-// the TTL-on-silence resolution path; ResolveSubject is the explicit fast-path.
-func (c *Coordinator) Prune(ctx context.Context, cutoff time.Time) (int, error) {
-	keys := c.engine.pruneKeys(cutoff)
+// Prune clears the given source's instances idle since cutoff and marks exactly
+// those resolved in the store as of cutoff (the idle boundary). Returns the
+// number cleared. This is the TTL-on-silence resolution path; ResolveSubject is
+// the explicit fast-path. Source-scoped because resolution windows differ per
+// producer (ADR-0029 §3) — a shared engine must not resolve one source's
+// instances on another source's cadence.
+func (c *Coordinator) Prune(ctx context.Context, source Source, cutoff time.Time) (int, error) {
+	keys := c.engine.pruneKeysForSource(source, cutoff)
 	return len(keys), c.resolveKeys(ctx, keys, cutoff)
 }
 
@@ -124,18 +126,3 @@ func (c *Coordinator) Load(ctx context.Context) (int, error) {
 // Engine returns the underlying in-memory engine for read-only projection
 // (Snapshot) by consumers that also read live state.
 func (c *Coordinator) Engine() *Engine { return c.engine }
-
-// records projects keys into persistable Records, tagging source and the stable
-// id and skipping keys no longer live.
-func (c *Coordinator) records(keys []instanceKey) []Record {
-	anoms := c.engine.snapshotKeys(keys)
-	out := make([]Record, 0, len(anoms))
-	for _, a := range anoms {
-		out = append(out, Record{
-			ID:      RecordID(a.DefKey, a.Subject),
-			Source:  c.source,
-			Anomaly: a,
-		})
-	}
-	return out
-}

--- a/internal/anomaly/coordinator_test.go
+++ b/internal/anomaly/coordinator_test.go
@@ -66,11 +66,15 @@ func coordTestCatalog(t *testing.T) *anomaly.Catalog {
 
 func newCoord(t *testing.T, store anomaly.Store, opts ...anomaly.Option) *anomaly.Coordinator {
 	t.Helper()
-	return anomaly.NewCoordinator(anomaly.NewEngine(coordTestCatalog(t), opts...), store, anomaly.SourceWiFi)
+	return anomaly.NewCoordinator(anomaly.NewEngine(coordTestCatalog(t), opts...), store)
 }
 
 func openSSID(id string) anomaly.Detection {
-	return anomaly.Detection{DefKey: "open-ssid", Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: id}}
+	return anomaly.Detection{
+		DefKey:  "open-ssid",
+		Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: id},
+		Source:  anomaly.SourceWiFi,
+	}
 }
 
 // TestCoordinatorWritesThroughOnCreate asserts a brand-new anomaly is persisted
@@ -174,7 +178,7 @@ func TestCoordinatorResolvesOnPrune(t *testing.T) {
 		t.Fatalf("Observe live: %v", err)
 	}
 
-	n, err := c.Prune(ctx, time.Unix(5000, 0))
+	n, err := c.Prune(ctx, anomaly.SourceWiFi, time.Unix(5000, 0))
 	if err != nil {
 		t.Fatalf("Prune: %v", err)
 	}
@@ -194,6 +198,52 @@ func TestCoordinatorResolvesOnPrune(t *testing.T) {
 	}
 	if _, revived := store.rows["open-ssid|bssid|stale"]; revived {
 		t.Error("Flush resurrected a pruned instance")
+	}
+}
+
+// TestCoordinatorPruneIsSourceScoped asserts that pruning one source leaves
+// another source's idle instances untouched (ADR-0029 §3): a single shared engine
+// must honor per-source resolution windows. Both instances are equally idle, but
+// only the pruned source's instance resolves.
+func TestCoordinatorPruneIsSourceScoped(t *testing.T) {
+	store := newFakeStore()
+	c := newCoord(t, store)
+	ctx := context.Background()
+	old := time.Unix(100, 0)
+
+	wifi := anomaly.Detection{
+		DefKey:  "open-ssid",
+		Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: "wifi-subj"},
+		Source:  anomaly.SourceWiFi,
+	}
+	probe := anomaly.Detection{
+		DefKey:  "open-ssid",
+		Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: "probe-subj"},
+		Source:  anomaly.SourceProbe,
+	}
+	if err := c.Observe(ctx, wifi, old); err != nil {
+		t.Fatalf("Observe wifi: %v", err)
+	}
+	if err := c.Observe(ctx, probe, old); err != nil {
+		t.Fatalf("Observe probe: %v", err)
+	}
+
+	// Prune the probe source past both instances' idle time.
+	n, err := c.Prune(ctx, anomaly.SourceProbe, time.Unix(5000, 0))
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("Prune cleared %d, want 1 (only the probe instance)", n)
+	}
+	if _, resolved := store.resolved["open-ssid|bssid|probe-subj"]; !resolved {
+		t.Errorf("probe instance not resolved; resolved=%v", store.resolved)
+	}
+	if _, stillResolved := store.resolved["open-ssid|bssid|wifi-subj"]; stillResolved {
+		t.Errorf("wifi instance was wrongly resolved by a probe-scoped prune")
+	}
+	if _, live := store.rows["open-ssid|bssid|wifi-subj"]; !live {
+		t.Errorf("wifi instance should remain live; rows=%v", store.rows)
 	}
 }
 
@@ -217,12 +267,16 @@ func TestCoordinatorResolveSubject(t *testing.T) {
 		t.Fatalf("NewCatalog: %v", err)
 	}
 	store := newFakeStore()
-	c := anomaly.NewCoordinator(anomaly.NewEngine(cat), store, anomaly.SourceWiFi)
+	c := anomaly.NewCoordinator(anomaly.NewEngine(cat), store)
 	ctx := context.Background()
 	at := time.Unix(1000, 0)
 
 	det := func(def, id string) anomaly.Detection {
-		return anomaly.Detection{DefKey: def, Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: id}}
+		return anomaly.Detection{
+			DefKey:  def,
+			Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: id},
+			Source:  anomaly.SourceWiFi,
+		}
 	}
 	// Two defs on subject A, one on subject B.
 	for _, d := range []anomaly.Detection{det("open-ssid", "A"), det("weak-cipher", "A"), det("open-ssid", "B")} {

--- a/internal/anomaly/engine.go
+++ b/internal/anomaly/engine.go
@@ -155,6 +155,7 @@ func (e *Engine) Restore(records []Record) int {
 				Subject:  a.Subject,
 				Severity: a.Severity,
 				Evidence: a.Evidence,
+				Source:   r.Source,
 			},
 			baseSeverity: a.Severity,
 			firstSeen:    a.FirstSeen,
@@ -221,6 +222,23 @@ func (e *Engine) pruneKeys(cutoff time.Time) []instanceKey {
 	return cleared
 }
 
+// pruneKeysForSource clears only the named source's instances not re-observed
+// since cutoff, returning their keys. Resolution windows are per-source (ADR-0029
+// §3) — Wi-Fi resolves on 5 m of silence, probe on 15 m — so a shared engine must
+// prune one source without touching another's still-live instances.
+func (e *Engine) pruneKeysForSource(source Source, cutoff time.Time) []instanceKey {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	var cleared []instanceKey
+	for k, t := range e.active {
+		if t.det.Source == source && t.lastSeen.Before(cutoff) {
+			cleared = append(cleared, k)
+			delete(e.active, k)
+		}
+	}
+	return cleared
+}
+
 // clearSubject removes every live instance for subject (across all defs) and
 // returns their keys, so a source that observes a subject return to health can
 // resolve all of its anomalies at once (the explicit recovery fast-path,
@@ -262,17 +280,27 @@ func (e *Engine) project(t *tracked) Anomaly {
 	}
 }
 
-// snapshotKeys projects the named live instances, skipping any no longer
-// present. Used by the persistence Coordinator to build write-through and Flush
-// records without re-projecting the whole stream.
-func (e *Engine) snapshotKeys(keys []instanceKey) []Anomaly {
+// recordsForKeys projects the named live instances into persistable Records,
+// skipping any no longer present. The Source is read from each tracked instance's
+// detection (ADR-0029 §2) — so one shared engine can persist instances under the
+// source that produced them, without the Coordinator holding a single source.
+// Used by the Coordinator to build write-through and Flush records without
+// re-projecting the whole stream.
+func (e *Engine) recordsForKeys(keys []instanceKey) []Record {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	out := make([]Anomaly, 0, len(keys))
+	out := make([]Record, 0, len(keys))
 	for _, k := range keys {
-		if t, ok := e.active[k]; ok {
-			out = append(out, e.project(t))
+		t, ok := e.active[k]
+		if !ok {
+			continue
 		}
+		a := e.project(t)
+		out = append(out, Record{
+			ID:      RecordID(a.DefKey, a.Subject),
+			Source:  t.det.Source,
+			Anomaly: a,
+		})
 	}
 	return out
 }

--- a/internal/probe/anomaly/producer.go
+++ b/internal/probe/anomaly/producer.go
@@ -99,7 +99,7 @@ func New(events <-chan probe.ResultEvent, store anomaly.Store, opts ...Option) (
 		logger = slog.Default()
 	}
 	engine := anomaly.NewEngine(cat)
-	coord := anomaly.NewCoordinator(engine, store, anomaly.SourceProbe)
+	coord := anomaly.NewCoordinator(engine, store)
 	return &Producer{
 		events:        events,
 		coord:         coord,
@@ -193,6 +193,8 @@ func (p *Producer) observe(ctx context.Context, re probe.ResultEvent, at time.Ti
 		return
 	}
 	for _, d := range dets {
+		// Stamp the producer source at the hand-off (ADR-0029 §2).
+		d.Source = anomaly.SourceProbe
 		if err := p.coord.Observe(ctx, d, at); err != nil {
 			p.logger.WarnContext(ctx, "probe anomaly persist (observe) failed",
 				"defKey", d.DefKey, "probeID", d.Subject.ID, "error", err)
@@ -236,7 +238,7 @@ func (p *Producer) flushAndPrune(ctx context.Context, now time.Time) {
 	if err := p.coord.Flush(ctx); err != nil {
 		p.logger.WarnContext(ctx, "probe anomaly persist (flush) failed", "error", err)
 	}
-	if _, err := p.coord.Prune(ctx, now.Add(-p.resolveWindow)); err != nil {
+	if _, err := p.coord.Prune(ctx, anomaly.SourceProbe, now.Add(-p.resolveWindow)); err != nil {
 		p.logger.WarnContext(ctx, "probe anomaly persist (prune) failed", "error", err)
 	}
 }

--- a/internal/wifi/visibility/service.go
+++ b/internal/wifi/visibility/service.go
@@ -153,7 +153,7 @@ func New(opts ...Option) (*Service, error) {
 	engine := anomaly.NewEngine(cat, anomaly.WithCapabilities(cfg.capabilities...))
 	var coord *anomaly.Coordinator
 	if cfg.store != nil {
-		coord = anomaly.NewCoordinator(engine, cfg.store, anomaly.SourceWiFi)
+		coord = anomaly.NewCoordinator(engine, cfg.store)
 	}
 	return &Service{
 		air:          airspace.New(),
@@ -202,6 +202,9 @@ func (s *Service) Evaluate(ctx context.Context, at time.Time) {
 // authoritative and the next tick re-persists.
 func (s *Service) evaluatePersistent(ctx context.Context, at, cutoff time.Time) {
 	for _, d := range s.detector.Detect(s.air.Tree()) {
+		// Stamp the producer source at the hand-off (ADR-0029 §2); the Wi-Fi
+		// detector stays source-agnostic.
+		d.Source = anomaly.SourceWiFi
 		if err := s.coordinator.Observe(ctx, d, at); err != nil {
 			s.logger.WarnContext(ctx, "anomaly persist (observe) failed",
 				"defKey", d.DefKey, "error", err)
@@ -210,7 +213,7 @@ func (s *Service) evaluatePersistent(ctx context.Context, at, cutoff time.Time) 
 	if err := s.coordinator.Flush(ctx); err != nil {
 		s.logger.WarnContext(ctx, "anomaly persist (flush) failed", "error", err)
 	}
-	if _, err := s.coordinator.Prune(ctx, cutoff); err != nil {
+	if _, err := s.coordinator.Prune(ctx, anomaly.SourceWiFi, cutoff); err != nil {
 		s.logger.WarnContext(ctx, "anomaly persist (prune) failed", "error", err)
 	}
 }


### PR DESCRIPTION
## What

**P1 of ADR-0029** — converging the two per-producer anomaly engines (`wifi/visibility.Service` source=wifi, `probe/anomaly.Producer` source=probe) onto one server-owned engine, the end-state of ADR-0021.

This slice is the **core type/plumbing refactor** that makes a single shared `Coordinator` possible. It is **behavior-preserving**: each producer still owns its own Coordinator; only the type shape changes.

## Why these changes

Three facts blocked a shared Coordinator (mapped from the current code):
1. **Source was a `Coordinator` field**, applied to all its writes → one shared Coordinator couldn't serve two sources. → `Source` moves onto `Detection`.
2. **Resolution windows differ per source** (wifi 5m idle, probe 15m silence — the latter must exceed the probe interval, ADR-0025) → `Prune` must be source-scoped, or a shared engine would mis-resolve one source on another's cadence.
3. (Consumer asymmetry is handled in P3, not here.)

## How

- `Detection` gains `Source`; the **producer stamps it** at the observe hand-off — the Wi-Fi detector and probe mapping stay source-agnostic.
- Engine carries source on the tracked instance, projects it into the persisted `Record` (new `recordsForKeys`, replacing the `Anomaly`-returning `snapshotKeys`), and gains `pruneKeysForSource`.
- `Coordinator` drops its source constructor arg (`NewCoordinator` is now 2-arg); `Observe` tags records from the detection's source; `Prune(ctx, source, cutoff)` is source-scoped.
- `visibility.Service` stamps `SourceWiFi` + prunes wifi (5m); `probeanomaly.Producer` stamps `SourceProbe` + prunes probe (15m).

## Tests / evidence

- New `TestCoordinatorPruneIsSourceScoped` — two sources in one engine, prune one, the other survives (locks the §3 semantics).
- `go build ./...` clean · `go test ./internal/anomaly/... ./internal/wifi/... ./internal/probe/... ./internal/app/... -race -count=1` green · isolated `golangci-lint --new-from-rev=origin/main` **0 issues**.

## Scope

No migration, no API change, no golden, no frontend. **ADR-0029** added (Accepted) with the full phasing. Next: **P2** (single server-owned Coordinator + merged catalog + one load-on-start), then **P3** (consumers read the store by source).