### PR TITLE
refactor(api): strangle the log query into a use-case (ADR-0020, WS-A11b)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ docs/WIKI_CONTENT.md
 go.work
 go.work.sum
 logs/
+!internal/logs/
 node_modules/
 npm-debug.log*
 storybook-static/

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/config/backups"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
-	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
 // ExportSplitCIDR exposes splitCIDR for testing.
@@ -77,38 +76,15 @@ func ExportValidateIperfClientRequest(req *IperfClientRequest) error {
 	return validateIperfClientRequest(req)
 }
 
-// ExportParseLogQueryParams exposes parseLogQueryParams for testing.
-func ExportParseLogQueryParams(r *http.Request) LogQueryParams {
-	return parseLogQueryParams(r)
-}
-
-// ExportMatchesLogFilters exposes matchesLogFilters for testing.
-func ExportMatchesLogFilters(log *logging.LogEntry, params *LogQueryParams) bool {
-	return matchesLogFilters(log, params)
-}
-
-// ExportPaginateLogs exposes paginateLogs for testing.
-func ExportPaginateLogs(logs []*logging.LogEntry, offset, limit int) []*logging.LogEntry {
-	return paginateLogs(logs, offset, limit)
-}
-
 // ExportParseCSV exposes parseCSV for testing.
 func ExportParseCSV(s string) []string {
 	return parseCSV(s)
-}
-
-// ExportContainsIgnoreCase exposes containsIgnoreCase for testing.
-func ExportContainsIgnoreCase(slice []string, target string) bool {
-	return containsIgnoreCase(slice, target)
 }
 
 // ExportIsValidOctet exposes isValidOctet for testing.
 func ExportIsValidOctet(s string) bool {
 	return isValidOctet(s)
 }
-
-// LogQueryParams is a type alias for logQueryParams for testing.
-type LogQueryParams = logQueryParams
 
 // ExportBodyLimitMiddleware exposes bodyLimitMiddleware for testing.
 func ExportBodyLimitMiddleware(next http.Handler) http.Handler {

--- a/internal/api/handlers_logs.go
+++ b/internal/api/handlers_logs.go
@@ -1,15 +1,14 @@
 package api
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
+	logquery "github.com/MustardSeedNetworks/seed/internal/logs/query"
 )
 
 // Log query constants.
@@ -150,96 +149,47 @@ func (s *Server) handleClientLogs(w http.ResponseWriter, r *http.Request) {
 }
 
 // logQueryParams holds parsed log query parameters.
-type logQueryParams struct {
-	levels     []string
-	layers     []string
-	components []string
-	search     string
-	limit      int
-	offset     int
-}
-
-// parseLogQueryParams extracts and validates query parameters from the request.
-func parseLogQueryParams(r *http.Request) logQueryParams {
+// parseLogQueryParams extracts and validates the log-query filter from the
+// request, producing the transport-neutral input the log-query use-case consumes.
+func parseLogQueryParams(r *http.Request) logquery.Params {
 	query := r.URL.Query()
-	params := logQueryParams{
-		levels:     parseCSV(query.Get("level")),
-		layers:     parseCSV(query.Get("layer")),
-		components: parseCSV(query.Get("component")),
-		search:     strings.ToLower(query.Get("search")),
-		limit:      logQueryDefaultLimit,
-		offset:     0,
+	params := logquery.Params{
+		Levels:     parseCSV(query.Get("level")),
+		Layers:     parseCSV(query.Get("layer")),
+		Components: parseCSV(query.Get("component")),
+		Search:     strings.ToLower(query.Get("search")),
+		Limit:      logQueryDefaultLimit,
+		Offset:     0,
 	}
 
 	if l := query.Get("limit"); l != "" {
 		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 1000 {
-			params.limit = parsed
+			params.Limit = parsed
 		}
 	}
 
 	if o := query.Get("offset"); o != "" {
 		if parsed, err := strconv.Atoi(o); err == nil && parsed >= 0 {
-			params.offset = parsed
+			params.Offset = parsed
 		}
 	}
 
 	return params
 }
 
-// matchesLogFilters checks if a log entry matches the given filter criteria.
-func matchesLogFilters(log *logging.LogEntry, params *logQueryParams) bool {
-	if len(params.levels) > 0 && !containsIgnoreCase(params.levels, log.Level) {
-		return false
-	}
-	if len(params.layers) > 0 && !containsIgnoreCase(params.layers, log.Layer) {
-		return false
-	}
-	if len(params.components) > 0 && !containsIgnoreCase(params.components, log.Component) {
-		return false
-	}
-	if params.search != "" && !strings.Contains(strings.ToLower(log.Message), params.search) {
-		return false
-	}
-	return true
-}
-
-// paginateLogs applies pagination to a slice of logs.
-func paginateLogs(logs []*logging.LogEntry, offset, limit int) []*logging.LogEntry {
-	if offset >= len(logs) {
-		return nil
-	}
-	end := min(offset+limit, len(logs))
-	return logs[offset:end]
-}
-
 // handleLogsQuery returns logs matching the specified filters.
 // GET /api/logs/query?level=ERROR,WARN&layer=backend,api&component=auth&search=failed&limit=100&offset=0 (fixes #703).
-// Reads from database for persistence, falls back to memory buffer.
+// Thin handler (ADR-0020): the log-query use-case owns the "persisted store first,
+// memory buffer fallback" decision and filtering/pagination.
 func (s *Server) handleLogsQuery(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
 
 	params := parseLogQueryParams(r)
 
-	// Try database first if available (for persisted logs)
-	if s.db() != nil {
-		dbLogs, err := s.queryLogsFromDB(r.Context(), params)
-		if err == nil {
-			sendJSONResponse(w, logger, http.StatusOK, LogQueryResponse{
-				Logs:       toLogEntries(dbLogs),
-				TotalCount: len(dbLogs), // TODO: get actual count from DB
-				Offset:     params.offset,
-				Limit:      params.limit,
-			})
-			return
-		}
-		// Fall through to memory buffer on error
-		logger.WarnContext(r.Context(), "Failed to query logs from database, falling back to memory", "error", err)
-	}
-
-	// Fall back to memory buffer
-	broadcaster := logging.GetBroadcaster()
-	if broadcaster == nil {
+	res, err := s.logQuery.Query(r.Context(), params)
+	if err != nil {
+		// The only error is ErrNoSource (neither store nor buffer available).
 		sendErrorResponseWithDetails(
 			w,
 			logger,
@@ -251,70 +201,12 @@ func (s *Server) handleLogsQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	allLogs := broadcaster.GetAllLogs()
-	filtered := make([]*logging.LogEntry, 0, len(allLogs))
-
-	for _, log := range allLogs {
-		if matchesLogFilters(log, &params) {
-			filtered = append(filtered, log)
-		}
-	}
-
-	totalCount := len(filtered)
-	filtered = paginateLogs(filtered, params.offset, params.limit)
-
 	sendJSONResponse(w, logger, http.StatusOK, LogQueryResponse{
-		Logs:       toLogEntries(filtered),
-		TotalCount: totalCount,
-		Offset:     params.offset,
-		Limit:      params.limit,
+		Logs:       toLogEntries(res.Entries),
+		TotalCount: res.TotalCount,
+		Offset:     params.Offset,
+		Limit:      params.Limit,
 	})
-}
-
-// queryLogsFromDB queries logs from the database with filters.
-func (s *Server) queryLogsFromDB(
-	ctx context.Context,
-	params logQueryParams,
-) ([]*logging.LogEntry, error) {
-	opts := database.LogListOptions{
-		Search: params.search,
-		Limit:  params.limit,
-		Offset: params.offset,
-	}
-
-	// Use first level/layer/component if specified
-	if len(params.levels) > 0 {
-		opts.Level = params.levels[0]
-	}
-	if len(params.layers) > 0 {
-		opts.Layer = params.layers[0]
-	}
-	if len(params.components) > 0 {
-		opts.Component = params.components[0]
-	}
-
-	dbEntries, err := s.db().Logs().List(ctx, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert database entries to logging.LogEntry
-	result := make([]*logging.LogEntry, len(dbEntries))
-	for i, e := range dbEntries {
-		result[i] = &logging.LogEntry{
-			Timestamp:  e.Timestamp,
-			Level:      e.Level,
-			Layer:      e.Layer,
-			Message:    e.Message,
-			Component:  e.Component,
-			RequestID:  e.RequestID,
-			SessionID:  e.SessionID,
-			DurationMs: e.DurationMs,
-			Stack:      e.Stack,
-		}
-	}
-
-	return result, nil
 }
 
 // handleLogsStats returns aggregated log statistics.
@@ -428,14 +320,4 @@ func parseCSV(s string) []string {
 		}
 	}
 	return result
-}
-
-// containsIgnoreCase checks if a slice contains a string (case-insensitive).
-func containsIgnoreCase(slice []string, target string) bool {
-	for _, s := range slice {
-		if strings.EqualFold(s, target) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -51,6 +51,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/listener/snmptrap"
 	"github.com/MustardSeedNetworks/seed/internal/listener/syslog"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
+	logquery "github.com/MustardSeedNetworks/seed/internal/logs/query"
 	"github.com/MustardSeedNetworks/seed/internal/mibdb"
 	"github.com/MustardSeedNetworks/seed/internal/netif"
 	"github.com/MustardSeedNetworks/seed/internal/network/ipconfig"
@@ -263,6 +264,7 @@ type Server struct {
 	alertInbox         *inbox.Service              // Alert-inbox (list/ack/resolve) use-case (ADR-0020)
 	configBackups      *backups.Service            // Config backup/restore use-case (ADR-0020)
 	exportService      *export.Service             // Diagnostic-export use-case (ADR-0020)
+	logQuery           *logquery.Service           // Log-query use-case (ADR-0020)
 	bluetoothScans     *bluetooth.Service          // Bluetooth-discovery use-case (ADR-0020)
 	healthMonitoring   *monitoring.Service         // Health-monitoring use-case (ADR-0020)
 	healthSettings     *healthsettings.Service     // Health-checks settings use-case (ADR-0020)
@@ -969,6 +971,7 @@ func (s *Server) initDiscoveryUseCases() {
 	s.networkProblems = app.NewProblems(s.problemDetector, s.discoveryService)
 	s.topologyQueries = app.NewTopologyQueries(s.db, topologyMaxLimit)
 	s.exportService = export.NewService(serverExportSources{s: s})
+	s.logQuery = app.NewLogQuery(s.db)
 	s.pollingTargets = app.NewPollingTargets(s.db)
 	s.alertInbox = app.NewAlertInbox(s.db)
 	s.bluetoothScans = app.NewBluetooth(s.bluetoothScanner)

--- a/internal/app/logs.go
+++ b/internal/app/logs.go
@@ -1,0 +1,82 @@
+package app
+
+// logs.go wires the composition root to the log-query use-case (ADR-0020): a Store
+// adapter over the database log repository and a Buffer adapter over the in-memory
+// log broadcaster. The database handle is resolved through a lazy accessor so a
+// later-set value (the api test harness) is honored and a nil handle degrades the
+// store to "unavailable" rather than panicking.
+
+import (
+	"context"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/logging"
+	logquery "github.com/MustardSeedNetworks/seed/internal/logs/query"
+)
+
+// NewLogQuery builds the log-query use-case over the database log store and the
+// in-memory broadcaster buffer.
+func NewLogQuery(db func() *database.DB) *logquery.Service {
+	return logquery.NewService(logStore{db: db}, logBuffer{})
+}
+
+// logStore implements logquery.Store over the database log repository, resolving
+// the handle lazily.
+type logStore struct {
+	db func() *database.DB
+}
+
+func (a logStore) Available() bool { return a.db() != nil }
+
+func (a logStore) List(ctx context.Context, p logquery.Params) ([]*logging.LogEntry, error) {
+	opts := database.LogListOptions{
+		Search: p.Search,
+		Limit:  p.Limit,
+		Offset: p.Offset,
+	}
+	// The store filters on the first value of each multi-valued filter — the
+	// original handler's contract.
+	if len(p.Levels) > 0 {
+		opts.Level = p.Levels[0]
+	}
+	if len(p.Layers) > 0 {
+		opts.Layer = p.Layers[0]
+	}
+	if len(p.Components) > 0 {
+		opts.Component = p.Components[0]
+	}
+
+	entries, err := a.db().Logs().List(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*logging.LogEntry, len(entries))
+	for i, e := range entries {
+		out[i] = &logging.LogEntry{
+			Timestamp:  e.Timestamp,
+			Level:      e.Level,
+			Layer:      e.Layer,
+			Message:    e.Message,
+			Component:  e.Component,
+			RequestID:  e.RequestID,
+			SessionID:  e.SessionID,
+			DurationMs: e.DurationMs,
+			Stack:      e.Stack,
+		}
+	}
+	return out, nil
+}
+
+// logBuffer implements logquery.Buffer over the process-local log broadcaster. A
+// nil broadcaster (not yet initialized) reports unavailable.
+type logBuffer struct{}
+
+func (logBuffer) Available() bool { return logging.GetBroadcaster() != nil }
+
+func (logBuffer) All() []*logging.LogEntry {
+	b := logging.GetBroadcaster()
+	if b == nil {
+		return nil
+	}
+	return b.GetAllLogs()
+}

--- a/internal/logs/query/query.go
+++ b/internal/logs/query/query.go
@@ -1,0 +1,126 @@
+// Package query is the log-query use-case (ADR-0020 clean-hexagonal, WS-A11b): it
+// owns the "persisted store first, fall back to the in-memory ring buffer"
+// decision the /api/logs/query handler used to carry inline. Both log sources are
+// reached through consumer-defined ports (Store for the database, Buffer for the
+// process-local broadcaster), satisfied by adapters in the composition root. The
+// filter/paginate logic for the memory path lives here so the transport layer only
+// parses the request and encodes the result.
+package query
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/MustardSeedNetworks/seed/internal/logging"
+)
+
+// ErrNoSource is returned when neither the persisted store nor the memory buffer
+// is available to serve a query (mapped to 503 by the transport layer).
+var ErrNoSource = errors.New("logquery: no log source available")
+
+// Params is the parsed, transport-neutral log-query filter.
+type Params struct {
+	Levels     []string
+	Layers     []string
+	Components []string
+	Search     string
+	Limit      int
+	Offset     int
+}
+
+// Store is the persisted-log source. Available reports whether a database is
+// wired; List returns the entries matching params (already filtered/paginated by
+// the database). A List error makes the use-case fall back to the memory buffer.
+type Store interface {
+	Available() bool
+	List(ctx context.Context, p Params) ([]*logging.LogEntry, error)
+}
+
+// Buffer is the in-memory ring buffer of recent logs. Available reports whether
+// the broadcaster is initialized; All returns every retained entry (newest-last),
+// which the use-case filters and paginates itself.
+type Buffer interface {
+	Available() bool
+	All() []*logging.LogEntry
+}
+
+// Result is a log-query outcome: the page of entries plus the total matched
+// before pagination (for the persisted path the total is the page length, the
+// original handler's behavior).
+type Result struct {
+	Entries    []*logging.LogEntry
+	TotalCount int
+}
+
+// Service is the log-query use-case.
+type Service struct {
+	store  Store
+	buffer Buffer
+}
+
+// NewService builds the use-case over its log-source ports.
+func NewService(store Store, buffer Buffer) *Service {
+	return &Service{store: store, buffer: buffer}
+}
+
+// Query returns the page of logs for params, preferring the persisted store and
+// falling back to the memory buffer on an absent/erroring store. Returns
+// ErrNoSource when neither source can serve.
+func (s *Service) Query(ctx context.Context, p Params) (Result, error) {
+	if s.store.Available() {
+		if entries, err := s.store.List(ctx, p); err == nil {
+			return Result{Entries: entries, TotalCount: len(entries)}, nil
+		}
+		// Fall through to the memory buffer on a store error.
+	}
+
+	if !s.buffer.Available() {
+		return Result{}, ErrNoSource
+	}
+
+	all := s.buffer.All()
+	filtered := make([]*logging.LogEntry, 0, len(all))
+	for _, entry := range all {
+		if matches(entry, p) {
+			filtered = append(filtered, entry)
+		}
+	}
+	total := len(filtered)
+	return Result{Entries: paginate(filtered, p.Offset, p.Limit), TotalCount: total}, nil
+}
+
+// matches reports whether entry passes every set filter in p.
+func matches(entry *logging.LogEntry, p Params) bool {
+	if len(p.Levels) > 0 && !containsFold(p.Levels, entry.Level) {
+		return false
+	}
+	if len(p.Layers) > 0 && !containsFold(p.Layers, entry.Layer) {
+		return false
+	}
+	if len(p.Components) > 0 && !containsFold(p.Components, entry.Component) {
+		return false
+	}
+	if p.Search != "" && !strings.Contains(strings.ToLower(entry.Message), p.Search) {
+		return false
+	}
+	return true
+}
+
+// paginate returns the [offset, offset+limit) window of logs, or nil past the end.
+func paginate(logs []*logging.LogEntry, offset, limit int) []*logging.LogEntry {
+	if offset >= len(logs) {
+		return nil
+	}
+	end := min(offset+limit, len(logs))
+	return logs[offset:end]
+}
+
+func containsFold(slice []string, target string) bool {
+	for _, s := range slice {
+		if strings.EqualFold(s, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/logs/query/query_test.go
+++ b/internal/logs/query/query_test.go
@@ -1,0 +1,114 @@
+package query_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/seed/internal/logging"
+	query "github.com/MustardSeedNetworks/seed/internal/logs/query"
+)
+
+type fakeStore struct {
+	available bool
+	entries   []*logging.LogEntry
+	err       error
+	gotParams query.Params
+}
+
+func (f *fakeStore) Available() bool { return f.available }
+func (f *fakeStore) List(_ context.Context, p query.Params) ([]*logging.LogEntry, error) {
+	f.gotParams = p
+	return f.entries, f.err
+}
+
+type fakeBuffer struct {
+	available bool
+	entries   []*logging.LogEntry
+}
+
+func (f *fakeBuffer) Available() bool          { return f.available }
+func (f *fakeBuffer) All() []*logging.LogEntry { return f.entries }
+
+func entry(level, layer, component, msg string) *logging.LogEntry {
+	return &logging.LogEntry{Level: level, Layer: layer, Component: component, Message: msg}
+}
+
+func TestQueryPrefersStore(t *testing.T) {
+	store := &fakeStore{available: true, entries: []*logging.LogEntry{entry("ERROR", "api", "auth", "boom")}}
+	buf := &fakeBuffer{available: true, entries: []*logging.LogEntry{entry("INFO", "backend", "x", "noise")}}
+	svc := query.NewService(store, buf)
+
+	res, err := svc.Query(context.Background(), query.Params{Limit: 10})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(res.Entries) != 1 || res.Entries[0].Message != "boom" {
+		t.Fatalf("expected store entry, got %+v", res.Entries)
+	}
+	if res.TotalCount != 1 {
+		t.Errorf("TotalCount = %d, want 1", res.TotalCount)
+	}
+}
+
+func TestQueryFallsBackOnStoreError(t *testing.T) {
+	store := &fakeStore{available: true, err: errors.New("db down")}
+	buf := &fakeBuffer{available: true, entries: []*logging.LogEntry{
+		entry("ERROR", "api", "auth", "failed login"),
+		entry("INFO", "backend", "poll", "ok"),
+	}}
+	svc := query.NewService(store, buf)
+
+	res, err := svc.Query(context.Background(), query.Params{Levels: []string{"error"}, Limit: 10})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(res.Entries) != 1 || res.Entries[0].Message != "failed login" {
+		t.Fatalf("expected the ERROR entry from the buffer, got %+v", res.Entries)
+	}
+}
+
+func TestQueryBufferFilterAndSearch(t *testing.T) {
+	buf := &fakeBuffer{available: true, entries: []*logging.LogEntry{
+		entry("ERROR", "api", "auth", "DNS lookup failed"),
+		entry("ERROR", "backend", "poll", "timeout"),
+		entry("WARN", "api", "auth", "retrying"),
+	}}
+	svc := query.NewService(&fakeStore{available: false}, buf)
+
+	res, err := svc.Query(context.Background(), query.Params{
+		Levels: []string{"error"}, Layers: []string{"api"}, Search: "dns", Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(res.Entries) != 1 || res.Entries[0].Message != "DNS lookup failed" {
+		t.Fatalf("filter+search wrong: %+v", res.Entries)
+	}
+}
+
+func TestQueryBufferPagination(t *testing.T) {
+	all := make([]*logging.LogEntry, 5)
+	for i := range all {
+		all[i] = entry("INFO", "api", "x", "m")
+	}
+	svc := query.NewService(&fakeStore{available: false}, &fakeBuffer{available: true, entries: all})
+
+	res, err := svc.Query(context.Background(), query.Params{Offset: 2, Limit: 2})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(res.Entries) != 2 {
+		t.Errorf("page size = %d, want 2", len(res.Entries))
+	}
+	if res.TotalCount != 5 {
+		t.Errorf("TotalCount = %d, want 5 (pre-pagination)", res.TotalCount)
+	}
+}
+
+func TestQueryNoSource(t *testing.T) {
+	svc := query.NewService(&fakeStore{available: false}, &fakeBuffer{available: false})
+	if _, err := svc.Query(context.Background(), query.Params{}); !errors.Is(err, query.ErrNoSource) {
+		t.Errorf("want ErrNoSource, got %v", err)
+	}
+}


### PR DESCRIPTION
handleLogsQuery reached s.db().Logs().List directly and carried the
"persisted store first, fall back to the in-memory ring buffer" decision —
plus the buffer filter/pagination — inline. Move it behind a use-case.

- New internal/logs/query: Service.Query owns the store-first/buffer-fallback
  policy over two consumer-defined ports (Store for the database log repository,
  Buffer for the broadcaster). The memory-path filter (matches) and pagination
  move here; Params is the transport-neutral filter. Returns ErrNoSource when
  neither source can serve (the 503 path).
- internal/app/logs.go: logStore (over database.LogRepository, db→logging.LogEntry
  conversion) and logBuffer (over the process-local broadcaster, nil-safe).
- handlers_logs.go: handleLogsQuery is now thin (parse → Query → encode);
  parseLogQueryParams produces logquery.Params. Deleted queryLogsFromDB,
  matchesLogFilters, paginateLogs, containsIgnoreCase (relocated) and the dead
  Export* test shims for them. No handler s.db() reach remains here.
- server.go field + app.NewLogQuery(s.db) constructor.

Tests: use-case suite covers store-preference, store-error fallback,
filter+search, pagination, and ErrNoSource. Behavior-preserving (one dropped
diagnostic warn on store error — not wire behavior). Full non-race api suite +
staticcheck + filename/route/escaping/lint gates green.
