### PR TITLE
refactor(api): route config-read/write residuals through use-cases (WS-A11a)

### DIFF
--- a/internal/api/handlers_discovery.go
+++ b/internal/api/handlers_discovery.go
@@ -150,36 +150,17 @@ func (s *Server) setDiscoveryOptions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Lock config for write access (fixes #759 - race condition)
-	// NOTE: Must unlock before Save() - Save() acquires RLock internally (fixes #783)
-	s.config.Lock()
-	s.config.NetworkDiscovery.Options = req
-	// Unlock before Save() to avoid deadlock
-	s.config.Unlock()
-
-	// Apply the options change to the running service
-	if err := s.discoveryService().Reload(); err != nil {
-		logger.ErrorContext(r.Context(), "Failed to reload discovery options", "error", err)
+	// Persist the new options and apply them to the running scanner via the
+	// discovery-settings use-case (fixes #759 race, #783 save deadlock, #735
+	// save-error surfacing — all owned by the service now).
+	if err := s.discoverySettings.SetOptions(req); err != nil {
+		logger.ErrorContext(r.Context(), "Failed to apply discovery options", "error", err)
 		sendErrorResponseWithDetails(
 			w,
 			logger,
 			http.StatusInternalServerError,
 			ErrCodeInternal,
 			localizer.T("errors.discovery.failedToApplyOptions"),
-			"",
-		)
-		return
-	}
-
-	// Save config to file (fixes #735 - return error on save failure)
-	if err := s.config.Save(s.configPath); err != nil {
-		logger.ErrorContext(r.Context(), "Failed to save config", "error", err)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			localizer.T("errors.settings.saveFailed"),
 			"",
 		)
 		return

--- a/internal/api/handlers_dns.go
+++ b/internal/api/handlers_dns.go
@@ -152,14 +152,8 @@ func (s *Server) handleDNSSecurity(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if len(req.Servers) == 0 {
-			// Use configured DNS servers from config
-			s.config.RLock()
-			for _, srv := range s.config.DNS.Servers {
-				if srv.Enabled {
-					req.Servers = append(req.Servers, srv.Address)
-				}
-			}
-			s.config.RUnlock()
+			// Fall back to the configured, enabled DNS servers.
+			req.Servers = s.enabledDNSServers()
 		}
 
 		if len(req.Servers) == 0 {

--- a/internal/api/handlers_guest_audit.go
+++ b/internal/api/handlers_guest_audit.go
@@ -9,6 +9,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -16,10 +17,39 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/security/guestaudit"
-	"github.com/MustardSeedNetworks/seed/internal/validation"
+	secsettings "github.com/MustardSeedNetworks/seed/internal/security/settings"
 )
 
 const guestAuditRunTimeout = 60 * time.Second
+
+// writeGuestAuditError maps a guest-audit settings error to its HTTP response: a
+// GuestAuditValidationError becomes a 400 with the field-specific i18n message and
+// the offending value as detail; anything else is a 500 save failure.
+func (s *Server) writeGuestAuditError(w http.ResponseWriter, r *http.Request, err error) {
+	logger := logging.FromContext(r.Context())
+	localizer := i18n.FromRequest(r)
+
+	var vErr secsettings.GuestAuditValidationError
+	if errors.As(err, &vErr) {
+		msgKey := "errors.guestAudit.invalidTarget"
+		detail := vErr.Value
+		if vErr.Kind == "port" {
+			msgKey = "errors.guestAudit.invalidPort"
+			detail = ""
+		}
+		sendErrorResponseWithDetails(
+			w, logger, http.StatusBadRequest, ErrCodeValidation,
+			localizer.T(msgKey), detail,
+		)
+		return
+	}
+
+	logger.ErrorContext(r.Context(), "Failed to save guest-audit settings", "error", err)
+	sendErrorResponseWithDetails(
+		w, logger, http.StatusInternalServerError, ErrCodeInternal,
+		localizer.T("errors.config.failedToSave"), "",
+	)
+}
 
 // handleGuestAuditSettings returns or updates the configured target list.
 // Routes: GET and PUT on /api/v1/security/guest-audit/settings.
@@ -29,7 +59,7 @@ func (s *Server) handleGuestAuditSettings(w http.ResponseWriter, r *http.Request
 
 	switch r.Method {
 	case http.MethodGet:
-		sendJSONResponse(w, logger, http.StatusOK, s.config.Security.GuestNetworkAudit)
+		sendJSONResponse(w, logger, http.StatusOK, s.securitySettings.GuestAudit())
 
 	case http.MethodPut:
 		var settings config.GuestNetworkAuditConfig
@@ -37,48 +67,8 @@ func (s *Server) handleGuestAuditSettings(w http.ResponseWriter, r *http.Request
 			return
 		}
 
-		// Validate each target before persisting.
-		for _, t := range settings.Targets {
-			if !validation.IsValidIP(t.IP) {
-				sendErrorResponseWithDetails(
-					w,
-					logger,
-					http.StatusBadRequest,
-					ErrCodeValidation,
-					localizer.T("errors.guestAudit.invalidTarget"),
-					t.IP,
-				)
-				return
-			}
-		}
-		for _, p := range settings.Ports {
-			if p < 1 || p > 65535 {
-				sendErrorResponseWithDetails(
-					w,
-					logger,
-					http.StatusBadRequest,
-					ErrCodeValidation,
-					localizer.T("errors.guestAudit.invalidPort"),
-					"",
-				)
-				return
-			}
-		}
-
-		s.config.Lock()
-		s.config.Security.GuestNetworkAudit = settings
-		s.config.Unlock()
-
-		if err := s.config.Save(s.configPath); err != nil {
-			logger.ErrorContext(r.Context(), "Failed to save guest-audit settings", "error", err)
-			sendErrorResponseWithDetails(
-				w,
-				logger,
-				http.StatusInternalServerError,
-				ErrCodeInternal,
-				localizer.T("errors.config.failedToSave"),
-				"",
-			)
+		if err := s.securitySettings.UpdateGuestAudit(settings); err != nil {
+			s.writeGuestAuditError(w, r, err)
 			return
 		}
 
@@ -107,7 +97,7 @@ func (s *Server) handleGuestAuditRun(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
 
-	cfg := s.config.Security.GuestNetworkAudit
+	cfg := s.securitySettings.GuestAudit()
 	if !cfg.Enabled {
 		sendErrorResponseWithDetails(
 			w,

--- a/internal/api/handlers_path.go
+++ b/internal/api/handlers_path.go
@@ -407,7 +407,7 @@ func (s *Server) performL2Trace(
 	}
 
 	// Build L2 path
-	builder := discovery.NewL2PathBuilder(s.deviceDiscovery(), &s.config.SNMP)
+	builder := discovery.NewL2PathBuilder(s.deviceDiscovery(), s.snmpConfig())
 	result, err := builder.BuildPath(ctx, sourceIP, req.Destination)
 	if err != nil {
 		return nil, err

--- a/internal/api/handlers_tools.go
+++ b/internal/api/handlers_tools.go
@@ -427,7 +427,7 @@ func (s *Server) handleAdvancedFingerprint(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Create fingerprinter with config timeout
-	timeout := s.config.NetworkDiscovery.ScanTimeout
+	timeout := s.discoveryScanTimeout()
 	if timeout == 0 {
 		timeout = fingerprintDefaultTimeoutSec * time.Second
 	}

--- a/internal/api/handlers_wifi.go
+++ b/internal/api/handlers_wifi.go
@@ -143,13 +143,7 @@ func (s *Server) handleWiFi(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get interface from query param or use current/default
-	wlanIface := s.getInterfaceFromRequest(r)
-	if wlanIface == "" {
-		wlanIface = s.config.Interface.WiFi
-		if wlanIface == "" {
-			wlanIface = s.config.Interface.Default
-		}
-	}
+	wlanIface := s.resolveWiFiInterface(r)
 
 	// Update WiFi manager to use the requested interface
 	s.wifiManager().SetInterface(wlanIface)
@@ -403,13 +397,7 @@ func (s *Server) handleWiFiForgetNetwork(w http.ResponseWriter, r *http.Request)
 // It scans available networks and organizes them by frequency band with channel overlap information.
 func (s *Server) handleWiFiChannelGraph(w http.ResponseWriter, r *http.Request) {
 	// Get interface from query param or use current/default
-	wlanIface := s.getInterfaceFromRequest(r)
-	if wlanIface == "" {
-		wlanIface = s.config.Interface.WiFi
-		if wlanIface == "" {
-			wlanIface = s.config.Interface.Default
-		}
-	}
+	wlanIface := s.resolveWiFiInterface(r)
 
 	if s.wifiScanner() == nil {
 		sendJSONResponse(w, nil, http.StatusOK, map[string]any{

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -864,11 +864,39 @@ func (s *Server) loginRateLimiter() *RateLimiter              { return s.loginLi
 func (s *Server) endpointRateLimiter() *EndpointRateLimiter   { return s.endpointLimiter }
 func (s *Server) netManager() *netif.Manager                  { return s.netMgr }
 func (s *Server) defaultInterface() string                    { return s.config.Interface.Default }
+func (s *Server) snmpConfig() *config.SNMPConfig              { return &s.config.SNMP }
+func (s *Server) discoveryScanTimeout() time.Duration         { return s.config.NetworkDiscovery.ScanTimeout }
 func (s *Server) linkMonitor() *netif.LinkMonitor             { return s.linkMon }
 func (s *Server) deviceDiscovery() *enumerate.DeviceDiscovery { return s.deviceDisc }
 func (s *Server) discoveryService() *enumerate.Service        { return s.discoverySvc }
 func (s *Server) discoveryEngine() *discovery.Engine          { return s.discoveryEng }
 func (s *Server) problemDetector() *discovery.ProblemDetector { return s.problemDet }
+
+// enabledDNSServers returns the addresses of the configured, enabled DNS servers,
+// encapsulating the config lock + layout so handlers stay free of it.
+func (s *Server) enabledDNSServers() []string {
+	s.config.RLock()
+	defer s.config.RUnlock()
+	addrs := make([]string, 0, len(s.config.DNS.Servers))
+	for _, srv := range s.config.DNS.Servers {
+		if srv.Enabled {
+			addrs = append(addrs, srv.Address)
+		}
+	}
+	return addrs
+}
+
+// resolveWiFiInterface picks the Wi-Fi interface for a request: an explicit query
+// override, else the configured Wi-Fi interface, else the default interface.
+func (s *Server) resolveWiFiInterface(r *http.Request) string {
+	if iface := s.getInterfaceFromRequest(r); iface != "" {
+		return iface
+	}
+	if wifi := s.config.Interface.WiFi; wifi != "" {
+		return wifi
+	}
+	return s.config.Interface.Default
+}
 
 // anomalyStore is the unified anomaly system of record (ADR-0021), the read
 // source for the health-checks anomaly endpoint after the bespoke health
@@ -935,7 +963,9 @@ func (s *Server) initWiFiUseCases() {
 // scan reads the discovered devices through the device-discovery accessor.
 func (s *Server) initDiscoveryUseCases() {
 	s.discoveryDevices = app.NewDiscoveryDevices(s.discoveryEngine)
-	s.discoverySettings = app.NewDiscoverySettings(s.config, s.configPath, s.deviceDiscovery)
+	s.discoverySettings = app.NewDiscoverySettings(
+		s.config, s.configPath, s.deviceDiscovery, s.discoveryService,
+	)
 	s.networkProblems = app.NewProblems(s.problemDetector, s.discoveryService)
 	s.topologyQueries = app.NewTopologyQueries(s.db, topologyMaxLimit)
 	s.exportService = export.NewService(serverExportSources{s: s})

--- a/internal/app/discovery.go
+++ b/internal/app/discovery.go
@@ -56,11 +56,13 @@ func NewBluetooth(scanner func() *enumerate.BluetoothScanner) *bluetooth.Service
 // lifetime; the scanner is resolved per call so a later-set value (the api test
 // harness) is honored, and a nil scanner makes the subnet sync a no-op.
 func NewDiscoverySettings(
-	cfg *config.Config, path string, dd func() *enumerate.DeviceDiscovery,
+	cfg *config.Config, path string,
+	dd func() *enumerate.DeviceDiscovery, svc func() *enumerate.Service,
 ) *settings.Service {
 	return settings.NewService(
 		discoverySettingsStore{cfg: cfg, path: path},
 		discoverySubnetSink{dd: dd},
+		discoveryOptionsApplier{svc: svc},
 	)
 }
 
@@ -102,6 +104,21 @@ func (a discoverySubnetSink) SetAdditionalSubnets(cidrs []string) error {
 		return nil
 	}
 	return d.SetAdditionalSubnets(cidrs)
+}
+
+// discoveryOptionsApplier implements settings.OptionsApplier over the enumeration
+// service, resolved lazily; a nil service is a no-op so a settings write still
+// persists when the live scanner is not running.
+type discoveryOptionsApplier struct {
+	svc func() *enumerate.Service
+}
+
+func (a discoveryOptionsApplier) ReloadOptions() error {
+	svc := a.svc()
+	if svc == nil {
+		return nil
+	}
+	return svc.Reload()
 }
 
 // discoveryEngineAdapter implements devices.Engine over the discovery engine,

--- a/internal/discovery/settings/settings.go
+++ b/internal/discovery/settings/settings.go
@@ -39,15 +39,23 @@ type SubnetSink interface {
 	SetAdditionalSubnets(cidrs []string) error
 }
 
+// OptionsApplier applies a discovery-options change to the running enumeration
+// service so an options update takes effect without a restart. A nil-backed
+// applier is a no-op.
+type OptionsApplier interface {
+	ReloadOptions() error
+}
+
 // Service is the network-discovery settings application service.
 type Service struct {
-	store Store
-	sink  SubnetSink
+	store   Store
+	sink    SubnetSink
+	applier OptionsApplier
 }
 
 // NewService builds the settings service over its ports.
-func NewService(store Store, sink SubnetSink) *Service {
-	return &Service{store: store, sink: sink}
+func NewService(store Store, sink SubnetSink, applier OptionsApplier) *Service {
+	return &Service{store: store, sink: sink, applier: applier}
 }
 
 // Settings returns the current network-discovery configuration.
@@ -63,6 +71,21 @@ func (s *Service) Update(in Update) error {
 	cur := s.store.Discovery()
 	in.mergeInto(&cur)
 	return s.store.SaveDiscovery(cur)
+}
+
+// SetOptions replaces the discovery options wholesale, persists, then applies the
+// change to the running enumeration service. Persisting before the apply lets the
+// applier read the new options off the live config (Reload re-reads it) and means
+// a successful write is durable even if the live reload reports an error — the
+// operator's setting survives a restart. Returns the applier error if the reload
+// fails after a successful save.
+func (s *Service) SetOptions(opts config.DiscoveryOptions) error {
+	cur := s.store.Discovery()
+	cur.Options = opts
+	if err := s.store.SaveDiscovery(cur); err != nil {
+		return err
+	}
+	return s.applier.ReloadOptions()
 }
 
 // Subnets returns the configured additional subnets.

--- a/internal/discovery/settings/settings_test.go
+++ b/internal/discovery/settings/settings_test.go
@@ -27,10 +27,18 @@ type fakeSink struct{ last []string }
 
 func (f *fakeSink) SetAdditionalSubnets(cidrs []string) error { f.last = cidrs; return nil }
 
+// fakeApplier records reload calls and can be made to fail.
+type fakeApplier struct {
+	reloads int
+	err     error
+}
+
+func (f *fakeApplier) ReloadOptions() error { f.reloads++; return f.err }
+
 func newService(cfg config.NetworkDiscoveryConfig) (*settings.Service, *fakeStore, *fakeSink) {
 	st := &fakeStore{cfg: cfg}
 	sk := &fakeSink{}
-	return settings.NewService(st, sk), st, sk
+	return settings.NewService(st, sk, &fakeApplier{}), st, sk
 }
 
 func TestUpdateMergeRules(t *testing.T) {
@@ -159,5 +167,39 @@ func TestUpdateAndDeleteSubnet(t *testing.T) {
 	}
 	if err := svc.DeleteSubnet("192.168.1.0/24"); !errors.Is(err, settings.ErrSubnetNotFound) {
 		t.Errorf("delete missing: want ErrSubnetNotFound, got %v", err)
+	}
+}
+
+func TestSetOptionsPersistsThenApplies(t *testing.T) {
+	st := &fakeStore{cfg: config.NetworkDiscoveryConfig{Enabled: true}}
+	ap := &fakeApplier{}
+	svc := settings.NewService(st, &fakeSink{}, ap)
+
+	opts := config.DiscoveryOptions{PortScan: config.PortScanConfig{Enabled: true}}
+	if err := svc.SetOptions(opts); err != nil {
+		t.Fatalf("SetOptions: %v", err)
+	}
+	if !st.cfg.Options.PortScan.Enabled {
+		t.Error("options not persisted")
+	}
+	if st.saved != 1 {
+		t.Errorf("want 1 save, got %d", st.saved)
+	}
+	if ap.reloads != 1 {
+		t.Errorf("want 1 reload, got %d", ap.reloads)
+	}
+}
+
+func TestSetOptionsReturnsApplyError(t *testing.T) {
+	st := &fakeStore{}
+	ap := &fakeApplier{err: errors.New("reload failed")}
+	svc := settings.NewService(st, &fakeSink{}, ap)
+
+	if err := svc.SetOptions(config.DiscoveryOptions{}); err == nil {
+		t.Error("SetOptions should surface the apply error")
+	}
+	// The save still committed before the apply was attempted.
+	if st.saved != 1 {
+		t.Errorf("want save committed before apply, got %d saves", st.saved)
 	}
 }

--- a/internal/security/settings/settings.go
+++ b/internal/security/settings/settings.go
@@ -9,9 +9,11 @@ package settings
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/validation"
 )
 
 // PasswordPlaceholder is the masked value returned for stored SNMP passwords. A
@@ -311,4 +313,48 @@ func (s *Service) UpdateRogueDHCP(in RogueUpdate) error {
 		s.detector.UpdateKnownServers(in.KnownServers)
 	}
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Guest-network isolation audit (#397)
+// ---------------------------------------------------------------------------
+
+// GuestAuditValidationError reports an invalid guest-audit setting. Kind is
+// "target" (Value is the offending IP) or "port" (Value is the offending port).
+// The transport layer maps Kind to the matching i18n message and surfaces Value
+// as the error detail.
+type GuestAuditValidationError struct {
+	Kind  string
+	Value string
+}
+
+func (e GuestAuditValidationError) Error() string {
+	return "settings: invalid guest-audit " + e.Kind + ": " + e.Value
+}
+
+// GuestAudit returns the configured guest-network isolation audit settings.
+func (s *Service) GuestAudit() config.GuestNetworkAuditConfig {
+	var out config.GuestNetworkAuditConfig
+	s.store.Read(func(c *config.Config) { out = c.Security.GuestNetworkAudit })
+	return out
+}
+
+// UpdateGuestAudit validates and persists the guest-audit settings. Every target
+// IP must parse and every port must be in 1..65535; the first offender is
+// returned as a GuestAuditValidationError before anything is persisted.
+func (s *Service) UpdateGuestAudit(in config.GuestNetworkAuditConfig) error {
+	for _, t := range in.Targets {
+		if !validation.IsValidIP(t.IP) {
+			return GuestAuditValidationError{Kind: "target", Value: t.IP}
+		}
+	}
+	for _, p := range in.Ports {
+		if p < 1 || p > 65535 {
+			return GuestAuditValidationError{Kind: "port", Value: strconv.Itoa(p)}
+		}
+	}
+	return s.store.Write(func(c *config.Config) error {
+		c.Security.GuestNetworkAudit = in
+		return nil
+	})
 }


### PR DESCRIPTION
- **refactor(api): strangle diagnostic export into a use-case (ADR-0020, WS-A10)**
- **refactor(api): route the config-read/write residuals through use-cases (ADR-0020, WS-A11a)**
