### PR TITLE
refactor(probe): narrow persistence port to domain types (WS-B1)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -278,6 +278,21 @@ linters:
               desc: "reporting is persistence-free — define a Repo port, implement it in internal/reporting/store"
             - pkg: github.com/MustardSeedNetworks/seed/internal/reporting/store
               desc: "inward-only — the store adapter imports reporting, never the reverse; wire it in internal/app"
+        # WS-B repository-port discipline: the probe engine declares its
+        # persistence needs as a consumer-side port (probeStorage) in its own
+        # domain types (probe.Probe / probe.Result); the concrete adapter lives
+        # in internal/app (NewProbeStorage) and translates to/from the database
+        # row representation. The probe package therefore never imports
+        # internal/database. Production-only: a probe test that wires a real DB
+        # end-to-end would do so through the app adapter, but today's tests use
+        # domain-typed fakes, so this also documents the inward direction.
+        "probe-no-persistence":
+          files:
+            - "**/internal/probe/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "probe is persistence-free — define a port in probe (domain types) and implement it in internal/app (NewProbeStorage)"
         # Phase 6 capture port: libpcap (via gopacket/pcap) carries the CGO
         # taint that re-links libpcap into every dependent test binary. It is
         # confined to the single adapter package internal/capture/pcap; every

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -488,7 +488,7 @@ func (s *Server) initProbeEngine(db *database.DB) {
 	sched := scheduler.New(probeSchedulerTick)
 
 	probeEngine := probe.NewEngine(logging.GetLogger()).
-		WithStorage(db.Probes(), sched)
+		WithStorage(app.NewProbeStorage(db.Probes()), sched)
 
 	// Register V1.0 baseline checkers plus the health-check vertical
 	// checkers absorbed onto the probe engine (ADR-0027 P1).

--- a/internal/app/probe.go
+++ b/internal/app/probe.go
@@ -1,0 +1,89 @@
+package app
+
+// probe.go wires the composition root to the probe engine's persistence port
+// (ADR-0020 / WS-B). The probe package declares a consumer-side persistence
+// port in its own domain types (probe.Probe / probe.Result) and stays
+// persistence-free; the adapter below implements that port over the concrete
+// *database.ProbeRepository, translating to and from the database row
+// representation. The translation that used to live inside internal/probe
+// (dbProbeToModel / the Result→ProbeResult build) lives here instead, so the
+// probe package no longer imports internal/database.
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/probe"
+)
+
+// ProbeStorage adapts *database.ProbeRepository to the probe engine's
+// consumer-side persistence port, translating between the database row types
+// and the probe package's domain types.
+type ProbeStorage struct {
+	repo *database.ProbeRepository
+}
+
+// NewProbeStorage builds the probe-engine persistence adapter over the concrete
+// probe repository. The result satisfies the probe engine's persistence port,
+// so it is passed to Engine.WithStorage in the composition root.
+func NewProbeStorage(repo *database.ProbeRepository) *ProbeStorage {
+	return &ProbeStorage{repo: repo}
+}
+
+// GetProbe loads one probe by ID and translates it to the domain type.
+func (s *ProbeStorage) GetProbe(ctx context.Context, id string) (probe.Probe, error) {
+	p, err := s.repo.GetProbe(ctx, id)
+	if err != nil {
+		return probe.Probe{}, err
+	}
+	return dbProbeToModel(p), nil
+}
+
+// ListProbes lists probes matching the client/kind filters and translates them.
+func (s *ProbeStorage) ListProbes(ctx context.Context, clientID, kind string) ([]probe.Probe, error) {
+	rows, err := s.repo.ListProbes(ctx, clientID, kind)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]probe.Probe, 0, len(rows))
+	for _, p := range rows {
+		out = append(out, dbProbeToModel(p))
+	}
+	return out, nil
+}
+
+// RecordResult persists a dispatch result, translating it into the database row
+// representation. The metadata column is TEXT and accepts opaque JSON.
+func (s *ProbeStorage) RecordResult(ctx context.Context, r probe.Result) error {
+	return s.repo.RecordResult(ctx, &database.ProbeResult{
+		ProbeID:      r.ProbeID,
+		ClientID:     r.ClientID,
+		Kind:         r.Kind,
+		Timestamp:    r.Timestamp,
+		Success:      r.Success,
+		LatencyMs:    r.LatencyMs,
+		Error:        r.Error,
+		MetadataJSON: string(r.Metadata),
+	})
+}
+
+// dbProbeToModel converts the database row representation into the probe
+// package's Probe type. The JSON columns are passed through as
+// [json.RawMessage]; consumers decode them per-Kind.
+func dbProbeToModel(p *database.Probe) probe.Probe {
+	return probe.Probe{
+		ID:              p.ID,
+		ClientID:        p.ClientID,
+		Kind:            p.Kind,
+		DisplayName:     p.DisplayName,
+		Target:          p.Target,
+		Params:          json.RawMessage(p.ParamsJSON),
+		IntervalSeconds: p.IntervalSeconds,
+		Enabled:         p.Enabled,
+		Warning:         json.RawMessage(p.WarningJSON),
+		Critical:        json.RawMessage(p.CriticalJSON),
+		CreatedAt:       p.CreatedAt,
+		UpdatedAt:       p.UpdatedAt,
+	}
+}

--- a/internal/app/probe_internal_test.go
+++ b/internal/app/probe_internal_test.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/database"
+)
+
+// TestDBProbeToModel asserts the composition-root adapter translates a probe
+// database row into the probe package's domain type, passing the JSON columns
+// through as raw message bytes (the translation that moved out of internal/probe
+// when its persistence port was narrowed to domain types, WS-B).
+func TestDBProbeToModel(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	row := &database.Probe{
+		ID:              "p-1",
+		ClientID:        "tenant-x",
+		Kind:            "dns",
+		DisplayName:     "internal",
+		Target:          "internal.example.com",
+		ParamsJSON:      `{"server":"10.0.0.5"}`,
+		IntervalSeconds: 60,
+		Enabled:         true,
+		WarningJSON:     `{"latency_ms":50}`,
+		CriticalJSON:    `{"latency_ms":200}`,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	got := dbProbeToModel(row)
+
+	if got.ID != "p-1" || got.ClientID != "tenant-x" || got.Kind != "dns" {
+		t.Errorf("identity fields mistranslated: %+v", got)
+	}
+	if got.DisplayName != "internal" || got.Target != "internal.example.com" {
+		t.Errorf("descriptor fields mistranslated: %+v", got)
+	}
+	if got.IntervalSeconds != 60 || !got.Enabled {
+		t.Errorf("schedule fields mistranslated: %+v", got)
+	}
+	if string(got.Params) != `{"server":"10.0.0.5"}` {
+		t.Errorf("Params = %q, want round-trip", string(got.Params))
+	}
+	if string(got.Warning) != `{"latency_ms":50}` {
+		t.Errorf("Warning = %q, want round-trip", string(got.Warning))
+	}
+	if string(got.Critical) != `{"latency_ms":200}` {
+		t.Errorf("Critical = %q, want round-trip", string(got.Critical))
+	}
+	if !got.CreatedAt.Equal(now) || !got.UpdatedAt.Equal(now) {
+		t.Errorf("timestamps mistranslated: created=%v updated=%v", got.CreatedAt, got.UpdatedAt)
+	}
+}

--- a/internal/probe/lifecycle.go
+++ b/internal/probe/lifecycle.go
@@ -2,12 +2,10 @@ package probe
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/scheduler"
 )
 
@@ -16,13 +14,15 @@ import (
 // via RunDefinition still works without storage.
 var ErrStorageNotConfigured = errors.New("probe.Engine has no storage configured (call WithStorage)")
 
-// probeStorage is the subset of *database.ProbeRepository the Engine
-// needs. Narrowed interface so tests can inject fakes without
+// probeStorage is the persistence port the Engine needs, expressed in the
+// probe package's own domain types. The concrete adapter (internal/app)
+// translates to/from the database row representation, so the probe package
+// itself stays persistence-free. Narrowed so tests can inject fakes without
 // constructing a real DB.
 type probeStorage interface {
-	GetProbe(ctx context.Context, id string) (*database.Probe, error)
-	ListProbes(ctx context.Context, clientID, kind string) ([]*database.Probe, error)
-	RecordResult(ctx context.Context, pr *database.ProbeResult) error
+	GetProbe(ctx context.Context, id string) (Probe, error)
+	ListProbes(ctx context.Context, clientID, kind string) ([]Probe, error)
+	RecordResult(ctx context.Context, r Result) error
 }
 
 // probeScheduler is the subset of *scheduler.Scheduler the Engine
@@ -175,8 +175,8 @@ func (e *Engine) RunNow(ctx context.Context, probeID string) (Result, error) {
 		return Result{}, fmt.Errorf("get probe %q: %w", probeID, err)
 	}
 
-	r := e.RunDefinition(ctx, dbProbeToModel(p))
-	if persistErr := persistResult(ctx, storage, r); persistErr != nil {
+	r := e.RunDefinition(ctx, p)
+	if persistErr := storage.RecordResult(ctx, r); persistErr != nil {
 		return r, fmt.Errorf("persist result for probe %q: %w", probeID, persistErr)
 	}
 	return r, nil
@@ -191,43 +191,6 @@ func (e *Engine) requireStorage() (probeStorage, probeScheduler, error) {
 		return nil, nil, ErrStorageNotConfigured
 	}
 	return e.storage, e.scheduler, nil
-}
-
-// dbProbeToModel converts the database row representation into the
-// probe package's Probe type. The JSON columns are passed through as
-// [json.RawMessage]; consumers decode them per-Kind.
-func dbProbeToModel(p *database.Probe) Probe {
-	return Probe{
-		ID:              p.ID,
-		ClientID:        p.ClientID,
-		Kind:            p.Kind,
-		DisplayName:     p.DisplayName,
-		Target:          p.Target,
-		Params:          json.RawMessage(p.ParamsJSON),
-		IntervalSeconds: p.IntervalSeconds,
-		Enabled:         p.Enabled,
-		Warning:         json.RawMessage(p.WarningJSON),
-		Critical:        json.RawMessage(p.CriticalJSON),
-		CreatedAt:       p.CreatedAt,
-		UpdatedAt:       p.UpdatedAt,
-	}
-}
-
-// persistResult writes a dispatch Result into probe_results via the
-// storage layer. Metadata is preserved as-is; the database column is
-// TEXT and accepts opaque JSON.
-func persistResult(ctx context.Context, storage probeStorage, r Result) error {
-	pr := &database.ProbeResult{
-		ProbeID:      r.ProbeID,
-		ClientID:     r.ClientID,
-		Kind:         r.Kind,
-		Timestamp:    r.Timestamp,
-		Success:      r.Success,
-		LatencyMs:    r.LatencyMs,
-		Error:        r.Error,
-		MetadataJSON: string(r.Metadata),
-	}
-	return storage.RecordResult(ctx, pr)
 }
 
 // probeJob is the scheduler.Job adapter that drives one probe at its

--- a/internal/probe/lifecycle_test.go
+++ b/internal/probe/lifecycle_test.go
@@ -7,16 +7,22 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
 	"github.com/MustardSeedNetworks/seed/internal/scheduler"
 )
 
-// fakeStorage implements probe.storage's behavior for tests.
+// errProbeNotFound is the fake's stand-in for a missing-probe lookup. The
+// engine wraps whatever the storage port returns with %w, so the concrete
+// sentinel value is not asserted — only that an error propagates.
+var errProbeNotFound = errors.New("probe not found")
+
+// fakeStorage implements the probe engine's probeStorage port for tests,
+// speaking the probe package's own domain types (the DB-row translation now
+// lives in the internal/app adapter).
 type fakeStorage struct {
 	mu           sync.Mutex
-	probes       map[string]*database.Probe
-	results      []*database.ProbeResult
+	probes       map[string]probe.Probe
+	results      []probe.Result
 	getErr       error
 	recordErr    error
 	listFilter   string // captures the kind filter passed to ListProbes
@@ -24,54 +30,54 @@ type fakeStorage struct {
 }
 
 func newFakeStorage() *fakeStorage {
-	return &fakeStorage{probes: make(map[string]*database.Probe)}
+	return &fakeStorage{probes: make(map[string]probe.Probe)}
 }
 
-func (f *fakeStorage) GetProbe(_ context.Context, id string) (*database.Probe, error) {
+func (f *fakeStorage) GetProbe(_ context.Context, id string) (probe.Probe, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.getErr != nil {
-		return nil, f.getErr
+		return probe.Probe{}, f.getErr
 	}
 	p, ok := f.probes[id]
 	if !ok {
-		return nil, database.ErrProbeNotFound
+		return probe.Probe{}, errProbeNotFound
 	}
 	return p, nil
 }
 
-func (f *fakeStorage) ListProbes(_ context.Context, clientID, kind string) ([]*database.Probe, error) {
+func (f *fakeStorage) ListProbes(_ context.Context, clientID, kind string) ([]probe.Probe, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.clientFilter = clientID
 	f.listFilter = kind
-	out := make([]*database.Probe, 0, len(f.probes))
+	out := make([]probe.Probe, 0, len(f.probes))
 	for _, p := range f.probes {
 		out = append(out, p)
 	}
 	return out, nil
 }
 
-func (f *fakeStorage) RecordResult(_ context.Context, pr *database.ProbeResult) error {
+func (f *fakeStorage) RecordResult(_ context.Context, r probe.Result) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.recordErr != nil {
 		return f.recordErr
 	}
-	f.results = append(f.results, pr)
+	f.results = append(f.results, r)
 	return nil
 }
 
-func (f *fakeStorage) addProbe(p *database.Probe) {
+func (f *fakeStorage) addProbe(p probe.Probe) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.probes[p.ID] = p
 }
 
-func (f *fakeStorage) recordedResults() []*database.ProbeResult {
+func (f *fakeStorage) recordedResults() []probe.Result {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	out := make([]*database.ProbeResult, len(f.results))
+	out := make([]probe.Result, len(f.results))
 	copy(out, f.results)
 	return out
 }
@@ -162,9 +168,9 @@ func TestEngine_Stop_IdempotentAndNoStorage(t *testing.T) {
 func TestEngine_Start_LoadsEnabledProbes_SkipsDisabled(t *testing.T) {
 	t.Parallel()
 	storage := newFakeStorage()
-	storage.addProbe(&database.Probe{ID: "p-1", Kind: "dns", IntervalSeconds: 60, Enabled: true})
-	storage.addProbe(&database.Probe{ID: "p-2", Kind: "tls", IntervalSeconds: 300, Enabled: false})
-	storage.addProbe(&database.Probe{ID: "p-3", Kind: "dns", IntervalSeconds: 30, Enabled: true})
+	storage.addProbe(probe.Probe{ID: "p-1", Kind: "dns", IntervalSeconds: 60, Enabled: true})
+	storage.addProbe(probe.Probe{ID: "p-2", Kind: "tls", IntervalSeconds: 300, Enabled: false})
+	storage.addProbe(probe.Probe{ID: "p-3", Kind: "dns", IntervalSeconds: 30, Enabled: true})
 	sched := newFakeScheduler()
 	e := probe.NewEngine(silentLogger()).WithStorage(storage, sched)
 
@@ -183,7 +189,7 @@ func TestEngine_Start_LoadsEnabledProbes_SkipsDisabled(t *testing.T) {
 func TestEngine_Start_Idempotent(t *testing.T) {
 	t.Parallel()
 	storage := newFakeStorage()
-	storage.addProbe(&database.Probe{ID: "p-1", Kind: "dns", IntervalSeconds: 60, Enabled: true})
+	storage.addProbe(probe.Probe{ID: "p-1", Kind: "dns", IntervalSeconds: 60, Enabled: true})
 	sched := newFakeScheduler()
 	e := probe.NewEngine(silentLogger()).WithStorage(storage, sched)
 
@@ -201,8 +207,8 @@ func TestEngine_Start_Idempotent(t *testing.T) {
 func TestEngine_Stop_UnregistersJobs(t *testing.T) {
 	t.Parallel()
 	storage := newFakeStorage()
-	storage.addProbe(&database.Probe{ID: "p-1", Kind: "dns", IntervalSeconds: 60, Enabled: true})
-	storage.addProbe(&database.Probe{ID: "p-2", Kind: "tls", IntervalSeconds: 300, Enabled: true})
+	storage.addProbe(probe.Probe{ID: "p-1", Kind: "dns", IntervalSeconds: 60, Enabled: true})
+	storage.addProbe(probe.Probe{ID: "p-2", Kind: "tls", IntervalSeconds: 300, Enabled: true})
 	sched := newFakeScheduler()
 	e := probe.NewEngine(silentLogger()).WithStorage(storage, sched)
 
@@ -224,13 +230,13 @@ func TestEngine_Stop_UnregistersJobs(t *testing.T) {
 func TestEngine_RunNow_DispatchesAndPersists(t *testing.T) {
 	t.Parallel()
 	storage := newFakeStorage()
-	storage.addProbe(&database.Probe{
+	storage.addProbe(probe.Probe{
 		ID:          "p-1",
 		ClientID:    "default",
 		Kind:        "dns",
 		DisplayName: "google.com",
 		Target:      "google.com",
-		ParamsJSON:  `{"record_type":"A"}`,
+		Params:      json.RawMessage(`{"record_type":"A"}`),
 		Enabled:     true,
 	})
 	sched := newFakeScheduler()
@@ -282,7 +288,7 @@ func TestEngine_RunNow_PropagatesProbeNotFound(t *testing.T) {
 func TestEngine_RunNow_PropagatesPersistError(t *testing.T) {
 	t.Parallel()
 	storage := newFakeStorage()
-	storage.addProbe(&database.Probe{ID: "p-1", Kind: "dns", Enabled: true})
+	storage.addProbe(probe.Probe{ID: "p-1", Kind: "dns", Enabled: true})
 	storage.recordErr = errors.New("disk full")
 	sched := newFakeScheduler()
 	e := probe.NewEngine(silentLogger()).WithStorage(storage, sched)
@@ -297,21 +303,20 @@ func TestEngine_RunNow_PropagatesPersistError(t *testing.T) {
 func TestEngine_RunNow_ProbeFieldsRoundTripToResult(t *testing.T) {
 	t.Parallel()
 	storage := newFakeStorage()
-	storage.addProbe(&database.Probe{
+	storage.addProbe(probe.Probe{
 		ID:          "p-1",
 		ClientID:    "tenant-x",
 		Kind:        "dns",
 		DisplayName: "internal",
 		Target:      "internal.example.com",
-		ParamsJSON:  `{"server":"10.0.0.5"}`,
-		WarningJSON: `{"latency_ms":50}`,
+		Params:      json.RawMessage(`{"server":"10.0.0.5"}`),
+		Warning:     json.RawMessage(`{"latency_ms":50}`),
 		Enabled:     true,
 	})
 	sched := newFakeScheduler()
 
-	// Checker echoes the probe back as metadata so we can verify
-	// the round-trip from DB row through Probe model into the
-	// Checker's input.
+	// Checker echoes the probe back as metadata so we can verify the
+	// Probe definition's fields reach the Checker's input unchanged.
 	echoer := &echoChecker{}
 	e := probe.NewEngine(silentLogger()).WithStorage(storage, sched)
 	e.RegisterChecker(echoer)


### PR DESCRIPTION
## What

WS-B1 of the Architecture Completion Plan (repository-port discipline everywhere).

`internal/probe` imported `internal/database` because its `probeStorage` port spoke database row types (`*database.Probe` / `*database.ProbeResult`). This bypassed repository-port discipline — the engine reached across a layer boundary for types it could express itself.

## Change

- **Port → domain types.** `probeStorage` now speaks `probe.Probe` / `probe.Result`. `internal/probe` no longer imports `internal/database`.
- **Translation → composition root.** `dbProbeToModel` and the `Result → database.ProbeResult` build moved into a new adapter `internal/app.NewProbeStorage`, wired at `server.go` via `WithStorage(app.NewProbeStorage(db.Probes()), …)`.
- **depguard lock.** New `probe-no-persistence` rule bans `internal/database` in `internal/probe/**` (production). **RED-proven**: a blank `internal/database` import in the package is flagged with the rule's message; removed → 0 issues.
- **Coverage preserved.** The moved translation gets a focused `internal/app` adapter test; the probe round-trip test now asserts model→checker flow with domain-typed fakes.

## Evidence

- `go build ./...` clean
- `go test -race ./internal/probe/... ./internal/app/...` → ok
- `golangci-lint run --enable-only depguard ./internal/probe/... ./internal/app/...` → 0 issues (GREEN); blank-import RED flagged
- `scripts/check-filename-policy.sh` → pass
- `gofmt -l` clean · gitleaks clean

Net: −77/+204, `internal/probe` is persistence-free and gated against regression.