### PR TITLE
refactor(api): strangle vulnerability-scanner settings into the security use-case (ADR-0020, WS-A5)

### DIFF
--- a/internal/api/handlers_vuln.go
+++ b/internal/api/handlers_vuln.go
@@ -24,6 +24,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/discovery/vuln"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
+	securitysettings "github.com/MustardSeedNetworks/seed/internal/security/settings"
 	"github.com/MustardSeedNetworks/seed/internal/validation"
 )
 
@@ -128,7 +129,7 @@ func (s *Server) handleVulnerabilityStatus(w http.ResponseWriter, r *http.Reques
 		jsonKeyEnabled:   true,
 		"scanning":       s.vulnScanner().IsRunning(),
 		"stats":          stats,
-		"severityFilter": s.config.Security.VulnerabilityScanning.SeverityThreshold,
+		"severityFilter": s.securitySettings.VulnSeverity(),
 	})
 }
 
@@ -229,7 +230,7 @@ func (s *Server) handleVulnerabilitySettings(w http.ResponseWriter, r *http.Requ
 
 	switch r.Method {
 	case http.MethodGet:
-		sendJSONResponse(w, logger, http.StatusOK, s.config.Security.VulnerabilityScanning)
+		sendJSONResponse(w, logger, http.StatusOK, s.securitySettings.Vuln())
 
 	case http.MethodPut:
 		var settings vuln.VulnerabilityScannerConfig
@@ -238,29 +239,20 @@ func (s *Server) handleVulnerabilitySettings(w http.ResponseWriter, r *http.Requ
 			return
 		}
 
-		// Update config
-		// NOTE: Must unlock before Save() - Save() acquires RLock internally (fixes #783)
-		s.config.Lock()
-		s.config.Security.VulnerabilityScanning.Enabled = settings.Enabled
-		s.config.Security.VulnerabilityScanning.CVEDatabase = settings.CVEDatabase
-		s.config.Security.VulnerabilityScanning.NVDAPIKey = settings.NVDAPIKey
-		s.config.Security.VulnerabilityScanning.UpdateInterval = settings.UpdateInterval
-		s.config.Security.VulnerabilityScanning.SeverityThreshold = settings.SeverityThreshold
-		s.config.Security.VulnerabilityScanning.MaxConcurrent = settings.MaxConcurrent
-		// Unlock before Save() to avoid deadlock
-		s.config.Unlock()
-
-		// Save config
-		if err := s.config.Save(s.configPath); err != nil {
+		err := s.securitySettings.UpdateVuln(securitysettings.VulnUpdate{
+			Enabled:           settings.Enabled,
+			CVEDatabase:       settings.CVEDatabase,
+			NVDAPIKey:         settings.NVDAPIKey,
+			UpdateInterval:    settings.UpdateInterval,
+			SeverityThreshold: settings.SeverityThreshold,
+			MaxConcurrent:     settings.MaxConcurrent,
+		})
+		if err != nil {
 			logger.ErrorContext(r.Context(), "Failed to save vulnerability config", "error", err)
 			sendErrorResponseWithDetails(
-				w,
-				logger,
-				http.StatusInternalServerError,
-				ErrCodeInternal,
-				localizer.T("errors.config.failedToSave"),
-				"",
-			) // fixes #694, #H7
+				w, logger, http.StatusInternalServerError, ErrCodeInternal,
+				localizer.T("errors.config.failedToSave"), "",
+			)
 			return
 		}
 

--- a/internal/security/settings/settings.go
+++ b/internal/security/settings/settings.go
@@ -1,6 +1,6 @@
 // Package settings is the application service for the security-settings endpoints
-// (ADR-0020 clean-hexagonal, WS-A3): SNMP credentials and rogue-DHCP detection
-// configuration. It owns the read/mask/encrypt/merge/persist logic the transport
+// (ADR-0020 clean-hexagonal, WS-A3/A5): SNMP credentials, rogue-DHCP detection,
+// and vulnerability-scanner configuration. It owns the read/mask/encrypt/merge/persist logic the transport
 // layer used to carry inline. Persistence is reached through the consumer-defined
 // Store port; the live rogue-DHCP detector through the RogueDetector port. Both
 // are satisfied by adapters in the composition root (internal/app).
@@ -198,6 +198,52 @@ func maskIfSet(stored string) string {
 		return PasswordPlaceholder
 	}
 	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Vulnerability scanning
+// ---------------------------------------------------------------------------
+
+// VulnUpdate is the vulnerability-scanner settings write model. It carries the
+// six operator-settable fields; AutoScan is left untouched (it is not exposed by
+// the settings endpoint — the original contract).
+type VulnUpdate struct {
+	Enabled           bool
+	CVEDatabase       string
+	NVDAPIKey         string
+	UpdateInterval    int
+	SeverityThreshold string
+	MaxConcurrent     int
+}
+
+// Vuln returns the current vulnerability-scanner configuration.
+func (s *Service) Vuln() config.VulnerabilityScanConfig {
+	var out config.VulnerabilityScanConfig
+	s.store.Read(func(c *config.Config) { out = c.Security.VulnerabilityScanning })
+	return out
+}
+
+// VulnSeverity returns the configured severity threshold — the single field the
+// scan-status endpoint surfaces, without reaching into the config directly.
+func (s *Service) VulnSeverity() string {
+	var out string
+	s.store.Read(func(c *config.Config) { out = c.Security.VulnerabilityScanning.SeverityThreshold })
+	return out
+}
+
+// UpdateVuln applies the six operator-settable fields and persists, leaving
+// AutoScan untouched.
+func (s *Service) UpdateVuln(in VulnUpdate) error {
+	return s.store.Write(func(c *config.Config) error {
+		v := &c.Security.VulnerabilityScanning
+		v.Enabled = in.Enabled
+		v.CVEDatabase = in.CVEDatabase
+		v.NVDAPIKey = in.NVDAPIKey
+		v.UpdateInterval = in.UpdateInterval
+		v.SeverityThreshold = in.SeverityThreshold
+		v.MaxConcurrent = in.MaxConcurrent
+		return nil
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/security/settings/settings_test.go
+++ b/internal/security/settings/settings_test.go
@@ -123,3 +123,38 @@ func TestUpdateRogueDHCPAppliesAndSyncsDetector(t *testing.T) {
 		t.Errorf("detector should not sync when KnownServers is nil, got %v", det.lastKnownSet)
 	}
 }
+
+func TestVulnReadAndSeverity(t *testing.T) {
+	svc, cfg, _ := newService(t)
+	cfg.Security.VulnerabilityScanning.Enabled = true
+	cfg.Security.VulnerabilityScanning.SeverityThreshold = "high"
+
+	if v := svc.Vuln(); !v.Enabled || v.SeverityThreshold != "high" {
+		t.Errorf("Vuln() did not reflect config: %+v", v)
+	}
+	if svc.VulnSeverity() != "high" {
+		t.Errorf("VulnSeverity() = %q, want high", svc.VulnSeverity())
+	}
+}
+
+func TestUpdateVulnAppliesSixFieldsAndKeepsAutoScan(t *testing.T) {
+	svc, cfg, _ := newService(t)
+	// AutoScan is not an operator-settable field; it must survive an update.
+	cfg.Security.VulnerabilityScanning.AutoScan = true
+
+	err := svc.UpdateVuln(settings.VulnUpdate{
+		Enabled: true, CVEDatabase: "nvd", NVDAPIKey: "k",
+		UpdateInterval: 3600, SeverityThreshold: "medium", MaxConcurrent: 4,
+	})
+	if err != nil {
+		t.Fatalf("UpdateVuln: %v", err)
+	}
+	v := cfg.Security.VulnerabilityScanning
+	if !v.Enabled || v.CVEDatabase != "nvd" || v.NVDAPIKey != "k" ||
+		v.UpdateInterval != 3600 || v.SeverityThreshold != "medium" || v.MaxConcurrent != 4 {
+		t.Errorf("UpdateVuln did not apply the six fields: %+v", v)
+	}
+	if !v.AutoScan {
+		t.Error("UpdateVuln must not clobber AutoScan")
+	}
+}


### PR DESCRIPTION
**WS-A5** — `handlers_vuln.go` had **11** inline `s.config.Security.VulnerabilityScanning` reaches (settings GET/PUT + a severity read in the scan-status handler).

Vuln scanning is security config, so it joins the **existing** `internal/security/settings` service (A3) rather than a new package — it needs only the `ConfigStore` port already there. **No new server/test wiring.**

- `internal/security/settings`: `Vuln()` (read), `VulnSeverity()` (status gate), `UpdateVuln(VulnUpdate)` — applies the 6 operator-settable fields via the unlock-before-save `Store.Write`, leaving `AutoScan` (not endpoint-exposed) untouched.
- `handlers_vuln.go`: settings GET/PUT + the status severity read delegate to `s.securitySettings`. **Zero `s.config` reaches.**

Tests: vuln read/severity + UpdateVuln applies-six-keeps-AutoScan. Behavior-preserving. Non-race api suite + full staticcheck + filename/route/escaping/`--new-from-rev` lint green.