### PR TITLE
refactor(api): finish the profiles handler strangle (ADR-0020, WS-A11c)

### DIFF
--- a/internal/api/handlers_profiles.go
+++ b/internal/api/handlers_profiles.go
@@ -67,7 +67,7 @@ func (s *Server) handleProfiles(w http.ResponseWriter, r *http.Request) {
 	localizer := i18n.FromRequest(r)
 
 	// Check if database is available
-	if s.db() == nil {
+	if !s.profiles.Available() {
 		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
 			ErrCodeServiceUnavail, localizer.T("errors.profile.dbNotAvailable"), "") // fixes #694
 		return
@@ -305,7 +305,7 @@ func (s *Server) handleActiveProfile(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
 
-	if s.db() == nil {
+	if !s.profiles.Available() {
 		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
 			ErrCodeServiceUnavail, localizer.T("errors.profile.dbNotAvailable"), "") // fixes #694
 		return
@@ -371,6 +371,10 @@ func (s *Server) handleSetActiveProfile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// SetActiveProfile sets the active profile and (via the use-case's LiveConfig
+	// applier) applies its saved settings to the running config, persisting them.
+	// A malformed saved config is skipped best-effort inside the use-case; only a
+	// failed persist surfaces here as ErrConfigApply (#781, #782).
 	profile, err := s.profiles.SetActiveProfile(r.Context(), req.ProfileID)
 	if err != nil {
 		switch {
@@ -380,32 +384,15 @@ func (s *Server) handleSetActiveProfile(w http.ResponseWriter, r *http.Request) 
 		case errors.Is(err, catalog.ErrNotFound):
 			sendErrorResponseWithDetails(w, logger, http.StatusNotFound,
 				ErrCodeNotFound, localizer.T("errors.profile.notFound"), "") // fixes #694
+		case errors.Is(err, catalog.ErrConfigApply):
+			logger.ErrorContext(r.Context(), "Failed to save config after profile switch", "error", err)
+			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+				ErrCodeInternal, localizer.T("errors.config.failedToSave"), "")
 		default:
 			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
 				ErrCodeInternal, localizer.T("errors.profile.setActiveFailed"), "") // fixes #694, #H7
 		}
 		return
-	}
-
-	// Apply profile settings to the active config (fixes #781).
-	// Uses Config.ApplyProfileJSON() - single source of truth.
-	if profile.ConfigJSON != "" {
-		if applyErr := s.config.ApplyProfileJSON(profile.ConfigJSON); applyErr != nil {
-			logger.WarnContext(r.Context(),
-				"Failed to parse profile settings, using defaults",
-				"error", applyErr, "profile_id", profile.ID,
-			)
-		} else if saveErr := s.config.Save(s.configPath); saveErr != nil {
-			// fixes #782 - return error instead of silent warning
-			logger.ErrorContext(r.Context(), "Failed to save config after profile switch", "error", saveErr)
-			sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
-				ErrCodeInternal, localizer.T("errors.config.failedToSave"), saveErr.Error())
-			return
-		} else {
-			logger.InfoContext(r.Context(),
-				"Applied profile settings", "profile_id", profile.ID, "profile_name", profile.Name,
-			)
-		}
 	}
 
 	// Broadcast profile change via SSE
@@ -428,7 +415,7 @@ func (s *Server) handleDuplicateProfile(w http.ResponseWriter, r *http.Request) 
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
 
-	if s.db() == nil {
+	if !s.profiles.Available() {
 		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
 			ErrCodeServiceUnavail, localizer.T("errors.profile.dbNotAvailable"), "") // fixes #694
 		return
@@ -486,7 +473,7 @@ func (s *Server) handleImportProfiles(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
 
-	if s.db() == nil {
+	if !s.profiles.Available() {
 		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
 			ErrCodeServiceUnavail, localizer.T("errors.profile.dbNotAvailable"), "") // fixes #694
 		return
@@ -527,7 +514,7 @@ func (s *Server) handleExportProfiles(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	localizer := i18n.FromRequest(r)
 
-	if s.db() == nil {
+	if !s.profiles.Available() {
 		sendErrorResponseWithDetails(w, logger, http.StatusServiceUnavailable,
 			ErrCodeServiceUnavail, localizer.T("errors.profile.dbNotAvailable"), "") // fixes #694
 		return
@@ -568,7 +555,7 @@ func (s *Server) handleExportProfiles(w http.ResponseWriter, r *http.Request) {
 func (s *Server) enforceMultiClientGate(w http.ResponseWriter, r *http.Request) bool {
 	logger := logging.FromContext(r.Context())
 
-	if s.db() == nil {
+	if !s.profiles.Available() {
 		// No DB → no profile count to compare; fall through. The downstream
 		// handler returns a service-unavailable error.
 		return true

--- a/internal/api/profiles_internal_test.go
+++ b/internal/api/profiles_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/MustardSeedNetworks/seed/internal/app"
+	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/profiles/catalog"
 )
@@ -25,7 +26,11 @@ func newProfilesTestServer(t *testing.T) (*Server, *database.DB) {
 
 	s := &Server{}
 	s.dbConn = db
-	s.profiles = app.NewProfiles(s.db)
+	// A real config + path so activating a profile (which applies its saved config
+	// to the running config and persists) has somewhere to write.
+	s.config = config.DefaultConfig()
+	s.configPath = filepath.Join(t.TempDir(), "config.yaml")
+	s.profiles = app.NewProfiles(s.db, s.config, s.configPath)
 	// Wire the identity use-cases (ADR-0024) so writeGated→requireRole→callerRole
 	// resolves through the repository port instead of nil-panicking.
 	s.initIdentityUseCases()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -391,7 +391,7 @@ func NewServer(
 
 	// Wire the profiles catalog use-case (ADR-0020). The composition root builds
 	// the adapter; api passes its lazy db accessor.
-	s.profiles = app.NewProfiles(s.db)
+	s.profiles = app.NewProfiles(s.db, s.config, s.configPath)
 
 	// Wire the network IP-config + MTU use-case (ADR-0020). The composition root
 	// builds the adapters; api passes its lazy manager accessor + config.

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -163,7 +163,7 @@ func NewTestServerWithConfig(cfg *config.Config) *Server {
 		s.healthProbeRepo, s.rescheduleProbeEngine,
 		s.config, s.configPath, s.dnsTester, s.speedtestTester,
 	)
-	s.profiles = app.NewProfiles(s.db)
+	s.profiles = app.NewProfiles(s.db, s.config, s.configPath)
 	s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)
 	s.alertRules = app.NewAlertRules(s.db)
 	s.initUseCases()

--- a/internal/app/profiles.go
+++ b/internal/app/profiles.go
@@ -10,18 +10,23 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 
+	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/profiles/catalog"
 )
 
-// profilesStore implements catalog.Store over the database repositories.
-// The database is resolved lazily; callers (handlers) gate on s.db() != nil
-// before invoking the use-case, so a nil db here is not expected.
+// profilesStore implements catalog.Store over the database repositories. The
+// database is resolved lazily; Available reports whether it is wired so the
+// use-case can degrade to the service-unavailable path.
 type profilesStore struct {
 	db func() *database.DB
 }
+
+func (s profilesStore) Available() bool { return s.db() != nil }
 
 // mapProfileErr translates database sentinels to use-case sentinels.
 func mapProfileErr(err error) error {
@@ -142,10 +147,33 @@ func (s profilesStore) SetActiveID(ctx context.Context, id string) error {
 	return s.db().Settings().Set(ctx, database.SettingKeyActiveProfile, id)
 }
 
+// profilesLiveConfig implements catalog.LiveConfig over the live config: it
+// applies an activated profile's saved settings and persists them. A malformed
+// saved config is logged and skipped (best-effort, never fatal); only a failed
+// persist is returned, wrapped as catalog.ErrConfigApply.
+type profilesLiveConfig struct {
+	cfg  *config.Config
+	path string
+}
+
+func (a profilesLiveConfig) Apply(ctx context.Context, profileJSON string) error {
+	if err := a.cfg.ApplyProfileJSON(profileJSON); err != nil {
+		logging.FromContext(ctx).WarnContext(ctx,
+			"profile activate: failed to apply saved config, keeping current", "error", err)
+		return nil
+	}
+	if err := a.cfg.Save(a.path); err != nil {
+		return fmt.Errorf("%w: %w", catalog.ErrConfigApply, err)
+	}
+	return nil
+}
+
 // NewProfiles builds the profiles catalog use-case (ADR-0020) over the lazy db
-// accessor, assembling the catalog.Store adapter over the database Profiles +
-// Settings repositories. The database is resolved through db on each call so the
-// api test harness's later-set DB is honored; handlers gate on db() != nil first.
-func NewProfiles(db func() *database.DB) *catalog.Service {
-	return catalog.NewService(profilesStore{db: db})
+// accessor and the live config. The catalog.Store adapter spans the database
+// Profiles + Settings repositories; the catalog.LiveConfig adapter applies an
+// activated profile's settings to cfg and persists to path. The database is
+// resolved through db on each call so the api test harness's later-set DB is
+// honored; the use-case reports Available()==false when no DB is wired.
+func NewProfiles(db func() *database.DB, cfg *config.Config, path string) *catalog.Service {
+	return catalog.NewService(profilesStore{db: db}, profilesLiveConfig{cfg: cfg, path: path})
 }

--- a/internal/profiles/catalog/catalog.go
+++ b/internal/profiles/catalog/catalog.go
@@ -37,6 +37,11 @@ var (
 	ErrNoActiveOrDefault = errors.New("no active or default profile")
 	ErrDefaultLookup     = errors.New("failed to read the default profile")
 	ErrActiveNotFound    = errors.New("active profile missing and no default")
+
+	// ErrConfigApply wraps a fatal failure to persist the running config after an
+	// activated profile's settings were applied. The transport layer maps it to a
+	// 500 "failed to save" — the active-id is already set, only the save failed.
+	ErrConfigApply = errors.New("failed to persist config after profile activation")
 )
 
 // Profile is the use-case profile model. The adapter maps it to/from
@@ -92,6 +97,9 @@ type ImportResult struct {
 // Settings repositories, mapping their ErrProfileNotFound/ErrProfileNameExists
 // to ErrNotFound/ErrNameExists.
 type Store interface {
+	// Available reports whether the backing persistence is wired. A false result
+	// means the profiles subsystem cannot serve any request (the 503 path).
+	Available() bool
 	List(ctx context.Context) ([]Profile, error)
 	Get(ctx context.Context, id string) (Profile, error)
 	// GetByName returns ok=false (and a nil error) when no profile has the name.
@@ -108,14 +116,30 @@ type Store interface {
 	SetActiveID(ctx context.Context, id string) error
 }
 
+// LiveConfig applies an activated profile's saved settings to the running config
+// and persists them. A nil-backed applier is a no-op (no live config wired, e.g.
+// tests). Apply returns ErrConfigApply only for a fatal persistence failure; a
+// profile whose JSON cannot be parsed is logged and skipped by the adapter
+// (best-effort), so a malformed saved config never fails activation.
+type LiveConfig interface {
+	Apply(ctx context.Context, profileJSON string) error
+}
+
 // Service is the profiles use-case.
 type Service struct {
 	store Store
+	live  LiveConfig
 }
 
-// NewService builds the use-case over its Store port.
-func NewService(store Store) *Service {
-	return &Service{store: store}
+// NewService builds the use-case over its Store port and an optional LiveConfig
+// applier (nil = activation does not touch the running config).
+func NewService(store Store, live LiveConfig) *Service {
+	return &Service{store: store, live: live}
+}
+
+// Available reports whether the profiles subsystem can serve requests.
+func (s *Service) Available() bool {
+	return s.store.Available()
 }
 
 // List returns all profiles.
@@ -244,6 +268,16 @@ func (s *Service) SetActiveProfile(ctx context.Context, id string) (Profile, err
 	}
 	if setErr := s.store.SetActiveID(ctx, id); setErr != nil {
 		return Profile{}, setErr
+	}
+
+	// Activating a profile applies its saved settings to the running config. The
+	// applier is best-effort on a malformed saved config (logged and skipped) and
+	// returns ErrConfigApply only when the post-apply persist fails — in which case
+	// the profile is already active but the config save did not land.
+	if p.ConfigJSON != "" && s.live != nil {
+		if applyErr := s.live.Apply(ctx, p.ConfigJSON); applyErr != nil {
+			return p, applyErr
+		}
 	}
 	return p, nil
 }

--- a/internal/profiles/catalog/catalog_test.go
+++ b/internal/profiles/catalog/catalog_test.go
@@ -18,6 +18,8 @@ type fakeStore struct {
 
 func newFakeStore() *fakeStore { return &fakeStore{byID: map[string]catalog.Profile{}} }
 
+func (f *fakeStore) Available() bool { return true }
+
 func (f *fakeStore) List(context.Context) ([]catalog.Profile, error) {
 	out := make([]catalog.Profile, 0, len(f.byID))
 	for _, p := range f.byID {
@@ -93,7 +95,7 @@ func (f *fakeStore) SetActiveID(_ context.Context, id string) error {
 func ctx() context.Context { return context.Background() }
 
 func TestCreateValidatesNameAndStores(t *testing.T) {
-	svc := catalog.NewService(newFakeStore())
+	svc := catalog.NewService(newFakeStore(), nil)
 
 	if _, err := svc.Create(ctx(), catalog.NewProfile{Name: ""}); !errors.Is(err, catalog.ErrNameRequired) {
 		t.Fatalf("empty name should be ErrNameRequired, got %v", err)
@@ -118,7 +120,7 @@ func TestCreateValidatesNameAndStores(t *testing.T) {
 func TestUpdatePartialSemantics(t *testing.T) {
 	store := newFakeStore()
 	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "orig", Description: "d", ConfigJSON: "{}"}
-	svc := catalog.NewService(store)
+	svc := catalog.NewService(store, nil)
 
 	// Empty name keeps existing; nil config keeps existing; description always applied.
 	got, err := svc.Update(ctx(), "p1", catalog.ProfileUpdate{Name: "", Description: "new", ConfigJSON: nil}, "")
@@ -147,7 +149,7 @@ func TestUpdateIfMatch(t *testing.T) {
 	store := newFakeStore()
 	// fakeStore.UpdateIfMatch treats ConfigJSON as the version token.
 	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "n", ConfigJSON: "v1"}
-	svc := catalog.NewService(store)
+	svc := catalog.NewService(store, nil)
 
 	// Matching ETag writes through.
 	upd := `v2`
@@ -177,7 +179,7 @@ func TestDeleteGuards(t *testing.T) {
 	store.byID["act"] = catalog.Profile{ID: "act", Name: "active"}
 	store.byID["ok"] = catalog.Profile{ID: "ok", Name: "ok"}
 	store.activeID = "act"
-	svc := catalog.NewService(store)
+	svc := catalog.NewService(store, nil)
 
 	if err := svc.Delete(ctx(), "def"); !errors.Is(err, catalog.ErrDeleteDefault) {
 		t.Fatalf("deleting default should be ErrDeleteDefault, got %v", err)
@@ -198,7 +200,7 @@ func TestActiveProfileResolution(t *testing.T) {
 		store := newFakeStore()
 		store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one"}
 		store.activeID = "p1"
-		got, err := catalog.NewService(store).ActiveProfile(ctx())
+		got, err := catalog.NewService(store, nil).ActiveProfile(ctx())
 		if err != nil || got.ID != "p1" {
 			t.Fatalf("want p1, got %+v err=%v", got, err)
 		}
@@ -207,14 +209,14 @@ func TestActiveProfileResolution(t *testing.T) {
 	t.Run("falls back to default when unset", func(t *testing.T) {
 		store := newFakeStore()
 		store.byID["d"] = catalog.Profile{ID: "d", Name: "def", IsDefault: true}
-		got, err := catalog.NewService(store).ActiveProfile(ctx())
+		got, err := catalog.NewService(store, nil).ActiveProfile(ctx())
 		if err != nil || got.ID != "d" {
 			t.Fatalf("want default d, got %+v err=%v", got, err)
 		}
 	})
 
 	t.Run("no active and no default", func(t *testing.T) {
-		_, err := catalog.NewService(newFakeStore()).ActiveProfile(ctx())
+		_, err := catalog.NewService(newFakeStore(), nil).ActiveProfile(ctx())
 		if !errors.Is(err, catalog.ErrNoActiveOrDefault) {
 			t.Fatalf("want ErrNoActiveOrDefault, got %v", err)
 		}
@@ -224,7 +226,7 @@ func TestActiveProfileResolution(t *testing.T) {
 		store := newFakeStore()
 		store.byID["d"] = catalog.Profile{ID: "d", Name: "def", IsDefault: true}
 		store.activeID = "ghost" // points at a deleted profile
-		got, err := catalog.NewService(store).ActiveProfile(ctx())
+		got, err := catalog.NewService(store, nil).ActiveProfile(ctx())
 		if err != nil || got.ID != "d" {
 			t.Fatalf("want self-heal to d, got %+v err=%v", got, err)
 		}
@@ -237,7 +239,7 @@ func TestActiveProfileResolution(t *testing.T) {
 func TestSetActiveProfile(t *testing.T) {
 	store := newFakeStore()
 	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one"}
-	svc := catalog.NewService(store)
+	svc := catalog.NewService(store, nil)
 
 	if _, err := svc.SetActiveProfile(ctx(), ""); !errors.Is(err, catalog.ErrIDRequired) {
 		t.Fatalf("empty id should be ErrIDRequired, got %v", err)
@@ -251,11 +253,65 @@ func TestSetActiveProfile(t *testing.T) {
 	}
 }
 
+// fakeLive records applied profile JSON and can be made to fail the persist.
+type fakeLive struct {
+	applied string
+	err     error
+}
+
+func (f *fakeLive) Apply(_ context.Context, profileJSON string) error {
+	f.applied = profileJSON
+	return f.err
+}
+
+func TestSetActiveProfileAppliesConfig(t *testing.T) {
+	store := newFakeStore()
+	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one", ConfigJSON: `{"k":1}`}
+	live := &fakeLive{}
+	svc := catalog.NewService(store, live)
+
+	if _, err := svc.SetActiveProfile(ctx(), "p1"); err != nil {
+		t.Fatalf("set active: %v", err)
+	}
+	if live.applied != `{"k":1}` {
+		t.Errorf("expected the profile config to be applied, got %q", live.applied)
+	}
+}
+
+func TestSetActiveProfileSurfacesApplyError(t *testing.T) {
+	store := newFakeStore()
+	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one", ConfigJSON: `{"k":1}`}
+	svc := catalog.NewService(store, &fakeLive{err: catalog.ErrConfigApply})
+
+	_, err := svc.SetActiveProfile(ctx(), "p1")
+	if !errors.Is(err, catalog.ErrConfigApply) {
+		t.Errorf("want ErrConfigApply, got %v", err)
+	}
+	// The profile is still activated even though the apply failed.
+	if store.activeID != "p1" {
+		t.Errorf("active id should be set despite apply error, got %q", store.activeID)
+	}
+}
+
+func TestSetActiveProfileSkipsApplyWhenConfigEmpty(t *testing.T) {
+	store := newFakeStore()
+	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one"} // no ConfigJSON
+	live := &fakeLive{err: errors.New("should not be called")}
+	svc := catalog.NewService(store, live)
+
+	if _, err := svc.SetActiveProfile(ctx(), "p1"); err != nil {
+		t.Fatalf("set active with empty config should not invoke apply: %v", err)
+	}
+	if live.applied != "" {
+		t.Errorf("apply should be skipped for an empty config, got %q", live.applied)
+	}
+}
+
 func TestDuplicateRetriesOnNameCollision(t *testing.T) {
 	store := newFakeStore()
 	store.byID["src"] = catalog.Profile{ID: "src", Name: "src", ConfigJSON: `{"k":1}`}
 	store.byID["copy"] = catalog.Profile{ID: "copy", Name: "src (Copy)"} // forces first-attempt collision
-	svc := catalog.NewService(store)
+	svc := catalog.NewService(store, nil)
 
 	dup, err := svc.Duplicate(ctx(), "src", "")
 	if err != nil {
@@ -272,7 +328,7 @@ func TestDuplicateRetriesOnNameCollision(t *testing.T) {
 func TestImportCreateUpdateSkip(t *testing.T) {
 	store := newFakeStore()
 	store.byID["e"] = catalog.Profile{ID: "e", Name: "exists", ConfigJSON: "{}"}
-	svc := catalog.NewService(store)
+	svc := catalog.NewService(store, nil)
 
 	res := svc.Import(ctx(), []catalog.ImportItem{
 		{Name: "fresh", ConfigJSON: `{"a":1}`},


### PR DESCRIPTION
The profiles CRUD already delegated to the catalog use-case, but the handler
still reached the infrastructure directly in two ways: six `s.db() == nil`
availability guards and the config apply+save side-effect in
handleSetActiveProfile (s.config.ApplyProfileJSON + s.config.Save). Fold both
into the use-case.

- catalog.Store gains Available(); catalog.Service.Available() surfaces it. The
  six handler guards become `!s.profiles.Available()`.
- catalog gains a LiveConfig port (Apply(ctx, json)) and an ErrConfigApply
  sentinel. SetActiveProfile now applies the activated profile's saved settings
  through the port and persists them — owning the "activating a profile applies
  its config" behavior. Best-effort on a malformed saved config (logged + skipped
  in the adapter), fatal only on a failed persist (#781, #782 preserved).
- internal/app/profiles.go: profilesStore.Available() over db()!=nil;
  profilesLiveConfig over the live config + path (contextual logger, no global).
  NewProfiles(db, cfg, path).
- handlers_profiles.go: handleSetActiveProfile drops the inline config block and
  maps catalog.ErrConfigApply → 500 failedToSave. Zero s.db()/s.config reaches
  remain — WS-A is complete (all 11 fat handlers strangled).

Tests: catalog suite covers Apply-on-activate, ErrConfigApply propagation
(profile still activated), and empty-config skip; profiles adapter test wires a
real config. Full non-race api suite + staticcheck + filename/route/escaping/
lint gates green.
