### PR TITLE
refactor(api): strangle config backup/restore into a use-case (ADR-0020, WS-A9)

### DIFF
--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/auth"
 	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/config/backups"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
@@ -137,11 +138,22 @@ func (rl *RateLimiter) Limit() int {
 // SetConfig sets the server config for testing.
 func (s *Server) SetConfig(cfg *config.Config) {
 	s.config = cfg
+	s.wireConfigBackupsForTest()
 }
 
 // SetConfigPath sets the server config path for testing.
 func (s *Server) SetConfigPath(path string) {
 	s.configPath = path
+	s.wireConfigBackupsForTest()
+}
+
+// wireConfigBackupsForTest builds the config-backups use-case once both the
+// config and its path are set, mirroring NewServer's wiring for the bare-Server
+// test harnesses.
+func (s *Server) wireConfigBackupsForTest() {
+	if s.config != nil && s.configPath != "" {
+		s.configBackups = backups.NewService(s.config, s.configPath)
+	}
 }
 
 // InitServices initializes the minimal services for testing.

--- a/internal/api/handlers_config.go
+++ b/internal/api/handlers_config.go
@@ -1,19 +1,15 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"path/filepath"
 	"regexp"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/config/backups"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
-)
-
-// Configuration backup constants.
-const (
-	// defaultBackupMaxCount is the maximum number of configuration backups to retain.
-	defaultBackupMaxCount = 10
 )
 
 // ============================================================================
@@ -42,10 +38,7 @@ func (s *Server) handleConfigBackups(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
 
-	backupDir := filepath.Dir(s.configPath)
-	backupMgr := config.NewBackupManager(s.configPath, backupDir, defaultBackupMaxCount)
-
-	backups, err := backupMgr.ListBackups()
+	backupList, err := s.configBackups.List()
 	if err != nil {
 		logger.ErrorContext(r.Context(), "Failed to list backups", "error", err)
 		sendErrorResponseWithDetails(
@@ -59,7 +52,7 @@ func (s *Server) handleConfigBackups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sendJSONResponse(w, logger, http.StatusOK, BackupListResponse{Backups: backups})
+	sendJSONResponse(w, logger, http.StatusOK, BackupListResponse{Backups: backupList})
 }
 
 // handleConfigBackupCreate handles POST /api/config/backup - create a new backup.
@@ -67,10 +60,7 @@ func (s *Server) handleConfigBackupCreate(w http.ResponseWriter, r *http.Request
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
 
-	backupDir := filepath.Dir(s.configPath)
-	backupMgr := config.NewBackupManager(s.configPath, backupDir, defaultBackupMaxCount)
-
-	backup, err := backupMgr.CreateBackup()
+	backup, err := s.configBackups.Create()
 	if err != nil {
 		logger.ErrorContext(r.Context(), "Failed to create backup", "error", err)
 		sendErrorResponseWithDetails(
@@ -116,43 +106,18 @@ func (s *Server) handleConfigRestore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	backupDir := filepath.Dir(s.configPath)
-	backupMgr := config.NewBackupManager(s.configPath, backupDir, defaultBackupMaxCount)
-
-	if err := backupMgr.RestoreBackup(req.BackupName); err != nil {
+	if err := s.configBackups.Restore(req.BackupName); err != nil {
+		msgKey := "errors.config.failedToRestoreBackup"
+		if errors.Is(err, backups.ErrReloadFailed) {
+			msgKey = "errors.config.failedToReloadAfterRestore"
+		}
 		logger.ErrorContext(r.Context(), "Failed to restore backup", "error", err, "backup_name", req.BackupName)
 		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			localizer.T("errors.config.failedToRestoreBackup"),
-			"",
-		) // fixes #694, #H7
+			w, logger, http.StatusInternalServerError, ErrCodeInternal,
+			localizer.T(msgKey), "",
+		)
 		return
 	}
-
-	// Reload config after restore
-	newCfg, err := config.Load(s.configPath)
-	if err != nil {
-		logger.ErrorContext(r.Context(), "Failed to reload config after restore", "error", err)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			localizer.T("errors.config.failedToReloadAfterRestore"),
-			"",
-		) // fixes #694, #H7
-		return
-	}
-
-	// Update server config using CopyFieldsFrom to prevent race conditions (fixes #691)
-	// CopyFieldsFrom uses struct literals for compile-time checking that no fields are missed
-	// Using defer for panic safety (fixes #783)
-	s.config.Lock()
-	defer s.config.Unlock()
-	s.config.CopyFieldsFrom(newCfg)
 
 	// Security audit log: config restored from backup (fixes #697)
 	clientIP := s.getClientIP(r)
@@ -203,10 +168,7 @@ func (s *Server) handleConfigBackupDelete(w http.ResponseWriter, r *http.Request
 	// Strip any directory components as additional safety measure
 	backupName = filepath.Base(backupName)
 
-	backupDir := filepath.Dir(s.configPath)
-	backupMgr := config.NewBackupManager(s.configPath, backupDir, defaultBackupMaxCount)
-
-	if err := backupMgr.DeleteBackup(backupName); err != nil {
+	if err := s.configBackups.Delete(backupName); err != nil {
 		logger.ErrorContext(r.Context(), "Failed to delete backup", "error", err, "backup_name", backupName)
 		sendErrorResponseWithDetails(
 			w,
@@ -238,14 +200,11 @@ func (s *Server) handleConfigBackupDelete(w http.ResponseWriter, r *http.Request
 func (s *Server) handleConfigVersion(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 
-	s.config.RLock()
-	currentVersion := s.config.Version
-	s.config.RUnlock()
-
+	current, latest := s.configBackups.Version()
 	resp := ConfigVersionResponse{
-		Current:        currentVersion,
-		Latest:         config.ConfigVersion,
-		NeedsMigration: currentVersion < config.ConfigVersion,
+		Current:        current,
+		Latest:         latest,
+		NeedsMigration: current < latest,
 	}
 
 	sendJSONResponse(w, logger, http.StatusOK, resp)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/auth"
 	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/config/backups"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/dhcp"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/cable"
@@ -259,6 +260,7 @@ type Server struct {
 	topologyQueries    *topology.Queries           // Topology read use-case (ADR-0020)
 	pollingTargets     *targets.Service            // Polling-targets CRUD use-case (ADR-0020)
 	alertInbox         *inbox.Service              // Alert-inbox (list/ack/resolve) use-case (ADR-0020)
+	configBackups      *backups.Service            // Config backup/restore use-case (ADR-0020)
 	bluetoothScans     *bluetooth.Service          // Bluetooth-discovery use-case (ADR-0020)
 	healthMonitoring   *monitoring.Service         // Health-monitoring use-case (ADR-0020)
 	healthSettings     *healthsettings.Service     // Health-checks settings use-case (ADR-0020)
@@ -382,6 +384,7 @@ func NewServer(
 	// builds the adapters; api passes its lazy db accessor + live config.
 	s.settingsStore = app.NewSettings(s.db, s.config)
 	s.settingsManagement = app.NewSettingsManagement(s.config, s.configPath)
+	s.configBackups = backups.NewService(s.config, s.configPath)
 	s.securitySettings = app.NewSecuritySettings(s.config, s.configPath, s.rogueDetector)
 
 	// Wire the profiles catalog use-case (ADR-0020). The composition root builds

--- a/internal/config/backups/backups.go
+++ b/internal/config/backups/backups.go
@@ -1,0 +1,78 @@
+// Package backups is the config backup/restore use-case (ADR-0020, WS-A9): the
+// /api/config/backup* endpoints' application service. It owns the BackupManager
+// (constructed once here instead of per-request in the transport layer) and the
+// restore reload-and-apply sequence, so the handlers depend on a use-case instead
+// of constructing infrastructure and mutating the live config inline.
+package backups
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+)
+
+// DefaultMaxCount is the number of configuration backups retained.
+const DefaultMaxCount = 10
+
+var (
+	// ErrRestoreFailed wraps a failure to restore the backup file.
+	ErrRestoreFailed = errors.New("backups: restore failed")
+	// ErrReloadFailed wraps a failure to reload the config after a restore.
+	ErrReloadFailed = errors.New("backups: reload after restore failed")
+)
+
+// Service is the config backup/restore use-case.
+type Service struct {
+	mgr  *config.BackupManager
+	cfg  *config.Config
+	path string
+}
+
+// NewService builds the use-case over the live config and its on-disk path,
+// constructing the BackupManager for the path's directory.
+func NewService(cfg *config.Config, path string) *Service {
+	return &Service{
+		mgr:  config.NewBackupManager(path, filepath.Dir(path), DefaultMaxCount),
+		cfg:  cfg,
+		path: path,
+	}
+}
+
+// List returns the available config backups.
+func (s *Service) List() ([]config.BackupInfo, error) { return s.mgr.ListBackups() }
+
+// Create writes a new backup of the current config.
+func (s *Service) Create() (*config.BackupInfo, error) { return s.mgr.CreateBackup() }
+
+// Delete removes the named backup.
+func (s *Service) Delete(name string) error { return s.mgr.DeleteBackup(name) }
+
+// Restore restores the named backup, reloads the config from disk, and copies the
+// reloaded fields into the live config under its write lock. A restore-file
+// failure returns ErrRestoreFailed; a reload failure returns ErrReloadFailed (the
+// transport layer maps the two to distinct messages).
+func (s *Service) Restore(name string) error {
+	if err := s.mgr.RestoreBackup(name); err != nil {
+		return fmt.Errorf("%w: %w", ErrRestoreFailed, err)
+	}
+	newCfg, err := config.Load(s.path)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrReloadFailed, err)
+	}
+	// CopyFieldsFrom uses struct literals for compile-time checking that no fields
+	// are missed; the lock guards the live config against concurrent readers.
+	s.cfg.Lock()
+	defer s.cfg.Unlock()
+	s.cfg.CopyFieldsFrom(newCfg)
+	return nil
+}
+
+// Version returns the live config's schema version and the latest known version.
+func (s *Service) Version() (int, int) {
+	s.cfg.RLock()
+	current := s.cfg.Version
+	s.cfg.RUnlock()
+	return current, config.ConfigVersion
+}

--- a/internal/config/backups/backups_test.go
+++ b/internal/config/backups/backups_test.go
@@ -1,0 +1,65 @@
+package backups_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/config/backups"
+	"github.com/MustardSeedNetworks/seed/internal/testutil"
+)
+
+func newSvc(t *testing.T) (*backups.Service, *config.Config) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.json")
+	cfg := testutil.NewConfigBuilder().WithPort(8080).Build()
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	return backups.NewService(cfg, path), cfg
+}
+
+func TestCreateListDeleteRoundTrip(t *testing.T) {
+	svc, _ := newSvc(t)
+
+	backup, err := svc.Create()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	list, err := svc.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != backup.Name {
+		t.Fatalf("List did not return the created backup: %+v", list)
+	}
+	if err = svc.Delete(backup.Name); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	list, err = svc.List()
+	if err != nil {
+		t.Fatalf("List after delete: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("backup not deleted: %+v", list)
+	}
+}
+
+func TestRestoreMissingBackupReturnsRestoreFailed(t *testing.T) {
+	svc, _ := newSvc(t)
+	if err := svc.Restore("does-not-exist"); !errors.Is(err, backups.ErrRestoreFailed) {
+		t.Errorf("want ErrRestoreFailed, got %v", err)
+	}
+}
+
+func TestVersionReportsCurrentAndLatest(t *testing.T) {
+	svc, cfg := newSvc(t)
+	current, latest := svc.Version()
+	if current != cfg.Version {
+		t.Errorf("current = %d, want %d", current, cfg.Version)
+	}
+	if latest != config.ConfigVersion {
+		t.Errorf("latest = %d, want %d", latest, config.ConfigVersion)
+	}
+}


### PR DESCRIPTION
**WS-A9** — `handlers_config.go` constructed a `config.BackupManager` inline in four handlers and, on restore, reloaded the config + `CopyFieldsFrom` into the live config under lock — infrastructure construction + config mutation in transport.

- **`internal/config/backups`** — `Service` owning the BackupManager (built once, not per-request) and the restore reload-and-apply sequence (`RestoreBackup` → `Load` → `CopyFieldsFrom` under lock), with `ErrRestoreFailed`/`ErrReloadFailed` sentinels so the handler keeps its two distinct restore error messages. `List`/`Create`/`Delete`/`Version` round out the surface. `DefaultMaxCount` moved here from the api package.
- **`handlers_config.go`** — the five handlers delegate to `s.configBackups`; the backup-name path-traversal validation stays as transport input-guarding. **Zero `s.config` / `config.NewBackupManager` / `config.Load` reaches.**
- Self-contained over config (no ports/adapter); the external config test wires it via the `SetConfig`/`SetConfigPath` test helpers.

Tests: `Service` (create/list/delete roundtrip, restore-missing → `ErrRestoreFailed`, `Version`); the existing api restore test now exercises the strangled path end-to-end. Non-race api suite + full staticcheck + filename/route/escaping/`--new-from-rev` lint green.