### PR TITLE
refactor(api): strangle alert inbox into a use-case (ADR-0020, WS-A8)

### DIFF
--- a/internal/alerts/inbox/inbox.go
+++ b/internal/alerts/inbox/inbox.go
@@ -1,0 +1,47 @@
+// Package inbox is the alert-inbox use-case (ADR-0020, WS-A8): the /api/v1/alerts
+// endpoints' application service over a narrow Repository port, so the transport
+// layer depends on a use-case instead of reaching into the database directly. The
+// Repository is satisfied by an adapter in the composition root over the alert
+// repository (the store the NMS pipelines write to).
+package inbox
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+// ErrUnavailable is returned when the store is not wired (handler → 503).
+var ErrUnavailable = errors.New("inbox: store unavailable")
+
+// Repository is the alert-store surface the use-case needs: list the alerts the
+// pipelines have written, and mark one acknowledged or resolved.
+type Repository interface {
+	List(ctx context.Context, opts database.AlertListOptions) ([]*database.Alert, error)
+	Acknowledge(ctx context.Context, id int64, username string) error
+	Resolve(ctx context.Context, id int64) error
+}
+
+// Service is the alert-inbox use-case.
+type Service struct {
+	repo Repository
+}
+
+// NewService builds the use-case over its Repository port.
+func NewService(repo Repository) *Service { return &Service{repo: repo} }
+
+// List returns the alerts matching opts.
+func (s *Service) List(ctx context.Context, opts database.AlertListOptions) ([]*database.Alert, error) {
+	return s.repo.List(ctx, opts)
+}
+
+// Acknowledge marks alert id acknowledged by username.
+func (s *Service) Acknowledge(ctx context.Context, id int64, username string) error {
+	return s.repo.Acknowledge(ctx, id, username)
+}
+
+// Resolve marks alert id resolved.
+func (s *Service) Resolve(ctx context.Context, id int64) error {
+	return s.repo.Resolve(ctx, id)
+}

--- a/internal/alerts/inbox/inbox_test.go
+++ b/internal/alerts/inbox/inbox_test.go
@@ -1,0 +1,58 @@
+package inbox_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/alerts/inbox"
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+type fakeRepo struct {
+	listOpts  database.AlertListOptions
+	ackID     int64
+	ackUser   string
+	resolveID int64
+	err       error
+}
+
+func (f *fakeRepo) List(_ context.Context, opts database.AlertListOptions) ([]*database.Alert, error) {
+	f.listOpts = opts
+	return []*database.Alert{{ID: 1}}, f.err
+}
+
+func (f *fakeRepo) Acknowledge(_ context.Context, id int64, user string) error {
+	f.ackID, f.ackUser = id, user
+	return f.err
+}
+
+func (f *fakeRepo) Resolve(_ context.Context, id int64) error {
+	f.resolveID = id
+	return f.err
+}
+
+func TestServiceDelegates(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := inbox.NewService(repo)
+	ctx := context.Background()
+
+	alerts, err := svc.List(ctx, database.AlertListOptions{Severity: "warning"})
+	if err != nil || len(alerts) != 1 || repo.listOpts.Severity != "warning" {
+		t.Errorf("List did not delegate: alerts=%v err=%v opts=%+v", alerts, err, repo.listOpts)
+	}
+	if err = svc.Acknowledge(ctx, 7, "alice"); err != nil || repo.ackID != 7 || repo.ackUser != "alice" {
+		t.Errorf("Acknowledge did not delegate: err=%v id=%d user=%q", err, repo.ackID, repo.ackUser)
+	}
+	if err = svc.Resolve(ctx, 9); err != nil || repo.resolveID != 9 {
+		t.Errorf("Resolve did not delegate: err=%v id=%d", err, repo.resolveID)
+	}
+}
+
+func TestServicePropagatesRepoError(t *testing.T) {
+	wantErr := errors.New("boom")
+	svc := inbox.NewService(&fakeRepo{err: wantErr})
+	if _, err := svc.List(context.Background(), database.AlertListOptions{}); !errors.Is(err, wantErr) {
+		t.Errorf("repo error not propagated: %v", err)
+	}
+}

--- a/internal/api/handlers_alerts.go
+++ b/internal/api/handlers_alerts.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/alerts/inbox"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
@@ -43,21 +44,16 @@ const (
 //	limit=100   offset=0         pagination
 func (s *Server) handleAlerts(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
-		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return
-	}
 
 	opts, parseErr := parseAlertListOptions(r)
 	if parseErr != nil {
 		http.Error(w, parseErr.Error(), http.StatusBadRequest)
 		return
 	}
-	alerts, err := db.Alerts().List(r.Context(), opts)
+	alerts, err := s.alertInbox.List(r.Context(), opts)
 	if err != nil {
 		logger.ErrorContext(r.Context(), "list alerts failed", "error", err)
-		http.Error(w, "Failed to list alerts", http.StatusInternalServerError)
+		writeAlertError(w, err, "Failed to list alerts")
 		return
 	}
 	writeJSON(w, r, map[string]any{
@@ -77,19 +73,13 @@ func (s *Server) handleAlertAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	logger := logging.FromContext(r.Context())
-	db := s.db()
-	if db == nil {
-		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
-		return
-	}
 
 	switch action {
 	case "acknowledge":
 		username := s.usernameFromRequest(r)
-		if err := db.Alerts().Acknowledge(r.Context(), id, username); err != nil {
-			logger.ErrorContext(r.Context(), "alert acknowledge failed",
-				"id", id, "error", err)
-			http.Error(w, "Failed to acknowledge alert", http.StatusInternalServerError)
+		if err := s.alertInbox.Acknowledge(r.Context(), id, username); err != nil {
+			logger.ErrorContext(r.Context(), "alert acknowledge failed", "id", id, "error", err)
+			writeAlertError(w, err, "Failed to acknowledge alert")
 			return
 		}
 		writeJSON(w, r, map[string]any{
@@ -98,10 +88,9 @@ func (s *Server) handleAlertAction(w http.ResponseWriter, r *http.Request) {
 			"acknowledgedBy": username,
 		})
 	case "resolve":
-		if err := db.Alerts().Resolve(r.Context(), id); err != nil {
-			logger.ErrorContext(r.Context(), "alert resolve failed",
-				"id", id, "error", err)
-			http.Error(w, "Failed to resolve alert", http.StatusInternalServerError)
+		if err := s.alertInbox.Resolve(r.Context(), id); err != nil {
+			logger.ErrorContext(r.Context(), "alert resolve failed", "id", id, "error", err)
+			writeAlertError(w, err, "Failed to resolve alert")
 			return
 		}
 		writeJSON(w, r, map[string]any{
@@ -112,6 +101,16 @@ func (s *Server) handleAlertAction(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unknown action; use acknowledge or resolve",
 			http.StatusBadRequest)
 	}
+}
+
+// writeAlertError maps an alert-inbox error to its HTTP status: the store unwired
+// → 503 (the prior "Database not initialized"), anything else → 500 with genericMsg.
+func writeAlertError(w http.ResponseWriter, err error, genericMsg string) {
+	if errors.Is(err, inbox.ErrUnavailable) {
+		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	http.Error(w, genericMsg, http.StatusInternalServerError)
 }
 
 // splitAlertActionPath parses /api/v1/alerts/{id}/{action} into

--- a/internal/api/handlers_alerts_internal_test.go
+++ b/internal/api/handlers_alerts_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
@@ -19,6 +20,7 @@ func newAlertsTestServer(t *testing.T) *Server {
 	db := newTestDB(t)
 	s := &Server{}
 	s.dbConn = db
+	s.alertInbox = app.NewAlertInbox(s.db)
 	return s
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/alerts/inbox"
 	alertpipeline "github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
 	"github.com/MustardSeedNetworks/seed/internal/alerts/rules"
 	"github.com/MustardSeedNetworks/seed/internal/anomaly"
@@ -257,6 +258,7 @@ type Server struct {
 	networkProblems    *problems.Service           // Network problem-detection use-case (ADR-0020)
 	topologyQueries    *topology.Queries           // Topology read use-case (ADR-0020)
 	pollingTargets     *targets.Service            // Polling-targets CRUD use-case (ADR-0020)
+	alertInbox         *inbox.Service              // Alert-inbox (list/ack/resolve) use-case (ADR-0020)
 	bluetoothScans     *bluetooth.Service          // Bluetooth-discovery use-case (ADR-0020)
 	healthMonitoring   *monitoring.Service         // Health-monitoring use-case (ADR-0020)
 	healthSettings     *healthsettings.Service     // Health-checks settings use-case (ADR-0020)
@@ -931,6 +933,7 @@ func (s *Server) initDiscoveryUseCases() {
 	s.networkProblems = app.NewProblems(s.problemDetector, s.discoveryService)
 	s.topologyQueries = app.NewTopologyQueries(s.db, topologyMaxLimit)
 	s.pollingTargets = app.NewPollingTargets(s.db)
+	s.alertInbox = app.NewAlertInbox(s.db)
 	s.bluetoothScans = app.NewBluetooth(s.bluetoothScanner)
 }
 

--- a/internal/app/alerts_inbox.go
+++ b/internal/app/alerts_inbox.go
@@ -1,0 +1,58 @@
+package app
+
+// alerts_inbox.go wires the composition root to the alert-inbox use-case
+// (ADR-0020, WS-A8). The adapter implements the inbox.Repository port over the
+// alert repository, resolving the database lazily; a nil database yields
+// inbox.ErrUnavailable so the handler degrades to 503 rather than panicking.
+
+import (
+	"context"
+
+	"github.com/MustardSeedNetworks/seed/internal/alerts/inbox"
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+// NewAlertInbox builds the alert-inbox use-case over a lazy database accessor.
+func NewAlertInbox(db func() *database.DB) *inbox.Service {
+	return inbox.NewService(alertInboxRepo{db: db})
+}
+
+// alertInboxRepo implements inbox.Repository over the alert repository. A nil
+// database makes every call return inbox.ErrUnavailable.
+type alertInboxRepo struct {
+	db func() *database.DB
+}
+
+func (a alertInboxRepo) repo() (*database.AlertRepository, error) {
+	db := a.db()
+	if db == nil {
+		return nil, inbox.ErrUnavailable
+	}
+	return db.Alerts(), nil
+}
+
+func (a alertInboxRepo) List(
+	ctx context.Context, opts database.AlertListOptions,
+) ([]*database.Alert, error) {
+	repo, err := a.repo()
+	if err != nil {
+		return nil, err
+	}
+	return repo.List(ctx, opts)
+}
+
+func (a alertInboxRepo) Acknowledge(ctx context.Context, id int64, username string) error {
+	repo, err := a.repo()
+	if err != nil {
+		return err
+	}
+	return repo.Acknowledge(ctx, id, username)
+}
+
+func (a alertInboxRepo) Resolve(ctx context.Context, id int64) error {
+	repo, err := a.repo()
+	if err != nil {
+		return err
+	}
+	return repo.Resolve(ctx, id)
+}


### PR DESCRIPTION
**WS-A8** — `handlers_alerts.go` reached `s.db().Alerts()` directly for list / acknowledge / resolve.

- **`internal/alerts/inbox`** — `Service` over a narrow `Repository` port (List/Acknowledge/Resolve) + `ErrUnavailable`. `internal/alerts` already depends on `internal/database` (the pipelines), so the passthrough is consistent there; WS-B addresses the package's repo-port discipline holistically.
- **`internal/app/alerts_inbox.go`** — adapter over `db.Alerts()`, nil-safe (nil db → `ErrUnavailable` → 503).
- **`handlers_alerts.go`** — `handleAlerts` + `handleAlertAction` delegate to `s.alertInbox` with a shared `writeAlertError` mapper (unavailable→503, else→500); parse/encode/splitPath/username transport helpers stay. **Zero `s.db()` reaches.**

Tests: `Service` delegation + repo-error propagation; api alerts handler tests pass through the strangled path. Non-race api suite + full staticcheck + filename/route/escaping/`--new-from-rev` lint green.