### PR TITLE
refactor(anomaly): converge producers onto one server-owned engine (ADR-0029 P2+P3)

### DIFF
--- a/cmd/seed/cmd_serve.go
+++ b/cmd/seed/cmd_serve.go
@@ -113,29 +113,27 @@ func initializeBackgroundComponents(cfg *config.Config, db *database.DB) *api.Ba
 	components.Reporting = app.NewReporting(cfg, db)
 	logging.GetLogger().Info("Reporting module initialized")
 
-	// Wi-Fi airspace visibility: holds the live airspace + anomaly engine, fed by
-	// the monitor-mode capture source. A malformed catalog is a programming error
-	// — log and continue without the component (handlers degrade gracefully).
-	if wifiVis, err := app.NewWiFiVisibility(db.Anomalies()); err != nil {
-		logging.GetLogger().Error("Wi-Fi visibility init failed; feature disabled", "error", err)
-	} else {
-		components.WiFiVisibility = wifiVis
-		logging.GetLogger().Info("Wi-Fi visibility module initialized")
+	// Wi-Fi airspace visibility: holds the live airspace + Wi-Fi detector, fed by
+	// the monitor-mode capture source. It is a producer into the shared anomaly
+	// engine, which the server owns — the server injects the Coordinator during
+	// init (ADR-0029), so construction here is airspace-only and cannot fail.
+	wifiVis := app.NewWiFiVisibility()
+	components.WiFiVisibility = wifiVis
+	logging.GetLogger().Info("Wi-Fi visibility module initialized")
 
-		// Monitor-mode capture is opt-in via a bring-your-own monitor interface
-		// (third-party adapter): set SEED_WIFI_MONITOR_IFACE to the iface name.
-		// Unset (the default) leaves the visibility endpoints serving an empty
-		// airspace; capture also degrades gracefully if the iface is not in
-		// monitor mode or libpcap is unavailable.
-		if iface := os.Getenv("SEED_WIFI_MONITOR_IFACE"); iface != "" {
-			// SEED_WIFI_MONITOR_AUTO=1 also switches the interface into monitor
-			// mode on start (Linux iw/nl80211); otherwise it must already be in
-			// monitor mode (bring-your-own).
-			autoEnable := os.Getenv("SEED_WIFI_MONITOR_AUTO") == "1"
-			components.WiFiCapture = app.NewWiFiCapture(wifiVis, iface, autoEnable)
-			logging.GetLogger().Info("Wi-Fi monitor capture configured",
-				"iface", iface, "autoEnable", autoEnable)
-		}
+	// Monitor-mode capture is opt-in via a bring-your-own monitor interface
+	// (third-party adapter): set SEED_WIFI_MONITOR_IFACE to the iface name. Unset
+	// (the default) leaves the visibility endpoints serving an empty airspace;
+	// capture also degrades gracefully if the iface is not in monitor mode or
+	// libpcap is unavailable.
+	if iface := os.Getenv("SEED_WIFI_MONITOR_IFACE"); iface != "" {
+		// SEED_WIFI_MONITOR_AUTO=1 also switches the interface into monitor mode
+		// on start (Linux iw/nl80211); otherwise it must already be in monitor
+		// mode (bring-your-own).
+		autoEnable := os.Getenv("SEED_WIFI_MONITOR_AUTO") == "1"
+		components.WiFiCapture = app.NewWiFiCapture(wifiVis, iface, autoEnable)
+		logging.GetLogger().Info("Wi-Fi monitor capture configured",
+			"iface", iface, "autoEnable", autoEnable)
 	}
 
 	return components

--- a/docs/architecture/decisions/0029-converge-anomaly-engines.md
+++ b/docs/architecture/decisions/0029-converge-anomaly-engines.md
@@ -103,6 +103,30 @@ lifecycle, no persistence). It is intentionally ephemeral and is **not** converg
 - **P3 — consumers read the store:** `/wifi/anomalies` → `ActiveBySource(wifi)`; remove the dead
   in-memory read path; goldens/tests updated.
 
+### As-built — P2 + P3 (shipped together)
+
+P2 and P3 landed in one PR: a shared, server-owned engine that is read in-memory per-source would
+over-report, so the consumer read switch could not be deferred behind P2. As built:
+
+- `api.initAnomalyPlatform` builds one `Engine` over `wifianomaly.Defs() ∪ probeanomaly.Defs()`
+  (NewCatalog's dup-id guard is the fail-fast), one `Coordinator` over `db.Anomalies()`, parked on
+  `Server.anomalyCoord`. Runs before `initProbeEngine`.
+- Both producers are injected with the shared Coordinator and no longer own an engine/Coordinator or
+  load on start: `probeanomaly.New(events, coord)`; `visibility.Service` gains
+  `WithCoordinator`/`SetCoordinator` (the cmd layer builds it airspace-only, the server injects the
+  Coordinator during init) and drops its owned engine, `WithStore`, `WithCapabilities`, and the
+  consumer `Anomalies()` method.
+- Single server-owned load-on-start: `coord.Load()` once in `initAnomalyPlatform`, before any
+  producer observes; the per-producer loads are removed. The shared engine holds every def, so
+  Restore no longer drops one producer's rows as orphans.
+- `Engine.LenBySource` added so `visibility.Status().Anomalies` reports only Wi-Fi (the shared engine
+  would otherwise over-count); `Engine.Snapshot` stays as the diagnostic in-memory view.
+- `/wifi/anomalies` reads `ActiveBySource(SourceWiFi)` via the troubleshooting `AnomalyStore` port
+  (symmetric with the probe endpoint's `source=probe` reader); the use-case composes the store list
+  with the live visibility `Status`. No route/capability change. The Wi-Fi card renders only persisted
+  fields, so there is no visible regression. Catalog-static `impact`/`followUps` re-derivation on read
+  (both endpoints, app-layer) is a deliberate, separate follow-up.
+
 ## Alternatives considered
 
 - **Keep two Coordinators sharing one store (status quo).** Rejected: leaves two engines, two catalogs,

--- a/internal/anomaly/coordinator_test.go
+++ b/internal/anomaly/coordinator_test.go
@@ -2,11 +2,54 @@ package anomaly_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/anomaly"
 )
+
+// syncStore is a thread-safe anomaly.Store for the concurrent-producers test
+// (the bare fakeStore is only exercised single-threaded).
+type syncStore struct {
+	mu       sync.Mutex
+	rows     map[string]anomaly.Record
+	resolved map[string]time.Time
+}
+
+func newSyncStore() *syncStore {
+	return &syncStore{rows: map[string]anomaly.Record{}, resolved: map[string]time.Time{}}
+}
+
+func (s *syncStore) Upsert(_ context.Context, recs []anomaly.Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, r := range recs {
+		s.rows[r.ID] = r
+		delete(s.resolved, r.ID)
+	}
+	return nil
+}
+
+func (s *syncStore) MarkResolved(_ context.Context, ids []string, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, id := range ids {
+		s.resolved[id] = at
+		delete(s.rows, id)
+	}
+	return nil
+}
+
+func (s *syncStore) LoadActive(_ context.Context) ([]anomaly.Record, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]anomaly.Record, 0, len(s.rows))
+	for _, r := range s.rows {
+		out = append(out, r)
+	}
+	return out, nil
+}
 
 // fakeStore is an in-memory anomaly.Store recording the calls a Coordinator
 // makes, so tests can assert the write cadence (write-through vs batched) without
@@ -387,5 +430,60 @@ func TestCoordinatorLoad(t *testing.T) {
 	}
 	if n != 1 || c.Engine().Len() != 1 {
 		t.Fatalf("Load restored n=%d engineLen=%d, want 1/1", n, c.Engine().Len())
+	}
+}
+
+// TestCoordinatorConcurrentProducers asserts the shared Coordinator (ADR-0029)
+// is safe under two producers observing and pruning it concurrently, and that
+// source-scoped prune only resolves the named source's instances — the property
+// that lets Wi-Fi (5 m) and probe (15 m) share one engine without one source
+// resolving the other's still-live instances.
+func TestCoordinatorConcurrentProducers(t *testing.T) {
+	c := newCoord(t, newSyncStore())
+	ctx := context.Background()
+	base := time.Unix(10000, 0).UTC()
+
+	const n = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+	observe := func(src anomaly.Source, prefix string) {
+		defer wg.Done()
+		for i := range n {
+			at := base.Add(time.Duration(i) * time.Millisecond)
+			id := prefix + string(rune('a'+i%26))
+			_ = c.Observe(ctx, anomaly.Detection{
+				DefKey:  "open-ssid",
+				Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: id},
+				Source:  src,
+			}, at)
+			if i%10 == 0 {
+				_ = c.Flush(ctx)
+			}
+		}
+	}
+	go observe(anomaly.SourceWiFi, "w-")
+	go observe(anomaly.SourceProbe, "p-")
+	wg.Wait()
+
+	// Both sources coalesced onto 26 distinct subjects each (no lost updates, no
+	// races under -race).
+	if got := c.Engine().LenBySource(anomaly.SourceWiFi); got != 26 {
+		t.Errorf("wifi instances = %d, want 26", got)
+	}
+	if got := c.Engine().LenBySource(anomaly.SourceProbe); got != 26 {
+		t.Errorf("probe instances = %d, want 26", got)
+	}
+
+	// Source-scoped prune past every observation resolves only Wi-Fi; probe stays.
+	cutoff := base.Add(time.Hour)
+	cleared, err := c.Prune(ctx, anomaly.SourceWiFi, cutoff)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if cleared != 26 {
+		t.Errorf("pruned wifi = %d, want 26", cleared)
+	}
+	if got := c.Engine().LenBySource(anomaly.SourceProbe); got != 26 {
+		t.Errorf("probe instances after wifi prune = %d, want 26 (untouched)", got)
 	}
 }

--- a/internal/anomaly/engine.go
+++ b/internal/anomaly/engine.go
@@ -355,9 +355,24 @@ func (e *Engine) projectFollowUps(fus []FollowUp) []FollowUp {
 	return out
 }
 
-// Len is the number of live anomaly instances.
+// Len is the number of live anomaly instances across all sources.
 func (e *Engine) Len() int {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	return len(e.active)
+}
+
+// LenBySource is the number of live instances produced by one source. With the
+// engine shared across producers (ADR-0029), a per-source producer reports its
+// own count — Len would over-count every source's instances.
+func (e *Engine) LenBySource(source Source) int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	n := 0
+	for _, t := range e.active {
+		if t.det.Source == source {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/anomaly/engine_test.go
+++ b/internal/anomaly/engine_test.go
@@ -264,6 +264,36 @@ func TestFollowUpCapabilityDegradation(t *testing.T) {
 	}
 }
 
+// TestLenBySource asserts the source-scoped count only tallies one producer's
+// instances, so a shared engine (ADR-0029) lets each producer report its own
+// count without over-counting the others.
+func TestLenBySource(t *testing.T) {
+	at := time.Unix(0, 0)
+	e := anomaly.NewEngine(testCatalog(t))
+	must(t, e.Observe(anomaly.Detection{
+		DefKey: "open-ssid", Subject: bssid("aa"), Source: anomaly.SourceWiFi,
+	}, at))
+	must(t, e.Observe(anomaly.Detection{
+		DefKey: "co-channel", Subject: bssid("bb"), Source: anomaly.SourceWiFi,
+	}, at))
+	must(t, e.Observe(anomaly.Detection{
+		DefKey: "open-ssid", Subject: bssid("cc"), Source: anomaly.SourceProbe,
+	}, at))
+
+	if got := e.Len(); got != 3 {
+		t.Errorf("Len = %d, want 3", got)
+	}
+	if got := e.LenBySource(anomaly.SourceWiFi); got != 2 {
+		t.Errorf("LenBySource(wifi) = %d, want 2", got)
+	}
+	if got := e.LenBySource(anomaly.SourceProbe); got != 1 {
+		t.Errorf("LenBySource(probe) = %d, want 1", got)
+	}
+	if got := e.LenBySource(anomaly.SourceWired); got != 0 {
+		t.Errorf("LenBySource(wired) = %d, want 0", got)
+	}
+}
+
 func must(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/internal/api/anomaly_platform.go
+++ b/internal/api/anomaly_platform.go
@@ -1,0 +1,56 @@
+package api
+
+// anomaly_platform.go builds the one server-owned anomaly engine (ADR-0029): a
+// single Coordinator over a merged catalog (every producer's defs) and the
+// unified store, shared by every producer instead of each owning its own engine.
+// It is the realization of ADR-0021's "ONE engine, ONE store, used everywhere".
+
+import (
+	"context"
+
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/logging"
+	probeanomaly "github.com/MustardSeedNetworks/seed/internal/probe/anomaly"
+	wifianomaly "github.com/MustardSeedNetworks/seed/internal/wifi/anomaly"
+)
+
+// initAnomalyPlatform constructs the single shared anomaly Coordinator and wires
+// it into the producers that feed it. It runs before initProbeEngine so the
+// probe producer can be built over the shared Coordinator, and it injects the
+// Coordinator into the already-constructed Wi-Fi visibility component (built in
+// the cmd layer before the server owns the engine).
+//
+// The catalog is the union of every producer's defs (Wi-Fi ∪ probe ∪ future);
+// NewCatalog's duplicate-id rejection is the fail-fast guard that two domains
+// never ship a colliding def id. A malformed merged catalog is a programming
+// error: it is logged and leaves s.anomalyCoord nil, so the producers degrade to
+// off rather than aborting server start.
+//
+// Load-on-start is performed here, once, before any producer observes (ADR-0029
+// §5): the merged engine holds every def, so Restore no longer silently drops one
+// producer's persisted rows as orphans. The producers therefore do not load.
+func (s *Server) initAnomalyPlatform(db *database.DB) {
+	defs := append(append([]anomaly.Def{}, wifianomaly.Defs()...), probeanomaly.Defs()...)
+	cat, err := anomaly.NewCatalog(defs...)
+	if err != nil {
+		logging.GetLogger().Error("anomaly platform disabled: merged catalog invalid", "error", err)
+		return
+	}
+
+	coord := anomaly.NewCoordinator(anomaly.NewEngine(cat), db.Anomalies())
+	s.anomalyCoord = coord
+
+	// Inject the shared Coordinator into the Wi-Fi visibility producer, which the
+	// cmd layer built before the server owned the engine.
+	if s.background != nil && s.background.WiFiVisibility != nil {
+		s.background.WiFiVisibility.SetCoordinator(coord)
+	}
+
+	// Single server-owned load-on-start, before any producer's loop runs.
+	if n, loadErr := coord.Load(context.Background()); loadErr != nil {
+		logging.GetLogger().Warn("anomaly load-on-start failed", "error", loadErr)
+	} else if n > 0 {
+		logging.GetLogger().Info("restored persisted anomalies", "count", n)
+	}
+}

--- a/internal/api/handlers_wifi_airspace.go
+++ b/internal/api/handlers_wifi_airspace.go
@@ -43,9 +43,14 @@ func (s *Server) handleWiFiAirspace(w http.ResponseWriter, _ *http.Request) {
 }
 
 // handleWiFiAnomalies serves GET /api/v1/wifi/anomalies. Thin handler delegating
-// to the use-case; feature-gated (wifi_association_forensics); degrades to an
-// empty stream when no capture component is present.
-func (s *Server) handleWiFiAnomalies(w http.ResponseWriter, _ *http.Request) {
-	res := s.wifiQueries.Anomalies()
+// to the use-case, which reads the active Wi-Fi anomalies from the unified store
+// (ADR-0029 §4). Feature-gated (wifi_association_forensics); an unwired store
+// degrades to an empty stream, while a genuine store error maps to 500.
+func (s *Server) handleWiFiAnomalies(w http.ResponseWriter, r *http.Request) {
+	res, err := s.wifiQueries.Anomalies(r.Context())
+	if err != nil {
+		http.Error(w, "Failed to read Wi-Fi anomalies", http.StatusInternalServerError)
+		return
+	}
 	sendJSONResponse(w, nil, http.StatusOK, WiFiAnomaliesResponse{Anomalies: res.Anomalies, Status: res.Status})
 }

--- a/internal/api/handlers_wifi_airspace_internal_test.go
+++ b/internal/api/handlers_wifi_airspace_internal_test.go
@@ -9,11 +9,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
 	wifianomaly "github.com/MustardSeedNetworks/seed/internal/wifi/anomaly"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/dot11"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/troubleshooting"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/visibility"
 )
+
+// stubAnomalyStore is the troubleshooting.AnomalyStore half of the read use-case:
+// the source=wifi anomaly list the handler now reads from the unified store
+// (ADR-0029 §4), instead of from the in-memory visibility engine.
+type stubAnomalyStore struct {
+	available bool
+	anomalies []anomaly.Anomaly
+}
+
+func (s stubAnomalyStore) Available() bool { return s.available }
+func (s stubAnomalyStore) ActiveWiFi(context.Context) ([]anomaly.Anomaly, error) {
+	return s.anomalies, nil
+}
 
 // The feature-gate middleware is applied at route registration and exercised by
 // the authchain golden harness; these tests drive the handlers directly to
@@ -47,8 +61,8 @@ func openBeacon(t *testing.T) *dot11.Frame {
 }
 
 func TestHandleWiFiAirspaceEmptyWhenNoComponent(t *testing.T) {
-	// No visibility source wired → graceful empty response, never 500/null.
-	s := &Server{wifiQueries: troubleshooting.NewQueries(nil)}
+	// No visibility source / store wired → graceful empty response, never 500/null.
+	s := &Server{wifiQueries: troubleshooting.NewQueries(nil, nil)}
 	rec := httptest.NewRecorder()
 	s.handleWiFiAirspace(rec, httptest.NewRequest(http.MethodGet, "/api/v1/wifi/airspace", nil))
 
@@ -59,17 +73,31 @@ func TestHandleWiFiAirspaceEmptyWhenNoComponent(t *testing.T) {
 	if len(resp.SSIDs) != 0 || resp.Status.CaptureActive {
 		t.Errorf("expected empty inactive airspace, got %+v", resp)
 	}
+
+	// Anomalies likewise degrade to an empty stream (never 500/null).
+	recN := httptest.NewRecorder()
+	s.handleWiFiAnomalies(recN, httptest.NewRequest(http.MethodGet, "/api/v1/wifi/anomalies", nil))
+	an := decodeJSON[WiFiAnomaliesResponse](t, recN)
+	if an.Anomalies == nil || len(an.Anomalies) != 0 {
+		t.Errorf("expected empty anomaly stream, got %+v", an.Anomalies)
+	}
 }
 
 func TestHandleWiFiAirspaceAndAnomaliesPopulated(t *testing.T) {
-	svc, err := visibility.New()
-	if err != nil {
-		t.Fatalf("visibility.New: %v", err)
-	}
+	// Airspace (tree + status) comes from the live visibility component...
+	svc := visibility.New()
 	svc.SetSource("monitor0")
 	svc.Ingest(openBeacon(t), time.Now())
 	svc.Evaluate(context.Background(), time.Now())
-	s := &Server{wifiQueries: troubleshooting.NewQueries(svc)}
+	// ...while the anomaly list comes from the unified store (ADR-0029 §4).
+	store := stubAnomalyStore{
+		available: true,
+		anomalies: []anomaly.Anomaly{{
+			DefKey:  wifianomaly.DefOpenNetwork,
+			Subject: anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: "00:11:22:33:44:55"},
+		}},
+	}
+	s := &Server{wifiQueries: troubleshooting.NewQueries(svc, store)}
 
 	// Airspace tree is populated and reports the active source.
 	recA := httptest.NewRecorder()
@@ -82,7 +110,7 @@ func TestHandleWiFiAirspaceAndAnomaliesPopulated(t *testing.T) {
 		t.Errorf("status should reflect the active source: %+v", air.Status)
 	}
 
-	// Anomaly stream contains the open-network detection.
+	// Anomaly stream (read from the store) contains the open-network detection.
 	recN := httptest.NewRecorder()
 	s.handleWiFiAnomalies(recN, httptest.NewRequest(http.MethodGet, "/api/v1/wifi/anomalies", nil))
 	an := decodeJSON[WiFiAnomaliesResponse](t, recN)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -15,6 +15,7 @@ import (
 
 	alertpipeline "github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
 	"github.com/MustardSeedNetworks/seed/internal/alerts/rules"
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
 	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/auth"
 	"github.com/MustardSeedNetworks/seed/internal/config"
@@ -197,6 +198,13 @@ type Server struct {
 	probeScheduler  *scheduler.Scheduler
 	probeAnomaly    *probeanomaly.Producer
 	retentionEngine *retention.Engine
+
+	// anomalyCoord is the single, server-owned anomaly Coordinator every producer
+	// shares (ADR-0029): one engine over the merged catalog + the unified store.
+	// Built by initAnomalyPlatform before the producers; nil only if the merged
+	// catalog is malformed (a programming error), in which case producers degrade
+	// to off.
+	anomalyCoord *anomaly.Coordinator
 
 	// --- Wi-Fi visibility (scan, manage, survey) ---
 	wifiMgr   *wifi.Manager
@@ -421,6 +429,7 @@ func (s *Server) initDatabaseDependentServices(db *database.DB) {
 		return
 	}
 	s.initLicenseAndAPITokens(db)
+	s.initAnomalyPlatform(db)
 	s.initProbeEngine(db)
 	s.initRetentionEngine(db)
 	s.initListeners(db)
@@ -487,11 +496,16 @@ func (s *Server) initProbeEngine(db *database.DB) {
 	// Wire the active-monitoring anomaly producer (ADR-0025): it subscribes to
 	// the probe engine's ResultEvent channel here (so it does not miss events
 	// before its own Start) and persists threshold breaches as anomalies under
-	// source=probe. Subscription happens now; the consume/maintenance loops start
-	// with the lifecycle. A catalog error is logged and skips the producer rather
-	// than aborting probe startup.
+	// source=probe through the shared, server-owned Coordinator (ADR-0029).
+	// Subscription happens now; the consume/maintenance loops start with the
+	// lifecycle. A nil Coordinator (malformed merged catalog) skips the producer
+	// rather than aborting probe startup.
+	if s.anomalyCoord == nil {
+		logging.GetLogger().Warn("probe anomaly producer not wired: no anomaly coordinator")
+		return
+	}
 	producer, prodErr := probeanomaly.New(
-		probeEngine.Subscribe(), db.Anomalies(),
+		probeEngine.Subscribe(), s.anomalyCoord,
 		probeanomaly.WithLogger(logging.GetLogger()),
 	)
 	if prodErr != nil {
@@ -876,7 +890,7 @@ func (s *Server) engineRegistry() *engine.Registry              { return s.engin
 // the server's lazy accessors + live config. Called after initDiscovery so the
 // discovery bridge the discovery use-case captures already exists.
 func (s *Server) initWiFiUseCases() {
-	s.wifiQueries = app.NewWiFiQueries(s.wifiVisibility)
+	s.wifiQueries = app.NewWiFiQueries(s.wifiVisibility, s.anomalyStore)
 	s.wifiManagement = app.NewWiFiManagement(s.wifiManager, s.wifiScanner, s.netManager, s.config, s.configPath)
 	s.wifiDiscovery = app.NewWiFiDiscovery(s.wifiBridge)
 }

--- a/internal/app/wifi.go
+++ b/internal/app/wifi.go
@@ -12,7 +12,9 @@ package app
 import (
 	"context"
 
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
 	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 	"github.com/MustardSeedNetworks/seed/internal/netif"
@@ -21,12 +23,16 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/wifi/visibility"
 )
 
-// NewWiFiQueries builds the Wi-Fi visibility read use-case (ADR-0020) over a lazy
-// accessor for the live visibility component. A nil component (no capture wired,
-// e.g. the test harness) yields a use-case that degrades to empty-but-valid
-// results rather than erroring.
-func NewWiFiQueries(src func() *visibility.Service) *troubleshooting.Queries {
-	return troubleshooting.NewQueries(wifiVisibilitySource(src))
+// NewWiFiQueries builds the Wi-Fi visibility read use-case (ADR-0020) over lazy
+// accessors for the live visibility component (airspace tree + status) and the
+// unified anomaly store (the source=wifi anomaly list, ADR-0029 §4). A nil
+// component or store (no capture / no DB, e.g. the test harness) yields a
+// use-case that degrades to empty-but-valid results rather than erroring.
+func NewWiFiQueries(
+	src func() *visibility.Service,
+	anomalyStore func() *database.AnomalyRepository,
+) *troubleshooting.Queries {
+	return troubleshooting.NewQueries(wifiVisibilitySource(src), wifiAnomalyStore{store: anomalyStore})
 }
 
 // wifiVisibilitySource returns the visibility port, or a genuinely-nil interface
@@ -37,6 +43,21 @@ func wifiVisibilitySource(src func() *visibility.Service) troubleshooting.Visibi
 		return s
 	}
 	return nil
+}
+
+// wifiAnomalyStore implements troubleshooting.AnomalyStore over the unified
+// anomaly store (ADR-0029 §4), reading the source=wifi slice — symmetric with the
+// health endpoint's source=probe reader (see health.go). The collaborator is
+// resolved lazily so a later-set value (the api test harness) is honored; a nil
+// store degrades to Available() == false (empty-but-valid list).
+type wifiAnomalyStore struct {
+	store func() *database.AnomalyRepository
+}
+
+func (a wifiAnomalyStore) Available() bool { return a.store() != nil }
+
+func (a wifiAnomalyStore) ActiveWiFi(ctx context.Context) ([]anomaly.Anomaly, error) {
+	return a.store().ActiveBySource(ctx, anomaly.SourceWiFi)
 }
 
 // NewWiFiManagement builds the Wi-Fi settings/scan/status/connect use-case

--- a/internal/app/wifi_visibility.go
+++ b/internal/app/wifi_visibility.go
@@ -1,17 +1,14 @@
 package app
 
 import (
-	"github.com/MustardSeedNetworks/seed/internal/anomaly"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/visibility"
 )
 
-// NewWiFiVisibility builds the Wi-Fi airspace visibility component. It is fed
-// decoded frames by the capture source (not the DB), but it persists its
-// detected-anomaly stream to the unified anomaly store (ADR-0021) when one is
-// supplied — pass db.Anomalies() so Wi-Fi anomalies survive restart and feed the
-// cross-source platform. A nil store leaves the engine purely in-memory. It
-// errors only if the Wi-Fi anomaly catalog is malformed — a build-time
-// programming error.
-func NewWiFiVisibility(store anomaly.Store) (*visibility.Service, error) {
-	return visibility.New(visibility.WithStore(store))
+// NewWiFiVisibility builds the Wi-Fi airspace visibility component, fed decoded
+// frames by the capture source (not the DB). It is a producer into the shared,
+// server-owned anomaly Coordinator (ADR-0029): the cmd layer builds it before the
+// server owns the merged engine, so the server injects the Coordinator later via
+// Service.SetCoordinator. Until then it runs airspace-only.
+func NewWiFiVisibility() *visibility.Service {
+	return visibility.New()
 }

--- a/internal/probe/anomaly/producer.go
+++ b/internal/probe/anomaly/producer.go
@@ -2,6 +2,7 @@ package probeanomaly
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -9,6 +10,10 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/anomaly"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
 )
+
+// errNilCoordinator guards New against a missing shared Coordinator — a wiring
+// bug, surfaced at startup rather than as a nil-deref in the consume loop.
+var errNilCoordinator = errors.New("probeanomaly: nil coordinator")
 
 const (
 	// defaultFlushInterval is how often the maintenance tick batches recurrence
@@ -82,24 +87,23 @@ func WithLogger(l *slog.Logger) Option {
 }
 
 // New builds a probe anomaly producer over the probe engine's event channel
-// (from Engine.Subscribe) and the unified anomaly store. It errors only if the
-// probe anomaly catalog is malformed — a programming error surfaced at startup,
-// never at runtime.
-func New(events <-chan probe.ResultEvent, store anomaly.Store, opts ...Option) (*Producer, error) {
+// (from Engine.Subscribe) and the shared, server-owned anomaly Coordinator
+// (ADR-0029): the producer no longer owns an engine or a Coordinator — it stamps
+// source=probe at the observe hand-off and drives its own Flush/Prune window on
+// the shared instance. The server performs the single load-on-start before any
+// producer observes, so Start does not load. coord must be non-nil.
+func New(events <-chan probe.ResultEvent, coord *anomaly.Coordinator, opts ...Option) (*Producer, error) {
+	if coord == nil {
+		return nil, errNilCoordinator
+	}
 	cfg := config{flushInterval: defaultFlushInterval, resolveWindow: defaultResolveWindow}
 	for _, o := range opts {
 		o(&cfg)
-	}
-	cat, err := Catalog()
-	if err != nil {
-		return nil, err
 	}
 	logger := cfg.logger
 	if logger == nil {
 		logger = slog.Default()
 	}
-	engine := anomaly.NewEngine(cat)
-	coord := anomaly.NewCoordinator(engine, store)
 	return &Producer{
 		events:        events,
 		coord:         coord,
@@ -112,9 +116,10 @@ func New(events <-chan probe.ResultEvent, store anomaly.Store, opts ...Option) (
 // Name implements engine.Engine.
 func (*Producer) Name() string { return "probe-anomaly" }
 
-// Start loads active instances from the store (so a restart keeps coalescing onto
-// persisted anomalies) and launches the consume + maintenance goroutines. It is
-// idempotent: a second call while running is a no-op.
+// Start launches the consume + maintenance goroutines. It is idempotent: a
+// second call while running is a no-op. Load-on-start is server-owned and
+// happens once on the shared Coordinator before any producer observes (ADR-0029),
+// so the producer does not load here.
 func (p *Producer) Start(ctx context.Context) error {
 	p.mu.Lock()
 	if p.cancel != nil {
@@ -124,14 +129,6 @@ func (p *Producer) Start(ctx context.Context) error {
 	loopCtx, cancel := context.WithCancel(ctx)
 	p.cancel = cancel
 	p.mu.Unlock()
-
-	// Load-on-start (ADR-0021). Best-effort — a store error degrades to a
-	// cold-start, not a failed Start.
-	if n, err := p.coord.Load(ctx); err != nil {
-		p.logger.WarnContext(ctx, "probe anomaly load-on-start failed", "error", err)
-	} else if n > 0 {
-		p.logger.InfoContext(ctx, "restored persisted probe anomalies", "count", n)
-	}
 
 	p.wg.Add(1)
 	go p.consume(loopCtx)

--- a/internal/probe/anomaly/producer_internal_test.go
+++ b/internal/probe/anomaly/producer_internal_test.go
@@ -43,6 +43,17 @@ func (f *fakeStore) snapshot() (int, []anomaly.Record, []string) {
 	return f.upserts, rows, res
 }
 
+// coordFor wraps a fake store in a Coordinator over the probe catalog — the
+// shared engine the server now owns (ADR-0029), stood up locally for the unit.
+func coordFor(t *testing.T, store anomaly.Store) *anomaly.Coordinator {
+	t.Helper()
+	cat, err := Catalog()
+	if err != nil {
+		t.Fatalf("Catalog: %v", err)
+	}
+	return anomaly.NewCoordinator(anomaly.NewEngine(cat), store)
+}
+
 func latencyEvent(probeID string) probe.ResultEvent {
 	return probe.ResultEvent{
 		Result: probe.Result{ProbeID: probeID, Kind: "http"},
@@ -69,7 +80,7 @@ func cleanEvent(probeID string) probe.ResultEvent {
 func TestObserveCleanResultResolvesImmediately(t *testing.T) {
 	t.Parallel()
 	fs := &fakeStore{}
-	p, err := New(nil, fs, WithResolveWindow(time.Hour))
+	p, err := New(nil, coordFor(t, fs), WithResolveWindow(time.Hour))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -90,12 +101,21 @@ func TestObserveCleanResultResolvesImmediately(t *testing.T) {
 	}
 }
 
+// TestNewRejectsNilCoordinator asserts the wiring guard: a producer cannot be
+// built without the shared Coordinator (ADR-0029).
+func TestNewRejectsNilCoordinator(t *testing.T) {
+	t.Parallel()
+	if _, err := New(nil, nil); err == nil {
+		t.Fatal("New with nil coordinator should error")
+	}
+}
+
 // TestObserveCleanResultNoActiveIsNoop asserts a clean run for a probe with no
 // active anomalies neither writes nor resolves anything.
 func TestObserveCleanResultNoActiveIsNoop(t *testing.T) {
 	t.Parallel()
 	fs := &fakeStore{}
-	p, err := New(nil, fs)
+	p, err := New(nil, coordFor(t, fs))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -111,7 +131,7 @@ func TestObserveCleanResultNoActiveIsNoop(t *testing.T) {
 func TestObservePersistsThroughCoordinator(t *testing.T) {
 	t.Parallel()
 	fs := &fakeStore{}
-	p, err := New(nil, fs)
+	p, err := New(nil, coordFor(t, fs))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -148,7 +168,7 @@ func TestObservePersistsThroughCoordinator(t *testing.T) {
 func TestFlushAndPruneResolvesAfterSilence(t *testing.T) {
 	t.Parallel()
 	fs := &fakeStore{}
-	p, err := New(nil, fs, WithResolveWindow(10*time.Minute))
+	p, err := New(nil, coordFor(t, fs), WithResolveWindow(10*time.Minute))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -177,7 +197,7 @@ func TestStartStopIsIdempotentAndDrains(t *testing.T) {
 	t.Parallel()
 	fs := &fakeStore{}
 	events := make(chan probe.ResultEvent, 4)
-	p, err := New(events, fs, WithFlushInterval(5*time.Millisecond), WithResolveWindow(time.Hour))
+	p, err := New(events, coordFor(t, fs), WithFlushInterval(5*time.Millisecond), WithResolveWindow(time.Hour))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/internal/wifi/troubleshooting/visibility.go
+++ b/internal/wifi/troubleshooting/visibility.go
@@ -9,18 +9,31 @@
 package troubleshooting
 
 import (
+	"context"
+
 	"github.com/MustardSeedNetworks/seed/internal/anomaly"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/airspace"
 	"github.com/MustardSeedNetworks/seed/internal/wifi/visibility"
 )
 
 // VisibilitySource is the narrow capability the read use-cases need from the
-// live visibility component. It is defined here, at the consumer (ADR-0016
-// interface-segregation), and satisfied by *visibility.Service.
+// live visibility component for the airspace tree and status summary. It is
+// defined here, at the consumer (ADR-0016 interface-segregation), and satisfied
+// by *visibility.Service. The anomaly list no longer comes from here — after the
+// engine convergence (ADR-0029 §4) it is read from the unified store via
+// AnomalyStore, mirroring the probe endpoint.
 type VisibilitySource interface {
 	Tree() []airspace.SSIDGroup
-	Anomalies() []anomaly.Anomaly
 	Status() visibility.Status
+}
+
+// AnomalyStore reads the Wi-Fi slice of the unified anomaly store (ADR-0029 §4).
+// Available reports whether the store is wired; ActiveWiFi returns the active
+// source=wifi instances. Defined at the consumer; the composition root satisfies
+// it over the anomaly repository, symmetric with the health endpoint's reader.
+type AnomalyStore interface {
+	Available() bool
+	ActiveWiFi(ctx context.Context) ([]anomaly.Anomaly, error)
 }
 
 // AirspaceResult is the airspace read use-case output: the tree plus the
@@ -37,14 +50,21 @@ type AnomaliesResult struct {
 }
 
 // Queries is the read use-case for Wi-Fi visibility. The API handlers depend on
-// it instead of on the background components directly.
+// it instead of on the background components directly. The airspace tree and
+// status come from the live visibility component; the anomaly list comes from the
+// unified store (ADR-0029 §4).
 type Queries struct {
-	src VisibilitySource
+	src   VisibilitySource
+	store AnomalyStore
 }
 
-// NewQueries builds the read use-case over src. A nil src (no capture component
-// wired) is valid: the queries then return empty-but-valid results.
-func NewQueries(src VisibilitySource) *Queries { return &Queries{src: src} }
+// NewQueries builds the read use-case over the visibility source (tree/status)
+// and the anomaly store (the source=wifi anomaly list). Either may be nil (no
+// capture component / no DB, e.g. the test harness): the queries then degrade to
+// empty-but-valid results.
+func NewQueries(src VisibilitySource, store AnomalyStore) *Queries {
+	return &Queries{src: src, store: store}
+}
 
 // Airspace returns the current airspace tree and status, degrading to an empty
 // tree (never nil) when no visibility source is present.
@@ -55,11 +75,25 @@ func (q *Queries) Airspace() AirspaceResult {
 	return AirspaceResult{SSIDs: q.src.Tree(), Status: q.src.Status()}
 }
 
-// Anomalies returns the current anomaly stream and status, degrading to an empty
-// stream (never nil) when no visibility source is present.
-func (q *Queries) Anomalies() AnomaliesResult {
-	if q == nil || q.src == nil {
-		return AnomaliesResult{Anomalies: []anomaly.Anomaly{}}
+// Anomalies returns the active Wi-Fi anomalies from the unified store plus the
+// live status summary (ADR-0029 §4). The status always comes from the visibility
+// source; the list comes from the store. An unwired store degrades to an empty
+// list (never nil) — Wi-Fi's historic graceful contract — while a genuine store
+// error is surfaced to the caller (mapped to 500 by the handler).
+func (q *Queries) Anomalies(ctx context.Context) (AnomaliesResult, error) {
+	status := visibility.Status{}
+	if q != nil && q.src != nil {
+		status = q.src.Status()
 	}
-	return AnomaliesResult{Anomalies: q.src.Anomalies(), Status: q.src.Status()}
+	if q == nil || q.store == nil || !q.store.Available() {
+		return AnomaliesResult{Anomalies: []anomaly.Anomaly{}, Status: status}, nil
+	}
+	list, err := q.store.ActiveWiFi(ctx)
+	if err != nil {
+		return AnomaliesResult{}, err
+	}
+	if list == nil {
+		list = []anomaly.Anomaly{}
+	}
+	return AnomaliesResult{Anomalies: list, Status: status}, nil
 }

--- a/internal/wifi/troubleshooting/visibility_test.go
+++ b/internal/wifi/troubleshooting/visibility_test.go
@@ -1,6 +1,8 @@
 package troubleshooting_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/MustardSeedNetworks/seed/internal/anomaly"
@@ -9,42 +11,91 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/wifi/visibility"
 )
 
+// fakeSource is the tree/status half of the read use-case (the anomaly list now
+// comes from the store, not here — ADR-0029 §4).
 type fakeSource struct {
-	tree      []airspace.SSIDGroup
-	anomalies []anomaly.Anomaly
-	status    visibility.Status
+	tree   []airspace.SSIDGroup
+	status visibility.Status
 }
 
-func (f fakeSource) Tree() []airspace.SSIDGroup   { return f.tree }
-func (f fakeSource) Anomalies() []anomaly.Anomaly { return f.anomalies }
-func (f fakeSource) Status() visibility.Status    { return f.status }
+func (f fakeSource) Tree() []airspace.SSIDGroup { return f.tree }
+func (f fakeSource) Status() visibility.Status  { return f.status }
+
+// fakeAnomalyStore is the AnomalyStore half: the source=wifi anomaly list.
+type fakeAnomalyStore struct {
+	available bool
+	anomalies []anomaly.Anomaly
+	err       error
+}
+
+func (f fakeAnomalyStore) Available() bool { return f.available }
+func (f fakeAnomalyStore) ActiveWiFi(context.Context) ([]anomaly.Anomaly, error) {
+	return f.anomalies, f.err
+}
 
 func TestQueriesNilSourceDegradesEmpty(t *testing.T) {
-	q := troubleshooting.NewQueries(nil)
+	q := troubleshooting.NewQueries(nil, nil)
 	air := q.Airspace()
 	if air.SSIDs == nil || len(air.SSIDs) != 0 || air.Status.CaptureActive {
 		t.Errorf("nil source should yield empty inactive airspace, got %+v", air)
 	}
-	an := q.Anomalies()
+	an, err := q.Anomalies(context.Background())
+	if err != nil {
+		t.Fatalf("nil store should not error: %v", err)
+	}
 	if an.Anomalies == nil || len(an.Anomalies) != 0 {
-		t.Errorf("nil source should yield empty anomaly stream, got %+v", an)
+		t.Errorf("nil store should yield empty anomaly stream, got %+v", an)
 	}
 }
 
-func TestQueriesDelegatesToSource(t *testing.T) {
-	src := fakeSource{
-		tree:      []airspace.SSIDGroup{{SSID: "corp"}},
-		anomalies: []anomaly.Anomaly{{DefKey: "wifi-open-network"}},
-		status:    visibility.Status{CaptureActive: true, Source: "mon0", SSIDs: 1},
+// TestQueriesUnavailableStoreDegradesEmpty asserts an unwired store still yields
+// the live status with an empty list (Wi-Fi's historic graceful contract).
+func TestQueriesUnavailableStoreDegradesEmpty(t *testing.T) {
+	src := fakeSource{status: visibility.Status{CaptureActive: true, Source: "mon0"}}
+	q := troubleshooting.NewQueries(src, fakeAnomalyStore{available: false})
+
+	an, err := q.Anomalies(context.Background())
+	if err != nil {
+		t.Fatalf("unavailable store should not error: %v", err)
 	}
-	q := troubleshooting.NewQueries(src)
+	if len(an.Anomalies) != 0 || an.Status.Source != "mon0" {
+		t.Errorf("want empty list with live status, got %+v", an)
+	}
+}
+
+func TestQueriesReadsListFromStoreStatusFromSource(t *testing.T) {
+	src := fakeSource{
+		tree:   []airspace.SSIDGroup{{SSID: "corp"}},
+		status: visibility.Status{CaptureActive: true, Source: "mon0", SSIDs: 1},
+	}
+	store := fakeAnomalyStore{
+		available: true,
+		anomalies: []anomaly.Anomaly{{DefKey: "wifi-open-network"}},
+	}
+	q := troubleshooting.NewQueries(src, store)
 
 	air := q.Airspace()
 	if len(air.SSIDs) != 1 || air.SSIDs[0].SSID != "corp" || !air.Status.CaptureActive {
 		t.Errorf("Airspace did not delegate to the source: %+v", air)
 	}
-	an := q.Anomalies()
+	an, err := q.Anomalies(context.Background())
+	if err != nil {
+		t.Fatalf("Anomalies: %v", err)
+	}
+	// List comes from the store; status comes from the visibility source.
 	if len(an.Anomalies) != 1 || an.Anomalies[0].DefKey != "wifi-open-network" || an.Status.Source != "mon0" {
-		t.Errorf("Anomalies did not delegate to the source: %+v", an)
+		t.Errorf("Anomalies did not compose store list + source status: %+v", an)
+	}
+}
+
+// TestQueriesSurfacesStoreError asserts a genuine store error propagates (the
+// handler maps it to 500) rather than being silently swallowed.
+func TestQueriesSurfacesStoreError(t *testing.T) {
+	wantErr := errors.New("db down")
+	q := troubleshooting.NewQueries(
+		fakeSource{}, fakeAnomalyStore{available: true, err: wantErr})
+
+	if _, err := q.Anomalies(context.Background()); !errors.Is(err, wantErr) {
+		t.Errorf("store error not surfaced: got %v", err)
 	}
 }

--- a/internal/wifi/visibility/service.go
+++ b/internal/wifi/visibility/service.go
@@ -1,14 +1,17 @@
 // Package visibility is the runtime orchestrator for Wi-Fi airspace visibility
 // and anomaly detection. It owns the live cross-referenced airspace model
-// (internal/wifi/airspace), a persistent anomaly engine (internal/anomaly) seeded
-// with the Wi-Fi rule catalog (internal/wifi/anomaly), and the detector that
-// evaluates one against the other.
+// (internal/wifi/airspace) and the detector that evaluates the Wi-Fi rules
+// (internal/wifi/anomaly) against it. It is a *producer* into the shared,
+// server-owned anomaly Coordinator (internal/anomaly, ADR-0029): it no longer
+// owns an engine — detections are stamped source=wifi and folded into the one
+// engine every producer shares, persisted through the unified store.
 //
 // A capture source (W3, libpcap/monitor-mode, built separately and CGO-tagged)
 // feeds decoded 802.11 frames in via Ingest; this package is itself CGO-free and
 // frame-source-agnostic, so it builds and tests everywhere. Start runs a periodic
-// evaluation loop (detector → engine), and Tree/Anomalies/Status are the read
-// model the API layer (W5b) serves Pro-gated.
+// evaluation loop (detector → Coordinator), and Tree/Status are the read model
+// the API layer (W5b) serves Pro-gated; the anomaly list itself is read from the
+// store (ADR-0029 §4), not from here.
 package visibility
 
 import (
@@ -46,15 +49,17 @@ type Status struct {
 	LastEvaluated time.Time `json:"lastEvaluated,omitzero"`
 }
 
-// Service owns the live airspace, the anomaly engine, and the evaluation loop.
-// All exported methods are safe for concurrent use.
+// Service owns the live airspace, the Wi-Fi detector, and the evaluation loop. It
+// is a producer into the shared anomaly Coordinator. All exported methods are
+// safe for concurrent use.
 type Service struct {
 	air      *airspace.Airspace
-	engine   *anomaly.Engine
 	detector *wifianomaly.Detector
-	// coordinator persists the engine's stream to the unified anomaly store
-	// (ADR-0021). Nil when no store is configured — the engine then stays purely
-	// in-memory (the prior behavior). When set, Evaluate writes through it.
+	// coordinator is the shared, server-owned anomaly Coordinator (ADR-0029).
+	// Wi-Fi detections persist through it under source=wifi. Nil leaves the
+	// service airspace-only (Ingest/Tree/Status still work; no anomaly
+	// detection) — the cmd layer builds the Service before the server owns the
+	// Coordinator, then injects it via SetCoordinator.
 	coordinator *anomaly.Coordinator
 	logger      *slog.Logger
 
@@ -75,8 +80,7 @@ type config struct {
 	evalInterval time.Duration
 	retention    time.Duration
 	detector     *wifianomaly.Detector
-	capabilities []string
-	store        anomaly.Store
+	coordinator  *anomaly.Coordinator
 	logger       *slog.Logger
 }
 
@@ -107,18 +111,12 @@ func WithDetector(d *wifianomaly.Detector) Option {
 	}
 }
 
-// WithCapabilities registers platform capabilities for the engine's auto
-// follow-ups (e.g. wifianomaly.CapActiveTest when active testing is available).
-func WithCapabilities(caps ...string) Option {
-	return func(c *config) { c.capabilities = append(c.capabilities, caps...) }
-}
-
-// WithStore persists the anomaly stream to the unified store (ADR-0021): the
-// service writes detections through a Coordinator (write-through on a material
-// change, batched on recurrence, resolve-on-prune) and reloads active instances
-// on Start. A nil store leaves the engine purely in-memory.
-func WithStore(store anomaly.Store) Option {
-	return func(c *config) { c.store = store }
+// WithCoordinator injects the shared, server-owned anomaly Coordinator
+// (ADR-0029) at construction. Production builds the Service in the cmd layer
+// before the server owns the Coordinator and injects it later via
+// SetCoordinator; this option is for tests that have the Coordinator up front.
+func WithCoordinator(coord *anomaly.Coordinator) Option {
+	return func(c *config) { c.coordinator = coord }
 }
 
 // WithLogger sets the logger for persistence diagnostics. Defaults to
@@ -131,16 +129,14 @@ func WithLogger(l *slog.Logger) Option {
 	}
 }
 
-// New builds a visibility service. It errors only if the Wi-Fi anomaly catalog
-// is malformed — a programming error surfaced at startup, never at runtime.
-func New(opts ...Option) (*Service, error) {
+// New builds a visibility service. The Wi-Fi anomaly catalog now lives on the
+// shared, server-owned engine (ADR-0029), so construction cannot fail; the
+// Coordinator is injected via WithCoordinator (tests) or SetCoordinator (the
+// server, after it owns the merged engine).
+func New(opts ...Option) *Service {
 	cfg := config{evalInterval: defaultEvalInterval, retention: defaultRetention}
 	for _, o := range opts {
 		o(&cfg)
-	}
-	cat, err := wifianomaly.Catalog()
-	if err != nil {
-		return nil, err
 	}
 	det := cfg.detector
 	if det == nil {
@@ -150,20 +146,24 @@ func New(opts ...Option) (*Service, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	engine := anomaly.NewEngine(cat, anomaly.WithCapabilities(cfg.capabilities...))
-	var coord *anomaly.Coordinator
-	if cfg.store != nil {
-		coord = anomaly.NewCoordinator(engine, cfg.store)
-	}
 	return &Service{
 		air:          airspace.New(),
-		engine:       engine,
 		detector:     det,
-		coordinator:  coord,
+		coordinator:  cfg.coordinator,
 		logger:       logger,
 		evalInterval: cfg.evalInterval,
 		retention:    cfg.retention,
-	}, nil
+	}
+}
+
+// SetCoordinator injects the shared anomaly Coordinator after construction
+// (ADR-0029): the cmd layer builds the Service before the server owns the merged
+// engine, so the server wires the Coordinator in during init, before Start. Wi-Fi
+// detections then persist through it under source=wifi.
+func (s *Service) SetCoordinator(coord *anomaly.Coordinator) {
+	s.mu.Lock()
+	s.coordinator = coord
+	s.mu.Unlock()
 }
 
 // Ingest folds one decoded frame into the airspace at observation time `at`.
@@ -181,15 +181,10 @@ func (s *Service) Evaluate(ctx context.Context, at time.Time) {
 	cutoff := at.Add(-s.retention)
 	s.air.Prune(cutoff)
 
-	if s.coordinator != nil {
-		s.evaluatePersistent(ctx, at, cutoff)
-	} else {
-		for _, d := range s.detector.Detect(s.air.Tree()) {
-			// Observe only errors on an uncatalogued def or invalid severity; the
-			// detector emits neither, so the error is structurally impossible.
-			_ = s.engine.Observe(d, at)
-		}
-		s.engine.Prune(cutoff)
+	// Airspace-only when no Coordinator is wired (ADR-0029): Ingest/Tree/Status
+	// stay live, but anomaly detection needs the shared engine.
+	if coord := s.snapshotCoordinator(); coord != nil {
+		s.evaluatePersistent(ctx, coord, at, cutoff)
 	}
 
 	s.mu.Lock()
@@ -197,32 +192,39 @@ func (s *Service) Evaluate(ctx context.Context, at time.Time) {
 	s.mu.Unlock()
 }
 
-// evaluatePersistent runs the detection + persistence path through the
+// evaluatePersistent runs the detection + persistence path through the shared
 // Coordinator. Store errors are logged, not fatal — the in-memory engine stays
 // authoritative and the next tick re-persists.
-func (s *Service) evaluatePersistent(ctx context.Context, at, cutoff time.Time) {
+func (s *Service) evaluatePersistent(ctx context.Context, coord *anomaly.Coordinator, at, cutoff time.Time) {
 	for _, d := range s.detector.Detect(s.air.Tree()) {
 		// Stamp the producer source at the hand-off (ADR-0029 §2); the Wi-Fi
 		// detector stays source-agnostic.
 		d.Source = anomaly.SourceWiFi
-		if err := s.coordinator.Observe(ctx, d, at); err != nil {
+		if err := coord.Observe(ctx, d, at); err != nil {
 			s.logger.WarnContext(ctx, "anomaly persist (observe) failed",
 				"defKey", d.DefKey, "error", err)
 		}
 	}
-	if err := s.coordinator.Flush(ctx); err != nil {
+	if err := coord.Flush(ctx); err != nil {
 		s.logger.WarnContext(ctx, "anomaly persist (flush) failed", "error", err)
 	}
-	if _, err := s.coordinator.Prune(ctx, anomaly.SourceWiFi, cutoff); err != nil {
+	// Source-scoped prune (ADR-0029 §3): resolve only Wi-Fi instances idle past
+	// the 5 m retention window, never another producer's still-live instances.
+	if _, err := coord.Prune(ctx, anomaly.SourceWiFi, cutoff); err != nil {
 		s.logger.WarnContext(ctx, "anomaly persist (prune) failed", "error", err)
 	}
 }
 
+// snapshotCoordinator reads the injected Coordinator under the lock so a
+// concurrent SetCoordinator (server init) is race-free.
+func (s *Service) snapshotCoordinator() *anomaly.Coordinator {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.coordinator
+}
+
 // Tree returns the current cross-referenced SSID → AP → BSSID → client view.
 func (s *Service) Tree() []airspace.SSIDGroup { return s.air.Tree() }
-
-// Anomalies returns the current anomaly stream, most urgent first.
-func (s *Service) Anomalies() []anomaly.Anomaly { return s.engine.Snapshot() }
 
 // SetSource records that a named capture source is actively feeding frames.
 func (s *Service) SetSource(name string) {
@@ -252,8 +254,15 @@ func (s *Service) Status() Status {
 	}
 
 	s.mu.Lock()
-	src, last := s.source, s.lastEvaluated
+	src, last, coord := s.source, s.lastEvaluated, s.coordinator
 	s.mu.Unlock()
+
+	// Source-scoped count (ADR-0029 §4): the shared engine holds every producer's
+	// instances, so Wi-Fi reports only its own — engine.Len would over-count.
+	anomalies := 0
+	if coord != nil {
+		anomalies = coord.Engine().LenBySource(anomaly.SourceWiFi)
+	}
 
 	return Status{
 		CaptureActive: src != "",
@@ -262,7 +271,7 @@ func (s *Service) Status() Status {
 		APs:           len(apKeys),
 		BSSes:         bsses,
 		Stations:      stations,
-		Anomalies:     s.engine.Len(),
+		Anomalies:     anomalies,
 		LastEvaluated: last,
 	}
 }
@@ -279,17 +288,9 @@ func (s *Service) Start(ctx context.Context) error {
 	s.cancel = cancel
 	s.mu.Unlock()
 
-	// Load-on-start: repopulate the engine from the unified store so a restart
-	// continues coalescing onto persisted instances (ADR-0021) rather than
-	// re-detecting them as new. Best-effort — a store error degrades to a
-	// cold-start, not a failed Start.
-	if s.coordinator != nil {
-		if n, err := s.coordinator.Load(ctx); err != nil {
-			s.logger.WarnContext(ctx, "anomaly load-on-start failed", "error", err)
-		} else if n > 0 {
-			s.logger.InfoContext(ctx, "restored persisted anomalies", "count", n)
-		}
-	}
+	// Load-on-start is server-owned and happens once on the shared Coordinator
+	// before any producer observes (ADR-0029 §5), so the service does not load
+	// here — it would re-load the merged engine a second time.
 
 	s.wg.Add(1)
 	go s.loop(loopCtx)

--- a/internal/wifi/visibility/service_test.go
+++ b/internal/wifi/visibility/service_test.go
@@ -38,7 +38,20 @@ func beacon(t *testing.T, bssid, ssid string, sec dot11.Security) *dot11.Frame {
 	}
 }
 
-func hasAnomaly(as []anomalyView, id string) bool {
+// wifiCoord wraps a store in a Coordinator over the Wi-Fi catalog — the slice of
+// the shared, server-owned engine (ADR-0029) a visibility unit exercises. The
+// test holds the Coordinator, so it can assert both the in-memory engine
+// (coalescing, counts) and the persisted store rows (the production read path).
+func wifiCoord(t *testing.T, store anomaly.Store) *anomaly.Coordinator {
+	t.Helper()
+	cat, err := wifianomaly.Catalog()
+	if err != nil {
+		t.Fatalf("Catalog: %v", err)
+	}
+	return anomaly.NewCoordinator(anomaly.NewEngine(cat), store)
+}
+
+func hasAnomaly(as []anomaly.Anomaly, id string) bool {
 	for _, a := range as {
 		if a.DefKey == id {
 			return true
@@ -47,33 +60,24 @@ func hasAnomaly(as []anomalyView, id string) bool {
 	return false
 }
 
-// anomalyView is the minimal shape we assert on (mirrors anomaly.Anomaly).
-type anomalyView = struct {
-	DefKey string
-}
-
-func TestNewIsEmpty(t *testing.T) {
-	svc, err := visibility.New()
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+func TestNewIsAirspaceOnlyWithoutCoordinator(t *testing.T) {
+	// No Coordinator wired → airspace-only: Tree/Status live, no anomaly work.
+	svc := visibility.New()
 	if got := len(svc.Tree()); got != 0 {
 		t.Errorf("fresh Tree len = %d, want 0", got)
-	}
-	if got := len(svc.Anomalies()); got != 0 {
-		t.Errorf("fresh Anomalies len = %d, want 0", got)
 	}
 	st := svc.Status()
 	if st.CaptureActive {
 		t.Error("fresh service should not report capture active")
 	}
+	if st.Anomalies != 0 {
+		t.Errorf("airspace-only Status.Anomalies = %d, want 0", st.Anomalies)
+	}
 }
 
 func TestIngestAndEvaluateProducesAnomaly(t *testing.T) {
-	svc, err := visibility.New()
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	coord := wifiCoord(t, newFakeAnomalyStore())
+	svc := visibility.New(visibility.WithCoordinator(coord))
 	now := time.Now()
 	// An open network on 2.4 GHz channel 6: trips wifi-open-network (and is on a
 	// valid non-overlapping channel, so no adjacent-channel noise).
@@ -83,13 +87,9 @@ func TestIngestAndEvaluateProducesAnomaly(t *testing.T) {
 	if len(svc.Tree()) == 0 {
 		t.Fatal("Tree empty after ingesting a beacon")
 	}
-	got := svc.Anomalies()
-	views := make([]anomalyView, len(got))
-	for i, a := range got {
-		views[i] = anomalyView{DefKey: a.DefKey}
-	}
-	if !hasAnomaly(views, wifianomaly.DefOpenNetwork) {
-		t.Errorf("expected %s anomaly, got %+v", wifianomaly.DefOpenNetwork, got)
+	if !hasAnomaly(coord.Engine().Snapshot(), wifianomaly.DefOpenNetwork) {
+		t.Errorf("expected %s in the shared engine, got %+v",
+			wifianomaly.DefOpenNetwork, coord.Engine().Snapshot())
 	}
 	if svc.Status().Anomalies == 0 {
 		t.Error("Status.Anomalies should be > 0 after evaluate")
@@ -97,10 +97,8 @@ func TestIngestAndEvaluateProducesAnomaly(t *testing.T) {
 }
 
 func TestEvaluateCoalesces(t *testing.T) {
-	svc, err := visibility.New()
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	coord := wifiCoord(t, newFakeAnomalyStore())
+	svc := visibility.New(visibility.WithCoordinator(coord))
 	now := time.Now()
 	b := beacon(t, "00:11:22:33:44:55", "guest", dot11.SecurityOpen)
 	svc.Ingest(b, now)
@@ -109,7 +107,7 @@ func TestEvaluateCoalesces(t *testing.T) {
 	svc.Evaluate(context.Background(), now.Add(time.Second))
 
 	open := 0
-	for _, a := range svc.Anomalies() {
+	for _, a := range coord.Engine().Snapshot() {
 		if a.DefKey == wifianomaly.DefOpenNetwork {
 			open++
 			if a.Count < 2 {
@@ -123,17 +121,15 @@ func TestEvaluateCoalesces(t *testing.T) {
 }
 
 func TestCustomDetectorAndOptions(t *testing.T) {
-	// A tuned detector (co-channel threshold 2) plus the non-default options, to
+	// A tuned detector (co-channel threshold 2) plus non-default options, to
 	// exercise the option path and a multi-BSS evaluation.
 	det := wifianomaly.NewDetector(wifianomaly.WithCoChannelThreshold(2))
-	svc, err := visibility.New(
+	coord := wifiCoord(t, newFakeAnomalyStore())
+	svc := visibility.New(
 		visibility.WithDetector(det),
 		visibility.WithRetention(time.Minute),
-		visibility.WithCapabilities(wifianomaly.CapActiveTest),
+		visibility.WithCoordinator(coord),
 	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
 	now := time.Now()
 	// Two WPA3/PMF BSSes sharing 2.4 GHz channel 6 → co-channel contention.
 	for _, m := range []string{"00:11:22:33:44:01", "00:11:22:33:44:02"} {
@@ -143,14 +139,9 @@ func TestCustomDetectorAndOptions(t *testing.T) {
 	}
 	svc.Evaluate(context.Background(), now)
 
-	found := false
-	for _, a := range svc.Anomalies() {
-		if a.DefKey == wifianomaly.DefCoChannelContention {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected co-channel-contention with threshold 2, got %+v", svc.Anomalies())
+	if !hasAnomaly(coord.Engine().Snapshot(), wifianomaly.DefCoChannelContention) {
+		t.Errorf("expected co-channel-contention with threshold 2, got %+v",
+			coord.Engine().Snapshot())
 	}
 	st := svc.Status()
 	if st.BSSes != 2 || st.APs == 0 {
@@ -159,10 +150,7 @@ func TestCustomDetectorAndOptions(t *testing.T) {
 }
 
 func TestSourceToggle(t *testing.T) {
-	svc, err := visibility.New()
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	svc := visibility.New()
 	svc.SetSource("monitor0")
 	st := svc.Status()
 	if !st.CaptureActive || st.Source != "monitor0" {
@@ -175,10 +163,11 @@ func TestSourceToggle(t *testing.T) {
 }
 
 func TestStartStopLifecycle(t *testing.T) {
-	svc, err := visibility.New(visibility.WithEvalInterval(5 * time.Millisecond))
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	coord := wifiCoord(t, newFakeAnomalyStore())
+	svc := visibility.New(
+		visibility.WithCoordinator(coord),
+		visibility.WithEvalInterval(5*time.Millisecond),
+	)
 	if startErr := svc.Start(t.Context()); startErr != nil {
 		t.Fatalf("Start: %v", startErr)
 	}
@@ -186,12 +175,12 @@ func TestStartStopLifecycle(t *testing.T) {
 	// Give the ticker a few cycles to evaluate.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if len(svc.Anomalies()) > 0 {
+		if coord.Engine().LenBySource(anomaly.SourceWiFi) > 0 {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	if len(svc.Anomalies()) == 0 {
+	if coord.Engine().LenBySource(anomaly.SourceWiFi) == 0 {
 		t.Error("background loop did not evaluate ingested frames")
 	}
 	if stopErr := svc.Stop(); stopErr != nil {
@@ -250,15 +239,12 @@ func (f *fakeAnomalyStore) snapshot() []anomaly.Record {
 	return out
 }
 
-// TestPersistsAnomaliesToStore asserts that with a store configured, evaluating
-// an open-network beacon writes the detected anomaly through to the store tagged
-// with the Wi-Fi source (ADR-0021 phase 3 producer).
+// TestPersistsAnomaliesToStore asserts that evaluating an open-network beacon
+// writes the detected anomaly through to the shared store tagged source=wifi
+// (ADR-0029 producer).
 func TestPersistsAnomaliesToStore(t *testing.T) {
 	fake := newFakeAnomalyStore()
-	svc, err := visibility.New(visibility.WithStore(fake))
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	svc := visibility.New(visibility.WithCoordinator(wifiCoord(t, fake)))
 	now := time.Now()
 	svc.Ingest(beacon(t, "00:11:22:33:44:55", "guest", dot11.SecurityOpen), now)
 	svc.Evaluate(context.Background(), now)
@@ -281,9 +267,10 @@ func TestPersistsAnomaliesToStore(t *testing.T) {
 	}
 }
 
-// TestLoadOnStartRestoresAnomalies asserts Start repopulates the engine from the
-// store's active instances so a restart does not lose live anomalies.
-func TestLoadOnStartRestoresAnomalies(t *testing.T) {
+// TestReflectsPreloadedSharedEngine asserts the service reads its Status count
+// from the shared engine, including instances restored by the server-owned
+// load-on-start (ADR-0029 §5) — the service itself no longer loads.
+func TestReflectsPreloadedSharedEngine(t *testing.T) {
 	fake := newFakeAnomalyStore()
 	t0 := time.Now().Add(-time.Minute)
 	fake.seed = []anomaly.Record{{
@@ -295,25 +282,18 @@ func TestLoadOnStartRestoresAnomalies(t *testing.T) {
 			FirstSeen: t0, LastSeen: t0, Count: 3,
 		},
 	}}
-	// Long eval interval so the background loop does not evaluate during the test;
-	// load-on-start runs synchronously inside Start.
-	svc, err := visibility.New(visibility.WithStore(fake), visibility.WithEvalInterval(time.Hour))
-	if err != nil {
-		t.Fatalf("New: %v", err)
+	coord := wifiCoord(t, fake)
+	// The server performs the single load-on-start before producers observe.
+	if n, err := coord.Load(context.Background()); err != nil || n != 1 {
+		t.Fatalf("Load = (%d, %v), want (1, nil)", n, err)
 	}
-	if startErr := svc.Start(t.Context()); startErr != nil {
-		t.Fatalf("Start: %v", startErr)
-	}
-	defer func() { _ = svc.Stop() }()
+	svc := visibility.New(visibility.WithCoordinator(coord), visibility.WithEvalInterval(time.Hour))
 
-	anoms := svc.Anomalies()
-	if len(anoms) != 1 || anoms[0].DefKey != wifianomaly.DefOpenNetwork {
-		t.Fatalf("restored anomalies = %+v, want one %s", anoms, wifianomaly.DefOpenNetwork)
+	if got := svc.Status().Anomalies; got != 1 {
+		t.Errorf("Status.Anomalies = %d, want 1 (restored)", got)
 	}
-	if anoms[0].Count != 3 {
-		t.Errorf("restored count = %d, want 3", anoms[0].Count)
-	}
-	if svc.Status().Anomalies != 1 {
-		t.Errorf("Status.Anomalies = %d, want 1", svc.Status().Anomalies)
+	snap := coord.Engine().Snapshot()
+	if len(snap) != 1 || snap[0].DefKey != wifianomaly.DefOpenNetwork || snap[0].Count != 3 {
+		t.Errorf("restored engine state = %+v, want one %s count=3", snap, wifianomaly.DefOpenNetwork)
 	}
 }


### PR DESCRIPTION
## What

Realizes the ADR-0021 end-state — **ONE engine, ONE store, read everywhere** — by converging the two long-lived anomaly producers (Wi-Fi visibility + probe) onto a single, server-owned `anomaly.Coordinator`. Completes ADR-0029 (P1 landed in #1651).

P2 (single engine) and P3 (consumer reads the store) ship **together**: a shared engine read in-memory per-source would over-report, so the read switch can't be deferred behind P2.

## P2 — single server-owned Coordinator
- New `internal/api/anomaly_platform.go`: one `Engine` over `wifianomaly.Defs() ∪ probeanomaly.Defs()` (NewCatalog's dup-id rejection is the fail-fast), one `Coordinator` over `db.Anomalies()`, on `Server.anomalyCoord`; built before `initProbeEngine`.
- `probeanomaly.New(events, coord)` and `visibility.Service` take the **injected** Coordinator; both drop their owned engine/Coordinator and per-producer load-on-start. `visibility` gains `WithCoordinator`/`SetCoordinator` (cmd builds it airspace-only, the server injects during init), drops `WithStore`/`WithCapabilities`.
- **Single** server-owned load-on-start (`coord.Load` once) before any producer observes; the merged catalog holds every def, so `Restore` no longer drops a producer's rows as orphans.
- `anomaly.Engine.LenBySource` so `visibility.Status().Anomalies` counts only Wi-Fi (the shared engine would over-count). `Snapshot` stays as the diagnostic in-memory view.

## P3 — consumers read the store
- `/wifi/anomalies` → `ActiveBySource(SourceWiFi)` via a new `troubleshooting.AnomalyStore` port (symmetric with the probe endpoint's `source=probe` reader). The use-case composes the store list with the live visibility `Status`; unwired store → graceful empty 200, genuine error → 500.
- Drops the consumer `Anomalies()` method + `VisibilitySource.Anomalies()`. **No route/capability change.** The Wi-Fi card renders only persisted fields (severity/title/count/subject/recommendation/defKey), so **no visible regression**.

`troubleshooting.AnalyzeBSSes` stays transient (out of scope, ADR §6). Catalog-static `impact`/`followUps` re-derivation on read (both endpoints, app-layer) is a deliberate separate follow-up.

## Tests / gates
- New: `Engine.LenBySource`; two-producers-one-coordinator concurrency (`-race`); server-owned single load (reflects pre-loaded shared engine); store-backed Wi-Fi read paths (unavailable/empty/error). Producer + visibility + troubleshooting suites rewritten to inject a Coordinator.
- Green: `go build ./...`; `go test -race` on anomaly/probe-anomaly/visibility/troubleshooting + `internal/api` (alone); `golangci-lint --new-from-rev=origin/main` = 0; `check-output-escaping.sh` + `check-route-policy.sh`. No migration, no goldens.

ADR-0029 as-built note added; after merge it is fully realized.