### PR TITLE
feat(anomaly): re-derive catalog-static impact/followUps on store read (ADR-0029)

### DIFF
--- a/internal/anomaly/engine.go
+++ b/internal/anomaly/engine.go
@@ -305,6 +305,25 @@ func (e *Engine) recordsForKeys(keys []instanceKey) []Record {
 	return out
 }
 
+// EnrichStatic fills the catalog-static fields a store read cannot reconstruct —
+// Impact and the capability-degraded FollowUps — from the catalog by DefKey,
+// returning the enriched copy. The persisted scalar fields (Title, Description,
+// Recommendation, Standards, Severity, …) are left exactly as the store returned
+// them; only the two unpersisted fields are filled. FollowUps reuse the same
+// capability degradation as the live Snapshot, so a store-backed read and an
+// in-memory read present the identical projection. An orphaned row whose DefKey
+// is no longer in the catalog is returned unchanged. Reads only the immutable
+// catalog and capability set, so it is safe to call while producers observe.
+func (e *Engine) EnrichStatic(a Anomaly) Anomaly {
+	def, ok := e.catalog.Lookup(a.DefKey)
+	if !ok {
+		return a
+	}
+	a.Impact = def.Impact
+	a.FollowUps = e.projectFollowUps(def.FollowUps)
+	return a
+}
+
 // Snapshot projects the live stream as deterministically-ordered Anomaly views,
 // merging catalog copy with instance evidence/lifecycle and degrading
 // capability-gated auto follow-ups to prompts. Ordering: severity (most urgent

--- a/internal/anomaly/engine_test.go
+++ b/internal/anomaly/engine_test.go
@@ -294,6 +294,52 @@ func TestLenBySource(t *testing.T) {
 	}
 }
 
+// TestEnrichStatic asserts the catalog re-hydration a store read needs (ADR-0029
+// follow-up): a store-backed Anomaly carries the persisted scalar fields but not
+// the catalog-static Impact / FollowUps, so EnrichStatic fills exactly those from
+// the catalog by DefKey, leaving the persisted fields untouched and reusing the
+// engine's capability degradation for follow-ups.
+func TestEnrichStatic(t *testing.T) {
+	// Without the capability, the gated auto follow-up degrades to a prompt — the
+	// same projection the live Snapshot would produce.
+	e := anomaly.NewEngine(testCatalog(t))
+	stored := anomaly.Anomaly{
+		DefKey:   "open-ssid",
+		Title:    "persisted title", // store-authoritative; must survive
+		Severity: anomaly.SeverityWarning,
+		Subject:  bssid("aa"),
+		// Impact + FollowUps intentionally blank (a store read cannot reconstruct them).
+	}
+	got := e.EnrichStatic(stored)
+
+	if got.Title != "persisted title" {
+		t.Errorf("Title = %q, want the persisted value left untouched", got.Title)
+	}
+	if got.Impact != "Traffic is cleartext." {
+		t.Errorf("Impact = %q, want it filled from the catalog", got.Impact)
+	}
+	if len(got.FollowUps) != 3 {
+		t.Fatalf("FollowUps = %d, want 3 from the catalog", len(got.FollowUps))
+	}
+	if got.FollowUps[0].Kind != anomaly.FollowUpPrompt {
+		t.Errorf("gated auto without capability: kind = %q, want prompt (degraded)",
+			got.FollowUps[0].Kind)
+	}
+
+	// With the capability registered the gated follow-up stays auto.
+	e2 := anomaly.NewEngine(testCatalog(t), anomaly.WithCapabilities("wifi-active-diag"))
+	if got := e2.EnrichStatic(stored).FollowUps[0].Kind; got != anomaly.FollowUpAuto {
+		t.Errorf("gated auto with capability: kind = %q, want auto", got)
+	}
+
+	// An orphaned row (def no longer in the catalog) is returned unchanged.
+	orphan := anomaly.Anomaly{DefKey: "gone", Title: "orphan"}
+	enriched := e.EnrichStatic(orphan)
+	if enriched.Impact != "" || len(enriched.FollowUps) != 0 || enriched.Title != "orphan" {
+		t.Errorf("unknown def should pass through unchanged, got %+v", enriched)
+	}
+}
+
 func must(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -858,6 +858,17 @@ func (s *Server) anomalyStore() *database.AnomalyRepository {
 	return s.dbConn.Anomalies()
 }
 
+// anomalyEngine is the shared, server-owned anomaly engine (ADR-0029), exposed so
+// the store-read adapters can re-derive the catalog-static Impact / FollowUps the
+// store does not persist. Nil when the merged catalog failed to build or no DB is
+// wired (the test harness) — enrichment then degrades to a passthrough.
+func (s *Server) anomalyEngine() *anomaly.Engine {
+	if s.anomalyCoord == nil {
+		return nil
+	}
+	return s.anomalyCoord.Engine()
+}
+
 func (s *Server) bluetoothScanner() *enumerate.BluetoothScanner { return s.bluetoothScan }
 func (s *Server) vulnScanner() *vuln.VulnerabilityScanner       { return s.vulnScan }
 func (s *Server) dnsTester() *dns.Tester                        { return s.dnsTest }
@@ -890,7 +901,7 @@ func (s *Server) engineRegistry() *engine.Registry              { return s.engin
 // the server's lazy accessors + live config. Called after initDiscovery so the
 // discovery bridge the discovery use-case captures already exists.
 func (s *Server) initWiFiUseCases() {
-	s.wifiQueries = app.NewWiFiQueries(s.wifiVisibility, s.anomalyStore)
+	s.wifiQueries = app.NewWiFiQueries(s.wifiVisibility, s.anomalyStore, s.anomalyEngine)
 	s.wifiManagement = app.NewWiFiManagement(s.wifiManager, s.wifiScanner, s.netManager, s.config, s.configPath)
 	s.wifiDiscovery = app.NewWiFiDiscovery(s.wifiBridge)
 }
@@ -911,7 +922,7 @@ func (s *Server) initDiscoveryUseCases() {
 // (the only remaining concern after the dead health_check_results read-path was
 // deleted — ADR-0026), so a nil or later-set store (the test harness) is honored.
 func (s *Server) initHealthUseCases() {
-	s.healthMonitoring = app.NewHealthMonitoring(s.anomalyStore)
+	s.healthMonitoring = app.NewHealthMonitoring(s.anomalyStore, s.anomalyEngine)
 }
 
 // initUpdateUseCases wires the update-lifecycle use-case (ADR-0020) from the

--- a/internal/app/anomaly.go
+++ b/internal/app/anomaly.go
@@ -1,0 +1,26 @@
+package app
+
+// anomaly.go holds the composition-root helper that re-hydrates store-backed
+// anomalies (ADR-0029 follow-up). The unified store does not persist the
+// catalog-static Impact / FollowUps — they are re-derived on read from the
+// shared, server-owned engine's catalog, so both anomaly endpoints (Wi-Fi and
+// probe) present the same complete view the in-memory Snapshot would.
+
+import (
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
+)
+
+// enrichAnomalies fills each anomaly's catalog-static Impact / FollowUps from the
+// shared engine's catalog (capability-degraded follow-ups, identical to the live
+// projection). It mutates in place and returns the slice for chaining. A nil
+// engine (anomaly platform not wired / test harness) leaves the list exactly as
+// the store returned it.
+func enrichAnomalies(engine *anomaly.Engine, list []anomaly.Anomaly) []anomaly.Anomaly {
+	if engine == nil {
+		return list
+	}
+	for i := range list {
+		list[i] = engine.EnrichStatic(list[i])
+	}
+	return list
+}

--- a/internal/app/anomaly_internal_test.go
+++ b/internal/app/anomaly_internal_test.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/anomaly"
+)
+
+// TestEnrichAnomalies asserts the composition-root helper fills the catalog-static
+// Impact / FollowUps a store read omits (ADR-0029), and that a nil engine (no
+// platform wired) leaves the list untouched.
+func TestEnrichAnomalies(t *testing.T) {
+	cat, err := anomaly.NewCatalog(anomaly.Def{
+		ID: "probe-unreachable", Category: anomaly.CategoryNetHealth,
+		DefaultSeverity: anomaly.SeverityCritical,
+		Title:           "Unreachable", Description: "down.",
+		Recommendation: "check it.", Impact: "service is down.",
+	})
+	if err != nil {
+		t.Fatalf("NewCatalog: %v", err)
+	}
+	engine := anomaly.NewEngine(cat)
+
+	// A store-backed read: scalar fields present, Impact blank (unpersisted).
+	list := []anomaly.Anomaly{{DefKey: "probe-unreachable", Title: "Unreachable"}}
+
+	got := enrichAnomalies(engine, list)
+	if len(got) != 1 || got[0].Impact != "service is down." {
+		t.Errorf("enriched Impact = %q, want it re-derived from the catalog", got[0].Impact)
+	}
+
+	// Nil engine → passthrough, no enrichment.
+	raw := []anomaly.Anomaly{{DefKey: "probe-unreachable"}}
+	if passthrough := enrichAnomalies(nil, raw); passthrough[0].Impact != "" {
+		t.Errorf("nil engine should not enrich, got Impact = %q", passthrough[0].Impact)
+	}
+}

--- a/internal/app/health.go
+++ b/internal/app/health.go
@@ -17,21 +17,32 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/health/monitoring"
 )
 
-// NewHealthMonitoring builds the health-monitoring use-case (ADR-0020) over a
-// lazy accessor for the unified anomaly store. A nil accessor result makes
-// Anomalies degrade to monitoring.ErrUnavailable (the golden-pinned 503 path).
-func NewHealthMonitoring(anomalyStore func() *database.AnomalyRepository) *monitoring.Service {
-	return monitoring.NewService(healthAnomaly{store: anomalyStore})
+// NewHealthMonitoring builds the health-monitoring use-case (ADR-0020) over lazy
+// accessors for the unified anomaly store and the shared engine (the latter
+// re-derives the catalog-static Impact / FollowUps the store does not persist,
+// ADR-0029). A nil store makes Anomalies degrade to monitoring.ErrUnavailable
+// (the golden-pinned 503 path).
+func NewHealthMonitoring(
+	anomalyStore func() *database.AnomalyRepository,
+	anomalyEngine func() *anomaly.Engine,
+) *monitoring.Service {
+	return monitoring.NewService(healthAnomaly{store: anomalyStore, engine: anomalyEngine})
 }
 
 // healthAnomaly implements monitoring.AnomalyReader over the unified anomaly
 // store (ADR-0021), reading the source=probe slice — the active-monitoring probe
-// engine is the producer of these anomalies (ADR-0025).
+// engine is the producer of these anomalies (ADR-0025) — and re-deriving the
+// catalog-static fields on read (ADR-0029).
 type healthAnomaly struct {
-	store func() *database.AnomalyRepository
+	store  func() *database.AnomalyRepository
+	engine func() *anomaly.Engine
 }
 
 func (a healthAnomaly) Available() bool { return a.store() != nil }
 func (a healthAnomaly) ActiveAnomalies(ctx context.Context) ([]anomaly.Anomaly, error) {
-	return a.store().ActiveBySource(ctx, anomaly.SourceProbe)
+	list, err := a.store().ActiveBySource(ctx, anomaly.SourceProbe)
+	if err != nil {
+		return nil, err
+	}
+	return enrichAnomalies(a.engine(), list), nil
 }

--- a/internal/app/wifi.go
+++ b/internal/app/wifi.go
@@ -31,8 +31,12 @@ import (
 func NewWiFiQueries(
 	src func() *visibility.Service,
 	anomalyStore func() *database.AnomalyRepository,
+	anomalyEngine func() *anomaly.Engine,
 ) *troubleshooting.Queries {
-	return troubleshooting.NewQueries(wifiVisibilitySource(src), wifiAnomalyStore{store: anomalyStore})
+	return troubleshooting.NewQueries(
+		wifiVisibilitySource(src),
+		wifiAnomalyStore{store: anomalyStore, engine: anomalyEngine},
+	)
 }
 
 // wifiVisibilitySource returns the visibility port, or a genuinely-nil interface
@@ -47,17 +51,23 @@ func wifiVisibilitySource(src func() *visibility.Service) troubleshooting.Visibi
 
 // wifiAnomalyStore implements troubleshooting.AnomalyStore over the unified
 // anomaly store (ADR-0029 §4), reading the source=wifi slice — symmetric with the
-// health endpoint's source=probe reader (see health.go). The collaborator is
-// resolved lazily so a later-set value (the api test harness) is honored; a nil
-// store degrades to Available() == false (empty-but-valid list).
+// health endpoint's source=probe reader (see health.go) — and re-deriving the
+// catalog-static Impact / FollowUps on read from the shared engine. Collaborators
+// are resolved lazily so a later-set value (the api test harness) is honored; a
+// nil store degrades to Available() == false (empty-but-valid list).
 type wifiAnomalyStore struct {
-	store func() *database.AnomalyRepository
+	store  func() *database.AnomalyRepository
+	engine func() *anomaly.Engine
 }
 
 func (a wifiAnomalyStore) Available() bool { return a.store() != nil }
 
 func (a wifiAnomalyStore) ActiveWiFi(ctx context.Context) ([]anomaly.Anomaly, error) {
-	return a.store().ActiveBySource(ctx, anomaly.SourceWiFi)
+	list, err := a.store().ActiveBySource(ctx, anomaly.SourceWiFi)
+	if err != nil {
+		return nil, err
+	}
+	return enrichAnomalies(a.engine(), list), nil
 }
 
 // NewWiFiManagement builds the Wi-Fi settings/scan/status/connect use-case

--- a/internal/database/repository_anomalies.go
+++ b/internal/database/repository_anomalies.go
@@ -260,9 +260,9 @@ func (r *AnomalyRepository) LoadActive(ctx context.Context) ([]anomaly.Record, e
 // as projected Anomaly views, canonically ordered (ADR-0021 §4: reads go through
 // the store). It is the source-scoped read path behind consumers like the
 // health-checks and Wi-Fi anomaly endpoints. Catalog-static copy (impact,
-// follow-ups) is not persisted; those fields are re-derived from the embedded
-// catalog by def_key once a server-owned catalog exists (the producer phase) —
-// the scalar, evidence, and lifecycle fields come straight from the row.
+// follow-ups) is not persisted; those fields are re-derived from the shared
+// engine's catalog by def_key at the app layer on read (ADR-0029, enrichAnomalies)
+// — the scalar, evidence, and lifecycle fields come straight from the row.
 func (r *AnomalyRepository) ActiveBySource(
 	ctx context.Context, source anomaly.Source,
 ) ([]anomaly.Anomaly, error) {


### PR DESCRIPTION
## What

The committed ADR-0029 follow-up. The unified store does not persist the catalog-static `Impact` / `FollowUps`, so the store-backed read path (`ActiveBySource`) dropped them — the **probe** endpoint lost the `Impact` text and the **Wi-Fi** endpoint lost `Impact` + the actionable follow-ups. Now that one server-owned engine/catalog exists (ADR-0029 P2), re-derive them on read so a store-backed read presents the same complete view the in-memory `Snapshot` would.

## How
- `anomaly.Engine.EnrichStatic(a)` fills `Impact` + capability-degraded `FollowUps` from the catalog by `DefKey`, leaving the persisted scalar fields untouched; an orphaned row (def gone) passes through unchanged. **Reuses `projectFollowUps`** so store-backed and in-memory reads project follow-ups identically. Reads only the immutable catalog/capabilities — safe to call while producers observe.
- `app.enrichAnomalies(engine, list)` — composition-root helper both store-read adapters call after `ActiveBySource` (`healthAnomaly` source=probe, `wifiAnomalyStore` source=wifi). A nil engine (platform not wired / test harness) is a passthrough.
- `Server.anomalyEngine()` exposes the shared engine; threaded into `NewHealthMonitoring` + `NewWiFiQueries`.

Applies uniformly to **both** endpoints (probe defs carry `Impact`; wifi defs carry `Impact` + `FollowUps`). No route/golden/migration change.

## Tests / gates
- New: `EnrichStatic` (fill + capability degradation + orphan passthrough); `enrichAnomalies` app helper (fill + nil-engine passthrough).
- Green: `go build ./...`; `go test -race` on anomaly/app/api(alone)/monitoring/troubleshooting; `golangci-lint --new-from-rev=origin/main` = 0; `check-output-escaping.sh` + `check-route-policy.sh`.