### PR TITLE
refactor(api): strangle diagnostic export into a use-case (ADR-0020, WS-A10)

### DIFF
--- a/internal/api/export_sources.go
+++ b/internal/api/export_sources.go
@@ -1,0 +1,208 @@
+package api
+
+// export_sources.go adapts the live diagnostic services to the export use-case's
+// Sources port (ADR-0020, WS-A10). Each method gathers and shapes one card from
+// the corresponding domain service; an absent service yields ok=false so the
+// use-case omits the card. The card-shaping that used to live as a fan-out of
+// *Server.export* methods on the handler now lives here, behind the port.
+
+import (
+	"context"
+
+	"github.com/MustardSeedNetworks/seed/internal/dhcp"
+)
+
+// serverExportSources implements export.Sources over the server's diagnostic
+// service accessors.
+type serverExportSources struct {
+	s *Server
+}
+
+func (a serverExportSources) RefreshInterfaces() error {
+	return a.s.netManager().RefreshInterfaces()
+}
+
+func (a serverExportSources) DeviceMAC(iface string) string {
+	if info, err := a.s.netManager().GetInterface(iface); err == nil {
+		return info.HardwareAddr
+	}
+	return ""
+}
+
+func (a serverExportSources) IPMode() string { return a.s.config.IP.Mode }
+
+// Cards gathers every present diagnostic card for iface, keyed by name; an absent
+// card (its source service unavailable or empty) is omitted.
+func (a serverExportSources) Cards(ctx context.Context, iface string) map[string]any {
+	cards := make(map[string]any)
+	add := func(name string, data map[string]any, ok bool) {
+		if ok {
+			cards[name] = data
+		}
+	}
+	link, ok := a.linkCard(iface)
+	add("link", link, ok)
+	ipCfg, ok := a.ipConfigCard(iface)
+	add("ipConfig", ipCfg, ok)
+	disc, ok := a.discoveryCard()
+	add("switch", disc, ok)
+	dnsCard, ok := a.dnsCard(ctx)
+	add("dns", dnsCard, ok)
+	gw, ok := a.gatewayCard()
+	add("gateway", gw, ok)
+	vlanCard, ok := a.vlanCard()
+	add("vlan", vlanCard, ok)
+	wifi, ok := a.wifiCard(iface)
+	add("wifi", wifi, ok)
+	cable, ok := a.cableCard()
+	add("cable", cable, ok)
+	speed, ok := a.speedtestCard()
+	add("speedtest", speed, ok)
+	iperfCard, ok := a.iperfCard()
+	add("iperf", iperfCard, ok)
+	return cards
+}
+
+func (a serverExportSources) linkCard(iface string) (map[string]any, bool) {
+	linkStatus, err := a.s.netManager().GetLinkStatus(iface)
+	if err != nil {
+		return nil, false
+	}
+	return map[string]any{
+		"linkUp": linkStatus.LinkUp, "speed": linkStatus.Speed,
+		"duplex": linkStatus.Duplex, "autoNeg": linkStatus.AutoNeg,
+	}, true
+}
+
+func (a serverExportSources) ipConfigCard(iface string) (map[string]any, bool) {
+	ifaceInfo, err := a.s.netManager().GetInterface(iface)
+	if err != nil {
+		return nil, false
+	}
+	ipData := map[string]any{"addresses": ifaceInfo.Addresses}
+	if leaseInfo, leaseErr := dhcp.GetLeaseInfo(iface); leaseErr == nil && leaseInfo != nil {
+		ipData["dhcpServer"] = leaseInfo.DHCPServer
+		ipData["gateway"] = leaseInfo.Gateway
+		ipData["leaseTime"] = leaseInfo.LeaseTime
+		ipData["dns"] = leaseInfo.DNS
+	}
+	return ipData, true
+}
+
+func (a serverExportSources) discoveryCard() (map[string]any, bool) {
+	if a.s.discoveryService() == nil {
+		return nil, false
+	}
+	neighbors := a.s.discoveryService().GetNeighbors()
+	neighborList := make([]map[string]any, 0, len(neighbors))
+	for _, n := range neighbors {
+		neighborList = append(neighborList, map[string]any{
+			"protocol": n.Protocol, "systemName": n.SystemName, "portId": n.PortID,
+			"portDescription": n.PortDescription, "managementAddress": n.ManagementAddress,
+		})
+	}
+	return map[string]any{
+		"running":   a.s.discoveryService().IsRunning(),
+		"neighbors": neighborList,
+	}, true
+}
+
+func (a serverExportSources) dnsCard(ctx context.Context) (map[string]any, bool) {
+	if a.s.dnsTester() == nil {
+		return nil, false
+	}
+	result := a.s.dnsTester().Test(ctx)
+	dnsData := map[string]any{"server": result.Server, "testHostname": result.TestHostname}
+	if result.Forward != nil {
+		dnsData["forward"] = map[string]any{
+			"result": result.Forward.Resolved, "time": result.Forward.Time.Milliseconds(),
+			"status": result.Forward.Status, "error": result.Forward.Error,
+		}
+	}
+	if result.Reverse != nil {
+		dnsData["reverse"] = map[string]any{
+			"result": result.Reverse.Resolved, "time": result.Reverse.Time.Milliseconds(),
+			"status": result.Reverse.Status, "error": result.Reverse.Error,
+		}
+	}
+	return dnsData, true
+}
+
+func (a serverExportSources) gatewayCard() (map[string]any, bool) {
+	if a.s.gatewayTester() == nil {
+		return nil, false
+	}
+	stats := a.s.gatewayTester().GetStats()
+	return map[string]any{
+		"gateway": stats.Gateway, "reachable": stats.Reachable, "sent": stats.Sent,
+		"received": stats.Received, "lossPercent": stats.LossPercent,
+		"avgTime": stats.AvgTime, "status": stats.Status,
+	}, true
+}
+
+func (a serverExportSources) vlanCard() (map[string]any, bool) {
+	if a.s.vlanManager() == nil {
+		return nil, false
+	}
+	vlanInfo := a.s.vlanManager().GetInfo()
+	return map[string]any{
+		"nativeVlan": vlanInfo.NativeVlan, "taggedVlans": vlanInfo.TaggedVlans,
+		"voiceVlan": vlanInfo.VoiceVlan, "configured": vlanInfo.Configured,
+	}, true
+}
+
+func (a serverExportSources) wifiCard(iface string) (map[string]any, bool) {
+	if !a.s.netManager().IsWireless(iface) || a.s.wifiManager() == nil {
+		return nil, false
+	}
+	wifiInfo := a.s.wifiManager().GetInfo()
+	if wifiInfo.SSID == "" {
+		return nil, false
+	}
+	return map[string]any{
+		"ssid": wifiInfo.SSID, "bssid": wifiInfo.BSSID, "signal": wifiInfo.Signal,
+		"channel": wifiInfo.Channel, "frequency": wifiInfo.Frequency, "security": wifiInfo.Security,
+	}, true
+}
+
+func (a serverExportSources) cableCard() (map[string]any, bool) {
+	if a.s.cableTester() == nil {
+		return nil, false
+	}
+	cableResult := a.s.cableTester().Test()
+	return map[string]any{
+		"supported": cableResult.Supported, "length": cableResult.Length,
+		"status": cableResult.Status, "faults": cableResult.Faults,
+	}, true
+}
+
+func (a serverExportSources) speedtestCard() (map[string]any, bool) {
+	if a.s.speedtestTester() == nil {
+		return nil, false
+	}
+	result := a.s.speedtestTester().GetLastResult()
+	if result == nil {
+		return nil, false
+	}
+	return map[string]any{
+		"download": result.Download, "upload": result.Upload, "latency": result.Latency,
+		"server": result.Server, "location": result.Location, "host": result.Host,
+		"distance": result.Distance, "timestamp": result.Timestamp, "testDuration": result.TestDuration,
+	}, true
+}
+
+func (a serverExportSources) iperfCard() (map[string]any, bool) {
+	if a.s.iperfManager() == nil {
+		return nil, false
+	}
+	result := a.s.iperfManager().GetLastResult()
+	if result == nil {
+		return nil, false
+	}
+	return map[string]any{
+		"bandwidth": result.Bandwidth, "transfer": result.Transfer, "retransmits": result.Retransmits,
+		"jitter": result.Jitter, "lostPackets": result.LostPackets, "lostPercent": result.LostPercent,
+		"protocol": result.Protocol, "direction": result.Direction, "duration": result.Duration,
+		"server": result.Server, "port": result.Port, "timestamp": result.Timestamp,
+	}, true
+}

--- a/internal/api/handlers_status.go
+++ b/internal/api/handlers_status.go
@@ -1,13 +1,11 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/dhcp"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/system"
 	"github.com/MustardSeedNetworks/seed/internal/version"
@@ -29,21 +27,6 @@ type StatusResponse struct {
 	ICMPAvailable bool   `json:"icmpAvailable"`
 }
 
-// ExportData represents the full diagnostic export.
-type ExportData struct {
-	Version   string           `json:"version"`
-	Timestamp string           `json:"timestamp"`
-	Device    ExportDeviceInfo `json:"device"`
-	Cards     map[string]any   `json:"cards"`
-}
-
-// ExportDeviceInfo contains device information.
-type ExportDeviceInfo struct {
-	Interface string `json:"interface"`
-	MAC       string `json:"mac,omitempty"`
-	IPMode    string `json:"ipMode"`
-}
-
 // handleStatus returns the system status (fixes #544 - split from handlers.go).
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
@@ -56,7 +39,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	resp := StatusResponse{
 		Status:        "ok",
 		Version:       version.GetVersion(),
-		Interface:     s.config.Interface.Default,
+		Interface:     s.defaultInterface(),
 		IsWireless:    isWireless,
 		ICMPAvailable: s.icmpAvailable,
 	}
@@ -64,199 +47,28 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	sendJSONResponse(w, logger, http.StatusOK, resp)
 }
 
-// handleExport exports current diagnostic data as JSON (fixes #544 - split from handlers.go).
-// Accepts optional query parameter: ?interface=eth0.
+// handleExport exports current diagnostic data as JSON (fixes #544 - split from
+// handlers.go). Accepts optional query parameter: ?interface=eth0. Thin transport
+// (ADR-0020): the export-assembly fan-out lives in the export use-case.
 func (s *Server) handleExport(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	// Get interface from query param or fallback to current.
-	currentIface := s.getInterfaceFromRequest(r)
-	if err := s.netManager().RefreshInterfaces(); err != nil {
+
+	data, err := s.exportService.Build(r.Context(), s.getInterfaceFromRequest(r), version.GetVersion())
+	if err != nil {
 		logger.ErrorContext(r.Context(), "Failed to refresh interfaces", "error", err)
 		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			"Failed to refresh interfaces",
-			"",
+			w, logger, http.StatusInternalServerError, ErrCodeInternal,
+			"Failed to refresh interfaces", "",
 		)
 		return
 	}
-
-	var mac string
-	if ifaceInfo, err := s.netManager().GetInterface(currentIface); err == nil {
-		mac = ifaceInfo.HardwareAddr
-	}
-
-	export := ExportData{
-		Version:   version.GetVersion(),
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		Device: ExportDeviceInfo{
-			Interface: currentIface,
-			MAC:       mac,
-			IPMode:    s.config.IP.Mode,
-		},
-		Cards: make(map[string]any),
-	}
-
-	s.exportLinkCard(currentIface, export.Cards)
-	s.exportIPConfigCard(currentIface, export.Cards)
-	s.exportDiscoveryCard(export.Cards)
-	s.exportDNSCard(r.Context(), export.Cards)
-	s.exportGatewayCard(export.Cards)
-	s.exportVLANCard(export.Cards)
-	s.exportWiFiCard(currentIface, export.Cards)
-	s.exportCableCard(export.Cards)
-	s.exportSpeedtestCard(export.Cards)
-	s.exportIperfCard(export.Cards)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Disposition", "attachment; filename=seed-export.json")
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(export); err != nil {
-		logger.ErrorContext(r.Context(), "Error encoding export response", "error", err)
-	}
-}
-
-func (s *Server) exportLinkCard(iface string, cards map[string]any) {
-	if linkStatus, err := s.netManager().GetLinkStatus(iface); err == nil {
-		cards["link"] = map[string]any{
-			"linkUp": linkStatus.LinkUp, "speed": linkStatus.Speed,
-			"duplex": linkStatus.Duplex, "autoNeg": linkStatus.AutoNeg,
-		}
-	}
-}
-
-func (s *Server) exportIPConfigCard(iface string, cards map[string]any) {
-	ifaceInfo, err := s.netManager().GetInterface(iface)
-	if err != nil {
-		return
-	}
-	ipData := map[string]any{"addresses": ifaceInfo.Addresses}
-	if leaseInfo, leaseErr := dhcp.GetLeaseInfo(iface); leaseErr == nil && leaseInfo != nil {
-		ipData["dhcpServer"] = leaseInfo.DHCPServer
-		ipData["gateway"] = leaseInfo.Gateway
-		ipData["leaseTime"] = leaseInfo.LeaseTime
-		ipData["dns"] = leaseInfo.DNS
-	}
-	cards["ipConfig"] = ipData
-}
-
-func (s *Server) exportDiscoveryCard(cards map[string]any) {
-	if s.discoveryService() == nil {
-		return
-	}
-	neighbors := s.discoveryService().GetNeighbors()
-	neighborList := make([]map[string]any, 0, len(neighbors))
-	for _, n := range neighbors {
-		neighborList = append(neighborList, map[string]any{
-			"protocol": n.Protocol, "systemName": n.SystemName, "portId": n.PortID,
-			"portDescription": n.PortDescription, "managementAddress": n.ManagementAddress,
-		})
-	}
-	cards["switch"] = map[string]any{
-		"running":   s.discoveryService().IsRunning(),
-		"neighbors": neighborList,
-	}
-}
-
-func (s *Server) exportDNSCard(ctx context.Context, cards map[string]any) {
-	if s.dnsTester() == nil {
-		return
-	}
-	result := s.dnsTester().Test(ctx)
-	dnsData := map[string]any{"server": result.Server, "testHostname": result.TestHostname}
-	if result.Forward != nil {
-		dnsData["forward"] = map[string]any{
-			"result": result.Forward.Resolved, "time": result.Forward.Time.Milliseconds(),
-			"status": result.Forward.Status, "error": result.Forward.Error,
-		}
-	}
-	if result.Reverse != nil {
-		dnsData["reverse"] = map[string]any{
-			"result": result.Reverse.Resolved, "time": result.Reverse.Time.Milliseconds(),
-			"status": result.Reverse.Status, "error": result.Reverse.Error,
-		}
-	}
-	cards["dns"] = dnsData
-}
-
-func (s *Server) exportGatewayCard(cards map[string]any) {
-	if s.gatewayTester() == nil {
-		return
-	}
-	stats := s.gatewayTester().GetStats()
-	cards["gateway"] = map[string]any{
-		"gateway": stats.Gateway, "reachable": stats.Reachable, "sent": stats.Sent,
-		"received": stats.Received, "lossPercent": stats.LossPercent,
-		"avgTime": stats.AvgTime, "status": stats.Status,
-	}
-}
-
-func (s *Server) exportVLANCard(cards map[string]any) {
-	if s.vlanManager() == nil {
-		return
-	}
-	vlanInfo := s.vlanManager().GetInfo()
-	cards["vlan"] = map[string]any{
-		"nativeVlan": vlanInfo.NativeVlan, "taggedVlans": vlanInfo.TaggedVlans,
-		"voiceVlan": vlanInfo.VoiceVlan, "configured": vlanInfo.Configured,
-	}
-}
-
-func (s *Server) exportWiFiCard(iface string, cards map[string]any) {
-	if !s.netManager().IsWireless(iface) || s.wifiManager() == nil {
-		return
-	}
-	wifiInfo := s.wifiManager().GetInfo()
-	if wifiInfo.SSID != "" {
-		cards["wifi"] = map[string]any{
-			"ssid": wifiInfo.SSID, "bssid": wifiInfo.BSSID, "signal": wifiInfo.Signal,
-			"channel": wifiInfo.Channel, "frequency": wifiInfo.Frequency, "security": wifiInfo.Security,
-		}
-	}
-}
-
-func (s *Server) exportCableCard(cards map[string]any) {
-	if s.cableTester() == nil {
-		return
-	}
-	cableResult := s.cableTester().Test()
-	cards["cable"] = map[string]any{
-		"supported": cableResult.Supported, "length": cableResult.Length,
-		"status": cableResult.Status, "faults": cableResult.Faults,
-	}
-}
-
-func (s *Server) exportSpeedtestCard(cards map[string]any) {
-	if s.speedtestTester() == nil {
-		return
-	}
-	result := s.speedtestTester().GetLastResult()
-	if result == nil {
-		return
-	}
-	cards["speedtest"] = map[string]any{
-		"download": result.Download, "upload": result.Upload, "latency": result.Latency,
-		"server": result.Server, "location": result.Location, "host": result.Host,
-		"distance": result.Distance, "timestamp": result.Timestamp, "testDuration": result.TestDuration,
-	}
-}
-
-func (s *Server) exportIperfCard(cards map[string]any) {
-	if s.iperfManager() == nil {
-		return
-	}
-	result := s.iperfManager().GetLastResult()
-	if result == nil {
-		return
-	}
-	cards["iperf"] = map[string]any{
-		"bandwidth": result.Bandwidth, "transfer": result.Transfer, "retransmits": result.Retransmits,
-		"jitter": result.Jitter, "lostPackets": result.LostPackets, "lostPercent": result.LostPercent,
-		"protocol": result.Protocol, "direction": result.Direction, "duration": result.Duration,
-		"server": result.Server, "port": result.Port, "timestamp": result.Timestamp,
+	if encErr := encoder.Encode(data); encErr != nil {
+		logger.ErrorContext(r.Context(), "Error encoding export response", "error", encErr)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/dhcp"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/cable"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/dns"
+	"github.com/MustardSeedNetworks/seed/internal/diagnostics/export"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/gateway"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/iperf"
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/speedtest"
@@ -261,6 +262,7 @@ type Server struct {
 	pollingTargets     *targets.Service            // Polling-targets CRUD use-case (ADR-0020)
 	alertInbox         *inbox.Service              // Alert-inbox (list/ack/resolve) use-case (ADR-0020)
 	configBackups      *backups.Service            // Config backup/restore use-case (ADR-0020)
+	exportService      *export.Service             // Diagnostic-export use-case (ADR-0020)
 	bluetoothScans     *bluetooth.Service          // Bluetooth-discovery use-case (ADR-0020)
 	healthMonitoring   *monitoring.Service         // Health-monitoring use-case (ADR-0020)
 	healthSettings     *healthsettings.Service     // Health-checks settings use-case (ADR-0020)
@@ -861,6 +863,7 @@ func (s *Server) webAuthnManager() *auth.WebAuthnManager      { return s.webAuth
 func (s *Server) loginRateLimiter() *RateLimiter              { return s.loginLimiter }
 func (s *Server) endpointRateLimiter() *EndpointRateLimiter   { return s.endpointLimiter }
 func (s *Server) netManager() *netif.Manager                  { return s.netMgr }
+func (s *Server) defaultInterface() string                    { return s.config.Interface.Default }
 func (s *Server) linkMonitor() *netif.LinkMonitor             { return s.linkMon }
 func (s *Server) deviceDiscovery() *enumerate.DeviceDiscovery { return s.deviceDisc }
 func (s *Server) discoveryService() *enumerate.Service        { return s.discoverySvc }
@@ -935,6 +938,7 @@ func (s *Server) initDiscoveryUseCases() {
 	s.discoverySettings = app.NewDiscoverySettings(s.config, s.configPath, s.deviceDiscovery)
 	s.networkProblems = app.NewProblems(s.problemDetector, s.discoveryService)
 	s.topologyQueries = app.NewTopologyQueries(s.db, topologyMaxLimit)
+	s.exportService = export.NewService(serverExportSources{s: s})
 	s.pollingTargets = app.NewPollingTargets(s.db)
 	s.alertInbox = app.NewAlertInbox(s.db)
 	s.bluetoothScans = app.NewBluetooth(s.bluetoothScanner)

--- a/internal/diagnostics/export/export.go
+++ b/internal/diagnostics/export/export.go
@@ -1,0 +1,64 @@
+// Package export is the diagnostic-export use-case (ADR-0020, WS-A10): the
+// /api/v1/export endpoint's application service. It coordinates the per-card
+// diagnostic sources into one export document, owning the assembly logic the
+// transport layer used to carry as a fan-out of *Server methods. The card data
+// is gathered through the consumer-defined Sources port, satisfied by an adapter
+// in the api layer over the live diagnostic services.
+package export
+
+import (
+	"context"
+	"time"
+)
+
+// DeviceInfo is the export's device summary.
+type DeviceInfo struct {
+	Interface string `json:"interface"`
+	MAC       string `json:"mac,omitempty"`
+	IPMode    string `json:"ipMode"`
+}
+
+// Data is the full diagnostic export document.
+type Data struct {
+	Version   string         `json:"version"`
+	Timestamp string         `json:"timestamp"`
+	Device    DeviceInfo     `json:"device"`
+	Cards     map[string]any `json:"cards"`
+}
+
+// Sources provides the export's device info and the assembled per-card
+// diagnostic data. Cards returns the present cards keyed by name (absent cards
+// are simply omitted); the per-card gathering/shaping lives in the adapter.
+type Sources interface {
+	RefreshInterfaces() error
+	DeviceMAC(iface string) string
+	IPMode() string
+	Cards(ctx context.Context, iface string) map[string]any
+}
+
+// Service is the diagnostic-export use-case.
+type Service struct {
+	src Sources
+}
+
+// NewService builds the use-case over its Sources port.
+func NewService(src Sources) *Service { return &Service{src: src} }
+
+// Build assembles the export document for iface, stamping it with ver. It first
+// refreshes the interface set (an error there aborts the export), then composes
+// the device summary and the gathered cards.
+func (s *Service) Build(ctx context.Context, iface, ver string) (Data, error) {
+	if err := s.src.RefreshInterfaces(); err != nil {
+		return Data{}, err
+	}
+	return Data{
+		Version:   ver,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Device: DeviceInfo{
+			Interface: iface,
+			MAC:       s.src.DeviceMAC(iface),
+			IPMode:    s.src.IPMode(),
+		},
+		Cards: s.src.Cards(ctx, iface),
+	}, nil
+}

--- a/internal/diagnostics/export/export_test.go
+++ b/internal/diagnostics/export/export_test.go
@@ -1,0 +1,53 @@
+package export_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/diagnostics/export"
+)
+
+// fakeSources returns a fixed device summary and a fixed set of cards.
+type fakeSources struct {
+	refreshErr error
+	cards      map[string]any
+}
+
+func (f fakeSources) RefreshInterfaces() error { return f.refreshErr }
+func (f fakeSources) DeviceMAC(string) string  { return "aa:bb:cc:dd:ee:ff" }
+func (f fakeSources) IPMode() string           { return "dhcp" }
+func (f fakeSources) Cards(context.Context, string) map[string]any {
+	return f.cards
+}
+
+func TestBuildComposesDocument(t *testing.T) {
+	src := fakeSources{cards: map[string]any{
+		"link": map[string]any{"linkUp": true},
+		"dns":  map[string]any{"server": "8.8.8.8"},
+	}}
+	svc := export.NewService(src)
+
+	data, err := svc.Build(context.Background(), "eth0", "1.2.3")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if data.Version != "1.2.3" || data.Device.Interface != "eth0" ||
+		data.Device.MAC != "aa:bb:cc:dd:ee:ff" || data.Device.IPMode != "dhcp" {
+		t.Errorf("device/meta wrong: %+v", data)
+	}
+	if data.Timestamp == "" {
+		t.Error("timestamp should be stamped")
+	}
+	if len(data.Cards) != 2 {
+		t.Errorf("want 2 cards, got %d: %+v", len(data.Cards), data.Cards)
+	}
+}
+
+func TestBuildAbortsOnRefreshError(t *testing.T) {
+	wantErr := errors.New("refresh failed")
+	svc := export.NewService(fakeSources{refreshErr: wantErr})
+	if _, err := svc.Build(context.Background(), "eth0", "1"); !errors.Is(err, wantErr) {
+		t.Errorf("Build should abort on refresh error, got %v", err)
+	}
+}


### PR DESCRIPTION
handlers_status.go's handleExport assembled the export document by fanning out to
ten *Server.export* card methods, each reaching a different diagnostic service,
plus two direct s.config reads (Interface.Default in handleStatus, IP.Mode in the
export). Move the assembly behind a use-case.

- New internal/diagnostics/export: Service.Build composes the export document
  (version/timestamp/device summary + cards) over a narrow Sources port
  (RefreshInterfaces/DeviceMAC/IPMode/Cards) — the refresh-gate and envelope are
  the use-case; the per-card gathering is delegated to Cards(). ExportData/
  ExportDeviceInfo moved here as export.Data/DeviceInfo.
- internal/api/export_sources.go: serverExportSources implements the port over the
  live diagnostic-service accessors; the ten card builders (relocated from the
  handler, returning (map,bool)) are gathered by Cards(). Collapsing the ten card
  methods into one Cards() keeps the port narrow (avoids interfacebloat) and gives
  the use-case the document-envelope responsibility while the adapter owns shaping.
- handlers_status.go: handleExport is now thin (Build → encode); handleStatus reads
  the default interface through the new defaultInterface() accessor. Zero direct
  s.config reaches remain.
- server.go field + constructor + defaultInterface() accessor; auto-wired via
  initDiscoveryUseCases (the api test harnesses pick it up).

Tests: Service (document composition, refresh-error abort); api status/export
handler tests pass through the strangled path. Behavior-preserving. Non-race api
suite + full staticcheck + interfacebloat + filename/route/escaping/lint gates green.
