### PR TITLE
refactor(api): strangle topology read endpoints into a use-case (ADR-0020, WS-A6)

### DIFF
--- a/internal/api/handlers_topology.go
+++ b/internal/api/handlers_topology.go
@@ -22,7 +22,22 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
+	"github.com/MustardSeedNetworks/seed/internal/topology"
 )
+
+// writeTopologyError maps a topology read error to its HTTP status: the store
+// being unwired → 503 (the prior "Database not initialized"), a missing node →
+// 404, anything else → 500 with genericMsg.
+func writeTopologyError(w http.ResponseWriter, err error, genericMsg string) {
+	switch {
+	case errors.Is(err, topology.ErrUnavailable):
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+	case errors.Is(err, topology.ErrNodeNotFound):
+		http.Error(w, "Node not found", http.StatusNotFound)
+	default:
+		http.Error(w, genericMsg, http.StatusInternalServerError)
+	}
+}
 
 // topologyPathPrefix is the route root for every topology handler.
 // Used to strip the prefix when extracting path parameters.
@@ -42,11 +57,6 @@ const topologyDefaultLimit = 200
 // requests.
 func (s *Server) handleTopologyNodes(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
-		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return
-	}
 
 	opts, parseErr := parseTopologyListOptions(r)
 	if parseErr != nil {
@@ -54,10 +64,10 @@ func (s *Server) handleTopologyNodes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	nodes, err := db.Topology().List(r.Context(), opts)
+	nodes, err := s.topologyQueries.Nodes(r.Context(), opts)
 	if err != nil {
 		logger.ErrorContext(r.Context(), "list topology_nodes failed", "error", err)
-		http.Error(w, "Failed to list nodes", http.StatusInternalServerError)
+		writeTopologyError(w, err, "Failed to list nodes")
 		return
 	}
 
@@ -74,48 +84,18 @@ func (s *Server) handleTopologyNodeByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
-		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return
-	}
 
-	// We don't have a GetByID — look up via List with no filter,
-	// then match in-memory. List is paged; with at most N=1000 nodes
-	// per page this is fine. A future GetByID method on the repo
-	// becomes a worthwhile optimization when the graph exceeds the
-	// page cap.
-	nodes, err := db.Topology().List(r.Context(), database.TopologyListOptions{Limit: topologyMaxLimit})
+	detail, err := s.topologyQueries.Node(r.Context(), id)
 	if err != nil {
-		logger.ErrorContext(r.Context(), "list topology_nodes failed", "error", err)
-		http.Error(w, "Failed to load node", http.StatusInternalServerError)
+		logger.ErrorContext(r.Context(), "load topology node failed", "node_id", id, "error", err)
+		writeTopologyError(w, err, "Failed to load node")
 		return
-	}
-	var node *database.TopologyNode
-	for _, n := range nodes {
-		if n.ID == id {
-			node = n
-			break
-		}
-	}
-	if node == nil {
-		http.Error(w, "Node not found", http.StatusNotFound)
-		return
-	}
-
-	interfaces, err := db.Topology().ListInterfaces(r.Context(), node.ID)
-	if err != nil {
-		logger.ErrorContext(r.Context(), "list interfaces failed", "node_id", node.ID, "error", err)
-	}
-	links, err := db.Topology().ListLinks(r.Context(), node.ID)
-	if err != nil {
-		logger.ErrorContext(r.Context(), "list links failed", "node_id", node.ID, "error", err)
 	}
 
 	writeJSON(w, r, map[string]any{
-		"node":       encodeNode(node),
-		"interfaces": encodeInterfaces(interfaces),
-		"links":      encodeLinks(links),
+		"node":       encodeNode(detail.Node),
+		"interfaces": encodeInterfaces(detail.Interfaces),
+		"links":      encodeLinks(detail.Links),
 	})
 }
 
@@ -124,21 +104,16 @@ func (s *Server) handleTopologyNodeByID(w http.ResponseWriter, r *http.Request) 
 // the edges incident to that node.
 func (s *Server) handleTopologyLinks(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
-		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return
-	}
 	nodeID := r.URL.Query().Get("node_id")
 	if nodeID == "" {
 		http.Error(w, "node_id query parameter required", http.StatusBadRequest)
 		return
 	}
 
-	links, err := db.Topology().ListLinks(r.Context(), nodeID)
+	links, err := s.topologyQueries.Links(r.Context(), nodeID)
 	if err != nil {
 		logger.ErrorContext(r.Context(), "list links failed", "node_id", nodeID, "error", err)
-		http.Error(w, "Failed to list links", http.StatusInternalServerError)
+		writeTopologyError(w, err, "Failed to list links")
 		return
 	}
 	writeTopologyJSON(w, r, "links", encodeLinks(links))
@@ -181,16 +156,11 @@ func (s *Server) handleTopologyARP(w http.ResponseWriter, r *http.Request) {
 		opts.Limit = n
 	}
 
-	db := s.db()
-	if db == nil {
-		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return
-	}
-	bindings, err := db.Topology().ListARPBindings(r.Context(), opts)
+	bindings, err := s.topologyQueries.ARP(r.Context(), opts)
 	if err != nil {
 		logging.FromContext(r.Context()).ErrorContext(r.Context(),
 			"list topology_arp_bindings failed", "error", err)
-		http.Error(w, "Failed to list ARP bindings", http.StatusInternalServerError)
+		writeTopologyError(w, err, "Failed to list ARP bindings")
 		return
 	}
 	writeTopologyJSON(w, r, "bindings", encodeARPBindings(bindings))

--- a/internal/api/handlers_topology_internal_test.go
+++ b/internal/api/handlers_topology_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
@@ -21,6 +22,7 @@ func newTopologyTestServer(t *testing.T) *Server {
 	db := newTestDB(t)
 	s := &Server{}
 	s.dbConn = db
+	s.topologyQueries = app.NewTopologyQueries(s.db, topologyMaxLimit)
 	return s
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -254,6 +254,7 @@ type Server struct {
 	discoveryDevices   *devices.Service            // Unified-discovery (engine) use-case (ADR-0020)
 	discoverySettings  *discoverysettings.Service  // Network-discovery settings use-case (ADR-0020)
 	networkProblems    *problems.Service           // Network problem-detection use-case (ADR-0020)
+	topologyQueries    *topology.Queries           // Topology read use-case (ADR-0020)
 	bluetoothScans     *bluetooth.Service          // Bluetooth-discovery use-case (ADR-0020)
 	healthMonitoring   *monitoring.Service         // Health-monitoring use-case (ADR-0020)
 	healthSettings     *healthsettings.Service     // Health-checks settings use-case (ADR-0020)
@@ -926,6 +927,7 @@ func (s *Server) initDiscoveryUseCases() {
 	s.discoveryDevices = app.NewDiscoveryDevices(s.discoveryEngine)
 	s.discoverySettings = app.NewDiscoverySettings(s.config, s.configPath, s.deviceDiscovery)
 	s.networkProblems = app.NewProblems(s.problemDetector, s.discoveryService)
+	s.topologyQueries = app.NewTopologyQueries(s.db, topologyMaxLimit)
 	s.bluetoothScans = app.NewBluetooth(s.bluetoothScanner)
 }
 

--- a/internal/app/topology.go
+++ b/internal/app/topology.go
@@ -1,0 +1,73 @@
+package app
+
+// topology.go wires the composition root to the topology read use-case
+// (ADR-0020, WS-A6). The adapter implements the topology.Reader port over the
+// topology repository, resolving the database lazily; a nil database yields
+// topology.ErrUnavailable so the handler degrades to 503 rather than panicking.
+
+import (
+	"context"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/topology"
+)
+
+// NewTopologyQueries builds the topology read use-case over a lazy database
+// accessor. maxLimit caps the node scan used for single-node lookups.
+func NewTopologyQueries(db func() *database.DB, maxLimit int) *topology.Queries {
+	return topology.NewQueries(topologyReader{db: db}, maxLimit)
+}
+
+// topologyReader implements topology.Reader over the topology repository. A nil
+// database makes every read return topology.ErrUnavailable.
+type topologyReader struct {
+	db func() *database.DB
+}
+
+func (a topologyReader) repo() (*database.TopologyRepository, error) {
+	db := a.db()
+	if db == nil {
+		return nil, topology.ErrUnavailable
+	}
+	return db.Topology(), nil
+}
+
+func (a topologyReader) List(
+	ctx context.Context, opts database.TopologyListOptions,
+) ([]*database.TopologyNode, error) {
+	repo, err := a.repo()
+	if err != nil {
+		return nil, err
+	}
+	return repo.List(ctx, opts)
+}
+
+func (a topologyReader) ListInterfaces(
+	ctx context.Context, nodeID string,
+) ([]*database.TopologyInterface, error) {
+	repo, err := a.repo()
+	if err != nil {
+		return nil, err
+	}
+	return repo.ListInterfaces(ctx, nodeID)
+}
+
+func (a topologyReader) ListLinks(
+	ctx context.Context, nodeID string,
+) ([]*database.TopologyLink, error) {
+	repo, err := a.repo()
+	if err != nil {
+		return nil, err
+	}
+	return repo.ListLinks(ctx, nodeID)
+}
+
+func (a topologyReader) ListARPBindings(
+	ctx context.Context, opts database.TopologyARPListOptions,
+) ([]*database.TopologyARPBinding, error) {
+	repo, err := a.repo()
+	if err != nil {
+		return nil, err
+	}
+	return repo.ListARPBindings(ctx, opts)
+}

--- a/internal/topology/read.go
+++ b/internal/topology/read.go
@@ -1,0 +1,91 @@
+package topology
+
+// read.go is the topology read use-case (ADR-0020, WS-A6): the GET endpoints'
+// application service over a narrow Reader port, so the transport layer depends
+// on a use-case instead of reaching into the database directly. The Reader is
+// satisfied by an adapter in the composition root over the topology repository.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+// ErrNodeNotFound is returned by Node when no node matches the id.
+var ErrNodeNotFound = errors.New("topology: node not found")
+
+// ErrUnavailable is returned when the underlying store is not wired (the handler
+// maps it to 503, preserving the prior "Database not initialized" behavior).
+var ErrUnavailable = errors.New("topology: store unavailable")
+
+// Reader is the read surface the topology queries need. It mirrors the topology
+// repository's read methods; the adapter satisfies it over database.TopologyRepository.
+type Reader interface {
+	List(ctx context.Context, opts database.TopologyListOptions) ([]*database.TopologyNode, error)
+	ListInterfaces(ctx context.Context, nodeID string) ([]*database.TopologyInterface, error)
+	ListLinks(ctx context.Context, nodeID string) ([]*database.TopologyLink, error)
+	ListARPBindings(ctx context.Context, opts database.TopologyARPListOptions) ([]*database.TopologyARPBinding, error)
+}
+
+// NodeDetail is the single-node read model: the node plus its interfaces and
+// incident links.
+type NodeDetail struct {
+	Node       *database.TopologyNode
+	Interfaces []*database.TopologyInterface
+	Links      []*database.TopologyLink
+}
+
+// Queries is the topology read use-case.
+type Queries struct {
+	reader   Reader
+	maxLimit int
+}
+
+// NewQueries builds the read use-case. maxLimit caps the node scan used by Node
+// (there is no GetByID on the repository yet; Node lists then matches in-memory).
+func NewQueries(reader Reader, maxLimit int) *Queries {
+	return &Queries{reader: reader, maxLimit: maxLimit}
+}
+
+// Nodes lists topology nodes matching opts.
+func (q *Queries) Nodes(ctx context.Context, opts database.TopologyListOptions) ([]*database.TopologyNode, error) {
+	return q.reader.List(ctx, opts)
+}
+
+// Node returns one node with its interfaces and incident links, or
+// ErrNodeNotFound. Interface/link loads are best-effort: a partial failure
+// yields an empty list rather than failing the whole detail view (the prior
+// handler behavior).
+func (q *Queries) Node(ctx context.Context, id string) (NodeDetail, error) {
+	nodes, err := q.reader.List(ctx, database.TopologyListOptions{Limit: q.maxLimit})
+	if err != nil {
+		return NodeDetail{}, err
+	}
+	var node *database.TopologyNode
+	for _, n := range nodes {
+		if n.ID == id {
+			node = n
+			break
+		}
+	}
+	if node == nil {
+		return NodeDetail{}, ErrNodeNotFound
+	}
+	interfaces, _ := q.reader.ListInterfaces(ctx, node.ID)
+	links, _ := q.reader.ListLinks(ctx, node.ID)
+	return NodeDetail{Node: node, Interfaces: interfaces, Links: links}, nil
+}
+
+// Links returns the links incident to nodeID.
+func (q *Queries) Links(ctx context.Context, nodeID string) ([]*database.TopologyLink, error) {
+	return q.reader.ListLinks(ctx, nodeID)
+}
+
+// ARP returns the ARP bindings matching opts.
+func (q *Queries) ARP(
+	ctx context.Context,
+	opts database.TopologyARPListOptions,
+) ([]*database.TopologyARPBinding, error) {
+	return q.reader.ListARPBindings(ctx, opts)
+}

--- a/internal/topology/read_test.go
+++ b/internal/topology/read_test.go
@@ -1,0 +1,71 @@
+package topology_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/topology"
+)
+
+type fakeReader struct {
+	nodes      []*database.TopologyNode
+	interfaces []*database.TopologyInterface
+	links      []*database.TopologyLink
+	listErr    error
+}
+
+func (f fakeReader) List(context.Context, database.TopologyListOptions) ([]*database.TopologyNode, error) {
+	return f.nodes, f.listErr
+}
+
+func (f fakeReader) ListInterfaces(context.Context, string) ([]*database.TopologyInterface, error) {
+	return f.interfaces, nil
+}
+
+func (f fakeReader) ListLinks(context.Context, string) ([]*database.TopologyLink, error) {
+	return f.links, nil
+}
+
+func (f fakeReader) ListARPBindings(
+	context.Context,
+	database.TopologyARPListOptions,
+) ([]*database.TopologyARPBinding, error) {
+	return nil, nil
+}
+
+func TestNodeReturnsDetailForMatch(t *testing.T) {
+	r := fakeReader{
+		nodes:      []*database.TopologyNode{{ID: "a"}, {ID: "b"}},
+		interfaces: []*database.TopologyInterface{{IfName: "eth0"}},
+		links:      []*database.TopologyLink{{LinkType: "lldp"}},
+	}
+	q := topology.NewQueries(r, 1000)
+
+	detail, err := q.Node(context.Background(), "b")
+	if err != nil {
+		t.Fatalf("Node: %v", err)
+	}
+	if detail.Node == nil || detail.Node.ID != "b" {
+		t.Errorf("wrong node: %+v", detail.Node)
+	}
+	if len(detail.Interfaces) != 1 || len(detail.Links) != 1 {
+		t.Errorf("interfaces/links not loaded: %+v", detail)
+	}
+}
+
+func TestNodeUnknownReturnsNotFound(t *testing.T) {
+	q := topology.NewQueries(fakeReader{nodes: []*database.TopologyNode{{ID: "a"}}}, 1000)
+	if _, err := q.Node(context.Background(), "missing"); !errors.Is(err, topology.ErrNodeNotFound) {
+		t.Errorf("want ErrNodeNotFound, got %v", err)
+	}
+}
+
+func TestNodeSurfacesListError(t *testing.T) {
+	wantErr := errors.New("db down")
+	q := topology.NewQueries(fakeReader{listErr: wantErr}, 1000)
+	if _, err := q.Node(context.Background(), "a"); !errors.Is(err, wantErr) {
+		t.Errorf("list error not surfaced: %v", err)
+	}
+}


### PR DESCRIPTION
**WS-A6** — the four topology GET handlers reached `s.db().Topology()` directly (list nodes, node-by-id, links, ARP), each with its own nil-db guard and the in-memory node-by-id filter inline.

- **`internal/topology/read.go`** — `Queries` read use-case over a narrow `Reader` port, with the node list+filter logic (no `GetByID` yet) + `ErrNodeNotFound`/`ErrUnavailable` sentinels. `internal/topology` already depends on `internal/database` (the reconcilers), so the read-model passthrough is consistent there; WS-B addresses that package's repo-port discipline holistically.
- **`internal/app/topology.go`** — adapter over `db.Topology()`, nil-safe (nil db → `ErrUnavailable` → handler 503).
- **`handlers_topology.go`** — the four handlers delegate to `s.topologyQueries` with a shared `writeTopologyError` mapper (unavailable→503, not-found→404, else 500); encode/parse/writeJSON transport helpers stay. **Zero `s.db()` reaches.**

Tests: `Queries` (detail match / not-found / list-error surface); api topology handler tests pass through the strangled path. Non-race api suite + full staticcheck + filename/route/escaping/`--new-from-rev` lint green.