### PR TITLE
refactor(api): strangle security settings into a use-case + fix SNMP deadlock (ADR-0020, WS-A3)

### DIFF
--- a/internal/api/handlers_security.go
+++ b/internal/api/handlers_security.go
@@ -14,9 +14,6 @@ import (
 	securitysettings "github.com/MustardSeedNetworks/seed/internal/security/settings"
 )
 
-// passwordPlaceholder is used to mask sensitive values in API responses.
-const passwordPlaceholder = "*****"
-
 // ============================================================================
 // Request/Response Types and Handlers (fixes #544 - split from handlers.go)
 // ============================================================================

--- a/internal/api/handlers_security.go
+++ b/internal/api/handlers_security.go
@@ -1,17 +1,17 @@
 package api
 
 import (
-	"fmt"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/dhcp"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/gateway"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
+	securitysettings "github.com/MustardSeedNetworks/seed/internal/security/settings"
 )
 
 // passwordPlaceholder is used to mask sensitive values in API responses.
@@ -83,7 +83,7 @@ func (s *Server) handleRogueDHCP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		resp := RogueDHCPResponse{
-			Enabled: s.config.DHCP.RogueDetection.Enabled,
+			Enabled: s.securitySettings.RogueEnabled(),
 			Running: s.rogueDetector().IsRunning(),
 		}
 		sendJSONResponse(w, logger, http.StatusOK, resp)
@@ -113,7 +113,7 @@ func (s *Server) handleRogueDHCPAction(
 		return
 	}
 
-	resp := RogueDHCPResponse{Enabled: s.config.DHCP.RogueDetection.Enabled}
+	resp := RogueDHCPResponse{Enabled: s.securitySettings.RogueEnabled()}
 
 	switch strings.ToLower(req.Action) {
 	case "start":
@@ -134,7 +134,7 @@ func (s *Server) handleRogueDHCPStart(
 	logger *slog.Logger,
 	resp *RogueDHCPResponse,
 ) {
-	if !s.config.DHCP.RogueDetection.Enabled {
+	if !s.securitySettings.RogueEnabled() {
 		resp.Error = "Rogue DHCP detection is disabled in configuration"
 		sendJSONResponse(w, logger, http.StatusBadRequest, *resp)
 		return
@@ -216,25 +216,18 @@ func (s *Server) handleRogueDHCPServers(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-// handleRogueDHCPConfig gets (GET) or updates (PUT) the rogue DHCP detector configuration.
+// handleRogueDHCPConfig gets (GET) or updates (PUT) the rogue DHCP detector
+// configuration. Thin transport (ADR-0020): delegates to the security-settings
+// service, which owns the config merge/persist + live-detector sync.
 func (s *Server) handleRogueDHCPConfig(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
 
 	switch r.Method {
 	case http.MethodGet:
-		// Get current configuration
-		rogueConfig := s.rogueDetector().GetConfig()
-		resp := RogueDHCPConfigResponse{
-			Enabled:          s.config.DHCP.RogueDetection.Enabled,
-			KnownServers:     rogueConfig.KnownServers,
-			AlertOnDetection: rogueConfig.AlertOnDetection,
-			Interface:        rogueConfig.Interface,
-		}
-		sendJSONResponse(w, logger, http.StatusOK, resp)
+		sendJSONResponse(w, logger, http.StatusOK, rogueViewToResponse(s.securitySettings.RogueDHCP()))
 
 	case http.MethodPut:
-		// Update configuration
 		var req struct {
 			Enabled          *bool    `json:"enabled,omitempty"`
 			KnownServers     []string `json:"knownServers,omitempty"`
@@ -243,57 +236,32 @@ func (s *Server) handleRogueDHCPConfig(w http.ResponseWriter, r *http.Request) {
 		if !decodeJSONStrictLocalized(w, r, &req, MaxBodySizeJSON, logger, localizer) {
 			return
 		}
-
-		// Update config
-		// NOTE: Must unlock before Save() - Save() acquires RLock internally (fixes #783)
-		s.config.Lock()
-		if req.Enabled != nil {
-			s.config.DHCP.RogueDetection.Enabled = *req.Enabled
-		}
-		if req.KnownServers != nil {
-			s.config.DHCP.RogueDetection.KnownServers = req.KnownServers
-			// Update detector's known servers
-			s.rogueDetector().UpdateKnownServers(req.KnownServers)
-		}
-		if req.AlertOnDetection != nil {
-			s.config.DHCP.RogueDetection.AlertOnDetection = *req.AlertOnDetection
-		}
-		// Unlock before Save() to avoid deadlock
-		s.config.Unlock()
-
-		// Save config (fixes #782 - return error instead of silent warning)
-		if err := s.config.Save(s.configPath); err != nil {
-			logger.ErrorContext(r.Context(), "Failed to save config", "error", err)
-			sendErrorResponseWithDetails(
-				w,
-				logger,
-				http.StatusInternalServerError,
-				ErrCodeInternal,
-				localizer.T("errors.config.failedToSave"),
-				"",
-			) // fixes #H7
+		err := s.securitySettings.UpdateRogueDHCP(securitysettings.RogueUpdate{
+			Enabled:          req.Enabled,
+			KnownServers:     req.KnownServers,
+			AlertOnDetection: req.AlertOnDetection,
+		})
+		if err != nil {
+			logger.ErrorContext(r.Context(), "Failed to save rogue DHCP config", "error", err)
+			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+				ErrCodeInternal, localizer.T("errors.config.failedToSave"), "")
 			return
 		}
-
-		// Return updated config
-		rogueConfig := s.rogueDetector().GetConfig()
-		resp := RogueDHCPConfigResponse{
-			Enabled:          s.config.DHCP.RogueDetection.Enabled,
-			KnownServers:     rogueConfig.KnownServers,
-			AlertOnDetection: rogueConfig.AlertOnDetection,
-			Interface:        rogueConfig.Interface,
-		}
-		sendJSONResponse(w, logger, http.StatusOK, resp)
+		sendJSONResponse(w, logger, http.StatusOK, rogueViewToResponse(s.securitySettings.RogueDHCP()))
 
 	default:
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusMethodNotAllowed,
-			ErrCodeMethodNotAllowed,
-			localizer.T("errors.api.methodNotAllowed"),
-			"",
-		) // fixes #694
+		sendErrorResponseWithDetails(w, logger, http.StatusMethodNotAllowed,
+			ErrCodeMethodNotAllowed, localizer.T("errors.api.methodNotAllowed"), "")
+	}
+}
+
+// rogueViewToResponse maps the service read model to the wire DTO.
+func rogueViewToResponse(v securitysettings.RogueView) RogueDHCPConfigResponse {
+	return RogueDHCPConfigResponse{
+		Enabled:          v.Enabled,
+		KnownServers:     v.KnownServers,
+		AlertOnDetection: v.AlertOnDetection,
+		Interface:        v.Interface,
 	}
 }
 
@@ -446,92 +414,15 @@ func (s *Server) handleSNMPSettings(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// getSNMPSettings serves the SNMP settings with passwords masked. Thin transport.
 func (s *Server) getSNMPSettings(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	s.config.RLock()
-	defer s.config.RUnlock()
-
-	// Convert v3 credentials to response format (fixes #518)
-	// NEVER return actual passwords in GET responses - use placeholder instead
-	v3Creds := make([]SNMPv3CredentialResponse, len(s.config.SNMP.V3Credentials))
-	for i := range s.config.SNMP.V3Credentials {
-		cred := &s.config.SNMP.V3Credentials[i]
-		// Use passwordPlaceholder for passwords (never expose actual values)
-		authPass := ""
-		if cred.AuthPassword != "" {
-			authPass = passwordPlaceholder
-		}
-		privPass := ""
-		if cred.PrivPassword != "" {
-			privPass = passwordPlaceholder
-		}
-
-		v3Creds[i] = SNMPv3CredentialResponse{
-			Name:          cred.Name,
-			Username:      cred.Username,
-			AuthProtocol:  cred.AuthProtocol,
-			AuthPassword:  authPass, // Never return actual password
-			PrivProtocol:  cred.PrivProtocol,
-			PrivPassword:  privPass, // Never return actual password
-			ContextName:   cred.ContextName,
-			SecurityLevel: cred.SecurityLevel,
-		}
-	}
-
-	resp := SNMPSettingsResponse{
-		Communities:   s.config.SNMP.Communities,
-		V3Credentials: v3Creds,
-		Timeout:       int(s.config.SNMP.Timeout.Milliseconds()),
-		Retries:       s.config.SNMP.Retries,
-		Port:          s.config.SNMP.Port,
-	}
-
-	sendJSONResponse(w, logger, http.StatusOK, resp)
+	sendJSONResponse(w, logger, http.StatusOK, snmpViewToResponse(s.securitySettings.SNMP()))
 }
 
-// convertSNMPv3Credential converts an API credential request to config format.
-// It handles password encryption and preserves existing passwords for placeholders.
-func (s *Server) convertSNMPv3Credential(
-	cred *SNMPv3CredentialResponse,
-	existingCred *config.SNMPv3Credential,
-	logger *slog.Logger,
-) (*config.SNMPv3Credential, error) {
-	newCred := &config.SNMPv3Credential{
-		Name:          cred.Name,
-		Username:      cred.Username,
-		AuthProtocol:  cred.AuthProtocol,
-		PrivProtocol:  cred.PrivProtocol,
-		ContextName:   cred.ContextName,
-		SecurityLevel: cred.SecurityLevel,
-	}
-
-	// Handle AuthPassword
-	if cred.AuthPassword != "" && cred.AuthPassword != passwordPlaceholder {
-		encrypted, err := s.config.EncryptCredentialValue(cred.AuthPassword)
-		if err != nil {
-			logger.Error("Failed to encrypt auth password", "error", err, "credential_name", cred.Name)
-			return nil, fmt.Errorf("encrypt auth password: %w", err)
-		}
-		newCred.AuthPassword = encrypted
-	} else if existingCred != nil {
-		newCred.AuthPassword = existingCred.AuthPassword
-	}
-
-	// Handle PrivPassword
-	if cred.PrivPassword != "" && cred.PrivPassword != passwordPlaceholder {
-		encrypted, err := s.config.EncryptCredentialValue(cred.PrivPassword)
-		if err != nil {
-			logger.Error("Failed to encrypt priv password", "error", err, "credential_name", cred.Name)
-			return nil, fmt.Errorf("encrypt priv password: %w", err)
-		}
-		newCred.PrivPassword = encrypted
-	} else if existingCred != nil {
-		newCred.PrivPassword = existingCred.PrivPassword
-	}
-
-	return newCred, nil
-}
-
+// updateSNMPSettings persists SNMP settings (encrypting new passwords). Thin
+// transport: decode, map to the domain update, delegate to the service, and map
+// the typed encrypt errors to the distinct i18n messages.
 func (s *Server) updateSNMPSettings(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
@@ -541,53 +432,68 @@ func (s *Server) updateSNMPSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Lock config for write access
-	// NOTE: Must unlock before Save() - Save() acquires RLock internally (fixes #783)
-	s.config.Lock()
-	defer s.config.Unlock()
-
-	// Convert request v3 credentials to config format (fixes #518)
-	v3Creds := make([]config.SNMPv3Credential, len(req.V3Credentials))
-	for i := range req.V3Credentials {
-		var existingCred *config.SNMPv3Credential
-		if i < len(s.config.SNMP.V3Credentials) {
-			existingCred = &s.config.SNMP.V3Credentials[i]
-		}
-		newCred, err := s.convertSNMPv3Credential(&req.V3Credentials[i], existingCred, logger)
-		if err != nil {
-			errMsg := localizer.T("errors.security.failedToEncryptAuth")
-			if strings.Contains(err.Error(), "priv") {
-				errMsg = localizer.T("errors.security.failedToEncryptPriv")
-			}
-			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError, ErrCodeInternal, errMsg, "")
-			return
-		}
-		v3Creds[i] = *newCred
+	switch err := s.securitySettings.UpdateSNMP(snmpRequestToUpdate(req)); {
+	case errors.Is(err, securitysettings.ErrEncryptPriv):
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, localizer.T("errors.security.failedToEncryptPriv"), "")
+	case errors.Is(err, securitysettings.ErrEncryptAuth):
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, localizer.T("errors.security.failedToEncryptAuth"), "")
+	case err != nil:
+		logger.ErrorContext(r.Context(), "Failed to save SNMP settings", "error", err)
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, localizer.T("errors.config.failedToSave"), "")
+	default:
+		sendJSONResponse(w, logger, http.StatusOK, map[string]string{
+			"status": statusSuccess, "message": "SNMP settings updated",
+		})
 	}
+}
 
-	// Update SNMP settings
-	s.config.SNMP.Communities = req.Communities
-	s.config.SNMP.V3Credentials = v3Creds
-	s.config.SNMP.Timeout = time.Duration(req.Timeout) * time.Millisecond
-	s.config.SNMP.Retries = req.Retries
-	s.config.SNMP.Port = req.Port
-
-	// Save config (passwords are now encrypted) (fixes #782 - return error instead of silent warning)
-	if err := s.config.Save(s.configPath); err != nil {
-		logger.ErrorContext(r.Context(), "Failed to save config", "error", err)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			localizer.T("errors.config.failedToSave"),
-			"",
-		) // fixes #H7
-		return
+// snmpViewToResponse maps the service read model to the wire DTO.
+func snmpViewToResponse(v securitysettings.SNMPView) SNMPSettingsResponse {
+	creds := make([]SNMPv3CredentialResponse, len(v.V3Credentials))
+	for i, c := range v.V3Credentials {
+		creds[i] = SNMPv3CredentialResponse{
+			Name:          c.Name,
+			Username:      c.Username,
+			AuthProtocol:  c.AuthProtocol,
+			AuthPassword:  c.AuthPassword,
+			PrivProtocol:  c.PrivProtocol,
+			PrivPassword:  c.PrivPassword,
+			ContextName:   c.ContextName,
+			SecurityLevel: c.SecurityLevel,
+		}
 	}
+	return SNMPSettingsResponse{
+		Communities:   v.Communities,
+		V3Credentials: creds,
+		Timeout:       v.TimeoutMs,
+		Retries:       v.Retries,
+		Port:          v.Port,
+	}
+}
 
-	sendJSONResponse(w, logger, http.StatusOK, map[string]string{
-		"status":  statusSuccess,
-		"message": "SNMP settings updated",
-	})
+// snmpRequestToUpdate maps the wire DTO to the domain update model.
+func snmpRequestToUpdate(req SNMPSettingsResponse) securitysettings.SNMPUpdate {
+	creds := make([]securitysettings.SNMPv3Credential, len(req.V3Credentials))
+	for i, c := range req.V3Credentials {
+		creds[i] = securitysettings.SNMPv3Credential{
+			Name:          c.Name,
+			Username:      c.Username,
+			AuthProtocol:  c.AuthProtocol,
+			AuthPassword:  c.AuthPassword,
+			PrivProtocol:  c.PrivProtocol,
+			PrivPassword:  c.PrivPassword,
+			ContextName:   c.ContextName,
+			SecurityLevel: c.SecurityLevel,
+		}
+	}
+	return securitysettings.SNMPUpdate{
+		Communities:   req.Communities,
+		V3Credentials: creds,
+		TimeoutMs:     req.Timeout,
+		Retries:       req.Retries,
+		Port:          req.Port,
+	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -61,6 +61,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
 	"github.com/MustardSeedNetworks/seed/internal/profiles/catalog"
 	"github.com/MustardSeedNetworks/seed/internal/scheduler"
+	securitysettings "github.com/MustardSeedNetworks/seed/internal/security/settings"
 	"github.com/MustardSeedNetworks/seed/internal/settings/management"
 	"github.com/MustardSeedNetworks/seed/internal/settings/persistence"
 	"github.com/MustardSeedNetworks/seed/internal/timeseries/retention"
@@ -244,6 +245,7 @@ type Server struct {
 	wifiDiscovery      *troubleshooting.Discovery  // Enhanced Wi-Fi discovery use-case (ADR-0020)
 	settingsStore      *persistence.Service        // Settings-to-profile persistence use-case (ADR-0020)
 	settingsManagement *management.Service         // Main settings read/apply use-case (ADR-0020)
+	securitySettings   *securitysettings.Service   // SNMP + rogue-DHCP settings use-case (ADR-0020)
 	profiles           *catalog.Service            // Profile CRUD/active/import use-case (ADR-0020)
 	networkIP          *ipconfig.Service           // IP-config + MTU use-case (ADR-0020)
 	alertRules         *rules.Service              // Alert-rule CRUD use-case (ADR-0020)
@@ -372,6 +374,7 @@ func NewServer(
 	// builds the adapters; api passes its lazy db accessor + live config.
 	s.settingsStore = app.NewSettings(s.db, s.config)
 	s.settingsManagement = app.NewSettingsManagement(s.config, s.configPath)
+	s.securitySettings = app.NewSecuritySettings(s.config, s.configPath, s.rogueDetector)
 
 	// Wire the profiles catalog use-case (ADR-0020). The composition root builds
 	// the adapter; api passes its lazy db accessor.

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -158,6 +158,7 @@ func NewTestServerWithConfig(cfg *config.Config) *Server {
 	// adapter-absent states.
 	s.settingsStore = app.NewSettings(s.db, s.config)
 	s.settingsManagement = app.NewSettingsManagement(s.config, s.configPath)
+	s.securitySettings = app.NewSecuritySettings(s.config, s.configPath, s.rogueDetector)
 	s.profiles = app.NewProfiles(s.db)
 	s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)
 	s.alertRules = app.NewAlertRules(s.db)

--- a/internal/app/security.go
+++ b/internal/app/security.go
@@ -1,0 +1,76 @@
+package app
+
+// security.go wires the composition root to the security-settings application
+// service (ADR-0020): SNMP credentials and rogue-DHCP detection configuration.
+// The adapters implement the narrow ports declared in internal/security/settings
+// over the live config and the live rogue-DHCP detector, so the handlers depend
+// on a use-case instead of reaching into s.config / the detector directly. The
+// detector is resolved lazily so a later-set value (the api test harness) is
+// honored; a nil detector degrades the rogue reads/updates to empty no-ops.
+
+import (
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/dhcp"
+	"github.com/MustardSeedNetworks/seed/internal/security/settings"
+)
+
+// NewSecuritySettings builds the security-settings use-case over the live config
+// (read/encrypt/persist) and a lazy accessor for the rogue-DHCP detector.
+func NewSecuritySettings(
+	cfg *config.Config, path string, detector func() *dhcp.RogueDetector,
+) *settings.Service {
+	return settings.NewService(
+		securitySettingsStore{cfg: cfg, path: path},
+		securityRogueDetector{detector: detector},
+	)
+}
+
+// securitySettingsStore implements settings.Store over the live config, owning the
+// lock + on-disk save the port abstracts away. Write releases the lock before
+// Save (Save acquires its own RLock; saving while write-locked would deadlock —
+// the #783 pattern).
+type securitySettingsStore struct {
+	cfg  *config.Config
+	path string
+}
+
+func (s securitySettingsStore) Read(fn func(*config.Config)) {
+	s.cfg.RLock()
+	defer s.cfg.RUnlock()
+	fn(s.cfg)
+}
+
+func (s securitySettingsStore) Write(fn func(*config.Config) error) error {
+	s.cfg.Lock()
+	err := fn(s.cfg)
+	s.cfg.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.cfg.Save(s.path)
+}
+
+// securityRogueDetector implements settings.RogueDetector over the live detector,
+// resolved lazily; a nil detector yields an empty config and a no-op update.
+type securityRogueDetector struct {
+	detector func() *dhcp.RogueDetector
+}
+
+func (a securityRogueDetector) Config() settings.DetectorConfig {
+	d := a.detector()
+	if d == nil {
+		return settings.DetectorConfig{}
+	}
+	c := d.GetConfig()
+	return settings.DetectorConfig{
+		Interface:        c.Interface,
+		KnownServers:     c.KnownServers,
+		AlertOnDetection: c.AlertOnDetection,
+	}
+}
+
+func (a securityRogueDetector) UpdateKnownServers(servers []string) {
+	if d := a.detector(); d != nil {
+		d.UpdateKnownServers(servers)
+	}
+}

--- a/internal/security/settings/settings.go
+++ b/internal/security/settings/settings.go
@@ -1,0 +1,268 @@
+// Package settings is the application service for the security-settings endpoints
+// (ADR-0020 clean-hexagonal, WS-A3): SNMP credentials and rogue-DHCP detection
+// configuration. It owns the read/mask/encrypt/merge/persist logic the transport
+// layer used to carry inline. Persistence is reached through the consumer-defined
+// Store port; the live rogue-DHCP detector through the RogueDetector port. Both
+// are satisfied by adapters in the composition root (internal/app).
+package settings
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+)
+
+// PasswordPlaceholder is the masked value returned for stored SNMP passwords. A
+// PUT carrying the placeholder for a credential leaves that stored password
+// unchanged (never re-encrypts the mask).
+const PasswordPlaceholder = "*****"
+
+// Sentinel errors the transport layer maps to HTTP status / i18n messages.
+var (
+	// ErrEncryptAuth wraps a failure to encrypt an SNMPv3 auth password.
+	ErrEncryptAuth = errors.New("settings: encrypt auth password")
+	// ErrEncryptPriv wraps a failure to encrypt an SNMPv3 priv password.
+	ErrEncryptPriv = errors.New("settings: encrypt priv password")
+)
+
+// Store reads and persists the live config. Read runs fn under the config RLock;
+// Write runs fn under the write lock and, when fn returns nil, persists to disk
+// after releasing the lock (the #783 unlock-before-save pattern — Save acquires
+// its own RLock, so saving while write-locked would deadlock).
+type Store interface {
+	Read(fn func(*config.Config))
+	Write(fn func(*config.Config) error) error
+}
+
+// RogueDetector is the live rogue-DHCP detector surface the use-case needs: its
+// effective config (interface/known-servers/alert) and a known-servers update.
+type RogueDetector interface {
+	Config() DetectorConfig
+	UpdateKnownServers(servers []string)
+}
+
+// DetectorConfig mirrors the live detector's effective configuration.
+type DetectorConfig struct {
+	Interface        string
+	KnownServers     []string
+	AlertOnDetection bool
+}
+
+// Service is the security-settings application service.
+type Service struct {
+	store    Store
+	detector RogueDetector
+}
+
+// NewService builds the service over its ports.
+func NewService(store Store, detector RogueDetector) *Service {
+	return &Service{store: store, detector: detector}
+}
+
+// ---------------------------------------------------------------------------
+// SNMP
+// ---------------------------------------------------------------------------
+
+// SNMPv3Credential is the wire-neutral SNMPv3 credential. On read, AuthPassword/
+// PrivPassword carry PasswordPlaceholder when a stored password exists; on write,
+// the placeholder means "keep the stored password".
+type SNMPv3Credential struct {
+	Name          string
+	Username      string
+	AuthProtocol  string
+	AuthPassword  string
+	PrivProtocol  string
+	PrivPassword  string
+	ContextName   string
+	SecurityLevel string
+}
+
+// SNMPView is the SNMP settings read model (passwords masked).
+type SNMPView struct {
+	Communities   []string
+	V3Credentials []SNMPv3Credential
+	TimeoutMs     int
+	Retries       int
+	Port          int
+}
+
+// SNMPUpdate is the SNMP settings write model.
+type SNMPUpdate struct {
+	Communities   []string
+	V3Credentials []SNMPv3Credential
+	TimeoutMs     int
+	Retries       int
+	Port          int
+}
+
+// SNMP returns the SNMP settings with passwords masked — actual stored passwords
+// are never returned.
+func (s *Service) SNMP() SNMPView {
+	var view SNMPView
+	s.store.Read(func(cfg *config.Config) {
+		creds := make([]SNMPv3Credential, len(cfg.SNMP.V3Credentials))
+		for i := range cfg.SNMP.V3Credentials {
+			c := &cfg.SNMP.V3Credentials[i]
+			creds[i] = SNMPv3Credential{
+				Name:          c.Name,
+				Username:      c.Username,
+				AuthProtocol:  c.AuthProtocol,
+				AuthPassword:  maskIfSet(c.AuthPassword),
+				PrivProtocol:  c.PrivProtocol,
+				PrivPassword:  maskIfSet(c.PrivPassword),
+				ContextName:   c.ContextName,
+				SecurityLevel: c.SecurityLevel,
+			}
+		}
+		view = SNMPView{
+			Communities:   cfg.SNMP.Communities,
+			V3Credentials: creds,
+			TimeoutMs:     int(cfg.SNMP.Timeout.Milliseconds()),
+			Retries:       cfg.SNMP.Retries,
+			Port:          cfg.SNMP.Port,
+		}
+	})
+	return view
+}
+
+// UpdateSNMP encrypts any newly-supplied passwords (preserving stored ones sent as
+// the placeholder) and persists the settings. Encryption runs under the write
+// lock; the save happens after the lock is released. Returns ErrEncryptAuth /
+// ErrEncryptPriv when a password cannot be encrypted.
+func (s *Service) UpdateSNMP(in SNMPUpdate) error {
+	return s.store.Write(func(cfg *config.Config) error {
+		creds := make([]config.SNMPv3Credential, len(in.V3Credentials))
+		for i := range in.V3Credentials {
+			var existing *config.SNMPv3Credential
+			if i < len(cfg.SNMP.V3Credentials) {
+				existing = &cfg.SNMP.V3Credentials[i]
+			}
+			converted, err := convertCredential(cfg, in.V3Credentials[i], existing)
+			if err != nil {
+				return err
+			}
+			creds[i] = converted
+		}
+		cfg.SNMP.Communities = in.Communities
+		cfg.SNMP.V3Credentials = creds
+		cfg.SNMP.Timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+		cfg.SNMP.Retries = in.Retries
+		cfg.SNMP.Port = in.Port
+		return nil
+	})
+}
+
+// convertCredential maps a wire credential to config form, encrypting a freshly
+// supplied password and preserving the stored one when the placeholder is sent.
+func convertCredential(
+	cfg *config.Config, in SNMPv3Credential, existing *config.SNMPv3Credential,
+) (config.SNMPv3Credential, error) {
+	out := config.SNMPv3Credential{
+		Name:          in.Name,
+		Username:      in.Username,
+		AuthProtocol:  in.AuthProtocol,
+		PrivProtocol:  in.PrivProtocol,
+		ContextName:   in.ContextName,
+		SecurityLevel: in.SecurityLevel,
+	}
+
+	switch {
+	case in.AuthPassword != "" && in.AuthPassword != PasswordPlaceholder:
+		enc, err := cfg.EncryptCredentialValue(in.AuthPassword)
+		if err != nil {
+			return out, fmt.Errorf("%w: %w", ErrEncryptAuth, err)
+		}
+		out.AuthPassword = enc
+	case existing != nil:
+		out.AuthPassword = existing.AuthPassword
+	}
+
+	switch {
+	case in.PrivPassword != "" && in.PrivPassword != PasswordPlaceholder:
+		enc, err := cfg.EncryptCredentialValue(in.PrivPassword)
+		if err != nil {
+			return out, fmt.Errorf("%w: %w", ErrEncryptPriv, err)
+		}
+		out.PrivPassword = enc
+	case existing != nil:
+		out.PrivPassword = existing.PrivPassword
+	}
+
+	return out, nil
+}
+
+func maskIfSet(stored string) string {
+	if stored != "" {
+		return PasswordPlaceholder
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Rogue DHCP detection
+// ---------------------------------------------------------------------------
+
+// RogueView is the rogue-DHCP configuration read model: Enabled from the config,
+// the rest from the live detector.
+type RogueView struct {
+	Enabled          bool
+	KnownServers     []string
+	AlertOnDetection bool
+	Interface        string
+}
+
+// RogueUpdate is the rogue-DHCP configuration write model; nil fields are left
+// unchanged (the original partial-update contract).
+type RogueUpdate struct {
+	Enabled          *bool
+	KnownServers     []string
+	AlertOnDetection *bool
+}
+
+// RogueEnabled reports whether rogue-DHCP detection is enabled in the config —
+// the precondition the detector-control handlers gate on, without reaching into
+// the config directly.
+func (s *Service) RogueEnabled() bool {
+	var enabled bool
+	s.store.Read(func(cfg *config.Config) { enabled = cfg.DHCP.RogueDetection.Enabled })
+	return enabled
+}
+
+// RogueDHCP returns the effective rogue-DHCP configuration.
+func (s *Service) RogueDHCP() RogueView {
+	var enabled bool
+	s.store.Read(func(cfg *config.Config) { enabled = cfg.DHCP.RogueDetection.Enabled })
+	dc := s.detector.Config()
+	return RogueView{
+		Enabled:          enabled,
+		KnownServers:     dc.KnownServers,
+		AlertOnDetection: dc.AlertOnDetection,
+		Interface:        dc.Interface,
+	}
+}
+
+// UpdateRogueDHCP applies the partial update to the config, persists it, then
+// syncs the live detector's known-server set when the caller supplied one.
+func (s *Service) UpdateRogueDHCP(in RogueUpdate) error {
+	err := s.store.Write(func(cfg *config.Config) error {
+		if in.Enabled != nil {
+			cfg.DHCP.RogueDetection.Enabled = *in.Enabled
+		}
+		if in.KnownServers != nil {
+			cfg.DHCP.RogueDetection.KnownServers = in.KnownServers
+		}
+		if in.AlertOnDetection != nil {
+			cfg.DHCP.RogueDetection.AlertOnDetection = *in.AlertOnDetection
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if in.KnownServers != nil {
+		s.detector.UpdateKnownServers(in.KnownServers)
+	}
+	return nil
+}

--- a/internal/security/settings/settings_test.go
+++ b/internal/security/settings/settings_test.go
@@ -1,0 +1,125 @@
+package settings_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/security/settings"
+)
+
+type fakeStore struct{ cfg *config.Config }
+
+func (f *fakeStore) Read(fn func(*config.Config))              { fn(f.cfg) }
+func (f *fakeStore) Write(fn func(*config.Config) error) error { return fn(f.cfg) }
+
+type fakeDetector struct {
+	cfg          settings.DetectorConfig
+	lastKnownSet []string
+}
+
+func (d *fakeDetector) Config() settings.DetectorConfig     { return d.cfg }
+func (d *fakeDetector) UpdateKnownServers(servers []string) { d.lastKnownSet = servers }
+
+func newService(t *testing.T) (*settings.Service, *config.Config, *fakeDetector) {
+	t.Helper()
+	cfg := &config.Config{}
+	if err := cfg.InitCredentialKeyring(t.TempDir()); err != nil {
+		t.Fatalf("InitCredentialKeyring: %v", err)
+	}
+	det := &fakeDetector{}
+	return settings.NewService(&fakeStore{cfg: cfg}, det), cfg, det
+}
+
+func TestSNMPMasksStoredPasswords(t *testing.T) {
+	svc, cfg, _ := newService(t)
+	cfg.SNMP.V3Credentials = []config.SNMPv3Credential{
+		{Name: "c1", Username: "u", AuthPassword: "stored-enc", PrivPassword: ""},
+	}
+	view := svc.SNMP()
+	if len(view.V3Credentials) != 1 {
+		t.Fatalf("want 1 credential, got %d", len(view.V3Credentials))
+	}
+	if view.V3Credentials[0].AuthPassword != settings.PasswordPlaceholder {
+		t.Errorf("stored auth password should be masked, got %q", view.V3Credentials[0].AuthPassword)
+	}
+	if view.V3Credentials[0].PrivPassword != "" {
+		t.Errorf("absent priv password should stay empty, got %q", view.V3Credentials[0].PrivPassword)
+	}
+}
+
+func TestUpdateSNMPEncryptsNewPassword(t *testing.T) {
+	svc, cfg, _ := newService(t)
+	err := svc.UpdateSNMP(settings.SNMPUpdate{
+		Communities:   []string{"public"},
+		V3Credentials: []settings.SNMPv3Credential{{Name: "c1", Username: "u", AuthPassword: "secret"}},
+		TimeoutMs:     2000,
+		Retries:       3,
+		Port:          161,
+	})
+	if err != nil {
+		t.Fatalf("UpdateSNMP: %v", err)
+	}
+	stored := cfg.SNMP.V3Credentials[0].AuthPassword
+	if stored == "" || stored == "secret" {
+		t.Errorf("auth password should be encrypted, got %q", stored)
+	}
+	if cfg.SNMP.Timeout != 2*time.Second || cfg.SNMP.Port != 161 {
+		t.Errorf("scalar fields not applied: %+v", cfg.SNMP)
+	}
+}
+
+func TestUpdateSNMPPlaceholderPreservesStored(t *testing.T) {
+	svc, cfg, _ := newService(t)
+	cfg.SNMP.V3Credentials = []config.SNMPv3Credential{{Name: "c1", AuthPassword: "already-enc"}}
+
+	err := svc.UpdateSNMP(settings.SNMPUpdate{
+		V3Credentials: []settings.SNMPv3Credential{{Name: "c1", AuthPassword: settings.PasswordPlaceholder}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateSNMP: %v", err)
+	}
+	if cfg.SNMP.V3Credentials[0].AuthPassword != "already-enc" {
+		t.Errorf("placeholder should preserve stored password, got %q", cfg.SNMP.V3Credentials[0].AuthPassword)
+	}
+}
+
+func TestRogueDHCPReadComposesConfigAndDetector(t *testing.T) {
+	svc, cfg, det := newService(t)
+	cfg.DHCP.RogueDetection.Enabled = true
+	det.cfg = settings.DetectorConfig{
+		Interface: "eth0", KnownServers: []string{"10.0.0.1"}, AlertOnDetection: true,
+	}
+	view := svc.RogueDHCP()
+	if !view.Enabled || view.Interface != "eth0" || !view.AlertOnDetection ||
+		len(view.KnownServers) != 1 {
+		t.Errorf("RogueDHCP did not compose config + detector: %+v", view)
+	}
+}
+
+func TestUpdateRogueDHCPAppliesAndSyncsDetector(t *testing.T) {
+	svc, cfg, det := newService(t)
+	enabled := true
+	err := svc.UpdateRogueDHCP(settings.RogueUpdate{
+		Enabled:      &enabled,
+		KnownServers: []string{"10.0.0.1", "10.0.0.2"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateRogueDHCP: %v", err)
+	}
+	if !cfg.DHCP.RogueDetection.Enabled || len(cfg.DHCP.RogueDetection.KnownServers) != 2 {
+		t.Errorf("config not applied: %+v", cfg.DHCP.RogueDetection)
+	}
+	if len(det.lastKnownSet) != 2 {
+		t.Errorf("detector known-servers not synced: %v", det.lastKnownSet)
+	}
+
+	// A nil-KnownServers update must not re-sync the detector.
+	det.lastKnownSet = nil
+	if err = svc.UpdateRogueDHCP(settings.RogueUpdate{Enabled: &enabled}); err != nil {
+		t.Fatalf("UpdateRogueDHCP (nil servers): %v", err)
+	}
+	if det.lastKnownSet != nil {
+		t.Errorf("detector should not sync when KnownServers is nil, got %v", det.lastKnownSet)
+	}
+}


### PR DESCRIPTION
**WS-A3** — `handlers_security.go` carried **32** inline `s.config` reaches across two settings surfaces (SNMP credentials + rogue-DHCP detection config). Both moved behind a clean-hexagonal service.

## 🐛 Bug fix (latent deadlock)
`updateSNMPSettings` held `config.Lock()` (write) via `defer Unlock()`, then called `config.Save()` — which does `c.mu.RLock()` on the **same goroutine**. Go's RWMutex can't recursively RLock while write-held → the SNMP PUT would **hang**. The service's `Store.Write` encrypts under the lock then saves *after* releasing it (the #783 pattern), fixing it.

## Shape
- **`internal/security/settings`** — `Service` over a `Store` port (Read/Write) + a `RogueDetector` port. `SNMP()` masks stored passwords; `UpdateSNMP()` encrypts new passwords under lock (placeholder ⇒ keep stored), typed `ErrEncryptAuth`/`ErrEncryptPriv`. `RogueDHCP()`/`UpdateRogueDHCP()`/`RogueEnabled()`.
- **`internal/app/security.go`** — `NewSecuritySettings` + adapters (config lock+save; nil-safe detector).
- **`handlers_security.go`** — SNMP + rogue-config handlers now thin; the 3 detector-control gate reads repoint to `RogueEnabled()`. **593→499 LOC; zero `s.config` reaches remain.**
- **`testing.go`** wires `securitySettings`.

## Gates
service tests (mask / encrypt-new / placeholder-preserve / rogue read+update+detector-sync); **non-race api suite green (39s)**; `-race` on the changed packages green; filename/route/escaping/`--new-from-rev` lint all green. No route/golden/migration change.

> Full-package `-race` runs hit the known Go 1.26.4 race-GC flake under local load; changed surface is race-clean. CI race job runs fresh.