### PR TITLE
refactor(api): strangle health-checks settings into a use-case (ADR-0020, WS-A4)

### DIFF
--- a/internal/api/handlers_health_checks_settings.go
+++ b/internal/api/handlers_health_checks_settings.go
@@ -9,8 +9,7 @@ import (
 	"net/http"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
-	"github.com/MustardSeedNetworks/seed/internal/database"
-	"github.com/MustardSeedNetworks/seed/internal/diagnostics/dns"
+	healthsettings "github.com/MustardSeedNetworks/seed/internal/health/settings"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
@@ -38,9 +37,9 @@ func (s *Server) handleHealthChecksSettings(w http.ResponseWriter, r *http.Reque
 }
 
 // buildDNSServersResponse converts config DNS servers to response format.
-func (s *Server) buildDNSServersResponse() []DNSServerResponse {
-	resp := make([]DNSServerResponse, 0, len(s.config.DNS.Servers))
-	for _, d := range s.config.DNS.Servers {
+func buildDNSServersResponse(servers []config.DNSServer) []DNSServerResponse {
+	resp := make([]DNSServerResponse, 0, len(servers))
+	for _, d := range servers {
 		resp = append(resp, DNSServerResponse{Address: d.Address, Enabled: d.Enabled})
 	}
 	return resp
@@ -222,9 +221,9 @@ func buildModbusEndpointsResponse(eps []config.ModbusEndpoint) []ModbusEndpointR
 func (s *Server) getHealthChecksSettings(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	hc, err := loadHealthCheckEndpoints(r.Context(), s.db().Probes())
+	st, err := s.healthSettings.Get(r.Context())
 	if err != nil {
-		logger.ErrorContext(r.Context(), "Failed to load health-check probes", "error", err)
+		logger.ErrorContext(r.Context(), "Failed to load health-check settings", "error", err)
 		sendErrorResponseWithDetails(
 			w, logger, http.StatusInternalServerError, ErrCodeInternal,
 			i18n.FromRequest(r).T("errors.settings.loadFailed"), "",
@@ -232,9 +231,10 @@ func (s *Server) getHealthChecksSettings(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	hc := st.Endpoints
 	resp := TestsSettingsResponse{
-		DNSHostname:        s.config.DNS.TestHostname,
-		DNSServers:         s.buildDNSServersResponse(),
+		DNSHostname:        st.DNSHostname,
+		DNSServers:         buildDNSServersResponse(st.DNSServers),
 		PingTargets:        buildPingTargetsResponse(hc.PingTargets),
 		TCPPorts:           buildTCPPortsResponse(hc.TCPPorts),
 		UDPPorts:           buildUDPPortsResponse(hc.UDPPorts),
@@ -249,47 +249,28 @@ func (s *Server) getHealthChecksSettings(w http.ResponseWriter, r *http.Request)
 		LTIEndpoints:       buildLTIEndpointsResponse(hc.LTIEndpoints),
 		OPCUAEndpoints:     buildOPCUAEndpointsResponse(hc.OPCUAEndpoints),
 		ModbusEndpoints:    buildModbusEndpointsResponse(hc.ModbusEndpoints),
-		RunPerformance:     s.config.HealthChecks.RunPerformance,
-		RunSpeedtest:       s.config.HealthChecks.RunSpeedtest,
-		RunIperf:           s.config.HealthChecks.RunIperf,
-		RunDiscovery:       s.config.HealthChecks.RunDiscovery,
+		RunPerformance:     st.RunPerformance,
+		RunSpeedtest:       st.RunSpeedtest,
+		RunIperf:           st.RunIperf,
+		RunDiscovery:       st.RunDiscovery,
 		Speedtest: SpeedtestSettingsResponse{
-			ServerID:      s.config.Speedtest.ServerID,
-			AutoRunOnLink: s.config.Speedtest.AutoRunOnLink,
+			ServerID:      st.SpeedtestServerID,
+			AutoRunOnLink: st.SpeedtestAutoRunOnLink,
 		},
 		Iperf: IperfSettingsResponse{
-			AutoRunOnLink: s.config.Iperf.AutoRunOnLink,
+			AutoRunOnLink: st.IperfAutoRunOnLink,
 		},
 	}
 	sendJSONResponse(w, logger, http.StatusOK, resp)
 }
 
-// applyDNSSettings applies DNS configuration from request.
-func (s *Server) applyDNSSettings(req *TestsSettingsResponse) {
-	if req.DNSHostname != "" {
-		s.config.DNS.TestHostname = req.DNSHostname
-		if s.dnsTester() != nil {
-			s.dnsTester().SetTestHostname(req.DNSHostname)
-		}
-	}
-
-	s.config.DNS.Servers = make([]config.DNSServer, 0, len(req.DNSServers))
+// requestDNSServers maps the wire DNS server list to config form.
+func requestDNSServers(req *TestsSettingsResponse) []config.DNSServer {
+	servers := make([]config.DNSServer, 0, len(req.DNSServers))
 	for _, d := range req.DNSServers {
-		s.config.DNS.Servers = append(
-			s.config.DNS.Servers,
-			config.DNSServer{Address: d.Address, Enabled: d.Enabled},
-		)
+		servers = append(servers, config.DNSServer{Address: d.Address, Enabled: d.Enabled})
 	}
-	if s.dnsTester() != nil {
-		configuredServers := make([]dns.ConfiguredServer, 0, len(s.config.DNS.Servers))
-		for _, d := range s.config.DNS.Servers {
-			configuredServers = append(
-				configuredServers,
-				dns.ConfiguredServer{Address: d.Address, Enabled: d.Enabled},
-			)
-		}
-		s.dnsTester().SetConfiguredServers(configuredServers)
-	}
+	return servers
 }
 
 // requestEndpointTargets builds a HealthChecksConfig from the request's
@@ -421,21 +402,9 @@ func requestEndpointTargets(req *TestsSettingsResponse) config.HealthChecksConfi
 }
 
 // applyPerformanceSettings applies performance test configuration from request.
-func (s *Server) applyPerformanceSettings(req *TestsSettingsResponse) {
-	s.config.HealthChecks.RunPerformance = req.RunPerformance
-	s.config.HealthChecks.RunSpeedtest = req.RunSpeedtest
-	s.config.HealthChecks.RunIperf = req.RunIperf
-	s.config.HealthChecks.RunDiscovery = req.RunDiscovery
-
-	s.config.Speedtest.ServerID = req.Speedtest.ServerID
-	s.config.Speedtest.AutoRunOnLink = req.Speedtest.AutoRunOnLink
-	if s.speedtestTester() != nil {
-		s.speedtestTester().SetServerID(req.Speedtest.ServerID)
-	}
-
-	s.config.Iperf.AutoRunOnLink = req.Iperf.AutoRunOnLink
-}
-
+// updateHealthChecksSettings persists the health-checks settings. Thin transport
+// (ADR-0020): decode, map the wire DTO to the domain model, and delegate the
+// probe-table + config persistence + tester sync to the service.
 func (s *Server) updateHealthChecksSettings(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
@@ -445,28 +414,23 @@ func (s *Server) updateHealthChecksSettings(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// The endpoint targets are the store-of-record in the probes table
-	// (ADR-0027 P2); the DNS, performance, and speedtest/iperf toggles
-	// remain config-file backed.
-	if !s.saveHealthCheckProbes(w, r, &req) {
-		return
-	}
-
-	// Lock config for write access (unlock before Save to avoid deadlock).
-	s.config.Lock()
-	s.applyDNSSettings(&req)
-	s.applyPerformanceSettings(&req)
-	s.config.Unlock()
-
-	if err := s.config.Save(s.configPath); err != nil {
-		logger.ErrorContext(r.Context(), "Failed to save config", "error", err)
+	err := s.healthSettings.Update(r.Context(), healthsettings.Settings{
+		Endpoints:              requestEndpointTargets(&req),
+		DNSHostname:            req.DNSHostname,
+		DNSServers:             requestDNSServers(&req),
+		RunPerformance:         req.RunPerformance,
+		RunSpeedtest:           req.RunSpeedtest,
+		RunIperf:               req.RunIperf,
+		RunDiscovery:           req.RunDiscovery,
+		SpeedtestServerID:      req.Speedtest.ServerID,
+		SpeedtestAutoRunOnLink: req.Speedtest.AutoRunOnLink,
+		IperfAutoRunOnLink:     req.Iperf.AutoRunOnLink,
+	})
+	if err != nil {
+		logger.ErrorContext(r.Context(), "Failed to save health-checks settings", "error", err)
 		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			localizer.T("errors.settings.saveFailed"),
-			"",
+			w, logger, http.StatusInternalServerError, ErrCodeInternal,
+			localizer.T("errors.settings.saveFailed"), "",
 		)
 		return
 	}
@@ -475,47 +439,6 @@ func (s *Server) updateHealthChecksSettings(w http.ResponseWriter, r *http.Reque
 		Status:  statusSuccess,
 		Message: "Health checks settings updated",
 	})
-}
-
-// saveHealthCheckProbes persists the request's endpoint targets to the
-// probes table (replacing the existing health-check-kind probes) and
-// reschedules the running probe engine so the change takes effect without
-// a restart. Returns false (after writing an error response) on failure.
-func (s *Server) saveHealthCheckProbes(w http.ResponseWriter, r *http.Request, req *TestsSettingsResponse) bool {
-	logger := logging.FromContext(r.Context())
-	localizer := i18n.FromRequest(r)
-
-	hc := requestEndpointTargets(req)
-	probes, err := healthCheckProbesFromConfig(&hc)
-	if err != nil {
-		logger.ErrorContext(r.Context(), "Failed to map health-check endpoints to probes", "error", err)
-		sendErrorResponseWithDetails(
-			w, logger, http.StatusInternalServerError, ErrCodeInternal,
-			localizer.T("errors.settings.saveFailed"), "",
-		)
-		return false
-	}
-
-	if dbErr := s.db().Probes().ReplaceProbesByKinds(
-		r.Context(), database.DefaultClientID, healthCheckKinds(), probes,
-	); dbErr != nil {
-		logger.ErrorContext(r.Context(), "Failed to persist health-check probes", "error", dbErr)
-		sendErrorResponseWithDetails(
-			w, logger, http.StatusInternalServerError, ErrCodeInternal,
-			localizer.T("errors.settings.saveFailed"), "",
-		)
-		return false
-	}
-
-	// Best-effort reschedule: persistence already succeeded, so a
-	// reschedule failure is logged but not surfaced — the new set takes
-	// effect on the next engine start regardless.
-	if s.probeEngine != nil {
-		if rErr := s.probeEngine.Reschedule(r.Context()); rErr != nil {
-			logger.WarnContext(r.Context(), "Failed to reschedule probe engine after settings save", "error", rErr)
-		}
-	}
-	return true
 }
 
 // statusResponse is the JSON body returned by simple ack-style endpoints.

--- a/internal/api/handlers_health_checks_settings_internal_test.go
+++ b/internal/api/handlers_health_checks_settings_internal_test.go
@@ -5,21 +5,56 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
+// wireHealthSettings wires the health-settings use-case onto s over its current
+// config/db/testers. Used by the api-internal tests that drive the GET/PUT
+// handlers on a bare Server (no probe engine / testers — those degrade to no-ops).
+func wireHealthSettings(s *Server) {
+	s.healthSettings = app.NewHealthSettings(
+		s.healthProbeRepo, s.rescheduleProbeEngine,
+		s.config, s.configPath, s.dnsTester, s.speedtestTester,
+	)
+}
+
+// newHealthSettingsServer builds a minimal Server wired with the health-settings
+// use-case over a real test DB and a temp config path (so the PUT's config save
+// succeeds), exercising the strangled PUT/GET path end-to-end.
+func newHealthSettingsServer(t *testing.T) *Server {
+	t.Helper()
+	s := &Server{
+		config:     &config.Config{},
+		configPath: filepath.Join(t.TempDir(), "config.yaml"),
+		dbConn:     newTestDB(t),
+	}
+	wireHealthSettings(s)
+	return s
+}
+
+func putHealthChecksSettings(t *testing.T, s *Server, req TestsSettingsResponse) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/settings/health-checks", bytes.NewReader(body))
+	s.updateHealthChecksSettings(w, r)
+	return w
+}
+
 // TestHealthChecksSettingsRoundTrip exercises the ADR-0027 P2 store-of-record
-// move: saving health-check settings persists the endpoint targets to the
-// probes table, and reading them back reconstructs the same endpoints —
-// including a vertical kind (HL7) that the pre-P2 save path silently dropped.
+// move: saving health-check settings persists the endpoint targets to the probes
+// table, and reading them back reconstructs the same endpoints — including a
+// vertical kind (HL7) that the pre-P2 save path silently dropped.
 func TestHealthChecksSettingsRoundTrip(t *testing.T) {
-	db := newTestDB(t)
-	s := &Server{config: &config.Config{}, dbConn: db}
+	s := newHealthSettingsServer(t)
 
 	req := TestsSettingsResponse{
 		PingTargets: []PingTargetResponse{
@@ -30,15 +65,11 @@ func TestHealthChecksSettingsRoundTrip(t *testing.T) {
 		},
 	}
 
-	// Save via the persistence path used by the PUT handler.
-	body, _ := json.Marshal(req)
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodPut, "/x", bytes.NewReader(body))
-	require.True(t, s.saveHealthCheckProbes(w, r, &req),
-		"saveHealthCheckProbes should succeed; got %d %s", w.Code, w.Body.String())
+	w := putHealthChecksSettings(t, s, req)
+	require.Equal(t, http.StatusOK, w.Code, "PUT body: %s", w.Body.String())
 
 	// The probes table now holds exactly the two endpoints, as their kinds.
-	probes, err := db.Probes().ListProbes(r.Context(), database.DefaultClientID, "")
+	probes, err := s.dbConn.Probes().ListProbes(t.Context(), database.DefaultClientID, "")
 	require.NoError(t, err)
 	kinds := map[string]string{}
 	for _, p := range probes {
@@ -49,7 +80,7 @@ func TestHealthChecksSettingsRoundTrip(t *testing.T) {
 
 	// Read back through the GET handler.
 	gw := httptest.NewRecorder()
-	gr := httptest.NewRequest(http.MethodGet, "/x", http.NoBody)
+	gr := httptest.NewRequest(http.MethodGet, "/api/v1/settings/health-checks", http.NoBody)
 	s.getHealthChecksSettings(gw, gr)
 	require.Equal(t, http.StatusOK, gw.Code, "GET body: %s", gw.Body.String())
 
@@ -63,11 +94,10 @@ func TestHealthChecksSettingsRoundTrip(t *testing.T) {
 	require.Equal(t, "SEED", got.HL7Endpoints[0].SendingApp, "vertical-specific params round-trip through params_json")
 }
 
-// TestSaveHealthCheckProbesReplacesPriorSet verifies that a second save
-// replaces the prior health-check probes rather than appending.
-func TestSaveHealthCheckProbesReplacesPriorSet(t *testing.T) {
-	db := newTestDB(t)
-	s := &Server{config: &config.Config{}, dbConn: db}
+// TestHealthChecksSettingsReplacesPriorSet verifies that a second save replaces
+// the prior health-check probes rather than appending.
+func TestHealthChecksSettingsReplacesPriorSet(t *testing.T) {
+	s := newHealthSettingsServer(t)
 
 	first := TestsSettingsResponse{
 		PingTargets: []PingTargetResponse{
@@ -75,16 +105,14 @@ func TestSaveHealthCheckProbesReplacesPriorSet(t *testing.T) {
 			{Name: "b", Host: "2.2.2.2", Enabled: true},
 		},
 	}
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodPut, "/x", http.NoBody)
-	require.True(t, s.saveHealthCheckProbes(w, r, &first))
+	require.Equal(t, http.StatusOK, putHealthChecksSettings(t, s, first).Code)
 
 	second := TestsSettingsResponse{
 		PingTargets: []PingTargetResponse{{Name: "c", Host: "3.3.3.3", Enabled: true}},
 	}
-	require.True(t, s.saveHealthCheckProbes(httptest.NewRecorder(), r, &second))
+	require.Equal(t, http.StatusOK, putHealthChecksSettings(t, s, second).Code)
 
-	count, err := db.Probes().CountProbes(r.Context(), database.DefaultClientID, "ping")
+	count, err := s.dbConn.Probes().CountProbes(t.Context(), database.DefaultClientID, "ping")
 	require.NoError(t, err)
 	require.Equal(t, 1, count, "second save should replace, not append")
 }

--- a/internal/api/healthcheckrun.go
+++ b/internal/api/healthcheckrun.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/health/probemap"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
@@ -298,7 +299,7 @@ func (s *Server) healthCheckProbes(ctx context.Context) ([]*database.Probe, erro
 // isHealthCheckKind reports whether kind is one of the fourteen kinds the
 // health-check surface owns.
 func isHealthCheckKind(kind string) bool {
-	return slices.Contains(healthCheckKinds(), kind)
+	return slices.Contains(probemap.Kinds(), kind)
 }
 
 // dispatchProbes runs each probe via Engine.RunNow with bounded concurrency

--- a/internal/api/healthcheckseed.go
+++ b/internal/api/healthcheckseed.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/health/probemap"
 )
 
 // settingKeyHealthChecksSeeded marks that the factory health-check probes
@@ -27,7 +28,7 @@ const settingKeyHealthChecksSeeded = "health_checks.seeded"
 // marker is set, and it never overwrites an install that already holds
 // health-check probes (the upgrade path, where the marker predates this
 // code). The factory set comes from config.DefaultConfig().HealthChecks and
-// is mapped through the same healthCheckProbesFromConfig used by the
+// is mapped through the same ProbesFromConfig used by the
 // settings-PUT save, so the two paths can never diverge.
 func (s *Server) seedDefaultHealthCheckProbes(ctx context.Context, db *database.DB) error {
 	settings := db.Settings()
@@ -43,7 +44,7 @@ func (s *Server) seedDefaultHealthCheckProbes(ctx context.Context, db *database.
 	// Upgrade guard: an install that already configured health-check probes
 	// (saved before this seeding existed, so no marker) must keep its set.
 	// Mark it seeded and leave the probes untouched.
-	existing, err := countHealthCheckProbes(ctx, db.Probes())
+	existing, err := probemap.CountProbes(ctx, db.Probes())
 	if err != nil {
 		return fmt.Errorf("count existing health-check probes: %w", err)
 	}
@@ -52,12 +53,12 @@ func (s *Server) seedDefaultHealthCheckProbes(ctx context.Context, db *database.
 	}
 
 	hc := config.DefaultConfig().HealthChecks
-	probes, err := healthCheckProbesFromConfig(&hc)
+	probes, err := probemap.ProbesFromConfig(&hc)
 	if err != nil {
 		return fmt.Errorf("build default health-check probes: %w", err)
 	}
 	if err = db.Probes().ReplaceProbesByKinds(
-		ctx, database.DefaultClientID, healthCheckKinds(), probes,
+		ctx, database.DefaultClientID, probemap.Kinds(), probes,
 	); err != nil {
 		return fmt.Errorf("seed default health-check probes: %w", err)
 	}

--- a/internal/api/healthcheckseed_internal_test.go
+++ b/internal/api/healthcheckseed_internal_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/health/probemap"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
 )
 
@@ -21,6 +22,7 @@ import (
 func TestSeedDefaultHealthCheckProbes_FreshInstall(t *testing.T) {
 	db := newTestDB(t)
 	s := &Server{config: &config.Config{}, dbConn: db}
+	wireHealthSettings(s)
 	ctx := context.Background()
 
 	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
@@ -75,7 +77,7 @@ func TestSeedDefaultHealthCheckProbes_NoReseedAfterDeleteAll(t *testing.T) {
 
 	// Operator clears the whole health-check set (settings save with no targets).
 	require.NoError(t, db.Probes().ReplaceProbesByKinds(
-		ctx, database.DefaultClientID, healthCheckKinds(), nil,
+		ctx, database.DefaultClientID, probemap.Kinds(), nil,
 	))
 
 	// A subsequent boot must NOT re-seed.
@@ -94,14 +96,16 @@ func TestSeedDefaultHealthCheckProbes_PreservesExistingProbes(t *testing.T) {
 	s := &Server{config: &config.Config{}, dbConn: db}
 	ctx := context.Background()
 
-	// Pre-existing operator-configured set, no seed marker.
+	// Pre-existing operator-configured set, no seed marker, written straight to
+	// the probes table (the store of record) via the shared mapping.
 	custom := TestsSettingsResponse{
 		PingTargets: []PingTargetResponse{{Name: "lab", Host: "10.0.0.1", Enabled: true}},
 	}
-	require.True(t, s.saveHealthCheckProbes(
-		httptest.NewRecorder(),
-		httptest.NewRequest(http.MethodPut, "/x", http.NoBody),
-		&custom,
+	hc := requestEndpointTargets(&custom)
+	customProbes, err := probemap.ProbesFromConfig(&hc)
+	require.NoError(t, err)
+	require.NoError(t, db.Probes().ReplaceProbesByKinds(
+		ctx, database.DefaultClientID, probemap.Kinds(), customProbes,
 	))
 
 	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -8,6 +8,7 @@ package api
 // retention each live in sibling server_*.go files.
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"strconv"
@@ -38,6 +39,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/engine"
 	enginestatus "github.com/MustardSeedNetworks/seed/internal/engine/status"
 	"github.com/MustardSeedNetworks/seed/internal/health/monitoring"
+	healthsettings "github.com/MustardSeedNetworks/seed/internal/health/settings"
 	ssosync "github.com/MustardSeedNetworks/seed/internal/identity/oauth"
 	"github.com/MustardSeedNetworks/seed/internal/identity/tokens"
 	"github.com/MustardSeedNetworks/seed/internal/identity/users"
@@ -254,6 +256,7 @@ type Server struct {
 	networkProblems    *problems.Service           // Network problem-detection use-case (ADR-0020)
 	bluetoothScans     *bluetooth.Service          // Bluetooth-discovery use-case (ADR-0020)
 	healthMonitoring   *monitoring.Service         // Health-monitoring use-case (ADR-0020)
+	healthSettings     *healthsettings.Service     // Health-checks settings use-case (ADR-0020)
 	updateLifecycle    *lifecycle.Service          // Update-lifecycle use-case (ADR-0020)
 	engineStatus       *enginestatus.Service       // Engine-status use-case (ADR-0020)
 	identityUsers      *users.Service              // User-management use-case (ADR-0020, ADR-0024)
@@ -932,6 +935,28 @@ func (s *Server) initDiscoveryUseCases() {
 // deleted — ADR-0026), so a nil or later-set store (the test harness) is honored.
 func (s *Server) initHealthUseCases() {
 	s.healthMonitoring = app.NewHealthMonitoring(s.anomalyStore, s.anomalyEngine)
+	s.healthSettings = app.NewHealthSettings(
+		s.healthProbeRepo, s.rescheduleProbeEngine,
+		s.config, s.configPath, s.dnsTester, s.speedtestTester,
+	)
+}
+
+// healthProbeRepo is the probes-table accessor the health-settings use-case reads
+// and writes through; nil when no DB is wired (the test harness).
+func (s *Server) healthProbeRepo() *database.ProbeRepository {
+	if s.dbConn == nil {
+		return nil
+	}
+	return s.dbConn.Probes()
+}
+
+// rescheduleProbeEngine reschedules the running probe engine after a settings
+// save; a nil engine is a no-op (best-effort, ADR-0027).
+func (s *Server) rescheduleProbeEngine(ctx context.Context) error {
+	if s.probeEngine == nil {
+		return nil
+	}
+	return s.probeEngine.Reschedule(ctx)
 }
 
 // initUpdateUseCases wires the update-lifecycle use-case (ADR-0020) from the

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -159,6 +159,10 @@ func NewTestServerWithConfig(cfg *config.Config) *Server {
 	s.settingsStore = app.NewSettings(s.db, s.config)
 	s.settingsManagement = app.NewSettingsManagement(s.config, s.configPath)
 	s.securitySettings = app.NewSecuritySettings(s.config, s.configPath, s.rogueDetector)
+	s.healthSettings = app.NewHealthSettings(
+		s.healthProbeRepo, s.rescheduleProbeEngine,
+		s.config, s.configPath, s.dnsTester, s.speedtestTester,
+	)
 	s.profiles = app.NewProfiles(s.db)
 	s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)
 	s.alertRules = app.NewAlertRules(s.db)

--- a/internal/app/healthsettings.go
+++ b/internal/app/healthsettings.go
@@ -1,0 +1,120 @@
+package app
+
+// healthsettings.go wires the composition root to the health-checks settings
+// application service (ADR-0020, WS-A4). The adapters implement the service's
+// ports over the probes table (the endpoint store of record, via the shared
+// internal/health/probemap mapping), the live config (DNS/perf toggles), and the
+// live DNS/speedtest testers. Collaborators are resolved lazily so a later-set
+// value (the api test harness) is honored, and nil collaborators degrade to
+// no-ops.
+
+import (
+	"context"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/diagnostics/dns"
+	"github.com/MustardSeedNetworks/seed/internal/diagnostics/speedtest"
+	"github.com/MustardSeedNetworks/seed/internal/health/probemap"
+	healthsettings "github.com/MustardSeedNetworks/seed/internal/health/settings"
+)
+
+// NewHealthSettings builds the health-checks settings use-case over the probes
+// table, the live config, and the live DNS/speedtest testers. reschedule is the
+// probe-engine reschedule (best-effort, nil-safe); dnsTester/speedTester are lazy
+// accessors.
+func NewHealthSettings(
+	probes func() *database.ProbeRepository,
+	reschedule func(context.Context) error,
+	cfg *config.Config,
+	path string,
+	dnsTester func() *dns.Tester,
+	speedTester func() *speedtest.Tester,
+) *healthsettings.Service {
+	return healthsettings.NewService(
+		healthProbeStore{probes: probes, reschedule: reschedule},
+		healthConfigStore{cfg: cfg, path: path},
+		healthAppliers{dnsTester: dnsTester, speedTester: speedTester},
+	)
+}
+
+// healthProbeStore implements healthsettings.ProbeStore over the probes table via
+// the shared probemap mapping, rescheduling the engine after a save.
+type healthProbeStore struct {
+	probes     func() *database.ProbeRepository
+	reschedule func(context.Context) error
+}
+
+func (a healthProbeStore) Endpoints(ctx context.Context) (config.HealthChecksConfig, error) {
+	return probemap.LoadEndpoints(ctx, a.probes())
+}
+
+func (a healthProbeStore) SaveEndpoints(ctx context.Context, hc config.HealthChecksConfig) error {
+	probes, err := probemap.ProbesFromConfig(&hc)
+	if err != nil {
+		return err
+	}
+	if err = a.probes().ReplaceProbesByKinds(
+		ctx, database.DefaultClientID, probemap.Kinds(), probes,
+	); err != nil {
+		return err
+	}
+	// Best-effort reschedule: persistence already succeeded, so a reschedule
+	// failure is non-fatal — the new set takes effect on the next engine start.
+	if a.reschedule != nil {
+		_ = a.reschedule(ctx)
+	}
+	return nil
+}
+
+// healthConfigStore implements healthsettings.ConfigStore over the live config,
+// owning the lock + on-disk save (Write releases the lock before Save — the #783
+// pattern).
+type healthConfigStore struct {
+	cfg  *config.Config
+	path string
+}
+
+func (s healthConfigStore) Read(fn func(*config.Config)) {
+	s.cfg.RLock()
+	defer s.cfg.RUnlock()
+	fn(s.cfg)
+}
+
+func (s healthConfigStore) Write(fn func(*config.Config) error) error {
+	s.cfg.Lock()
+	err := fn(s.cfg)
+	s.cfg.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.cfg.Save(s.path)
+}
+
+// healthAppliers implements healthsettings.Appliers over the live DNS and
+// speedtest testers, resolved lazily; nil testers are no-ops.
+type healthAppliers struct {
+	dnsTester   func() *dns.Tester
+	speedTester func() *speedtest.Tester
+}
+
+func (a healthAppliers) ApplyDNS(hostname string, servers []config.DNSServer) {
+	t := a.dnsTester()
+	if t == nil {
+		return
+	}
+	if hostname != "" {
+		t.SetTestHostname(hostname)
+	}
+	configured := make([]dns.ConfiguredServer, 0, len(servers))
+	for _, d := range servers {
+		configured = append(configured, dns.ConfiguredServer{Address: d.Address, Enabled: d.Enabled})
+	}
+	t.SetConfiguredServers(configured)
+}
+
+func (a healthAppliers) ApplySpeedtestServer(id string) {
+	if t := a.speedTester(); t != nil {
+		t.SetServerID(id)
+	}
+}

--- a/internal/health/probemap/probemap.go
+++ b/internal/health/probemap/probemap.go
@@ -1,4 +1,4 @@
-package api
+package probemap
 
 // healthcheckmapping.go converts between the health-check endpoint
 // configuration shapes (config.*Endpoint) and probe.Probe definitions
@@ -28,10 +28,10 @@ import (
 // engine schedules each probe at this cadence.
 const defaultHealthCheckIntervalSeconds = 60
 
-// healthCheckKinds lists the probe kinds owned by the health-check
+// Kinds lists the probe kinds owned by the health-check
 // settings surface. Used to scope the replace-by-kind save so the
 // migration never touches probes of other kinds.
-func healthCheckKinds() []string {
+func Kinds() []string {
 	return []string{
 		probe.KindPing, probe.KindTCP, probe.KindUDP, probe.KindHTTP,
 		probe.KindRTSP, probe.KindDICOM, probe.KindHL7, probe.KindFHIR,
@@ -40,13 +40,13 @@ func healthCheckKinds() []string {
 	}
 }
 
-// countHealthCheckProbes returns the total number of probes across the
+// CountProbes returns the total number of probes across the
 // health-check kinds for the default client. Used by the first-run seed to
 // detect an install that already holds a configured set (the upgrade path)
 // so the factory defaults never overwrite it.
-func countHealthCheckProbes(ctx context.Context, repo *database.ProbeRepository) (int, error) {
+func CountProbes(ctx context.Context, repo *database.ProbeRepository) (int, error) {
 	total := 0
-	for _, kind := range healthCheckKinds() {
+	for _, kind := range Kinds() {
 		n, err := repo.CountProbes(ctx, database.DefaultClientID, kind)
 		if err != nil {
 			return 0, fmt.Errorf("count %s probes: %w", kind, err)
@@ -276,13 +276,13 @@ func probeToModbusEndpoint(p *database.Probe) (config.ModbusEndpoint, error) {
 	return e, nil
 }
 
-// loadHealthCheckEndpoints reads the health-check probe definitions from
+// LoadEndpoints reads the health-check probe definitions from
 // the probes table and assembles them into the endpoint lists of a
 // HealthChecksConfig. Only the endpoint lists are populated; the
 // performance/discovery toggles live in the config file and are not
 // sourced here. A malformed params row is skipped with the error
 // returned so the caller can log it without dropping the whole set.
-func loadHealthCheckEndpoints(ctx context.Context, repo *database.ProbeRepository) (config.HealthChecksConfig, error) {
+func LoadEndpoints(ctx context.Context, repo *database.ProbeRepository) (config.HealthChecksConfig, error) {
 	var hc config.HealthChecksConfig
 	probes, err := repo.ListProbes(ctx, database.DefaultClientID, "")
 	if err != nil {
@@ -390,12 +390,12 @@ func appendProbeToConfig(hc *config.HealthChecksConfig, p *database.Probe) error
 	return nil
 }
 
-// healthCheckProbesFromConfig flattens the endpoint lists of a
+// ProbesFromConfig flattens the endpoint lists of a
 // HealthChecksConfig into the probe rows to persist. Order follows
-// healthCheckKinds; a marshal failure aborts the whole set.
+// Kinds; a marshal failure aborts the whole set.
 //
 //nolint:gocognit,cyclop // A flat fan over the fourteen endpoint lists; one block each.
-func healthCheckProbesFromConfig(hc *config.HealthChecksConfig) ([]*database.Probe, error) {
+func ProbesFromConfig(hc *config.HealthChecksConfig) ([]*database.Probe, error) {
 	var out []*database.Probe
 	add := func(p *database.Probe, err error) error {
 		if err != nil {

--- a/internal/health/probemap/probemap_internal_test.go
+++ b/internal/health/probemap/probemap_internal_test.go
@@ -1,4 +1,4 @@
-package api
+package probemap
 
 import (
 	"encoding/json"
@@ -90,9 +90,9 @@ func TestHealthCheckProbesFromConfigAndBack(t *testing.T) {
 			},
 		},
 	}
-	probes, err := healthCheckProbesFromConfig(&hc)
+	probes, err := ProbesFromConfig(&hc)
 	if err != nil {
-		t.Fatalf("healthCheckProbesFromConfig: %v", err)
+		t.Fatalf("ProbesFromConfig: %v", err)
 	}
 	if len(probes) != 2 {
 		t.Fatalf("expected 2 probes, got %d", len(probes))

--- a/internal/health/settings/settings.go
+++ b/internal/health/settings/settings.go
@@ -1,0 +1,117 @@
+// Package settings is the application service for the health-checks settings
+// endpoint (ADR-0020 clean-hexagonal, WS-A4). It composes the two stores of
+// record: the endpoint target lists live in the probes table (ProbeStore, since
+// ADR-0027 P2) while the DNS/performance/speedtest/iperf toggles remain
+// config-file backed (ConfigStore). On update it also syncs the live DNS and
+// speedtest testers through the Appliers port. All three ports are satisfied by
+// adapters in the composition root.
+package settings
+
+import (
+	"context"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+)
+
+// ProbeStore is the endpoint-target store of record (the probes table). Endpoints
+// loads the configured health-check targets; SaveEndpoints replaces them (and
+// reschedules the running probe engine).
+type ProbeStore interface {
+	Endpoints(ctx context.Context) (config.HealthChecksConfig, error)
+	SaveEndpoints(ctx context.Context, hc config.HealthChecksConfig) error
+}
+
+// ConfigStore reads/persists the config-file-backed toggles. Read runs fn under
+// the config RLock; Write runs fn under the write lock and saves after releasing
+// it (the #783 unlock-before-save pattern).
+type ConfigStore interface {
+	Read(fn func(*config.Config))
+	Write(fn func(*config.Config) error) error
+}
+
+// Appliers syncs the live testers with newly-saved settings.
+type Appliers interface {
+	ApplyDNS(hostname string, servers []config.DNSServer)
+	ApplySpeedtestServer(id string)
+}
+
+// Service is the health-checks settings application service.
+type Service struct {
+	probes   ProbeStore
+	cfg      ConfigStore
+	appliers Appliers
+}
+
+// NewService builds the service over its ports.
+func NewService(probes ProbeStore, cfg ConfigStore, appliers Appliers) *Service {
+	return &Service{probes: probes, cfg: cfg, appliers: appliers}
+}
+
+// Settings is the read/write model: the endpoint targets plus the
+// config-file-backed toggles.
+type Settings struct {
+	Endpoints config.HealthChecksConfig
+
+	DNSHostname string
+	DNSServers  []config.DNSServer
+
+	RunPerformance bool
+	RunSpeedtest   bool
+	RunIperf       bool
+	RunDiscovery   bool
+
+	SpeedtestServerID      string
+	SpeedtestAutoRunOnLink bool
+	IperfAutoRunOnLink     bool
+}
+
+// Get composes the current settings: endpoint targets from the probes table and
+// the toggles from the config.
+func (s *Service) Get(ctx context.Context) (Settings, error) {
+	eps, err := s.probes.Endpoints(ctx)
+	if err != nil {
+		return Settings{}, err
+	}
+	out := Settings{Endpoints: eps}
+	s.cfg.Read(func(c *config.Config) {
+		out.DNSHostname = c.DNS.TestHostname
+		out.DNSServers = c.DNS.Servers
+		out.RunPerformance = c.HealthChecks.RunPerformance
+		out.RunSpeedtest = c.HealthChecks.RunSpeedtest
+		out.RunIperf = c.HealthChecks.RunIperf
+		out.RunDiscovery = c.HealthChecks.RunDiscovery
+		out.SpeedtestServerID = c.Speedtest.ServerID
+		out.SpeedtestAutoRunOnLink = c.Speedtest.AutoRunOnLink
+		out.IperfAutoRunOnLink = c.Iperf.AutoRunOnLink
+	})
+	return out, nil
+}
+
+// Update persists the settings: the endpoint targets are saved to the probes
+// table first (the store of record), then the toggles are written to the config,
+// and finally the live testers are synced. A non-empty DNS hostname is applied;
+// the DNS server list always replaces the prior one (the original contract).
+func (s *Service) Update(ctx context.Context, in Settings) error {
+	if err := s.probes.SaveEndpoints(ctx, in.Endpoints); err != nil {
+		return err
+	}
+	if err := s.cfg.Write(func(c *config.Config) error {
+		if in.DNSHostname != "" {
+			c.DNS.TestHostname = in.DNSHostname
+		}
+		c.DNS.Servers = in.DNSServers
+		c.HealthChecks.RunPerformance = in.RunPerformance
+		c.HealthChecks.RunSpeedtest = in.RunSpeedtest
+		c.HealthChecks.RunIperf = in.RunIperf
+		c.HealthChecks.RunDiscovery = in.RunDiscovery
+		c.Speedtest.ServerID = in.SpeedtestServerID
+		c.Speedtest.AutoRunOnLink = in.SpeedtestAutoRunOnLink
+		c.Iperf.AutoRunOnLink = in.IperfAutoRunOnLink
+		return nil
+	}); err != nil {
+		return err
+	}
+	s.appliers.ApplyDNS(in.DNSHostname, in.DNSServers)
+	s.appliers.ApplySpeedtestServer(in.SpeedtestServerID)
+	return nil
+}

--- a/internal/health/settings/settings_test.go
+++ b/internal/health/settings/settings_test.go
@@ -1,0 +1,120 @@
+package settings_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/health/settings"
+)
+
+type fakeProbeStore struct {
+	endpoints config.HealthChecksConfig
+	saved     *config.HealthChecksConfig
+	loadErr   error
+	saveErr   error
+}
+
+func (f *fakeProbeStore) Endpoints(context.Context) (config.HealthChecksConfig, error) {
+	return f.endpoints, f.loadErr
+}
+
+func (f *fakeProbeStore) SaveEndpoints(_ context.Context, hc config.HealthChecksConfig) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	f.saved = &hc
+	return nil
+}
+
+type fakeConfigStore struct{ cfg *config.Config }
+
+func (f *fakeConfigStore) Read(fn func(*config.Config))              { fn(f.cfg) }
+func (f *fakeConfigStore) Write(fn func(*config.Config) error) error { return fn(f.cfg) }
+
+type fakeAppliers struct {
+	dnsHostname string
+	dnsServers  []config.DNSServer
+	speedID     string
+}
+
+func (f *fakeAppliers) ApplyDNS(hostname string, servers []config.DNSServer) {
+	f.dnsHostname = hostname
+	f.dnsServers = servers
+}
+func (f *fakeAppliers) ApplySpeedtestServer(id string) { f.speedID = id }
+
+func TestGetComposesProbesAndConfig(t *testing.T) {
+	probes := &fakeProbeStore{endpoints: config.HealthChecksConfig{
+		PingTargets: []config.PingTarget{{Name: "g", Host: "8.8.8.8", Enabled: true}},
+	}}
+	cfg := &config.Config{}
+	cfg.DNS.TestHostname = "example.com"
+	cfg.HealthChecks.RunSpeedtest = true
+	cfg.Speedtest.ServerID = "42"
+	svc := settings.NewService(probes, &fakeConfigStore{cfg: cfg}, &fakeAppliers{})
+
+	got, err := svc.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.Endpoints.PingTargets) != 1 || got.Endpoints.PingTargets[0].Host != "8.8.8.8" {
+		t.Errorf("endpoints not sourced from probe store: %+v", got.Endpoints)
+	}
+	if got.DNSHostname != "example.com" || !got.RunSpeedtest || got.SpeedtestServerID != "42" {
+		t.Errorf("config toggles not composed: %+v", got)
+	}
+}
+
+func TestGetSurfacesProbeError(t *testing.T) {
+	wantErr := errors.New("db down")
+	svc := settings.NewService(
+		&fakeProbeStore{loadErr: wantErr}, &fakeConfigStore{cfg: &config.Config{}}, &fakeAppliers{})
+	if _, err := svc.Get(context.Background()); !errors.Is(err, wantErr) {
+		t.Errorf("probe load error not surfaced: %v", err)
+	}
+}
+
+func TestUpdatePersistsProbesConfigAndSyncsTesters(t *testing.T) {
+	probes := &fakeProbeStore{}
+	cfg := &config.Config{}
+	appliers := &fakeAppliers{}
+	svc := settings.NewService(probes, &fakeConfigStore{cfg: cfg}, appliers)
+
+	in := settings.Settings{
+		Endpoints:         config.HealthChecksConfig{PingTargets: []config.PingTarget{{Host: "1.1.1.1"}}},
+		DNSHostname:       "host.test",
+		DNSServers:        []config.DNSServer{{Address: "9.9.9.9", Enabled: true}},
+		RunSpeedtest:      true,
+		SpeedtestServerID: "7",
+	}
+	if err := svc.Update(context.Background(), in); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if probes.saved == nil || len(probes.saved.PingTargets) != 1 {
+		t.Errorf("endpoints not persisted to the probe store: %+v", probes.saved)
+	}
+	if cfg.DNS.TestHostname != "host.test" || !cfg.HealthChecks.RunSpeedtest || cfg.Speedtest.ServerID != "7" {
+		t.Errorf("config not written: %+v", cfg)
+	}
+	if appliers.dnsHostname != "host.test" || appliers.speedID != "7" || len(appliers.dnsServers) != 1 {
+		t.Errorf("testers not synced: %+v", appliers)
+	}
+}
+
+// TestUpdateSkipsConfigOnProbeFailure asserts probe persistence is the gate: if it
+// fails, the config is not written and the testers are not synced.
+func TestUpdateSkipsConfigOnProbeFailure(t *testing.T) {
+	probes := &fakeProbeStore{saveErr: errors.New("probe write failed")}
+	cfg := &config.Config{}
+	appliers := &fakeAppliers{}
+	svc := settings.NewService(probes, &fakeConfigStore{cfg: cfg}, appliers)
+
+	if err := svc.Update(context.Background(), settings.Settings{DNSHostname: "x"}); err == nil {
+		t.Fatal("Update should return the probe save error")
+	}
+	if cfg.DNS.TestHostname != "" || appliers.dnsHostname != "" {
+		t.Error("config/testers must not be touched when probe save fails")
+	}
+}


### PR DESCRIPTION
**WS-A4** — `handlers_health_checks_settings.go` carried **28** inline reaches across two stores of record (endpoint targets in the probes table + DNS/perf/speedtest/iperf toggles in config), plus inline live-tester sync and probe-engine reschedule.

## Bonus: god-layer reduction
Extracted the shared `config↔database.Probe` mapping — `internal/api/healthcheckmapping.go` (**478 LOC**, no `*Server`/HTTP) → **`internal/health/probemap`** (exported `Kinds`/`CountProbes`/`LoadEndpoints`/`ProbesFromConfig`). Repointed the other two callers (`healthcheckseed`, `healthcheckrun`). 478 LOC out of the api god-layer (toward WS-D).

## Shape
- **`internal/health/settings`** — `Service.Get`/`Update` over three ports: `ProbeStore` (endpoint lists + reschedule), `ConfigStore` (DNS/perf toggles, Read/Write unlock-before-save), `Appliers` (live dnsTester/speedtestTester sync).
- **`internal/app/healthsettings.go`** — adapter over `probemap` + config + testers; nil-safe reschedule.
- **`handlers_health_checks_settings.go`** — thin get/update; the 14-kind wire↔config DTO mapping stays as pure transport. Deleted `applyDNSSettings`/`applyPerformanceSettings`/`saveHealthCheckProbes`. **460 LOC; zero `s.config`/`s.db` reaches.**
- Round-trip + seed internal tests rewritten to drive the strangled PUT/GET path against a real DB.

## Gates
service tests (compose / probe-error surface / persist+sync / probe-failure gate); probemap tests moved; **non-race api suite green (30s)**; targeted `-race` + **full staticcheck** (the A3 dead-symbol lesson) + filename/route/escaping/`--new-from-rev` lint all green. No route/golden/migration change.