### PR TITLE
refactor(api): strangle the last residual handler config/db reaches (ADR-0020, WS-A)

### DIFF
--- a/internal/alerts/rules/rules.go
+++ b/internal/alerts/rules/rules.go
@@ -46,6 +46,9 @@ type Rule struct {
 // repository, mapping ErrAlertRuleNotFound -> ErrNotFound and the repo's
 // "alert_rules:"-prefixed validation errors -> *ValidationError.
 type Store interface {
+	// Available reports whether the backing persistence is wired; a false result
+	// means the rule subsystem cannot serve any request (the 503 path).
+	Available() bool
 	List(ctx context.Context, enabledOnly bool) ([]Rule, error)
 	Get(ctx context.Context, id int64) (Rule, error)
 	// Create stores r and returns it with the generated ID + timestamps.
@@ -62,6 +65,11 @@ type Service struct {
 // NewService builds the use-case over its Store port.
 func NewService(store Store) *Service {
 	return &Service{store: store}
+}
+
+// Available reports whether the rule subsystem can serve requests.
+func (s *Service) Available() bool {
+	return s.store.Available()
 }
 
 // minThreshold mirrors the pre-strangle max(threshold, 1): a rule fires on the

--- a/internal/alerts/rules/rules_test.go
+++ b/internal/alerts/rules/rules_test.go
@@ -19,6 +19,8 @@ func newFakeRuleStore() *fakeRuleStore {
 	return &fakeRuleStore{byID: map[int64]rules.Rule{}, nextID: 1}
 }
 
+func (f *fakeRuleStore) Available() bool { return true }
+
 func (f *fakeRuleStore) List(_ context.Context, enabledOnly bool) ([]rules.Rule, error) {
 	out := make([]rules.Rule, 0, len(f.byID))
 	for _, r := range f.byID {

--- a/internal/api/handlers_alert_rules.go
+++ b/internal/api/handlers_alert_rules.go
@@ -78,7 +78,7 @@ func (s *Server) handleAlertRuleByID(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) listAlertRules(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	if s.db() == nil {
+	if !s.alertRules.Available() {
 		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
 		return
 	}
@@ -97,7 +97,7 @@ func (s *Server) listAlertRules(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getAlertRule(w http.ResponseWriter, r *http.Request, id int64) {
 	logger := logging.FromContext(r.Context())
-	if s.db() == nil {
+	if !s.alertRules.Available() {
 		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
 		return
 	}
@@ -116,7 +116,7 @@ func (s *Server) getAlertRule(w http.ResponseWriter, r *http.Request, id int64) 
 
 func (s *Server) createAlertRule(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-	if s.db() == nil {
+	if !s.alertRules.Available() {
 		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
 		return
 	}
@@ -142,7 +142,7 @@ func (s *Server) createAlertRule(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) updateAlertRule(w http.ResponseWriter, r *http.Request, id int64) {
 	logger := logging.FromContext(r.Context())
-	if s.db() == nil {
+	if !s.alertRules.Available() {
 		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
 		return
 	}
@@ -168,7 +168,7 @@ func (s *Server) updateAlertRule(w http.ResponseWriter, r *http.Request, id int6
 
 func (s *Server) deleteAlertRule(w http.ResponseWriter, r *http.Request, id int64) {
 	logger := logging.FromContext(r.Context())
-	if s.db() == nil {
+	if !s.alertRules.Available() {
 		http.Error(w, "Database not initialized", http.StatusServiceUnavailable)
 		return
 	}

--- a/internal/api/handlers_devices.go
+++ b/internal/api/handlers_devices.go
@@ -133,8 +133,8 @@ func (s *Server) handleDevicesScan(w http.ResponseWriter, r *http.Request) {
 // postScanVulnerabilityCheck runs vulnerability scans after device discovery if auto-scan is enabled.
 // This method extracts business logic from the handler for better separation of concerns.
 func (s *Server) postScanVulnerabilityCheck(logger *slog.Logger) {
-	if s.vulnScanner() == nil || !s.config.Security.VulnerabilityScanning.Enabled ||
-		!s.config.Security.VulnerabilityScanning.AutoScan {
+	vuln := s.securitySettings.Vuln()
+	if s.vulnScanner() == nil || !vuln.Enabled || !vuln.AutoScan {
 		return
 	}
 

--- a/internal/api/handlers_settings.go
+++ b/internal/api/handlers_settings.go
@@ -94,7 +94,7 @@ func (s *Server) updateSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Emit the fresh token so the client can chain a subsequent conditional write.
-	w.Header().Set("ETag", s.config.SettingsETag())
+	w.Header().Set("ETag", s.settingsManagement.ETag())
 	sendJSONResponse(w, logger, http.StatusOK, map[string]string{"status": "updated"})
 }
 func (s *Server) handleLinkSettings(w http.ResponseWriter, r *http.Request) {
@@ -116,21 +116,10 @@ func (s *Server) handleLinkSettings(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// getLinkSettings returns current link settings from config.
+// getLinkSettings returns current link settings via the settings use-case.
 func (s *Server) getLinkSettings(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-
-	// Read directly from Config (single source of truth)
-	s.config.RLock()
-	settings := s.config.Link
-	s.config.RUnlock()
-
-	// Default to "auto" if not set
-	if settings.Mode == "" {
-		settings.Mode = "auto"
-	}
-
-	sendJSONResponse(w, logger, http.StatusOK, settings)
+	sendJSONResponse(w, logger, http.StatusOK, s.settingsManagement.Link())
 }
 
 // updateLinkSettings updates link settings in config and saves to active profile.
@@ -146,39 +135,24 @@ func (s *Server) updateLinkSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate mode value (combined speed/duplex format like "100/full" or "auto")
-	validModes := map[string]bool{
-		"auto": true, "10/half": true, "10/full": true, "100/half": true, "100/full": true,
-		"1000/full": true, "2500/full": true, "5000/full": true, "10000/full": true,
-	}
-	if updates.Mode != "" && !validModes[updates.Mode] {
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusBadRequest,
-			ErrCodeValidation,
-			"Invalid mode value",
-			"",
-		)
+	// Validate + persist via the settings use-case; an invalid mode is a 400.
+	if err := s.settingsManagement.UpdateLink(updates); err != nil {
+		if errors.Is(err, management.ErrValidation) {
+			sendErrorResponseWithDetails(w, logger, http.StatusBadRequest,
+				ErrCodeValidation, "Invalid mode value", "")
+			return
+		}
+		logger.ErrorContext(ctx, "Failed to save link settings", "error", err)
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, "Failed to save link settings", "")
 		return
 	}
-
-	// Update Config directly (single source of truth)
-	s.config.Lock()
-	s.config.Link = updates
-	s.config.Unlock()
 
 	// Persist to the active profile (ADR-0016 phase 3; no-op without a db).
 	if err := s.settingsStore.SaveToActiveProfile(ctx); err != nil {
 		logger.ErrorContext(ctx, "Failed to save link settings to profile", "error", err)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			"Failed to save link settings",
-			"",
-		)
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, "Failed to save link settings", "")
 		return
 	}
 
@@ -210,16 +184,10 @@ func (s *Server) handleCableTestSettings(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-// getCableTestSettings returns current cable test settings from config.
+// getCableTestSettings returns current cable test settings via the settings use-case.
 func (s *Server) getCableTestSettings(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
-
-	// Read directly from Config (single source of truth)
-	s.config.RLock()
-	settings := s.config.CableTest
-	s.config.RUnlock()
-
-	sendJSONResponse(w, logger, http.StatusOK, settings)
+	sendJSONResponse(w, logger, http.StatusOK, s.settingsManagement.CableTest())
 }
 
 // updateCableTestSettings updates cable test settings in config and saves to active profile.
@@ -235,22 +203,19 @@ func (s *Server) updateCableTestSettings(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Update Config directly (single source of truth)
-	s.config.Lock()
-	s.config.CableTest = updates
-	s.config.Unlock()
+	// Persist via the settings use-case, then to the active profile.
+	if err := s.settingsManagement.UpdateCableTest(updates); err != nil {
+		logger.ErrorContext(ctx, "Failed to save cable test settings", "error", err)
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, "Failed to save cable test settings", "")
+		return
+	}
 
 	// Persist to the active profile (ADR-0016 phase 3; no-op without a db).
 	if err := s.settingsStore.SaveToActiveProfile(ctx); err != nil {
 		logger.ErrorContext(ctx, "Failed to save cable test settings to profile", "error", err)
-		sendErrorResponseWithDetails(
-			w,
-			logger,
-			http.StatusInternalServerError,
-			ErrCodeInternal,
-			"Failed to save cable test settings",
-			"",
-		)
+		sendErrorResponseWithDetails(w, logger, http.StatusInternalServerError,
+			ErrCodeInternal, "Failed to save cable test settings", "")
 		return
 	}
 

--- a/internal/api/handlers_sse.go
+++ b/internal/api/handlers_sse.go
@@ -372,7 +372,7 @@ func (s *Server) sendSSEInitialState(w http.ResponseWriter, flusher http.Flusher
 		Type: "initial_state",
 		Payload: map[string]any{
 			"status":     "connected",
-			"interface":  s.config.Interface.Default,
+			"interface":  s.defaultInterface(),
 			"isWireless": isWireless,
 			"cards":      cards,
 		},

--- a/internal/app/alerts.go
+++ b/internal/app/alerts.go
@@ -29,6 +29,8 @@ type alertRuleStore struct {
 	db func() *database.DB
 }
 
+func (a alertRuleStore) Available() bool { return a.db() != nil }
+
 func toAppRule(r *database.AlertRule) rules.Rule {
 	return rules.Rule{
 		ID:                   r.ID,

--- a/internal/settings/management/management.go
+++ b/internal/settings/management/management.go
@@ -856,3 +856,64 @@ func applyDisplayOptionsUpdates(updates map[string]any, cfg *config.Config) erro
 
 	return nil
 }
+
+// ---------------------------------------------------------------------------
+// Link settings (#740-adjacent: dedicated link/cable settings endpoints)
+// ---------------------------------------------------------------------------
+
+// validLinkMode reports whether mode is an accepted combined speed/duplex value
+// for a link override.
+func validLinkMode(mode string) bool {
+	switch mode {
+	case "auto", "10/half", "10/full", "100/half", "100/full",
+		"1000/full", "2500/full", "5000/full", "10000/full":
+		return true
+	default:
+		return false
+	}
+}
+
+// ETag returns the current settings concurrency token (the value the settings
+// endpoints emit after a successful write).
+func (s *Service) ETag() string {
+	var etag string
+	s.store.Read(func(cfg *config.Config) { etag = cfg.SettingsETagLocked() })
+	return etag
+}
+
+// Link returns the current link settings, defaulting an unset mode to "auto".
+func (s *Service) Link() config.LinkConfig {
+	var out config.LinkConfig
+	s.store.Read(func(cfg *config.Config) { out = cfg.Link })
+	if out.Mode == "" {
+		out.Mode = "auto"
+	}
+	return out
+}
+
+// UpdateLink validates and persists the link settings. An unrecognized mode
+// returns ErrValidation; "" (unset) is allowed.
+func (s *Service) UpdateLink(in config.LinkConfig) error {
+	if in.Mode != "" && !validLinkMode(in.Mode) {
+		return fmt.Errorf("%w: link mode %q", ErrValidation, in.Mode)
+	}
+	return s.store.Write(func(cfg *config.Config) error {
+		cfg.Link = in
+		return nil
+	})
+}
+
+// CableTest returns the current cable-test settings.
+func (s *Service) CableTest() config.CableTestConfig {
+	var out config.CableTestConfig
+	s.store.Read(func(cfg *config.Config) { out = cfg.CableTest })
+	return out
+}
+
+// UpdateCableTest persists the cable-test settings.
+func (s *Service) UpdateCableTest(in config.CableTestConfig) error {
+	return s.store.Write(func(cfg *config.Config) error {
+		cfg.CableTest = in
+		return nil
+	})
+}

--- a/internal/settings/management/management_test.go
+++ b/internal/settings/management/management_test.go
@@ -75,3 +75,43 @@ func TestUpdateInvalidTypeValidation(t *testing.T) {
 		t.Error("invalid update should not have mutated config")
 	}
 }
+
+func TestLinkSettingsDefaultAndUpdate(t *testing.T) {
+	svc := management.NewService(&fakeStore{cfg: config.DefaultConfig()})
+
+	// Unset mode defaults to "auto" on read.
+	if got := svc.Link(); got.Mode != "auto" {
+		t.Errorf("default link mode = %q, want auto", got.Mode)
+	}
+
+	// A valid mode persists.
+	if err := svc.UpdateLink(config.LinkConfig{Mode: "1000/full"}); err != nil {
+		t.Fatalf("UpdateLink valid: %v", err)
+	}
+	if got := svc.Link(); got.Mode != "1000/full" {
+		t.Errorf("link mode = %q, want 1000/full", got.Mode)
+	}
+
+	// An invalid mode is a validation error.
+	if err := svc.UpdateLink(config.LinkConfig{Mode: "bogus"}); !errors.Is(err, management.ErrValidation) {
+		t.Errorf("UpdateLink bogus: want ErrValidation, got %v", err)
+	}
+}
+
+func TestCableTestSettingsRoundTrip(t *testing.T) {
+	svc := management.NewService(&fakeStore{cfg: config.DefaultConfig()})
+	in := config.CableTestConfig{Enabled: true}
+	if err := svc.UpdateCableTest(in); err != nil {
+		t.Fatalf("UpdateCableTest: %v", err)
+	}
+	if got := svc.CableTest(); !got.Enabled {
+		t.Errorf("cable test round-trip mismatch: %+v", got)
+	}
+}
+
+func TestETagNonEmpty(t *testing.T) {
+	svc := management.NewService(&fakeStore{cfg: config.DefaultConfig()})
+	if svc.ETag() == "" {
+		t.Error("ETag should be non-empty")
+	}
+}


### PR DESCRIPTION
Completes WS-A: after this, no non-auth handler in internal/api reaches s.db()
or s.config.* directly (verified by audit). Four handlers still had reaches the
A11 pass missed:

- handlers_settings.go (Link + CableTest get/set, post-update ETag): the
  settings-management use-case gains Link()/UpdateLink() (with mode validation →
  ErrValidation), CableTest()/UpdateCableTest(), and ETag(), all over its existing
  Store.Read/Write config port. The four sub-handlers are now thin; the profile
  persistence (settingsStore.SaveToActiveProfile) stays as a use-case call.
- handlers_alert_rules.go (5 s.db()==nil guards): rules.Store/Service gain
  Available(); the guards become !s.alertRules.Available() (the profiles pattern).
- handlers_devices.go: the auto-scan check reads through securitySettings.Vuln()
  instead of s.config.Security.VulnerabilityScanning.
- handlers_sse.go: the initial-state interface reads through s.defaultInterface().

Tests: management Link default/validation, CableTest round-trip, ETag; rules
Available via the fake. Full non-race api suite + staticcheck + lint +
filename/route/escaping gates green. WS-A exit criterion met.
