### PR TITLE
refactor(api): strangle device-discovery settings into a use-case (ADR-0020, WS-A1)

### DIFF
--- a/internal/api/handlers_devices.go
+++ b/internal/api/handlers_devices.go
@@ -2,12 +2,13 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
-	"net"
 	"net/http"
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
+	discoverysettings "github.com/MustardSeedNetworks/seed/internal/discovery/settings"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
@@ -275,12 +276,46 @@ func (s *Server) handleDevicesSettings(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// getDevicesSettings serves the current network-discovery settings. Thin
+// transport (ADR-0020): read from the discovery-settings service, map the domain
+// config to the wire DTO (duration → ms).
 func (s *Server) getDevicesSettings(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	cfg := s.config.NetworkDiscovery
+	sendJSONResponse(w, logger, http.StatusOK, discoveryConfigToResponse(s.discoverySettings.Settings()))
+}
 
-	resp := NetworkDiscoverySettingsResponse{
-		// Legacy fields (backward compatibility)
+// updateDevicesSettings persists the network-discovery settings. Thin transport:
+// decode the wire DTO, map it to the domain update, delegate the merge/persist to
+// the service, and map a store error to 500.
+func (s *Server) updateDevicesSettings(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+	localizer := i18n.FromRequest(r)
+	r.Body = http.MaxBytesReader(w, r.Body, MaxBodySizeJSON)
+
+	var req NetworkDiscoverySettingsResponse
+	if !decodeJSONStrict(w, r, &req, MaxBodySizeJSON) {
+		return
+	}
+
+	if err := s.discoverySettings.Update(requestToDiscoveryUpdate(req)); err != nil {
+		logger.ErrorContext(r.Context(), "Failed to save discovery settings", "error", err)
+		sendErrorResponseWithDetails(
+			w, logger, http.StatusInternalServerError, ErrCodeInternal,
+			localizer.T("errors.settings.saveFailed"), "",
+		)
+		return
+	}
+
+	sendJSONResponse(w, logger, http.StatusOK, map[string]string{
+		"status":  statusSuccess,
+		"message": "Network discovery settings updated",
+	})
+}
+
+// discoveryConfigToResponse maps the domain discovery config to the wire DTO
+// (duration → milliseconds). Pure transport serialization.
+func discoveryConfigToResponse(cfg config.NetworkDiscoveryConfig) NetworkDiscoverySettingsResponse {
+	return NetworkDiscoverySettingsResponse{
 		Enabled:        cfg.Enabled,
 		ARPScanWorkers: cfg.ARPScanWorkers,
 		PingTimeoutMs:  cfg.PingTimeout.Milliseconds(),
@@ -288,9 +323,7 @@ func (s *Server) getDevicesSettings(w http.ResponseWriter, r *http.Request) {
 		AutoScan:       cfg.AutoScan,
 		ScanIntervalMs: cfg.ScanInterval.Milliseconds(),
 		OUIFilePath:    cfg.OUIFilePath,
-
-		// Direct options configuration (profiles removed).
-		IPv6Enabled: cfg.IPv6Enabled,
+		IPv6Enabled:    cfg.IPv6Enabled,
 		Options: OptionsResponse{
 			PassiveProtocols: PassiveProtocolResponse{
 				LLDP: cfg.Options.PassiveProtocols.LLDP,
@@ -330,134 +363,59 @@ func (s *Server) getDevicesSettings(w http.ResponseWriter, r *http.Request) {
 			ServiceProbes: cfg.Fingerprinting.ServiceProbes,
 		},
 	}
-
-	sendJSONResponse(w, logger, http.StatusOK, resp)
 }
 
-// applyLegacyDiscoveryConfig applies legacy/backward-compatible discovery settings.
-func (s *Server) applyLegacyDiscoveryConfig(req *NetworkDiscoverySettingsResponse) {
-	s.config.NetworkDiscovery.Enabled = req.Enabled
-	if req.ARPScanWorkers > 0 {
-		s.config.NetworkDiscovery.ARPScanWorkers = req.ARPScanWorkers
+// requestToDiscoveryUpdate maps the wire DTO to the domain update model. Pure
+// transport mapping; the field-specific merge rules live in the service.
+func requestToDiscoveryUpdate(req NetworkDiscoverySettingsResponse) discoverysettings.Update {
+	return discoverysettings.Update{
+		Enabled:        req.Enabled,
+		ARPScanWorkers: req.ARPScanWorkers,
+		PingTimeoutMs:  req.PingTimeoutMs,
+		ScanTimeoutMs:  req.ScanTimeoutMs,
+		AutoScan:       req.AutoScan,
+		ScanIntervalMs: req.ScanIntervalMs,
+		OUIFilePath:    req.OUIFilePath,
+		IPv6Enabled:    req.IPv6Enabled,
+		Options: discoverysettings.OptionsUpdate{
+			PassiveProtocols: discoverysettings.PassiveProtocolsUpdate{
+				LLDP: req.Options.PassiveProtocols.LLDP,
+				CDP:  req.Options.PassiveProtocols.CDP,
+				EDP:  req.Options.PassiveProtocols.EDP,
+				NDP:  req.Options.PassiveProtocols.NDP,
+			},
+			ARPScan:  req.Options.ARPScan,
+			ICMPScan: req.Options.ICMPScan,
+			PortScan: discoverysettings.PortScanUpdate{
+				Enabled:         req.Options.PortScan.Enabled,
+				TCPPorts:        req.Options.PortScan.TCPPorts,
+				UDPPorts:        req.Options.PortScan.UDPPorts,
+				BannerTimeoutMs: req.Options.PortScan.BannerTimeoutMs,
+			},
+			TCPProbe: discoverysettings.TCPProbeUpdate{
+				TimeoutMs: req.Options.TCPProbe.TimeoutMs,
+				Workers:   req.Options.TCPProbe.Workers,
+			},
+			Traceroute: req.Options.Traceroute,
+			SNMPQuery:  req.Options.SNMPQuery,
+		},
+		Timing: discoverysettings.TimingUpdate{
+			ProbeIntervalMs:  req.Timing.ProbeIntervalMs,
+			RescanIntervalMs: req.Timing.RescanIntervalMs,
+			Workers:          req.Timing.Workers,
+		},
+		Profiler: discoverysettings.ProfilerUpdate{
+			Enabled:       req.Profiler.Enabled,
+			TimeoutMs:     req.Profiler.TimeoutMs,
+			MaxConcurrent: req.Profiler.MaxConcurrent,
+			QuickPorts:    req.Profiler.QuickPorts,
+		},
+		Fingerprinting: discoverysettings.FingerprintingUpdate{
+			Enabled:       req.Fingerprinting.Enabled,
+			OSDetection:   req.Fingerprinting.OSDetection,
+			ServiceProbes: req.Fingerprinting.ServiceProbes,
+		},
 	}
-	if req.PingTimeoutMs > 0 {
-		s.config.NetworkDiscovery.PingTimeout = time.Duration(req.PingTimeoutMs) * time.Millisecond
-	}
-	if req.ScanTimeoutMs > 0 {
-		s.config.NetworkDiscovery.ScanTimeout = time.Duration(req.ScanTimeoutMs) * time.Millisecond
-	}
-	s.config.NetworkDiscovery.AutoScan = req.AutoScan
-	s.config.NetworkDiscovery.ScanInterval = time.Duration(req.ScanIntervalMs) * time.Millisecond
-	if req.OUIFilePath != "" {
-		s.config.NetworkDiscovery.OUIFilePath = req.OUIFilePath
-	}
-	s.config.NetworkDiscovery.IPv6Enabled = req.IPv6Enabled
-}
-
-// applyDiscoveryOptions applies discovery options including protocols, port scan, and TCP probe.
-func (s *Server) applyDiscoveryOptions(req *NetworkDiscoverySettingsResponse) {
-	opts := &s.config.NetworkDiscovery.Options
-	opts.PassiveProtocols.LLDP = req.Options.PassiveProtocols.LLDP
-	opts.PassiveProtocols.CDP = req.Options.PassiveProtocols.CDP
-	opts.PassiveProtocols.EDP = req.Options.PassiveProtocols.EDP
-	opts.PassiveProtocols.NDP = req.Options.PassiveProtocols.NDP
-	opts.ARPScan = req.Options.ARPScan
-	opts.ICMPScan = req.Options.ICMPScan
-	opts.Traceroute = req.Options.Traceroute
-	opts.SNMPQuery = req.Options.SNMPQuery
-
-	// Port scan config
-	opts.PortScan.Enabled = req.Options.PortScan.Enabled
-	if req.Options.PortScan.TCPPorts != "" {
-		opts.PortScan.TCPPorts = req.Options.PortScan.TCPPorts
-	}
-	if req.Options.PortScan.UDPPorts != "" {
-		opts.PortScan.UDPPorts = req.Options.PortScan.UDPPorts
-	}
-	if req.Options.PortScan.BannerTimeoutMs > 0 {
-		opts.PortScan.BannerTimeout = time.Duration(
-			req.Options.PortScan.BannerTimeoutMs,
-		) * time.Millisecond
-	}
-
-	// TCP probe config
-	if req.Options.TCPProbe.TimeoutMs > 0 {
-		opts.TCPProbe.Timeout = time.Duration(req.Options.TCPProbe.TimeoutMs) * time.Millisecond
-	}
-	if req.Options.TCPProbe.Workers > 0 {
-		opts.TCPProbe.Workers = req.Options.TCPProbe.Workers
-	}
-}
-
-// applyAdvancedDiscoverySettings applies timing, profiler, and fingerprinting settings.
-func (s *Server) applyAdvancedDiscoverySettings(req *NetworkDiscoverySettingsResponse) {
-	// Timing config
-	if req.Timing.ProbeIntervalMs > 0 {
-		s.config.NetworkDiscovery.Timing.ProbeInterval = time.Duration(
-			req.Timing.ProbeIntervalMs,
-		) * time.Millisecond
-	}
-	if req.Timing.RescanIntervalMs > 0 {
-		s.config.NetworkDiscovery.Timing.RescanInterval = time.Duration(
-			req.Timing.RescanIntervalMs,
-		) * time.Millisecond
-	}
-	if req.Timing.Workers > 0 {
-		s.config.NetworkDiscovery.Timing.Workers = req.Timing.Workers
-	}
-
-	// Profiler config
-	s.config.NetworkDiscovery.Profiler.Enabled = req.Profiler.Enabled
-	if req.Profiler.TimeoutMs > 0 {
-		s.config.NetworkDiscovery.Profiler.Timeout = time.Duration(
-			req.Profiler.TimeoutMs,
-		) * time.Millisecond
-	}
-	if req.Profiler.MaxConcurrent > 0 {
-		s.config.NetworkDiscovery.Profiler.MaxConcurrent = req.Profiler.MaxConcurrent
-	}
-	if len(req.Profiler.QuickPorts) > 0 {
-		s.config.NetworkDiscovery.Profiler.QuickPorts = req.Profiler.QuickPorts
-	}
-
-	// Fingerprinting config
-	s.config.NetworkDiscovery.Fingerprinting.Enabled = req.Fingerprinting.Enabled
-	s.config.NetworkDiscovery.Fingerprinting.OSDetection = req.Fingerprinting.OSDetection
-	s.config.NetworkDiscovery.Fingerprinting.ServiceProbes = req.Fingerprinting.ServiceProbes
-}
-
-func (s *Server) updateDevicesSettings(w http.ResponseWriter, r *http.Request) {
-	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
-	r.Body = http.MaxBytesReader(w, r.Body, MaxBodySizeJSON)
-
-	var req NetworkDiscoverySettingsResponse
-	if !decodeJSONStrict(w, r, &req, MaxBodySizeJSON) {
-		return
-	}
-
-	// Lock config for write access (fixes #759 - race condition)
-	// NOTE: Must unlock before Save() - Save() acquires RLock internally (fixes #783)
-	s.config.Lock()
-	s.applyLegacyDiscoveryConfig(&req)
-	s.applyDiscoveryOptions(&req)
-	s.applyAdvancedDiscoverySettings(&req)
-	s.config.Unlock()
-
-	// Save config to file (fixes #735 - return error on save failure)
-	if err := s.config.Save(s.configPath); err != nil {
-		logger.ErrorContext(r.Context(), "Failed to save config", "error", err)
-		sendErrorResponseWithDetails(
-			w, logger, http.StatusInternalServerError, ErrCodeInternal,
-			localizer.T("errors.settings.saveFailed"), "",
-		)
-		return
-	}
-
-	sendJSONResponse(w, logger, http.StatusOK, map[string]string{
-		"status":  statusSuccess,
-		"message": "Network discovery settings updated",
-	})
 }
 
 // SubnetRequest represents a subnet configuration request.
@@ -498,24 +456,22 @@ func (s *Server) handleDevicesSubnets(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// getDevicesSubnets lists the configured additional subnets. Thin transport.
 func (s *Server) getDevicesSubnets(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	subnets := make([]SubnetResponse, 0, len(s.config.NetworkDiscovery.AdditionalSubnets))
-	for _, subnet := range s.config.NetworkDiscovery.AdditionalSubnets {
+	cfgSubnets := s.discoverySettings.Subnets()
+	subnets := make([]SubnetResponse, 0, len(cfgSubnets))
+	for _, subnet := range cfgSubnets {
 		subnets = append(subnets, SubnetResponse{
 			CIDR:    subnet.CIDR,
 			Name:    subnet.Name,
 			Enabled: subnet.Enabled,
 		})
 	}
-
 	sendJSONResponse(w, logger, http.StatusOK, subnets)
 }
 
 func (s *Server) addDevicesSubnet(w http.ResponseWriter, r *http.Request) {
-	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
-	// Limit request body size to prevent DoS attacks (fixes #693)
 	r.Body = http.MaxBytesReader(w, r.Body, MaxBodySizeJSON)
 
 	var req SubnetRequest
@@ -523,74 +479,13 @@ func (s *Server) addDevicesSubnet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate CIDR format
-	_, _, err := net.ParseCIDR(req.CIDR)
-	if err != nil {
-		logger.WarnContext(r.Context(), "Invalid CIDR format", "error", err, "cidr", req.CIDR)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusBadRequest,
-			ErrCodeBadRequest,
-			"Invalid CIDR format",
-			"",
-		)
-		return
-	}
-
-	// Check for duplicates
-	for _, existing := range s.config.NetworkDiscovery.AdditionalSubnets {
-		if existing.CIDR == req.CIDR {
-			sendErrorResponseWithDetails(
-				w,
-				logger,
-				http.StatusConflict,
-				ErrCodeConflict,
-				"Subnet already exists",
-				"",
-			) // fixes #694, #699
-			return
-		}
-	}
-
-	// Add the new subnet
-	newSubnet := config.SubnetConfig{
-		CIDR:    req.CIDR,
-		Name:    req.Name,
-		Enabled: req.Enabled,
-	}
-	s.config.NetworkDiscovery.AdditionalSubnets = append(
-		s.config.NetworkDiscovery.AdditionalSubnets,
-		newSubnet,
-	)
-
-	// Update the device discovery scanner
-	s.syncDeviceDiscoverySubnets(logger)
-
-	// Save config to file (fixes #735 - return error on save failure)
-	if saveErr := s.config.Save(s.configPath); saveErr != nil {
-		logger.ErrorContext(r.Context(), "Failed to save config", "error", saveErr)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			localizer.T("errors.settings.saveFailed"),
-			"",
-		)
-		return
-	}
-
-	sendJSONResponse(w, logger, http.StatusOK, map[string]string{
-		"status":  statusSuccess,
-		"message": "Subnet added",
+	err := s.discoverySettings.AddSubnet(config.SubnetConfig{
+		CIDR: req.CIDR, Name: req.Name, Enabled: req.Enabled,
 	})
+	s.writeSubnetResult(w, r, err, "Subnet added")
 }
 
 func (s *Server) updateDevicesSubnet(w http.ResponseWriter, r *http.Request) {
-	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
-	// Limit request body size to prevent DoS attacks (fixes #693)
 	r.Body = http.MaxBytesReader(w, r.Body, MaxBodySizeJSON)
 
 	var req SubnetRequest
@@ -598,146 +493,50 @@ func (s *Server) updateDevicesSubnet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate CIDR format
-	if _, _, err := net.ParseCIDR(req.CIDR); err != nil {
-		logger.WarnContext(r.Context(), "Invalid CIDR format", "error", err, "cidr", req.CIDR)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusBadRequest,
-			ErrCodeBadRequest,
-			"Invalid CIDR format",
-			"",
-		)
-		return
-	}
-
-	// Find and update the subnet
-	found := false
-	for i, existing := range s.config.NetworkDiscovery.AdditionalSubnets {
-		if existing.CIDR == req.CIDR {
-			s.config.NetworkDiscovery.AdditionalSubnets[i].Name = req.Name
-			s.config.NetworkDiscovery.AdditionalSubnets[i].Enabled = req.Enabled
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusNotFound,
-			ErrCodeNotFound,
-			"Subnet not found",
-			"",
-		) // fixes #694, #699
-		return
-	}
-
-	// Update the device discovery scanner
-	s.syncDeviceDiscoverySubnets(logger)
-
-	// Save config to file (fixes #735 - return error on save failure)
-	if err := s.config.Save(s.configPath); err != nil {
-		logger.ErrorContext(r.Context(), "Failed to save config", "error", err)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			localizer.T("errors.settings.saveFailed"),
-			"",
-		)
-		return
-	}
-
-	sendJSONResponse(w, logger, http.StatusOK, map[string]string{
-		"status":  statusSuccess,
-		"message": "Subnet updated",
+	err := s.discoverySettings.UpdateSubnet(config.SubnetConfig{
+		CIDR: req.CIDR, Name: req.Name, Enabled: req.Enabled,
 	})
+	s.writeSubnetResult(w, r, err, "Subnet updated")
 }
 
 func (s *Server) deleteDevicesSubnet(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
 	cidr := r.URL.Query().Get("cidr")
 	if cidr == "" {
 		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusBadRequest,
-			ErrCodeBadRequest,
-			"CIDR parameter required",
-			"",
-		) // fixes #694, #699
-		return
-	}
-
-	// Find and remove the subnet
-	found := false
-	newSubnets := make([]config.SubnetConfig, 0, len(s.config.NetworkDiscovery.AdditionalSubnets))
-	for _, existing := range s.config.NetworkDiscovery.AdditionalSubnets {
-		if existing.CIDR == cidr {
-			found = true
-			continue
-		}
-		newSubnets = append(newSubnets, existing)
-	}
-
-	if !found {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusNotFound,
-			ErrCodeNotFound,
-			"Subnet not found",
-			"",
-		) // fixes #694, #699
-		return
-	}
-
-	s.config.NetworkDiscovery.AdditionalSubnets = newSubnets
-
-	// Update the device discovery scanner
-	s.syncDeviceDiscoverySubnets(logger)
-
-	// Save config to file (fixes #735 - return error on save failure)
-	if err := s.config.Save(s.configPath); err != nil {
-		logger.ErrorContext(r.Context(), "Failed to save config", "error", err)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			localizer.T("errors.settings.saveFailed"),
-			"",
+			w, logger, http.StatusBadRequest, ErrCodeBadRequest, "CIDR parameter required", "",
 		)
 		return
 	}
-
-	sendJSONResponse(w, logger, http.StatusOK, map[string]string{
-		"status":  statusSuccess,
-		"message": "Subnet deleted",
-	})
+	s.writeSubnetResult(w, r, s.discoverySettings.DeleteSubnet(cidr), "Subnet deleted")
 }
 
-// syncDeviceDiscoverySubnets synchronizes enabled subnets from config to the device discovery scanner.
-// This helper method eliminates DRY violation across add/update/delete subnet handlers.
-func (s *Server) syncDeviceDiscoverySubnets(logger *slog.Logger) {
-	if s.deviceDiscovery() == nil {
-		return
-	}
-
-	enabledCIDRs := make([]string, 0, len(s.config.NetworkDiscovery.AdditionalSubnets))
-	for _, subnet := range s.config.NetworkDiscovery.AdditionalSubnets {
-		if subnet.Enabled {
-			enabledCIDRs = append(enabledCIDRs, subnet.CIDR)
-		}
-	}
-
-	if err := s.deviceDiscovery().SetAdditionalSubnets(enabledCIDRs); err != nil {
-		logger.Warn("Failed to update scanner subnets", "error", err)
+// writeSubnetResult maps a discovery-settings subnet error to an HTTP response,
+// or writes the success message. Centralizes the validation/conflict/not-found/
+// save error mapping shared by the subnet add/update/delete handlers.
+func (s *Server) writeSubnetResult(
+	w http.ResponseWriter, r *http.Request, err error, successMsg string,
+) {
+	logger := logging.FromContext(r.Context())
+	switch {
+	case errors.Is(err, discoverysettings.ErrInvalidCIDR):
+		sendErrorResponseWithDetails(
+			w, logger, http.StatusBadRequest, ErrCodeBadRequest, "Invalid CIDR format", "")
+	case errors.Is(err, discoverysettings.ErrSubnetExists):
+		sendErrorResponseWithDetails(
+			w, logger, http.StatusConflict, ErrCodeConflict, "Subnet already exists", "")
+	case errors.Is(err, discoverysettings.ErrSubnetNotFound):
+		sendErrorResponseWithDetails(
+			w, logger, http.StatusNotFound, ErrCodeNotFound, "Subnet not found", "")
+	case err != nil:
+		logger.ErrorContext(r.Context(), "Failed to save subnet change", "error", err)
+		sendErrorResponseWithDetails(
+			w, logger, http.StatusInternalServerError, ErrCodeInternal,
+			i18n.FromRequest(r).T("errors.settings.saveFailed"), "")
+	default:
+		sendJSONResponse(w, logger, http.StatusOK, map[string]string{
+			"status": statusSuccess, "message": successMsg,
+		})
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/fingerprint"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/problems"
+	discoverysettings "github.com/MustardSeedNetworks/seed/internal/discovery/settings"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
 	enginestatus "github.com/MustardSeedNetworks/seed/internal/engine/status"
@@ -245,6 +246,7 @@ type Server struct {
 	networkIP          *ipconfig.Service           // IP-config + MTU use-case (ADR-0020)
 	alertRules         *rules.Service              // Alert-rule CRUD use-case (ADR-0020)
 	discoveryDevices   *devices.Service            // Unified-discovery (engine) use-case (ADR-0020)
+	discoverySettings  *discoverysettings.Service  // Network-discovery settings use-case (ADR-0020)
 	networkProblems    *problems.Service           // Network problem-detection use-case (ADR-0020)
 	bluetoothScans     *bluetooth.Service          // Bluetooth-discovery use-case (ADR-0020)
 	healthMonitoring   *monitoring.Service         // Health-monitoring use-case (ADR-0020)
@@ -913,6 +915,7 @@ func (s *Server) initWiFiUseCases() {
 // scan reads the discovered devices through the device-discovery accessor.
 func (s *Server) initDiscoveryUseCases() {
 	s.discoveryDevices = app.NewDiscoveryDevices(s.discoveryEngine)
+	s.discoverySettings = app.NewDiscoverySettings(s.config, s.configPath, s.deviceDiscovery)
 	s.networkProblems = app.NewProblems(s.problemDetector, s.discoveryService)
 	s.bluetoothScans = app.NewBluetooth(s.bluetoothScanner)
 }

--- a/internal/app/discovery.go
+++ b/internal/app/discovery.go
@@ -14,11 +14,13 @@ package app
 import (
 	"context"
 
+	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/discovery"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/bluetooth"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/devices"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/enumerate"
 	"github.com/MustardSeedNetworks/seed/internal/discovery/problems"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/settings"
 )
 
 // NewDiscoveryDevices builds the unified-discovery use-case (ADR-0020) over a lazy
@@ -46,6 +48,60 @@ func NewProblems(
 // methods degrade to bluetooth.ErrUnavailable, while Status reports unavailable.
 func NewBluetooth(scanner func() *enumerate.BluetoothScanner) *bluetooth.Service {
 	return bluetooth.NewService(bluetoothScannerAdapter{scanner: scanner})
+}
+
+// NewDiscoverySettings builds the network-discovery settings service (ADR-0020)
+// over the live config (read/merge/persist) and a lazy accessor for the
+// device-discovery scanner (subnet re-sync). cfg/path are fixed for the process
+// lifetime; the scanner is resolved per call so a later-set value (the api test
+// harness) is honored, and a nil scanner makes the subnet sync a no-op.
+func NewDiscoverySettings(
+	cfg *config.Config, path string, dd func() *enumerate.DeviceDiscovery,
+) *settings.Service {
+	return settings.NewService(
+		discoverySettingsStore{cfg: cfg, path: path},
+		discoverySubnetSink{dd: dd},
+	)
+}
+
+// discoverySettingsStore implements settings.Store over the live config, owning
+// the lock + on-disk save the port abstracts away.
+type discoverySettingsStore struct {
+	cfg  *config.Config
+	path string
+}
+
+func (s discoverySettingsStore) Discovery() config.NetworkDiscoveryConfig {
+	s.cfg.RLock()
+	defer s.cfg.RUnlock()
+	nd := s.cfg.NetworkDiscovery
+	// Copy the subnet slice so the service can mutate its working copy without
+	// touching the live config's backing array before SaveDiscovery commits.
+	nd.AdditionalSubnets = append([]config.SubnetConfig(nil), nd.AdditionalSubnets...)
+	return nd
+}
+
+func (s discoverySettingsStore) SaveDiscovery(nd config.NetworkDiscoveryConfig) error {
+	// Lock for the in-memory mutation only; Save acquires its own RLock and so
+	// must run unlocked to avoid the historic deadlock (fixes #783).
+	s.cfg.Lock()
+	s.cfg.NetworkDiscovery = nd
+	s.cfg.Unlock()
+	return s.cfg.Save(s.path)
+}
+
+// discoverySubnetSink implements settings.SubnetSink over the device-discovery
+// scanner, resolved lazily; a nil scanner is a no-op.
+type discoverySubnetSink struct {
+	dd func() *enumerate.DeviceDiscovery
+}
+
+func (a discoverySubnetSink) SetAdditionalSubnets(cidrs []string) error {
+	d := a.dd()
+	if d == nil {
+		return nil
+	}
+	return d.SetAdditionalSubnets(cidrs)
 }
 
 // discoveryEngineAdapter implements devices.Engine over the discovery engine,

--- a/internal/discovery/settings/settings.go
+++ b/internal/discovery/settings/settings.go
@@ -1,0 +1,306 @@
+// Package settings is the application service for network-discovery settings and
+// the additional-subnet list (ADR-0020 clean-hexagonal). It owns the read/merge/
+// validate/persist logic the transport layer used to carry inline: the HTTP
+// handler decodes the request, calls one method here, and encodes the result.
+// Persistence and the live-scanner side effect are reached through the
+// consumer-defined Store and SubnetSink ports, satisfied by adapters in the
+// composition root (internal/app).
+package settings
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+)
+
+// Sentinel errors the transport layer maps to HTTP status codes.
+var (
+	// ErrInvalidCIDR is returned when a subnet CIDR does not parse.
+	ErrInvalidCIDR = errors.New("settings: invalid CIDR")
+	// ErrSubnetExists is returned when adding a subnet whose CIDR is already present.
+	ErrSubnetExists = errors.New("settings: subnet already exists")
+	// ErrSubnetNotFound is returned when updating/deleting an absent subnet.
+	ErrSubnetNotFound = errors.New("settings: subnet not found")
+)
+
+// Store reads and persists the network-discovery configuration. Discovery
+// returns a copy of the current config; SaveDiscovery atomically replaces it and
+// persists it to disk. The adapter owns the config lock and the on-disk save.
+type Store interface {
+	Discovery() config.NetworkDiscoveryConfig
+	SaveDiscovery(config.NetworkDiscoveryConfig) error
+}
+
+// SubnetSink pushes the active (enabled) subnet set to the live device-discovery
+// scanner so a config change reconfigures scanning. A nil-backed sink is a no-op.
+type SubnetSink interface {
+	SetAdditionalSubnets(cidrs []string) error
+}
+
+// Service is the network-discovery settings application service.
+type Service struct {
+	store Store
+	sink  SubnetSink
+}
+
+// NewService builds the settings service over its ports.
+func NewService(store Store, sink SubnetSink) *Service {
+	return &Service{store: store, sink: sink}
+}
+
+// Settings returns the current network-discovery configuration.
+func (s *Service) Settings() config.NetworkDiscoveryConfig {
+	return s.store.Discovery()
+}
+
+// Update merges in onto the current configuration and persists it. The merge is
+// field-specific (some fields are set unconditionally, others only when a
+// positive/non-empty value is supplied) — preserved verbatim from the original
+// handler so the wire contract is unchanged.
+func (s *Service) Update(in Update) error {
+	cur := s.store.Discovery()
+	in.mergeInto(&cur)
+	return s.store.SaveDiscovery(cur)
+}
+
+// Subnets returns the configured additional subnets.
+func (s *Service) Subnets() []config.SubnetConfig {
+	return s.store.Discovery().AdditionalSubnets
+}
+
+// AddSubnet validates and appends a subnet, then persists and re-syncs the
+// scanner. Returns ErrInvalidCIDR for a malformed CIDR or ErrSubnetExists for a
+// duplicate.
+func (s *Service) AddSubnet(in config.SubnetConfig) error {
+	if _, _, err := net.ParseCIDR(in.CIDR); err != nil {
+		return ErrInvalidCIDR
+	}
+	cur := s.store.Discovery()
+	for _, existing := range cur.AdditionalSubnets {
+		if existing.CIDR == in.CIDR {
+			return ErrSubnetExists
+		}
+	}
+	cur.AdditionalSubnets = append(cur.AdditionalSubnets, in)
+	return s.saveAndSync(cur)
+}
+
+// UpdateSubnet renames/toggles the subnet matching in.CIDR. Returns ErrInvalidCIDR
+// for a malformed CIDR or ErrSubnetNotFound if no subnet matches.
+func (s *Service) UpdateSubnet(in config.SubnetConfig) error {
+	if _, _, err := net.ParseCIDR(in.CIDR); err != nil {
+		return ErrInvalidCIDR
+	}
+	cur := s.store.Discovery()
+	found := false
+	for i := range cur.AdditionalSubnets {
+		if cur.AdditionalSubnets[i].CIDR == in.CIDR {
+			cur.AdditionalSubnets[i].Name = in.Name
+			cur.AdditionalSubnets[i].Enabled = in.Enabled
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ErrSubnetNotFound
+	}
+	return s.saveAndSync(cur)
+}
+
+// DeleteSubnet removes the subnet with the given CIDR. Returns ErrSubnetNotFound
+// if absent.
+func (s *Service) DeleteSubnet(cidr string) error {
+	cur := s.store.Discovery()
+	kept := make([]config.SubnetConfig, 0, len(cur.AdditionalSubnets))
+	found := false
+	for _, existing := range cur.AdditionalSubnets {
+		if existing.CIDR == cidr {
+			found = true
+			continue
+		}
+		kept = append(kept, existing)
+	}
+	if !found {
+		return ErrSubnetNotFound
+	}
+	cur.AdditionalSubnets = kept
+	return s.saveAndSync(cur)
+}
+
+// saveAndSync persists the config and pushes the enabled subnet set to the live
+// scanner. The scanner sync is best-effort — it never fails the save.
+func (s *Service) saveAndSync(cur config.NetworkDiscoveryConfig) error {
+	if err := s.store.SaveDiscovery(cur); err != nil {
+		return err
+	}
+	enabled := make([]string, 0, len(cur.AdditionalSubnets))
+	for _, sn := range cur.AdditionalSubnets {
+		if sn.Enabled {
+			enabled = append(enabled, sn.CIDR)
+		}
+	}
+	_ = s.sink.SetAdditionalSubnets(enabled)
+	return nil
+}
+
+// Update is the write model for network-discovery settings: the same field set
+// the wire DTO carries, in milliseconds, so the merge rules (set-if-positive)
+// match the original contract exactly. The transport layer maps its request DTO
+// onto this domain input.
+type Update struct {
+	Enabled        bool
+	ARPScanWorkers int
+	PingTimeoutMs  int64
+	ScanTimeoutMs  int64
+	AutoScan       bool
+	ScanIntervalMs int64
+	OUIFilePath    string
+	IPv6Enabled    bool
+
+	Options        OptionsUpdate
+	Timing         TimingUpdate
+	Profiler       ProfilerUpdate
+	Fingerprinting FingerprintingUpdate
+}
+
+// OptionsUpdate mirrors the discovery options write model.
+type OptionsUpdate struct {
+	PassiveProtocols PassiveProtocolsUpdate
+	ARPScan          bool
+	ICMPScan         bool
+	PortScan         PortScanUpdate
+	TCPProbe         TCPProbeUpdate
+	Traceroute       bool
+	SNMPQuery        bool
+}
+
+// PassiveProtocolsUpdate mirrors the passive-protocol toggles.
+type PassiveProtocolsUpdate struct {
+	LLDP bool
+	CDP  bool
+	EDP  bool
+	NDP  bool
+}
+
+// PortScanUpdate mirrors the port-scan write model.
+type PortScanUpdate struct {
+	Enabled         bool
+	TCPPorts        string
+	UDPPorts        string
+	BannerTimeoutMs int64
+}
+
+// TCPProbeUpdate mirrors the TCP-probe write model.
+type TCPProbeUpdate struct {
+	TimeoutMs int64
+	Workers   int
+}
+
+// TimingUpdate mirrors the discovery-timing write model.
+type TimingUpdate struct {
+	ProbeIntervalMs  int64
+	RescanIntervalMs int64
+	Workers          int
+}
+
+// ProfilerUpdate mirrors the profiler write model.
+type ProfilerUpdate struct {
+	Enabled       bool
+	TimeoutMs     int64
+	MaxConcurrent int
+	QuickPorts    []int
+}
+
+// FingerprintingUpdate mirrors the fingerprinting write model.
+type FingerprintingUpdate struct {
+	Enabled       bool
+	OSDetection   bool
+	ServiceProbes bool
+}
+
+// mergeInto applies the update onto cur with the original field-specific rules:
+// booleans and ScanInterval are set unconditionally; counts/timeouts/intervals
+// and paths are set only when a positive/non-empty value is supplied (treating
+// zero/empty as "keep existing").
+func (u Update) mergeInto(cur *config.NetworkDiscoveryConfig) {
+	cur.Enabled = u.Enabled
+	if u.ARPScanWorkers > 0 {
+		cur.ARPScanWorkers = u.ARPScanWorkers
+	}
+	if u.PingTimeoutMs > 0 {
+		cur.PingTimeout = msDuration(u.PingTimeoutMs)
+	}
+	if u.ScanTimeoutMs > 0 {
+		cur.ScanTimeout = msDuration(u.ScanTimeoutMs)
+	}
+	cur.AutoScan = u.AutoScan
+	cur.ScanInterval = msDuration(u.ScanIntervalMs)
+	if u.OUIFilePath != "" {
+		cur.OUIFilePath = u.OUIFilePath
+	}
+	cur.IPv6Enabled = u.IPv6Enabled
+
+	u.Options.mergeInto(&cur.Options)
+	u.Timing.mergeInto(&cur.Timing)
+	u.Profiler.mergeInto(&cur.Profiler)
+	cur.Fingerprinting.Enabled = u.Fingerprinting.Enabled
+	cur.Fingerprinting.OSDetection = u.Fingerprinting.OSDetection
+	cur.Fingerprinting.ServiceProbes = u.Fingerprinting.ServiceProbes
+}
+
+func (o OptionsUpdate) mergeInto(cur *config.DiscoveryOptions) {
+	cur.PassiveProtocols.LLDP = o.PassiveProtocols.LLDP
+	cur.PassiveProtocols.CDP = o.PassiveProtocols.CDP
+	cur.PassiveProtocols.EDP = o.PassiveProtocols.EDP
+	cur.PassiveProtocols.NDP = o.PassiveProtocols.NDP
+	cur.ARPScan = o.ARPScan
+	cur.ICMPScan = o.ICMPScan
+	cur.Traceroute = o.Traceroute
+	cur.SNMPQuery = o.SNMPQuery
+
+	cur.PortScan.Enabled = o.PortScan.Enabled
+	if o.PortScan.TCPPorts != "" {
+		cur.PortScan.TCPPorts = o.PortScan.TCPPorts
+	}
+	if o.PortScan.UDPPorts != "" {
+		cur.PortScan.UDPPorts = o.PortScan.UDPPorts
+	}
+	if o.PortScan.BannerTimeoutMs > 0 {
+		cur.PortScan.BannerTimeout = msDuration(o.PortScan.BannerTimeoutMs)
+	}
+	if o.TCPProbe.TimeoutMs > 0 {
+		cur.TCPProbe.Timeout = msDuration(o.TCPProbe.TimeoutMs)
+	}
+	if o.TCPProbe.Workers > 0 {
+		cur.TCPProbe.Workers = o.TCPProbe.Workers
+	}
+}
+
+func (t TimingUpdate) mergeInto(cur *config.DiscoveryTiming) {
+	if t.ProbeIntervalMs > 0 {
+		cur.ProbeInterval = msDuration(t.ProbeIntervalMs)
+	}
+	if t.RescanIntervalMs > 0 {
+		cur.RescanInterval = msDuration(t.RescanIntervalMs)
+	}
+	if t.Workers > 0 {
+		cur.Workers = t.Workers
+	}
+}
+
+func (p ProfilerUpdate) mergeInto(cur *config.DeviceProfilerConfig) {
+	cur.Enabled = p.Enabled
+	if p.TimeoutMs > 0 {
+		cur.Timeout = msDuration(p.TimeoutMs)
+	}
+	if p.MaxConcurrent > 0 {
+		cur.MaxConcurrent = p.MaxConcurrent
+	}
+	if len(p.QuickPorts) > 0 {
+		cur.QuickPorts = p.QuickPorts
+	}
+}
+
+func msDuration(ms int64) time.Duration { return time.Duration(ms) * time.Millisecond }

--- a/internal/discovery/settings/settings_test.go
+++ b/internal/discovery/settings/settings_test.go
@@ -1,0 +1,163 @@
+package settings_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/discovery/settings"
+)
+
+// fakeStore is an in-memory settings.Store.
+type fakeStore struct {
+	cfg   config.NetworkDiscoveryConfig
+	saved int
+}
+
+func (f *fakeStore) Discovery() config.NetworkDiscoveryConfig { return f.cfg }
+func (f *fakeStore) SaveDiscovery(c config.NetworkDiscoveryConfig) error {
+	f.cfg = c
+	f.saved++
+	return nil
+}
+
+// fakeSink records the last subnet set pushed to the scanner.
+type fakeSink struct{ last []string }
+
+func (f *fakeSink) SetAdditionalSubnets(cidrs []string) error { f.last = cidrs; return nil }
+
+func newService(cfg config.NetworkDiscoveryConfig) (*settings.Service, *fakeStore, *fakeSink) {
+	st := &fakeStore{cfg: cfg}
+	sk := &fakeSink{}
+	return settings.NewService(st, sk), st, sk
+}
+
+func TestUpdateMergeRules(t *testing.T) {
+	// Seed with non-zero values so "keep existing" is observable.
+	svc, st, _ := newService(config.NetworkDiscoveryConfig{
+		ARPScanWorkers: 7,
+		PingTimeout:    500 * time.Millisecond,
+		ScanInterval:   9 * time.Second,
+		OUIFilePath:    "/old/oui",
+		Enabled:        true,
+	})
+
+	// Conditional fields with zero/empty input keep the existing value; bools and
+	// ScanInterval are set unconditionally.
+	err := svc.Update(settings.Update{
+		Enabled:        false, // unconditional → flips to false
+		ARPScanWorkers: 0,     // keep 7
+		PingTimeoutMs:  0,     // keep 500ms
+		ScanIntervalMs: 0,     // unconditional → set to 0
+		OUIFilePath:    "",    // keep /old/oui
+		AutoScan:       true,  // unconditional
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got := st.cfg
+	if got.Enabled {
+		t.Error("Enabled should be set unconditionally to false")
+	}
+	if !got.AutoScan {
+		t.Error("AutoScan should be set unconditionally to true")
+	}
+	if got.ARPScanWorkers != 7 {
+		t.Errorf("ARPScanWorkers = %d, want 7 (kept)", got.ARPScanWorkers)
+	}
+	if got.PingTimeout != 500*time.Millisecond {
+		t.Errorf("PingTimeout = %v, want 500ms (kept)", got.PingTimeout)
+	}
+	if got.ScanInterval != 0 {
+		t.Errorf("ScanInterval = %v, want 0 (set unconditionally)", got.ScanInterval)
+	}
+	if got.OUIFilePath != "/old/oui" {
+		t.Errorf("OUIFilePath = %q, want kept", got.OUIFilePath)
+	}
+}
+
+func TestUpdatePositiveValuesConvertMs(t *testing.T) {
+	svc, st, _ := newService(config.NetworkDiscoveryConfig{})
+	err := svc.Update(settings.Update{
+		ARPScanWorkers: 4,
+		PingTimeoutMs:  250,
+		ScanTimeoutMs:  3000,
+		Options: settings.OptionsUpdate{
+			PortScan: settings.PortScanUpdate{BannerTimeoutMs: 2000},
+			TCPProbe: settings.TCPProbeUpdate{TimeoutMs: 1500, Workers: 20},
+		},
+		Timing:   settings.TimingUpdate{ProbeIntervalMs: 75, RescanIntervalMs: 600000, Workers: 50},
+		Profiler: settings.ProfilerUpdate{TimeoutMs: 2000, MaxConcurrent: 5, QuickPorts: []int{22, 80}},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	c := st.cfg
+	if c.PingTimeout != 250*time.Millisecond || c.ScanTimeout != 3*time.Second {
+		t.Errorf("ms→duration conversion off: ping=%v scan=%v", c.PingTimeout, c.ScanTimeout)
+	}
+	if c.Options.PortScan.BannerTimeout != 2*time.Second || c.Options.TCPProbe.Timeout != 1500*time.Millisecond {
+		t.Errorf("options durations off: %+v", c.Options)
+	}
+	if c.Timing.RescanInterval != 10*time.Minute || c.Timing.Workers != 50 {
+		t.Errorf("timing off: %+v", c.Timing)
+	}
+	if c.Profiler.MaxConcurrent != 5 || len(c.Profiler.QuickPorts) != 2 {
+		t.Errorf("profiler off: %+v", c.Profiler)
+	}
+}
+
+func TestAddSubnet(t *testing.T) {
+	svc, st, sk := newService(config.NetworkDiscoveryConfig{})
+
+	if err := svc.AddSubnet(config.SubnetConfig{CIDR: "10.0.0.0/24", Name: "lan", Enabled: true}); err != nil {
+		t.Fatalf("AddSubnet: %v", err)
+	}
+	if len(st.cfg.AdditionalSubnets) != 1 {
+		t.Fatalf("want 1 subnet, got %d", len(st.cfg.AdditionalSubnets))
+	}
+	if len(sk.last) != 1 || sk.last[0] != "10.0.0.0/24" {
+		t.Errorf("enabled subnet not synced to scanner: %v", sk.last)
+	}
+
+	// Duplicate.
+	if err := svc.AddSubnet(config.SubnetConfig{CIDR: "10.0.0.0/24"}); !errors.Is(err, settings.ErrSubnetExists) {
+		t.Errorf("duplicate add: want ErrSubnetExists, got %v", err)
+	}
+	// Invalid CIDR.
+	if err := svc.AddSubnet(config.SubnetConfig{CIDR: "not-a-cidr"}); !errors.Is(err, settings.ErrInvalidCIDR) {
+		t.Errorf("invalid CIDR: want ErrInvalidCIDR, got %v", err)
+	}
+}
+
+func TestUpdateAndDeleteSubnet(t *testing.T) {
+	svc, st, sk := newService(config.NetworkDiscoveryConfig{
+		AdditionalSubnets: []config.SubnetConfig{{CIDR: "192.168.1.0/24", Name: "old", Enabled: true}},
+	})
+
+	if err := svc.UpdateSubnet(config.SubnetConfig{CIDR: "192.168.1.0/24", Name: "new", Enabled: false}); err != nil {
+		t.Fatalf("UpdateSubnet: %v", err)
+	}
+	if st.cfg.AdditionalSubnets[0].Name != "new" || st.cfg.AdditionalSubnets[0].Enabled {
+		t.Errorf("subnet not updated: %+v", st.cfg.AdditionalSubnets[0])
+	}
+	// Disabled subnet is excluded from the scanner sync.
+	if len(sk.last) != 0 {
+		t.Errorf("disabled subnet should not sync: %v", sk.last)
+	}
+
+	if err := svc.UpdateSubnet(config.SubnetConfig{CIDR: "10.9.9.0/24"}); !errors.Is(err, settings.ErrSubnetNotFound) {
+		t.Errorf("update missing: want ErrSubnetNotFound, got %v", err)
+	}
+
+	if err := svc.DeleteSubnet("192.168.1.0/24"); err != nil {
+		t.Fatalf("DeleteSubnet: %v", err)
+	}
+	if len(st.cfg.AdditionalSubnets) != 0 {
+		t.Errorf("subnet not deleted: %+v", st.cfg.AdditionalSubnets)
+	}
+	if err := svc.DeleteSubnet("192.168.1.0/24"); !errors.Is(err, settings.ErrSubnetNotFound) {
+		t.Errorf("delete missing: want ErrSubnetNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
**WS-A1** of the architecture-completion plan — the first complete handler strangle, and the **template** the remaining WS-A slices copy.

`handlers_devices.go` carried ~40 inline `s.config.NetworkDiscovery` mutations + subnet CRUD with the config lock, save, CIDR validation, and live-scanner sync all in the transport layer. Moved behind a clean-hexagonal application service.

## Shape (the template)
- **`internal/discovery/settings`** — `Service` over consumer-defined `Store` (read/merge/persist the discovery config) + `SubnetSink` (push enabled subnets to the live scanner) ports. Owns the field-specific merge rules (**preserved verbatim — pure refactor, no wire change**), ms↔duration conversion, and subnet validate/CRUD with typed errors. Domain-meaningful naming per ADR-0020 §2 (`Service`/`Update`/`Store`, never `*UseCase`).
- **`internal/app/discovery.go`** — adapters: `discoverySettingsStore` (config lock + save; copies the subnet slice so the working copy can't mutate live config pre-commit), `discoverySubnetSink` (nil-safe over the scanner).
- **`handlers_devices.go`** — settings GET/PUT + the 4 subnet handlers are now thin transport (decode → service → encode) with pure wire↔domain mapping + a shared subnet error→HTTP mapper. Deleted the 3 `applyXxx` helpers + `syncDeviceDiscoverySubnets`. **No direct `s.config` access for discovery settings** (2 residual reaches = the vuln auto-scan gate, WS-A5). 780→579 LOC.

## Gates
settings service tests (merge keep/set rules, ms conversion, subnet CRUD + errors + scanner sync); `internal/api` `-race`; filename-policy + route-policy + output-escaping + `--new-from-rev` lint all green. No route/golden/migration change.