### PR TITLE
refactor(api): strangle polling-targets CRUD into a use-case (ADR-0020, WS-A7)

### DIFF
--- a/internal/api/handlers_polling_targets.go
+++ b/internal/api/handlers_polling_targets.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
+	"github.com/MustardSeedNetworks/seed/internal/polling/targets"
 )
 
 const (
@@ -78,38 +79,24 @@ func (s *Server) handlePollingTargetByID(w http.ResponseWriter, r *http.Request)
 
 func (s *Server) listPollingTargets(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
-		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return
-	}
-	targets, err := db.PollingTargets().List(r.Context(), r.URL.Query().Get("client_id"))
+	list, err := s.pollingTargets.List(r.Context(), r.URL.Query().Get("client_id"))
 	if err != nil {
 		logger.ErrorContext(r.Context(), "list polling_targets failed", "error", err)
-		http.Error(w, "Failed to list polling targets", http.StatusInternalServerError)
+		writePollingError(w, err, "Failed to list polling targets")
 		return
 	}
 	writeJSON(w, r, map[string]any{
-		jsonKeyCount: len(targets),
-		"targets":    encodePollingTargets(targets),
+		jsonKeyCount: len(list),
+		"targets":    encodePollingTargets(list),
 	})
 }
 
 func (s *Server) getPollingTarget(w http.ResponseWriter, r *http.Request, id string) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
-		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return
-	}
-	target, err := db.PollingTargets().Get(r.Context(), id)
+	target, err := s.pollingTargets.Get(r.Context(), id)
 	if err != nil {
-		if errors.Is(err, database.ErrPollingTargetNotFound) {
-			http.Error(w, "Target not found", http.StatusNotFound)
-			return
-		}
 		logger.ErrorContext(r.Context(), "get polling_target failed", "id", id, "error", err)
-		http.Error(w, "Failed to load target", http.StatusInternalServerError)
+		writePollingError(w, err, "Failed to load target")
 		return
 	}
 	writeJSON(w, r, encodePollingTarget(target))
@@ -117,29 +104,15 @@ func (s *Server) getPollingTarget(w http.ResponseWriter, r *http.Request, id str
 
 func (s *Server) createPollingTarget(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
-		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return
-	}
 	in, err := decodePollingTargetInput(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	target := inputToTarget(in, "")
-	if createErr := db.PollingTargets().Create(r.Context(), target); createErr != nil {
+	if createErr := s.pollingTargets.Create(r.Context(), target); createErr != nil {
 		logger.ErrorContext(r.Context(), "create polling_target failed", "error", createErr)
-		// Validation errors from the repo are user input; everything
-		// else is a server problem. The repo signals validation via
-		// errors that don't wrap an underlying sql error — pragmatic
-		// classification by prefix keeps us from inventing a typed
-		// error hierarchy for one endpoint.
-		if strings.HasPrefix(createErr.Error(), "polling_targets:") {
-			http.Error(w, createErr.Error(), http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "Failed to create target", http.StatusInternalServerError)
+		writePollingError(w, createErr, "Failed to create target")
 		return
 	}
 	w.Header().Set("Location", pollingTargetsPathPrefix+target.ID)
@@ -148,31 +121,15 @@ func (s *Server) createPollingTarget(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) updatePollingTarget(w http.ResponseWriter, r *http.Request, id string) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
-		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return
-	}
 	in, err := decodePollingTargetInput(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	target := inputToTarget(in, id)
-	if updErr := db.PollingTargets().Update(r.Context(), target); updErr != nil {
-		if errors.Is(updErr, database.ErrPollingTargetNotFound) {
-			http.Error(w, "Target not found", http.StatusNotFound)
-			return
-		}
+	current, updErr := s.pollingTargets.Update(r.Context(), inputToTarget(in, id))
+	if updErr != nil {
 		logger.ErrorContext(r.Context(), "update polling_target failed", "id", id, "error", updErr)
-		http.Error(w, "Failed to update target", http.StatusInternalServerError)
-		return
-	}
-	// Echo the freshly-read row so the client sees the audit columns
-	// (updated_at) the repo refreshed.
-	current, _ := db.PollingTargets().Get(r.Context(), id)
-	if current == nil {
-		writeJSON(w, r, encodePollingTarget(target))
+		writePollingError(w, updErr, "Failed to update target")
 		return
 	}
 	writeJSON(w, r, encodePollingTarget(current))
@@ -180,21 +137,29 @@ func (s *Server) updatePollingTarget(w http.ResponseWriter, r *http.Request, id 
 
 func (s *Server) deletePollingTarget(w http.ResponseWriter, r *http.Request, id string) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
-		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return
-	}
-	if err := db.PollingTargets().Delete(r.Context(), id); err != nil {
-		if errors.Is(err, database.ErrPollingTargetNotFound) {
-			http.Error(w, "Target not found", http.StatusNotFound)
-			return
-		}
+	if err := s.pollingTargets.Delete(r.Context(), id); err != nil {
 		logger.ErrorContext(r.Context(), "delete polling_target failed", "id", id, "error", err)
-		http.Error(w, "Failed to delete target", http.StatusInternalServerError)
+		writePollingError(w, err, "Failed to delete target")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// writePollingError maps a polling-targets use-case error to its HTTP status: the
+// store unwired → 503 (the prior "Database not initialized"), a missing target →
+// 404, a repo validation error → 400 with its message, anything else → 500.
+func writePollingError(w http.ResponseWriter, err error, genericMsg string) {
+	var ve targets.ValidationError
+	switch {
+	case errors.Is(err, targets.ErrUnavailable):
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+	case errors.Is(err, targets.ErrNotFound):
+		http.Error(w, "Target not found", http.StatusNotFound)
+	case errors.As(err, &ve):
+		http.Error(w, ve.Msg, http.StatusBadRequest)
+	default:
+		http.Error(w, genericMsg, http.StatusInternalServerError)
+	}
 }
 
 // decodePollingTargetInput parses the JSON body. Returns a 400-

--- a/internal/api/handlers_polling_targets_internal_test.go
+++ b/internal/api/handlers_polling_targets_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
@@ -18,6 +19,7 @@ func newPollingTargetsTestServer(t *testing.T) *Server {
 	db := newTestDB(t)
 	s := &Server{}
 	s.dbConn = db
+	s.pollingTargets = app.NewPollingTargets(s.db)
 	return s
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -58,6 +58,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/platform/jobs"
 	snmporchestrator "github.com/MustardSeedNetworks/seed/internal/polling/snmp/orchestrator"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/snmpclient"
+	"github.com/MustardSeedNetworks/seed/internal/polling/targets"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
 	probeanomaly "github.com/MustardSeedNetworks/seed/internal/probe/anomaly"
 	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
@@ -255,6 +256,7 @@ type Server struct {
 	discoverySettings  *discoverysettings.Service  // Network-discovery settings use-case (ADR-0020)
 	networkProblems    *problems.Service           // Network problem-detection use-case (ADR-0020)
 	topologyQueries    *topology.Queries           // Topology read use-case (ADR-0020)
+	pollingTargets     *targets.Service            // Polling-targets CRUD use-case (ADR-0020)
 	bluetoothScans     *bluetooth.Service          // Bluetooth-discovery use-case (ADR-0020)
 	healthMonitoring   *monitoring.Service         // Health-monitoring use-case (ADR-0020)
 	healthSettings     *healthsettings.Service     // Health-checks settings use-case (ADR-0020)
@@ -928,6 +930,7 @@ func (s *Server) initDiscoveryUseCases() {
 	s.discoverySettings = app.NewDiscoverySettings(s.config, s.configPath, s.deviceDiscovery)
 	s.networkProblems = app.NewProblems(s.problemDetector, s.discoveryService)
 	s.topologyQueries = app.NewTopologyQueries(s.db, topologyMaxLimit)
+	s.pollingTargets = app.NewPollingTargets(s.db)
 	s.bluetoothScans = app.NewBluetooth(s.bluetoothScanner)
 }
 

--- a/internal/app/polling.go
+++ b/internal/app/polling.go
@@ -1,0 +1,73 @@
+package app
+
+// polling.go wires the composition root to the polling-targets CRUD use-case
+// (ADR-0020, WS-A7). The adapter implements the targets.Repository port over the
+// polling-target repository, resolving the database lazily; a nil database yields
+// targets.ErrUnavailable so the handler degrades to 503 rather than panicking.
+
+import (
+	"context"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling/targets"
+)
+
+// NewPollingTargets builds the polling-targets CRUD use-case over a lazy database
+// accessor.
+func NewPollingTargets(db func() *database.DB) *targets.Service {
+	return targets.NewService(pollingTargetRepo{db: db})
+}
+
+// pollingTargetRepo implements targets.Repository over the polling-target
+// repository. A nil database makes every call return targets.ErrUnavailable.
+type pollingTargetRepo struct {
+	db func() *database.DB
+}
+
+func (a pollingTargetRepo) repo() (*database.PollingTargetRepository, error) {
+	db := a.db()
+	if db == nil {
+		return nil, targets.ErrUnavailable
+	}
+	return db.PollingTargets(), nil
+}
+
+func (a pollingTargetRepo) List(ctx context.Context, clientID string) ([]*database.PollingTarget, error) {
+	repo, err := a.repo()
+	if err != nil {
+		return nil, err
+	}
+	return repo.List(ctx, clientID)
+}
+
+func (a pollingTargetRepo) Get(ctx context.Context, id string) (*database.PollingTarget, error) {
+	repo, err := a.repo()
+	if err != nil {
+		return nil, err
+	}
+	return repo.Get(ctx, id)
+}
+
+func (a pollingTargetRepo) Create(ctx context.Context, t *database.PollingTarget) error {
+	repo, err := a.repo()
+	if err != nil {
+		return err
+	}
+	return repo.Create(ctx, t)
+}
+
+func (a pollingTargetRepo) Update(ctx context.Context, t *database.PollingTarget) error {
+	repo, err := a.repo()
+	if err != nil {
+		return err
+	}
+	return repo.Update(ctx, t)
+}
+
+func (a pollingTargetRepo) Delete(ctx context.Context, id string) error {
+	repo, err := a.repo()
+	if err != nil {
+		return err
+	}
+	return repo.Delete(ctx, id)
+}

--- a/internal/polling/targets/targets.go
+++ b/internal/polling/targets/targets.go
@@ -1,0 +1,95 @@
+// Package targets is the polling-targets CRUD use-case (ADR-0020, WS-A7): the
+// /api/v1/polling-targets endpoints' application service over a narrow Repository
+// port, so the transport layer depends on a use-case instead of reaching into the
+// database directly. The Repository is satisfied by an adapter in the composition
+// root over the polling-target repository.
+package targets
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+var (
+	// ErrNotFound is returned when no polling target matches the id.
+	ErrNotFound = errors.New("targets: polling target not found")
+	// ErrUnavailable is returned when the store is not wired (handler → 503).
+	ErrUnavailable = errors.New("targets: store unavailable")
+)
+
+// ValidationError carries a user-input validation message from the repository
+// (the handler maps it to 400 with the message verbatim).
+type ValidationError struct{ Msg string }
+
+func (e ValidationError) Error() string { return e.Msg }
+
+// Repository is the persistence surface the use-case needs. It mirrors the
+// polling-target repository; the adapter satisfies it over
+// database.PollingTargetRepository and surfaces ErrUnavailable when no DB is wired.
+type Repository interface {
+	List(ctx context.Context, clientID string) ([]*database.PollingTarget, error)
+	Get(ctx context.Context, id string) (*database.PollingTarget, error)
+	Create(ctx context.Context, t *database.PollingTarget) error
+	Update(ctx context.Context, t *database.PollingTarget) error
+	Delete(ctx context.Context, id string) error
+}
+
+// Service is the polling-targets CRUD use-case.
+type Service struct {
+	repo Repository
+}
+
+// NewService builds the use-case over its Repository port.
+func NewService(repo Repository) *Service { return &Service{repo: repo} }
+
+// List returns the polling targets for clientID ("" for all).
+func (s *Service) List(ctx context.Context, clientID string) ([]*database.PollingTarget, error) {
+	return s.repo.List(ctx, clientID)
+}
+
+// Get returns one target, mapping the repository's not-found to ErrNotFound.
+func (s *Service) Get(ctx context.Context, id string) (*database.PollingTarget, error) {
+	t, err := s.repo.Get(ctx, id)
+	return t, mapNotFound(err)
+}
+
+// Create persists a new target. A repository validation error (the
+// "polling_targets:" prefix is the repo's user-input signal) is returned as a
+// ValidationError; everything else propagates as-is.
+func (s *Service) Create(ctx context.Context, t *database.PollingTarget) error {
+	err := s.repo.Create(ctx, t)
+	if err != nil && strings.HasPrefix(err.Error(), "polling_targets:") {
+		return ValidationError{Msg: err.Error()}
+	}
+	return err
+}
+
+// Update applies a full update and returns the freshly-read row so the caller
+// sees the refreshed audit columns; on a re-read miss it returns the written
+// value. Maps the repository's not-found to ErrNotFound.
+func (s *Service) Update(ctx context.Context, t *database.PollingTarget) (*database.PollingTarget, error) {
+	if err := mapNotFound(s.repo.Update(ctx, t)); err != nil {
+		return nil, err
+	}
+	if current, err := s.repo.Get(ctx, t.ID); err == nil && current != nil {
+		return current, nil
+	}
+	return t, nil
+}
+
+// Delete removes a target, mapping the repository's not-found to ErrNotFound.
+func (s *Service) Delete(ctx context.Context, id string) error {
+	return mapNotFound(s.repo.Delete(ctx, id))
+}
+
+// mapNotFound normalizes the repository's not-found sentinel to ErrNotFound,
+// leaving other errors (including ErrUnavailable from the adapter) untouched.
+func mapNotFound(err error) error {
+	if errors.Is(err, database.ErrPollingTargetNotFound) {
+		return ErrNotFound
+	}
+	return err
+}

--- a/internal/polling/targets/targets_test.go
+++ b/internal/polling/targets/targets_test.go
@@ -1,0 +1,103 @@
+package targets_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling/targets"
+)
+
+type fakeRepo struct {
+	store     map[string]*database.PollingTarget
+	createErr error
+}
+
+func newFakeRepo() *fakeRepo { return &fakeRepo{store: map[string]*database.PollingTarget{}} }
+
+func (f *fakeRepo) List(context.Context, string) ([]*database.PollingTarget, error) {
+	out := make([]*database.PollingTarget, 0, len(f.store))
+	for _, t := range f.store {
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+func (f *fakeRepo) Get(_ context.Context, id string) (*database.PollingTarget, error) {
+	if t, ok := f.store[id]; ok {
+		return t, nil
+	}
+	return nil, database.ErrPollingTargetNotFound
+}
+
+func (f *fakeRepo) Create(_ context.Context, t *database.PollingTarget) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	if t.ID == "" {
+		t.ID = "generated"
+	}
+	f.store[t.ID] = t
+	return nil
+}
+
+func (f *fakeRepo) Update(_ context.Context, t *database.PollingTarget) error {
+	if _, ok := f.store[t.ID]; !ok {
+		return database.ErrPollingTargetNotFound
+	}
+	f.store[t.ID] = t
+	return nil
+}
+
+func (f *fakeRepo) Delete(_ context.Context, id string) error {
+	if _, ok := f.store[id]; !ok {
+		return database.ErrPollingTargetNotFound
+	}
+	delete(f.store, id)
+	return nil
+}
+
+func TestCreateClassifiesRepoValidationError(t *testing.T) {
+	repo := newFakeRepo()
+	repo.createErr = errors.New("polling_targets: name must be unique")
+	svc := targets.NewService(repo)
+
+	err := svc.Create(context.Background(), &database.PollingTarget{Name: "x"})
+	var ve targets.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want ValidationError, got %v", err)
+	}
+	if ve.Msg != "polling_targets: name must be unique" {
+		t.Errorf("validation message not preserved: %q", ve.Msg)
+	}
+}
+
+func TestGetAndDeleteMapNotFound(t *testing.T) {
+	svc := targets.NewService(newFakeRepo())
+	if _, err := svc.Get(context.Background(), "missing"); !errors.Is(err, targets.ErrNotFound) {
+		t.Errorf("Get: want ErrNotFound, got %v", err)
+	}
+	if err := svc.Delete(context.Background(), "missing"); !errors.Is(err, targets.ErrNotFound) {
+		t.Errorf("Delete: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestUpdateEchoesFreshRowAndMapsNotFound(t *testing.T) {
+	repo := newFakeRepo()
+	repo.store["t1"] = &database.PollingTarget{ID: "t1", Name: "old"}
+	svc := targets.NewService(repo)
+
+	got, err := svc.Update(context.Background(), &database.PollingTarget{ID: "t1", Name: "new"})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got.Name != "new" {
+		t.Errorf("Update did not echo the fresh row: %+v", got)
+	}
+
+	_, err = svc.Update(context.Background(), &database.PollingTarget{ID: "nope"})
+	if !errors.Is(err, targets.ErrNotFound) {
+		t.Errorf("Update missing: want ErrNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
**WS-A7** — the five polling-targets CRUD handlers reached `s.db().PollingTargets()` directly (list/get/create/update/delete), each with inline nil-db guards + error classification.

- **`internal/polling/targets`** — `Service` CRUD over a narrow `Repository` port, owning the not-found normalization (`ErrNotFound`), the repo validation-prefix classification (typed `ValidationError` preserving the message), the update re-read echo, and `ErrUnavailable`. `internal/polling` already depends on `internal/database` (the SNMP poller), so the passthrough is consistent there; WS-B addresses the package's repo-port discipline holistically.
- **`internal/app/polling.go`** — adapter over `db.PollingTargets()`, nil-safe (nil db → `ErrUnavailable` → 503).
- **`handlers_polling_targets.go`** — the five handlers delegate to `s.pollingTargets` with a shared `writePollingError` mapper (unavailable→503, not-found→404, validation→400 with message, else→500); decode/encode/input transport helpers stay. **Zero `s.db()` reaches.**

Tests: `Service` (validation classification / not-found mapping / update re-read echo); api CRUD handler tests pass through the strangled path. Non-race api suite + full staticcheck + filename/route/escaping/`--new-from-rev` lint green.