### PR TITLE
fix(database): de-collide anomaly census test fixtures (flaky)

### DIFF
--- a/internal/database/repository_anomalies_test.go
+++ b/internal/database/repository_anomalies_test.go
@@ -5,6 +5,7 @@ package database_test
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,6 +39,14 @@ func setupAnomalyTest(t *testing.T) (*database.AnomalyRepository, context.Contex
 
 func sampleRecord(id string) anomaly.Record {
 	t0 := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	// Derive the subject from the id's last "|"-segment so distinct fixtures get
+	// distinct census keys (day_bucket, def_key, subject_kind, subject_id). A fixed
+	// subject would collide unrelated records (e.g. "A|bssid|aa:bb" and
+	// "B|bssid|cc:dd") on that key, making the daily census nondeterministic.
+	subject := id
+	if i := strings.LastIndex(id, "|"); i >= 0 {
+		subject = id[i+1:]
+	}
 	return anomaly.Record{
 		ID:     id,
 		Source: anomaly.SourceWiFi,
@@ -45,7 +54,7 @@ func sampleRecord(id string) anomaly.Record {
 			DefKey:         "open-ssid",
 			Category:       anomaly.CategorySecurity,
 			Severity:       anomaly.SeverityWarning,
-			Subject:        anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: "aa:bb"},
+			Subject:        anomaly.SubjectRef{Kind: anomaly.SubjectBSSID, ID: subject},
 			Title:          "Open network",
 			Description:    "No encryption.",
 			Recommendation: "Enable WPA2/WPA3.",


### PR DESCRIPTION
## Problem
`TestRunCleanupCensusesResolvedRowBeforePurge` flakes (and was failing CI on every open PR near 00:00–01:00 UTC). `sampleRecord` hardcoded `Subject.ID="aa:bb"` for every fixture, so `"A|bssid|aa:bb"` and `"B|bssid|cc:dd"` collided on the daily-census key `(day_bucket, def_key, subject_kind, subject_id)`. The census coalesces on that key with no `ORDER BY`, so for a bucket touched by both A (resolved) and B (active) the surviving `is_resolved` was undefined.

## Fix
Derive `Subject.ID` from the id's last `|`-segment so distinct fixtures get distinct census keys. Test-fixture only — census/production code unchanged.

## Evidence
- formerly-flaky test passes **5/5**
- full `internal/database` suite green

Unblocks the open WS-A PRs (#1668, #1669) whose CI was red only because of this shared flake.