### PR TITLE
refactor(topology): relocate row types to domain pkgs, make persistence-free (WS-B)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -293,6 +293,22 @@ linters:
           deny:
             - pkg: github.com/MustardSeedNetworks/seed/internal/database
               desc: "probe is persistence-free — define a port in probe (domain types) and implement it in internal/app (NewProbeStorage)"
+        # WS-B repository-port discipline: topology owns its row types
+        # (TopologyNode/Link/Interface/ARPBinding + list options + the
+        # ErrTopologyNodeNotFound sentinel) in internal/topology, and the SNMP
+        # observations it reconciles live in internal/polling/observation. The
+        # TopologyRepository / SNMPObservationsRepository stay in internal/database
+        # and map SQL rows to those domain types — dependency points inward
+        # (database imports the domain pkgs, never the reverse). So internal/topology
+        # never imports internal/database. Production-only (tests build domain-typed
+        # fakes); the api/app composition root still holds the database handle.
+        "topology-no-persistence":
+          files:
+            - "**/internal/topology/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "topology is persistence-free — its row types live in internal/topology and the TopologyRepository (internal/database) maps rows to them; wire it in internal/app"
         # Phase 6 capture port: libpcap (via gopacket/pcap) carries the CGO
         # taint that re-links libpcap into every dependent test binary. It is
         # confined to the single adapter package internal/capture/pcap; every

--- a/internal/alerts/pipeline/observation_pipeline.go
+++ b/internal/alerts/pipeline/observation_pipeline.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 )
 
 // degradedTickMultiplier is how many scan intervals can elapse
@@ -37,7 +38,7 @@ const (
 
 // observationReader is the narrowed surface this pipeline needs.
 type observationReader interface {
-	List(ctx context.Context, opts database.ListOptions) ([]*database.SNMPObservation, error)
+	List(ctx context.Context, opts observation.ListOptions) ([]*observation.SNMPObservation, error)
 }
 
 // ObservationPipeline consumes the snmp_observations stream, detects
@@ -223,7 +224,7 @@ func (p *ObservationPipeline) Start(ctx context.Context) error {
 // real previous values instead of zero.
 func (p *ObservationPipeline) primeFromHistory(ctx context.Context) error {
 	for _, kind := range observationKinds() {
-		observations, err := p.obs.List(ctx, database.ListOptions{
+		observations, err := p.obs.List(ctx, observation.ListOptions{
 			Kind:  kind,
 			Limit: p.replayDepth,
 		})
@@ -242,7 +243,7 @@ func (p *ObservationPipeline) primeFromHistory(ctx context.Context) error {
 // primeOne dispatches to the per-kind primer. Unknown kinds are
 // silently skipped — they were filtered out by observationKinds()
 // at the caller, but we double-check here for safety.
-func (p *ObservationPipeline) primeOne(kind string, obs *database.SNMPObservation) {
+func (p *ObservationPipeline) primeOne(kind string, obs *observation.SNMPObservation) {
 	switch kind {
 	case "if_table":
 		p.primeIfTable(obs)
@@ -253,7 +254,7 @@ func (p *ObservationPipeline) primeOne(kind string, obs *database.SNMPObservatio
 	}
 }
 
-func (p *ObservationPipeline) primeIfTable(obs *database.SNMPObservation) {
+func (p *ObservationPipeline) primeIfTable(obs *observation.SNMPObservation) {
 	var pay ifTableObsPayload
 	if err := json.Unmarshal([]byte(obs.PayloadJSON), &pay); err != nil {
 		return
@@ -264,7 +265,7 @@ func (p *ObservationPipeline) primeIfTable(obs *database.SNMPObservation) {
 	}
 }
 
-func (p *ObservationPipeline) primeBGP(obs *database.SNMPObservation) {
+func (p *ObservationPipeline) primeBGP(obs *observation.SNMPObservation) {
 	var pay bgpObsPayload
 	if err := json.Unmarshal([]byte(obs.PayloadJSON), &pay); err != nil {
 		return
@@ -275,7 +276,7 @@ func (p *ObservationPipeline) primeBGP(obs *database.SNMPObservation) {
 	}
 }
 
-func (p *ObservationPipeline) primeHostResources(obs *database.SNMPObservation) {
+func (p *ObservationPipeline) primeHostResources(obs *observation.SNMPObservation) {
 	var pay hostResObsPayload
 	if err := json.Unmarshal([]byte(obs.PayloadJSON), &pay); err != nil {
 		return
@@ -400,7 +401,7 @@ func observationKinds() []string {
 func (p *ObservationPipeline) scanKind(
 	ctx context.Context, kind string, since time.Time,
 ) (int, time.Time, error) {
-	observations, err := p.obs.List(ctx, database.ListOptions{
+	observations, err := p.obs.List(ctx, observation.ListOptions{
 		Kind: kind, Since: since, Limit: defaultBatch,
 	})
 	if err != nil {
@@ -442,7 +443,7 @@ const ifOperUp = 1
 // else. Up→up and any change from initial unknown state do NOT fire
 // (we need a "previous up" to define a transition).
 func (p *ObservationPipeline) evaluateIfTable(
-	ctx context.Context, obs *database.SNMPObservation,
+	ctx context.Context, obs *observation.SNMPObservation,
 ) int {
 	var pay ifTableObsPayload
 	if err := json.Unmarshal([]byte(obs.PayloadJSON), &pay); err != nil {
@@ -488,7 +489,7 @@ const bgpStateEstablished = 6
 
 // evaluateBGP detects peers leaving the Established state.
 func (p *ObservationPipeline) evaluateBGP(
-	ctx context.Context, obs *database.SNMPObservation,
+	ctx context.Context, obs *observation.SNMPObservation,
 ) int {
 	var pay bgpObsPayload
 	if err := json.Unmarshal([]byte(obs.PayloadJSON), &pay); err != nil {
@@ -537,7 +538,7 @@ type hostResObsPayload struct {
 // fire only on the upward crossing (not every poll while above the
 // threshold).
 func (p *ObservationPipeline) evaluateHostResources(
-	ctx context.Context, obs *database.SNMPObservation,
+	ctx context.Context, obs *observation.SNMPObservation,
 ) int {
 	var pay hostResObsPayload
 	if err := json.Unmarshal([]byte(obs.PayloadJSON), &pay); err != nil {

--- a/internal/alerts/pipeline/observation_pipeline_test.go
+++ b/internal/alerts/pipeline/observation_pipeline_test.go
@@ -8,14 +8,18 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
 	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 )
 
 type fakeObservations struct {
-	rows []*database.SNMPObservation
+	rows []*observation.SNMPObservation
 }
 
-func (f *fakeObservations) List(_ context.Context, opts database.ListOptions) ([]*database.SNMPObservation, error) {
-	out := make([]*database.SNMPObservation, 0, len(f.rows))
+func (f *fakeObservations) List(
+	_ context.Context,
+	opts observation.ListOptions,
+) ([]*observation.SNMPObservation, error) {
+	out := make([]*observation.SNMPObservation, 0, len(f.rows))
 	for _, row := range f.rows {
 		if opts.Kind != "" && row.Kind != opts.Kind {
 			continue
@@ -25,9 +29,9 @@ func (f *fakeObservations) List(_ context.Context, opts database.ListOptions) ([
 	return out, nil
 }
 
-func iftableObs(target string, observed time.Time, rows []map[string]any) *database.SNMPObservation {
+func iftableObs(target string, observed time.Time, rows []map[string]any) *observation.SNMPObservation {
 	b, _ := json.Marshal(map[string]any{"Rows": rows})
-	return &database.SNMPObservation{
+	return &observation.SNMPObservation{
 		ClientID: "default", TargetID: target, Kind: "if_table",
 		ObservedAt: observed, PayloadJSON: string(b),
 	}
@@ -37,17 +41,17 @@ func iftableObs(target string, observed time.Time, rows []map[string]any) *datab
 // only exercise single-target scenarios for these kinds; iftable
 // tests cover the multi-target case. If multi-target bgp/storage
 // tests arrive later, lift target back into a parameter.
-func bgpObs(observed time.Time, peers []map[string]any) *database.SNMPObservation {
+func bgpObs(observed time.Time, peers []map[string]any) *observation.SNMPObservation {
 	b, _ := json.Marshal(map[string]any{"Peers": peers})
-	return &database.SNMPObservation{
+	return &observation.SNMPObservation{
 		ClientID: "default", TargetID: "t-1", Kind: "bgp4_mib",
 		ObservedAt: observed, PayloadJSON: string(b),
 	}
 }
 
-func hostObs(observed time.Time, storage []map[string]any) *database.SNMPObservation {
+func hostObs(observed time.Time, storage []map[string]any) *observation.SNMPObservation {
 	b, _ := json.Marshal(map[string]any{"Storage": storage})
-	return &database.SNMPObservation{
+	return &observation.SNMPObservation{
 		ClientID: "default", TargetID: "t-1", Kind: "host_resources",
 		ObservedAt: observed, PayloadJSON: string(b),
 	}
@@ -76,7 +80,7 @@ func TestNewObservationPipeline_RejectsMissingDeps(t *testing.T) {
 func TestObservationScanOnce_InterfaceUpToDownEmitsAlert(t *testing.T) {
 	t.Parallel()
 	alerts := &fakeAlerts{}
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		iftableObs("t-1", at().Add(-time.Minute), []map[string]any{
 			{"IfIndex": 1, "IfName": "Gi0/0", "IfAdmin": 1, "IfOper": 1},
 		}),
@@ -103,7 +107,7 @@ func TestObservationScanOnce_InterfaceUpToDownEmitsAlert(t *testing.T) {
 func TestObservationScanOnce_AdminDownDoesNotAlert(t *testing.T) {
 	t.Parallel()
 	alerts := &fakeAlerts{}
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		iftableObs("t-1", at().Add(-time.Minute), []map[string]any{
 			{"IfIndex": 1, "IfName": "Gi0/0", "IfAdmin": 1, "IfOper": 1},
 		}),
@@ -127,7 +131,7 @@ func TestObservationScanOnce_FirstObservationDoesNotAlert(t *testing.T) {
 	t.Parallel()
 	// No prior state -> the first observation cannot be a transition.
 	alerts := &fakeAlerts{}
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		iftableObs("t-1", at(), []map[string]any{
 			{"IfIndex": 1, "IfName": "Gi0/0", "IfAdmin": 1, "IfOper": 2},
 		}),
@@ -145,7 +149,7 @@ func TestObservationScanOnce_FirstObservationDoesNotAlert(t *testing.T) {
 func TestObservationScanOnce_BGPLeavingEstablishedFires(t *testing.T) {
 	t.Parallel()
 	alerts := &fakeAlerts{}
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		bgpObs(at().Add(-time.Minute), []map[string]any{
 			{"RemoteAddr": "192.0.2.1", "State": 6, "RemoteAS": 65001},
 		}),
@@ -169,7 +173,7 @@ func TestObservationScanOnce_BGPLeavingEstablishedFires(t *testing.T) {
 func TestObservationScanOnce_BGPStillEstablishedNoAlert(t *testing.T) {
 	t.Parallel()
 	alerts := &fakeAlerts{}
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		bgpObs(at().Add(-time.Minute), []map[string]any{
 			{"RemoteAddr": "192.0.2.1", "State": 6, "RemoteAS": 65001},
 		}),
@@ -190,7 +194,7 @@ func TestObservationScanOnce_BGPStillEstablishedNoAlert(t *testing.T) {
 func TestObservationScanOnce_StorageCrosses85FiresWarning(t *testing.T) {
 	t.Parallel()
 	alerts := &fakeAlerts{}
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		hostObs(at().Add(-time.Minute), []map[string]any{
 			{"Index": 1, "Description": "/", "SizeBytes": 1000, "UsedBytes": 800}, // 80%
 		}),
@@ -211,7 +215,7 @@ func TestObservationScanOnce_StorageCrosses85FiresWarning(t *testing.T) {
 func TestObservationScanOnce_StorageCrosses95FiresCritical(t *testing.T) {
 	t.Parallel()
 	alerts := &fakeAlerts{}
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		hostObs(at().Add(-time.Minute), []map[string]any{
 			{"Index": 1, "Description": "/", "SizeBytes": 1000, "UsedBytes": 800},
 		}),
@@ -235,7 +239,7 @@ func TestObservationScanOnce_StorageRemainingHighNoRepeatAlert(t *testing.T) {
 	// (initial unknown) to 87%, so warning fires once. Second is
 	// 87% to 87%, no upward crossing -> no alert.
 	alerts := &fakeAlerts{}
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		hostObs(at().Add(-time.Minute), []map[string]any{
 			{"Index": 1, "Description": "/", "SizeBytes": 1000, "UsedBytes": 870},
 		}),
@@ -256,7 +260,7 @@ func TestObservationScanOnce_StorageRemainingHighNoRepeatAlert(t *testing.T) {
 func TestObservationScanOnce_DifferentTargetsTrackedIndependently(t *testing.T) {
 	t.Parallel()
 	alerts := &fakeAlerts{}
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		iftableObs("t-1", at().Add(-time.Minute), []map[string]any{
 			{"IfIndex": 1, "IfName": "Gi0/0", "IfAdmin": 1, "IfOper": 1},
 		}),
@@ -284,7 +288,7 @@ func TestObservationScanOnce_PersistsMaxObservedAtAcrossKinds(t *testing.T) {
 	t.Parallel()
 	newer := at()
 	older := at().Add(-2 * time.Hour)
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		iftableObs("t-1", older, nil),
 		bgpObs(newer, nil),
 	}}

--- a/internal/alerts/pipeline/reporter_test.go
+++ b/internal/alerts/pipeline/reporter_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 )
 
 func TestListenerPipeline_Status_BeforeFirstScan(t *testing.T) {
@@ -84,15 +84,15 @@ func TestListenerPipeline_Status_AfterStop(t *testing.T) {
 
 // fakeObs lets us drive ObservationPipeline.ScanOnce.
 type fakeObs struct {
-	rows    []*database.SNMPObservation
+	rows    []*observation.SNMPObservation
 	listErr error
 }
 
-func (f *fakeObs) List(_ context.Context, _ database.ListOptions) ([]*database.SNMPObservation, error) {
+func (f *fakeObs) List(_ context.Context, _ observation.ListOptions) ([]*observation.SNMPObservation, error) {
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	out := make([]*database.SNMPObservation, len(f.rows))
+	out := make([]*observation.SNMPObservation, len(f.rows))
 	copy(out, f.rows)
 	return out, nil
 }

--- a/internal/api/handlers_topology.go
+++ b/internal/api/handlers_topology.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/topology"
 )
@@ -131,7 +130,7 @@ func (s *Server) handleTopologyLinks(w http.ResponseWriter, r *http.Request) {
 // that sharing would just push the divergence into the helper.
 func (s *Server) handleTopologyARP(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
-	opts := database.TopologyARPListOptions{
+	opts := topology.ARPListOptions{
 		ClientID:     q.Get("client_id"),
 		SourceNodeID: q.Get("node_id"),
 		Limit:        topologyDefaultLimit,
@@ -166,8 +165,8 @@ func (s *Server) handleTopologyARP(w http.ResponseWriter, r *http.Request) {
 	writeTopologyJSON(w, r, "bindings", encodeARPBindings(bindings))
 }
 
-// encodeARPBindings flattens TopologyARPBinding rows for JSON.
-func encodeARPBindings(bindings []*database.TopologyARPBinding) []map[string]any {
+// encodeARPBindings flattens ARPBinding rows for JSON.
+func encodeARPBindings(bindings []*topology.ARPBinding) []map[string]any {
 	out := make([]map[string]any, 0, len(bindings))
 	for _, b := range bindings {
 		out = append(out, map[string]any{
@@ -186,9 +185,9 @@ func encodeARPBindings(bindings []*database.TopologyARPBinding) []map[string]any
 
 // parseTopologyListOptions extracts query-string filters for the
 // nodes endpoint. Returns 400-shaped errors via plain text.
-func parseTopologyListOptions(r *http.Request) (database.TopologyListOptions, error) {
+func parseTopologyListOptions(r *http.Request) (topology.ListOptions, error) {
 	q := r.URL.Query()
-	opts := database.TopologyListOptions{
+	opts := topology.ListOptions{
 		ClientID:   q.Get("client_id"),
 		DeviceType: q.Get("device_type"),
 		Limit:      topologyDefaultLimit,
@@ -196,14 +195,14 @@ func parseTopologyListOptions(r *http.Request) (database.TopologyListOptions, er
 	if sinceRaw := q.Get("since"); sinceRaw != "" {
 		t, err := time.Parse(time.RFC3339, sinceRaw)
 		if err != nil {
-			return database.TopologyListOptions{}, errors.New("invalid 'since' (expect RFC3339)")
+			return topology.ListOptions{}, errors.New("invalid 'since' (expect RFC3339)")
 		}
 		opts.SeenSince = t
 	}
 	if limitRaw := q.Get("limit"); limitRaw != "" {
 		n, err := strconv.Atoi(limitRaw)
 		if err != nil || n < 1 {
-			return database.TopologyListOptions{}, errors.New("invalid 'limit' (positive integer)")
+			return topology.ListOptions{}, errors.New("invalid 'limit' (positive integer)")
 		}
 		if n > topologyMaxLimit {
 			n = topologyMaxLimit
@@ -213,10 +212,10 @@ func parseTopologyListOptions(r *http.Request) (database.TopologyListOptions, er
 	return opts, nil
 }
 
-// encodeNode flattens a TopologyNode for JSON. Done explicitly
+// encodeNode flattens a Node for JSON. Done explicitly
 // (rather than tagging the DB struct) so the wire format stays
 // stable when DB columns evolve.
-func encodeNode(n *database.TopologyNode) map[string]any {
+func encodeNode(n *topology.Node) map[string]any {
 	return map[string]any{
 		"id":           n.ID,
 		"clientId":     n.ClientID,
@@ -233,7 +232,7 @@ func encodeNode(n *database.TopologyNode) map[string]any {
 	}
 }
 
-func encodeNodes(nodes []*database.TopologyNode) []map[string]any {
+func encodeNodes(nodes []*topology.Node) []map[string]any {
 	out := make([]map[string]any, 0, len(nodes))
 	for _, n := range nodes {
 		out = append(out, encodeNode(n))
@@ -241,7 +240,7 @@ func encodeNodes(nodes []*database.TopologyNode) []map[string]any {
 	return out
 }
 
-func encodeInterfaces(ifaces []*database.TopologyInterface) []map[string]any {
+func encodeInterfaces(ifaces []*topology.Interface) []map[string]any {
 	out := make([]map[string]any, 0, len(ifaces))
 	for _, i := range ifaces {
 		out = append(out, map[string]any{
@@ -262,7 +261,7 @@ func encodeInterfaces(ifaces []*database.TopologyInterface) []map[string]any {
 	return out
 }
 
-func encodeLinks(links []*database.TopologyLink) []map[string]any {
+func encodeLinks(links []*topology.Link) []map[string]any {
 	out := make([]map[string]any, 0, len(links))
 	for _, l := range links {
 		out = append(out, map[string]any{

--- a/internal/api/handlers_topology_internal_test.go
+++ b/internal/api/handlers_topology_internal_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/topology"
 )
 
 // newTopologyTestServer builds a minimal Server backed by a temp
@@ -32,7 +33,7 @@ func newTopologyTestServer(t *testing.T) *Server {
 func seedTopology(t *testing.T, db *database.DB) string {
 	t.Helper()
 	ctx := context.Background()
-	node, err := db.Topology().Upsert(ctx, &database.TopologyNode{
+	node, err := db.Topology().Upsert(ctx, &topology.Node{
 		ID:           "node-test-1",
 		ClientID:     "default",
 		IdentityHash: "hash-test-1",
@@ -45,7 +46,7 @@ func seedTopology(t *testing.T, db *database.DB) string {
 	if err != nil {
 		t.Fatalf("seed node: %v", err)
 	}
-	if upErr := db.Topology().UpsertInterface(ctx, &database.TopologyInterface{
+	if upErr := db.Topology().UpsertInterface(ctx, &topology.Interface{
 		NodeID: node.ID, IfIndex: 1, IfName: "Gi0/0",
 		IfAdminStatus: 1, IfOperStatus: 1, SpeedBps: 1_000_000_000,
 		LastSeen: time.Now().UTC(),
@@ -53,7 +54,7 @@ func seedTopology(t *testing.T, db *database.DB) string {
 		t.Fatalf("seed interface: %v", upErr)
 	}
 	// Create a second node so the edge has both endpoints.
-	other, _ := db.Topology().Upsert(ctx, &database.TopologyNode{
+	other, _ := db.Topology().Upsert(ctx, &topology.Node{
 		ID:           "node-test-2",
 		ClientID:     "default",
 		IdentityHash: "hash-test-2",
@@ -61,7 +62,7 @@ func seedTopology(t *testing.T, db *database.DB) string {
 		SysName:      "core-sw",
 		LastSeen:     time.Now().UTC(),
 	})
-	if linkErr := db.Topology().UpsertLink(ctx, &database.TopologyLink{
+	if linkErr := db.Topology().UpsertLink(ctx, &topology.Link{
 		ID:           "link-test-1",
 		SourceNodeID: node.ID,
 		TargetNodeID: other.ID,
@@ -222,7 +223,7 @@ func seedARPBindingsForHandler(t *testing.T, db *database.DB) {
 	// insert two bindings under node-test-1.
 	_ = seedTopology(t, db)
 	ctx := context.Background()
-	for _, b := range []*database.TopologyARPBinding{
+	for _, b := range []*topology.ARPBinding{
 		{
 			ClientID: "default", SourceNodeID: "node-test-1", IfIndex: 1,
 			IPAddress: "10.0.0.1", MACAddress: "aa:bb:cc:dd:ee:01",

--- a/internal/app/topology.go
+++ b/internal/app/topology.go
@@ -33,8 +33,8 @@ func (a topologyReader) repo() (*database.TopologyRepository, error) {
 }
 
 func (a topologyReader) List(
-	ctx context.Context, opts database.TopologyListOptions,
-) ([]*database.TopologyNode, error) {
+	ctx context.Context, opts topology.ListOptions,
+) ([]*topology.Node, error) {
 	repo, err := a.repo()
 	if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (a topologyReader) List(
 
 func (a topologyReader) ListInterfaces(
 	ctx context.Context, nodeID string,
-) ([]*database.TopologyInterface, error) {
+) ([]*topology.Interface, error) {
 	repo, err := a.repo()
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func (a topologyReader) ListInterfaces(
 
 func (a topologyReader) ListLinks(
 	ctx context.Context, nodeID string,
-) ([]*database.TopologyLink, error) {
+) ([]*topology.Link, error) {
 	repo, err := a.repo()
 	if err != nil {
 		return nil, err
@@ -63,8 +63,8 @@ func (a topologyReader) ListLinks(
 }
 
 func (a topologyReader) ListARPBindings(
-	ctx context.Context, opts database.TopologyARPListOptions,
-) ([]*database.TopologyARPBinding, error) {
+	ctx context.Context, opts topology.ARPListOptions,
+) ([]*topology.ARPBinding, error) {
 	repo, err := a.repo()
 	if err != nil {
 		return nil, err

--- a/internal/database/repository_snmp_observations.go
+++ b/internal/database/repository_snmp_observations.go
@@ -6,20 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"time"
-)
 
-// SNMPObservation is one row of snmp_observations. PayloadJSON
-// carries the typed collector Observation struct serialized as JSON
-// — callers decode it back into the kind-specific shape they own.
-type SNMPObservation struct {
-	ID          int64
-	ClientID    string
-	TargetID    string
-	Kind        string
-	ObservedAt  time.Time
-	PayloadJSON string
-	IngestedAt  time.Time
-}
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
+)
 
 // SNMPObservationsRepository owns CRUD over snmp_observations.
 type SNMPObservationsRepository struct {
@@ -28,7 +17,7 @@ type SNMPObservationsRepository struct {
 
 // Insert records one observation. ObservedAt and IngestedAt are
 // stamped if zero.
-func (r *SNMPObservationsRepository) Insert(ctx context.Context, obs *SNMPObservation) error {
+func (r *SNMPObservationsRepository) Insert(ctx context.Context, obs *observation.SNMPObservation) error {
 	if obs.Kind == "" {
 		return errors.New("snmp_observations: Kind required")
 	}
@@ -66,19 +55,12 @@ func (r *SNMPObservationsRepository) Insert(ctx context.Context, obs *SNMPObserv
 	return nil
 }
 
-// ListOptions narrows the query — empty values disable that filter.
-type ListOptions struct {
-	ClientID string
-	TargetID string
-	Kind     string
-	Since    time.Time
-	Until    time.Time
-	Limit    int
-}
-
 // List returns observations matching opts ordered by ObservedAt
 // descending (newest first). Limit defaults to 100; clamped to 1000.
-func (r *SNMPObservationsRepository) List(ctx context.Context, opts ListOptions) ([]*SNMPObservation, error) {
+func (r *SNMPObservationsRepository) List(
+	ctx context.Context,
+	opts observation.ListOptions,
+) ([]*observation.SNMPObservation, error) {
 	const defaultLimit, maxLimit = 100, 1000
 
 	query, args := newListQueryBuilder(`
@@ -116,9 +98,9 @@ func (r *SNMPObservationsRepository) DeleteOlderThan(ctx context.Context, cutoff
 
 // scanSNMPObservation reads a row via a [sql.Row.Scan] or
 // [sql.Rows.Scan] signature.
-func scanSNMPObservation(scan func(...any) error) (*SNMPObservation, error) {
+func scanSNMPObservation(scan func(...any) error) (*observation.SNMPObservation, error) {
 	var (
-		obs           SNMPObservation
+		obs           observation.SNMPObservation
 		observedAtStr string
 		ingestedAtStr string
 	)

--- a/internal/database/repository_topology.go
+++ b/internal/database/repository_topology.go
@@ -7,29 +7,9 @@ import (
 	"fmt"
 	"strings"
 	"time"
-)
 
-// TopologyNode is one row of topology_nodes. The fat-Node carries
-// every observation source's contribution: identity from sys_info,
-// per-interface state from if_table (folded into MetadataJSON),
-// addresses from arp, neighbors from lldp/cdp/fdp. Reconcilers in
-// internal/topology own writes; alert rules + the operator UI own
-// reads.
-type TopologyNode struct {
-	ID           string
-	ClientID     string
-	IdentityHash string
-	DisplayName  string
-	DeviceType   string
-	ChassisID    string
-	SysName      string
-	PrimaryMAC   string
-	PrimaryIP    string
-	FirstSeen    time.Time
-	LastSeen     time.Time
-	ExpiresAt    time.Time
-	MetadataJSON string
-}
+	"github.com/MustardSeedNetworks/seed/internal/topology"
+)
 
 // TopologyRepository owns CRUD over topology_nodes + topology_links.
 // Stage A4.1 wires the nodes side; links arrive in A4.3.
@@ -38,11 +18,11 @@ type TopologyRepository struct {
 }
 
 // GetByIdentityHash returns the node with the given identity hash
-// or ErrTopologyNodeNotFound when absent.
+// or topology.ErrTopologyNodeNotFound when absent.
 func (r *TopologyRepository) GetByIdentityHash(
 	ctx context.Context,
 	hash string,
-) (*TopologyNode, error) {
+) (*topology.Node, error) {
 	row := r.db.QueryRow(ctx, `
 		SELECT id, client_id, identity_hash, display_name, device_type,
 		       chassis_id, sys_name, primary_mac, primary_ip,
@@ -51,9 +31,6 @@ func (r *TopologyRepository) GetByIdentityHash(
 	`, hash)
 	return scanTopologyNode(row.Scan)
 }
-
-// ErrTopologyNodeNotFound is returned when a node lookup misses.
-var ErrTopologyNodeNotFound = errors.New("topology node not found")
 
 // Upsert inserts or updates a node by identity_hash. The hash is
 // the merge key — same hash = same physical device regardless of
@@ -65,8 +42,8 @@ var ErrTopologyNodeNotFound = errors.New("topology node not found")
 // record carried.
 func (r *TopologyRepository) Upsert(
 	ctx context.Context,
-	node *TopologyNode,
-) (*TopologyNode, error) {
+	node *topology.Node,
+) (*topology.Node, error) {
 	if node.IdentityHash == "" {
 		return nil, errors.New("topology_nodes: IdentityHash required")
 	}
@@ -92,7 +69,7 @@ func (r *TopologyRepository) Upsert(
 		if updErr := r.update(ctx, node); updErr != nil {
 			return nil, updErr
 		}
-	case errors.Is(err, ErrTopologyNodeNotFound):
+	case errors.Is(err, topology.ErrTopologyNodeNotFound):
 		if insErr := r.insert(ctx, node); insErr != nil {
 			return nil, insErr
 		}
@@ -102,7 +79,7 @@ func (r *TopologyRepository) Upsert(
 	return node, nil
 }
 
-func (r *TopologyRepository) insert(ctx context.Context, node *TopologyNode) error {
+func (r *TopologyRepository) insert(ctx context.Context, node *topology.Node) error {
 	_, err := r.db.Exec(ctx, `
 		INSERT INTO topology_nodes
 		  (id, client_id, identity_hash, display_name, device_type,
@@ -125,7 +102,7 @@ func (r *TopologyRepository) insert(ctx context.Context, node *TopologyNode) err
 	return nil
 }
 
-func (r *TopologyRepository) update(ctx context.Context, node *TopologyNode) error {
+func (r *TopologyRepository) update(ctx context.Context, node *topology.Node) error {
 	_, err := r.db.Exec(ctx, `
 		UPDATE topology_nodes SET
 			display_name = ?, device_type = ?, chassis_id = ?, sys_name = ?,
@@ -148,19 +125,11 @@ func (r *TopologyRepository) update(ctx context.Context, node *TopologyNode) err
 	return nil
 }
 
-// TopologyListOptions narrows a topology_nodes query.
-type TopologyListOptions struct {
-	ClientID   string
-	DeviceType string
-	SeenSince  time.Time
-	Limit      int
-}
-
 // List returns nodes matching opts ordered by LastSeen desc.
 func (r *TopologyRepository) List(
 	ctx context.Context,
-	opts TopologyListOptions,
-) ([]*TopologyNode, error) {
+	opts topology.ListOptions,
+) ([]*topology.Node, error) {
 	const defaultLimit, maxLimit = 100, 5000
 
 	query, args := newListQueryBuilder(`
@@ -188,25 +157,10 @@ func toNullTime(t time.Time) sql.NullString {
 	return sql.NullString{String: t.UTC().Format(time.RFC3339Nano), Valid: true}
 }
 
-// TopologyARPBinding mirrors one row of topology_arp_bindings.
-// Reconciled from arp observations; the row's MAC is the join key
-// used to backfill node.primary_ip when a binding matches a known
-// node's chassis/primary MAC.
-type TopologyARPBinding struct {
-	ID           int64
-	ClientID     string
-	SourceNodeID string
-	IfIndex      uint32
-	IPAddress    string
-	MACAddress   string
-	MediaType    int
-	LastSeen     time.Time
-}
-
 // UpsertARPBinding writes one binding row. The unique constraint
 // (source_node, if_index, ip_address) ensures repeated observations
 // of the same binding update one row.
-func (r *TopologyRepository) UpsertARPBinding(ctx context.Context, b *TopologyARPBinding) error {
+func (r *TopologyRepository) UpsertARPBinding(ctx context.Context, b *topology.ARPBinding) error {
 	if b.SourceNodeID == "" {
 		return errors.New("topology_arp_bindings: SourceNodeID required")
 	}
@@ -238,22 +192,13 @@ func (r *TopologyRepository) UpsertARPBinding(ctx context.Context, b *TopologyAR
 	return nil
 }
 
-// TopologyARPListOptions filters the ListARPBindings query.
-// Empty fields mean "no filter".
-type TopologyARPListOptions struct {
-	ClientID     string
-	SourceNodeID string
-	Since        time.Time
-	Limit        int
-}
-
 // ListARPBindings returns ARP bindings ordered by LastSeen desc.
 // All filter fields are optional. The Limit field caps the result
 // set; callers in handlers_topology.go clamp it to topologyMaxLimit
 // before invoking.
 func (r *TopologyRepository) ListARPBindings(
-	ctx context.Context, opts TopologyARPListOptions,
-) ([]*TopologyARPBinding, error) {
+	ctx context.Context, opts topology.ARPListOptions,
+) ([]*topology.ARPBinding, error) {
 	const maxFilterArgs = 4 // client_id + source_node_id + since + limit
 	args := make([]any, 0, maxFilterArgs)
 	clauses := []string{}
@@ -288,10 +233,10 @@ func (r *TopologyRepository) ListARPBindings(
 	}
 	defer func() { _ = rows.Close() }()
 
-	out := make([]*TopologyARPBinding, 0)
+	out := make([]*topology.ARPBinding, 0)
 	for rows.Next() {
 		var (
-			b       TopologyARPBinding
+			b       topology.ARPBinding
 			lastStr string
 		)
 		if scanErr := rows.Scan(
@@ -330,7 +275,7 @@ func (r *TopologyRepository) SetNodePrimaryIP(ctx context.Context, nodeID, ip st
 }
 
 // NodeIDForMAC resolves a MAC address to a node by matching against
-// topology_nodes.primary_mac. Returns ErrTopologyNodeNotFound when
+// topology_nodes.primary_mac. Returns topology.ErrTopologyNodeNotFound when
 // no node has that MAC. Used by the ARP reconciler to identify
 // which (if any) node a binding's MAC corresponds to.
 func (r *TopologyRepository) NodeIDForMAC(ctx context.Context, clientID, mac string) (string, error) {
@@ -338,7 +283,7 @@ func (r *TopologyRepository) NodeIDForMAC(ctx context.Context, clientID, mac str
 		clientID = "default"
 	}
 	if mac == "" {
-		return "", ErrTopologyNodeNotFound
+		return "", topology.ErrTopologyNodeNotFound
 	}
 	row := r.db.QueryRow(ctx, `
 		SELECT id FROM topology_nodes
@@ -349,43 +294,23 @@ func (r *TopologyRepository) NodeIDForMAC(ctx context.Context, clientID, mac str
 	var id string
 	if err := row.Scan(&id); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", ErrTopologyNodeNotFound
+			return "", topology.ErrTopologyNodeNotFound
 		}
 		return "", fmt.Errorf("nodeIDForMAC: %w", err)
 	}
 	return id, nil
 }
 
-// TopologyLink mirrors one row of topology_links. Edges are
-// identity-merged the same way nodes are — the link ID is derived
-// from (source_node, source_interface, target_node, target_interface)
-// so re-observations of the same physical cable upsert rather than
-// duplicate.
-type TopologyLink struct {
-	ID              string
-	SourceNodeID    string
-	TargetNodeID    string
-	SourceInterface string
-	TargetInterface string
-	LinkType        string // "lldp", "cdp", "fdp"
-	Status          string // "up", "down", "unknown"
-	SpeedMbps       uint32
-	UtilizationPct  float64
-	FirstSeen       time.Time
-	LastSeen        time.Time
-	EvidenceJSON    string
-}
-
 // NodeIDForSysName resolves a sys_name back to its node_id by
 // looking up topology_nodes. Used by the edge reconciler to map
 // an LLDP/CDP neighbor's reported hostname to a known node.
-// Returns ErrTopologyNodeNotFound when no node has that sys_name.
+// Returns topology.ErrTopologyNodeNotFound when no node has that sys_name.
 func (r *TopologyRepository) NodeIDForSysName(ctx context.Context, clientID, sysName string) (string, error) {
 	if clientID == "" {
 		clientID = "default"
 	}
 	if sysName == "" {
-		return "", ErrTopologyNodeNotFound
+		return "", topology.ErrTopologyNodeNotFound
 	}
 	row := r.db.QueryRow(ctx, `
 		SELECT id FROM topology_nodes
@@ -396,7 +321,7 @@ func (r *TopologyRepository) NodeIDForSysName(ctx context.Context, clientID, sys
 	var id string
 	if err := row.Scan(&id); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", ErrTopologyNodeNotFound
+			return "", topology.ErrTopologyNodeNotFound
 		}
 		return "", fmt.Errorf("nodeIDForSysName: %w", err)
 	}
@@ -408,7 +333,7 @@ func (r *TopologyRepository) NodeIDForSysName(ctx context.Context, clientID, sys
 // deterministically from (source_node, source_interface,
 // target_node, target_interface) so two LLDP polls of the same
 // physical cable update one row instead of inserting two.
-func (r *TopologyRepository) UpsertLink(ctx context.Context, link *TopologyLink) error {
+func (r *TopologyRepository) UpsertLink(ctx context.Context, link *topology.Link) error {
 	if link.ID == "" {
 		return errors.New("topology_links: ID required")
 	}
@@ -463,7 +388,7 @@ func (r *TopologyRepository) UpsertLink(ctx context.Context, link *TopologyLink)
 
 // ListLinks returns every link involving nodeID (either source or
 // target) ordered by LastSeen desc.
-func (r *TopologyRepository) ListLinks(ctx context.Context, nodeID string) ([]*TopologyLink, error) {
+func (r *TopologyRepository) ListLinks(ctx context.Context, nodeID string) ([]*topology.Link, error) {
 	rows, err := r.db.Query(ctx, `
 		SELECT id, source_node_id, target_node_id, source_interface, target_interface,
 		       link_type, status, speed_mbps, utilization_pct,
@@ -477,7 +402,7 @@ func (r *TopologyRepository) ListLinks(ctx context.Context, nodeID string) ([]*T
 	}
 	defer func() { _ = rows.Close() }()
 
-	var out []*TopologyLink
+	var out []*topology.Link
 	for rows.Next() {
 		link, scanErr := scanTopologyLink(rows.Scan)
 		if scanErr != nil {
@@ -515,9 +440,9 @@ func nullableFloat(v float64) sql.NullFloat64 {
 	return sql.NullFloat64{Float64: v, Valid: true}
 }
 
-func scanTopologyLink(scan func(...any) error) (*TopologyLink, error) {
+func scanTopologyLink(scan func(...any) error) (*topology.Link, error) {
 	var (
-		link         TopologyLink
+		link         topology.Link
 		srcIface     sql.NullString
 		tgtIface     sql.NullString
 		speedMbps    sql.NullInt32
@@ -533,7 +458,7 @@ func scanTopologyLink(scan func(...any) error) (*TopologyLink, error) {
 		&firstSeenStr, &lastSeenStr, &evidenceJSON,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrTopologyNodeNotFound
+		return nil, topology.ErrTopologyNodeNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("scan topology_link: %w", err)
@@ -560,24 +485,6 @@ func scanTopologyLink(scan func(...any) error) (*TopologyLink, error) {
 		link.LastSeen = parsed
 	}
 	return &link, nil
-}
-
-// TopologyInterface mirrors one row of topology_interfaces.
-// Reconciled from if_table observations; columns shaped so alert
-// rules can index admin/oper status and speed without parsing JSON.
-type TopologyInterface struct {
-	ID            int64
-	NodeID        string
-	IfIndex       uint32
-	IfName        string
-	IfDescr       string
-	IfAlias       string
-	IfType        uint32
-	IfAdminStatus int
-	IfOperStatus  int
-	IfPhysAddr    string
-	SpeedBps      uint64
-	LastSeen      time.Time
 }
 
 // UpsertTargetNode records the (client_id, target_id) -> node_id
@@ -619,7 +526,7 @@ func (r *TopologyRepository) UpsertTargetNode(
 }
 
 // NodeIDForTarget resolves (client_id, target_id) -> node_id. Returns
-// "" + ErrTopologyNodeNotFound when no mapping exists yet (the
+// "" + topology.ErrTopologyNodeNotFound when no mapping exists yet (the
 // sysinfo reconciler hasn't seen this target).
 func (r *TopologyRepository) NodeIDForTarget(
 	ctx context.Context,
@@ -635,7 +542,7 @@ func (r *TopologyRepository) NodeIDForTarget(
 	var nodeID string
 	if err := row.Scan(&nodeID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", ErrTopologyNodeNotFound
+			return "", topology.ErrTopologyNodeNotFound
 		}
 		return "", fmt.Errorf("nodeIDForTarget: %w", err)
 	}
@@ -644,7 +551,7 @@ func (r *TopologyRepository) NodeIDForTarget(
 
 // UpsertInterface inserts or updates one topology_interfaces row.
 // Reconcilers call this once per if_table row per node per poll.
-func (r *TopologyRepository) UpsertInterface(ctx context.Context, iface *TopologyInterface) error {
+func (r *TopologyRepository) UpsertInterface(ctx context.Context, iface *topology.Interface) error {
 	if iface.NodeID == "" {
 		return errors.New("topology_interfaces: NodeID required")
 	}
@@ -689,7 +596,7 @@ func (r *TopologyRepository) UpsertInterface(ctx context.Context, iface *Topolog
 func (r *TopologyRepository) ListInterfaces(
 	ctx context.Context,
 	nodeID string,
-) ([]*TopologyInterface, error) {
+) ([]*topology.Interface, error) {
 	rows, err := r.db.Query(ctx, `
 		SELECT id, node_id, if_index, if_name, if_descr, if_alias,
 		       if_type, if_admin_status, if_oper_status, if_phys_addr,
@@ -703,7 +610,7 @@ func (r *TopologyRepository) ListInterfaces(
 	}
 	defer func() { _ = rows.Close() }()
 
-	var out []*TopologyInterface
+	var out []*topology.Interface
 	for rows.Next() {
 		iface, scanErr := scanTopologyInterface(rows.Scan)
 		if scanErr != nil {
@@ -717,9 +624,9 @@ func (r *TopologyRepository) ListInterfaces(
 	return out, nil
 }
 
-func scanTopologyInterface(scan func(...any) error) (*TopologyInterface, error) {
+func scanTopologyInterface(scan func(...any) error) (*topology.Interface, error) {
 	var (
-		iface       TopologyInterface
+		iface       topology.Interface
 		ifName      sql.NullString
 		ifDescr     sql.NullString
 		ifAlias     sql.NullString
@@ -733,7 +640,7 @@ func scanTopologyInterface(scan func(...any) error) (*TopologyInterface, error) 
 		&ifPhysAddr, &iface.SpeedBps, &lastSeenStr,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrTopologyNodeNotFound
+		return nil, topology.ErrTopologyNodeNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("scan topology_interface: %w", err)
@@ -756,9 +663,9 @@ func scanTopologyInterface(scan func(...any) error) (*TopologyInterface, error) 
 	return &iface, nil
 }
 
-func scanTopologyNode(scan func(...any) error) (*TopologyNode, error) {
+func scanTopologyNode(scan func(...any) error) (*topology.Node, error) {
 	var (
-		node         TopologyNode
+		node         topology.Node
 		deviceType   sql.NullString
 		chassisID    sql.NullString
 		sysName      sql.NullString
@@ -775,7 +682,7 @@ func scanTopologyNode(scan func(...any) error) (*TopologyNode, error) {
 		&firstSeenStr, &lastSeenStr, &expiresAt, &metadataJSON,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrTopologyNodeNotFound
+		return nil, topology.ErrTopologyNodeNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("scan topology_node: %w", err)

--- a/internal/database/repository_topology_arp_test.go
+++ b/internal/database/repository_topology_arp_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/topology"
 )
 
 func newTopoARPDB(t *testing.T) *database.DB {
@@ -22,7 +23,7 @@ func seedARPBindings(t *testing.T, db *database.DB) {
 	t.Helper()
 	ctx := context.Background()
 	// FK requires topology_nodes rows for both source nodes.
-	for _, n := range []*database.TopologyNode{
+	for _, n := range []*topology.Node{
 		{
 			ID: "node-a", ClientID: "default", IdentityHash: "h-a",
 			DisplayName: "router-a", LastSeen: time.Now().UTC(),
@@ -36,7 +37,7 @@ func seedARPBindings(t *testing.T, db *database.DB) {
 			t.Fatalf("seed node %s: %v", n.ID, err)
 		}
 	}
-	rows := []*database.TopologyARPBinding{
+	rows := []*topology.ARPBinding{
 		{
 			ClientID: "default", SourceNodeID: "node-a", IfIndex: 1,
 			IPAddress: "10.0.0.1", MACAddress: "aa:bb:cc:00:00:01",
@@ -64,7 +65,7 @@ func TestListARPBindings_EmptyReturnsEmpty(t *testing.T) {
 	t.Parallel()
 	db := newTopoARPDB(t)
 	rows, err := db.Topology().ListARPBindings(context.Background(),
-		database.TopologyARPListOptions{})
+		topology.ARPListOptions{})
 	if err != nil {
 		t.Fatalf("ListARPBindings: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestListARPBindings_ReturnsAllRowsOrderedByLastSeenDesc(t *testing.T) {
 	seedARPBindings(t, db)
 
 	rows, err := db.Topology().ListARPBindings(context.Background(),
-		database.TopologyARPListOptions{})
+		topology.ARPListOptions{})
 	if err != nil {
 		t.Fatalf("ListARPBindings: %v", err)
 	}
@@ -98,7 +99,7 @@ func TestListARPBindings_FilterBySourceNode(t *testing.T) {
 	seedARPBindings(t, db)
 
 	rows, err := db.Topology().ListARPBindings(context.Background(),
-		database.TopologyARPListOptions{SourceNodeID: "node-b"})
+		topology.ARPListOptions{SourceNodeID: "node-b"})
 	if err != nil {
 		t.Fatalf("ListARPBindings: %v", err)
 	}
@@ -117,7 +118,7 @@ func TestListARPBindings_FilterBySince(t *testing.T) {
 
 	cutoff := time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)
 	rows, err := db.Topology().ListARPBindings(context.Background(),
-		database.TopologyARPListOptions{Since: cutoff})
+		topology.ARPListOptions{Since: cutoff})
 	if err != nil {
 		t.Fatalf("ListARPBindings: %v", err)
 	}
@@ -132,7 +133,7 @@ func TestListARPBindings_LimitClamps(t *testing.T) {
 	seedARPBindings(t, db)
 
 	rows, err := db.Topology().ListARPBindings(context.Background(),
-		database.TopologyARPListOptions{Limit: 1})
+		topology.ARPListOptions{Limit: 1})
 	if err != nil {
 		t.Fatalf("ListARPBindings: %v", err)
 	}

--- a/internal/polling/observation/observation.go
+++ b/internal/polling/observation/observation.go
@@ -1,0 +1,35 @@
+// Package observation holds the domain types for SNMP observations.
+// These are the row-level types that flow from the snmp_observations
+// table through the polling pipeline into the topology reconcilers
+// and alert pipelines.
+//
+// This package is a pure-types leaf: it imports nothing from
+// internal/database or any other infrastructure package, so callers
+// (topology reconcilers, alert pipelines) can depend on it without
+// taking a persistence dependency.
+package observation
+
+import "time"
+
+// SNMPObservation is one row of snmp_observations. PayloadJSON
+// carries the typed collector Observation struct serialized as JSON
+// — callers decode it back into the kind-specific shape they own.
+type SNMPObservation struct {
+	ID          int64
+	ClientID    string
+	TargetID    string
+	Kind        string
+	ObservedAt  time.Time
+	PayloadJSON string
+	IngestedAt  time.Time
+}
+
+// ListOptions narrows the query — empty values disable that filter.
+type ListOptions struct {
+	ClientID string
+	TargetID string
+	Kind     string
+	Since    time.Time
+	Until    time.Time
+	Limit    int
+}

--- a/internal/polling/snmp/sink/sink.go
+++ b/internal/polling/snmp/sink/sink.go
@@ -22,7 +22,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/collectors/arp"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/collectors/bgp4"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/collectors/cdp"
@@ -53,7 +53,7 @@ const (
 // observationsStore is the narrowed surface the Sink needs from the
 // database layer. Tests inject a fake.
 type observationsStore interface {
-	Insert(ctx context.Context, obs *database.SNMPObservation) error
+	Insert(ctx context.Context, obs *observation.SNMPObservation) error
 }
 
 // Sink persists every kind of collector Observation into the
@@ -93,7 +93,7 @@ func (s *Sink) persist(
 			"kind", kind, "target_id", targetID, "error", err)
 		return fmt.Errorf("snmp sink: marshal %s: %w", kind, err)
 	}
-	obs := &database.SNMPObservation{
+	obs := &observation.SNMPObservation{
 		ClientID:    clientID,
 		TargetID:    targetID,
 		Kind:        kind,

--- a/internal/polling/snmp/sink/sink_test.go
+++ b/internal/polling/snmp/sink/sink_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/collectors/arp"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/collectors/bgp4"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/collectors/cdp"
@@ -27,11 +27,11 @@ func at() time.Time              { return time.Date(2026, 5, 31, 12, 0, 0, 0, ti
 
 type fakeStore struct {
 	mu     sync.Mutex
-	rows   []*database.SNMPObservation
+	rows   []*observation.SNMPObservation
 	insErr error
 }
 
-func (f *fakeStore) Insert(_ context.Context, obs *database.SNMPObservation) error {
+func (f *fakeStore) Insert(_ context.Context, obs *observation.SNMPObservation) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.insErr != nil {

--- a/internal/topology/arp_reconciler.go
+++ b/internal/topology/arp_reconciler.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 )
 
 // ARPReconcilerName is the engine identifier.
@@ -28,7 +28,7 @@ const arpHighWaterKey = "topology.arp.high_water"
 type arpStore interface {
 	NodeIDForTarget(ctx context.Context, clientID, targetID string) (string, error)
 	NodeIDForMAC(ctx context.Context, clientID, mac string) (string, error)
-	UpsertARPBinding(ctx context.Context, b *database.TopologyARPBinding) error
+	UpsertARPBinding(ctx context.Context, b *ARPBinding) error
 	SetNodePrimaryIP(ctx context.Context, nodeID, ip string) error
 }
 
@@ -171,7 +171,7 @@ func (r *ARPReconciler) reconcileOnceInner(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)
 	}
-	observations, err := r.obs.List(ctx, database.ListOptions{
+	observations, err := r.obs.List(ctx, observation.ListOptions{
 		Kind:  "arp",
 		Since: since,
 		Limit: defaultBatchLimit,
@@ -229,7 +229,7 @@ type arpEntry struct {
 // matches an entry's MAC. Returns (bindingCount, backfillCount).
 func (r *ARPReconciler) applyObservation(
 	ctx context.Context,
-	obs *database.SNMPObservation,
+	obs *observation.SNMPObservation,
 	sourceNodeID string,
 ) (int, int) {
 	var p arpPayload
@@ -243,7 +243,7 @@ func (r *ARPReconciler) applyObservation(
 		if e.IPAddress == "" || e.MACAddress == "" {
 			continue
 		}
-		binding := &database.TopologyARPBinding{
+		binding := &ARPBinding{
 			ClientID:     obs.ClientID,
 			SourceNodeID: sourceNodeID,
 			IfIndex:      e.IfIndex,

--- a/internal/topology/arp_reconciler_test.go
+++ b/internal/topology/arp_reconciler_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 	"github.com/MustardSeedNetworks/seed/internal/topology"
 )
 
@@ -18,7 +18,7 @@ type fakeARPStore struct {
 	targetMap map[string]string // (client|target) -> node_id
 	macMap    map[string]string // mac -> node_id
 
-	bindings   []*database.TopologyARPBinding
+	bindings   []*topology.ARPBinding
 	primaryIPs map[string]string // node_id -> ip
 
 	upsertErr error
@@ -38,7 +38,7 @@ func (f *fakeARPStore) NodeIDForTarget(_ context.Context, clientID, targetID str
 	defer f.mu.Unlock()
 	id, ok := f.targetMap[clientID+"|"+targetID]
 	if !ok {
-		return "", database.ErrTopologyNodeNotFound
+		return "", topology.ErrTopologyNodeNotFound
 	}
 	return id, nil
 }
@@ -48,12 +48,12 @@ func (f *fakeARPStore) NodeIDForMAC(_ context.Context, _, mac string) (string, e
 	defer f.mu.Unlock()
 	id, ok := f.macMap[mac]
 	if !ok {
-		return "", database.ErrTopologyNodeNotFound
+		return "", topology.ErrTopologyNodeNotFound
 	}
 	return id, nil
 }
 
-func (f *fakeARPStore) UpsertARPBinding(_ context.Context, b *database.TopologyARPBinding) error {
+func (f *fakeARPStore) UpsertARPBinding(_ context.Context, b *topology.ARPBinding) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.upsertErr != nil {
@@ -73,9 +73,9 @@ func (f *fakeARPStore) SetNodePrimaryIP(_ context.Context, nodeID, ip string) er
 	return nil
 }
 
-func arpObs(target string, observed time.Time, entries []map[string]any) *database.SNMPObservation {
+func arpObs(target string, observed time.Time, entries []map[string]any) *observation.SNMPObservation {
 	b, _ := json.Marshal(map[string]any{"Entries": entries})
-	return &database.SNMPObservation{
+	return &observation.SNMPObservation{
 		ClientID:    "c",
 		TargetID:    target,
 		Kind:        "arp",
@@ -109,7 +109,7 @@ func TestARPReconcileOnce_UpsertsOneBindingPerEntry(t *testing.T) {
 	store := newFakeARPStore()
 	store.targetMap["c|t-1"] = "node-source"
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		arpObs("t-1", at(), []map[string]any{
 			{"IfIndex": 1, "IPAddress": "10.0.0.1", "MACAddress": "aa:bb:cc:dd:ee:01", "MediaType": 3},
 			{"IfIndex": 1, "IPAddress": "10.0.0.2", "MACAddress": "aa:bb:cc:dd:ee:02", "MediaType": 3},
@@ -141,7 +141,7 @@ func TestARPReconcileOnce_BackfillsPrimaryIPOnMACMatch(t *testing.T) {
 	// should be backfilled.
 	store.macMap["aa:bb:cc:dd:ee:99"] = "node-B"
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		arpObs("t-1", at(), []map[string]any{
 			{"IfIndex": 1, "IPAddress": "192.0.2.10", "MACAddress": "aa:bb:cc:dd:ee:99"},
 		}),
@@ -163,7 +163,7 @@ func TestARPReconcileOnce_UnmatchedMACSkipsBackfill(t *testing.T) {
 	store.targetMap["c|t-1"] = "node-source"
 	// macMap deliberately empty — no node matches the binding's MAC.
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		arpObs("t-1", at(), []map[string]any{
 			{"IfIndex": 1, "IPAddress": "10.0.0.5", "MACAddress": "11:22:33:44:55:66"},
 		}),
@@ -187,7 +187,7 @@ func TestARPReconcileOnce_SourceNotMappedSkips(t *testing.T) {
 	t.Parallel()
 	store := newFakeARPStore() // empty target map -> source unknown
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		arpObs("t-orphan", at(), []map[string]any{
 			{"IfIndex": 1, "IPAddress": "10.0.0.1", "MACAddress": "aa:aa:aa:aa:aa:aa"},
 		}),
@@ -209,7 +209,7 @@ func TestARPReconcileOnce_EmptyIPOrMACSkipped(t *testing.T) {
 	store := newFakeARPStore()
 	store.targetMap["c|t-1"] = "node-source"
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		arpObs("t-1", at(), []map[string]any{
 			{"IfIndex": 1, "IPAddress": "10.0.0.1", "MACAddress": ""},                  // bad
 			{"IfIndex": 1, "IPAddress": "", "MACAddress": "aa:bb:cc:dd:ee:ff"},         // bad
@@ -234,7 +234,7 @@ func TestARPReconcileOnce_UpsertErrorSkipsBackfill(t *testing.T) {
 	store.macMap["aa:aa:aa:aa:aa:aa"] = "node-B"
 	store.upsertErr = errors.New("constraint")
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		arpObs("t-1", at(), []map[string]any{
 			{"IfIndex": 1, "IPAddress": "10.0.0.1", "MACAddress": "aa:aa:aa:aa:aa:aa"},
 		}),
@@ -255,7 +255,7 @@ func TestARPReconcileOnce_MalformedPayloadSkipsObservation(t *testing.T) {
 	t.Parallel()
 	store := newFakeARPStore()
 	store.targetMap["c|t-1"] = "node-source"
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		{
 			ClientID: "c", TargetID: "t-1", Kind: "arp",
 			ObservedAt: at(), PayloadJSON: "{not valid",
@@ -278,7 +278,7 @@ func TestARPReconcileOnce_PersistsHighWater(t *testing.T) {
 	store := newFakeARPStore()
 	store.targetMap["c|t-1"] = "node-source"
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		arpObs("t-1", at(), []map[string]any{
 			{"IfIndex": 1, "IPAddress": "10.0.0.1", "MACAddress": "aa:bb:cc:dd:ee:ff"},
 		}),

--- a/internal/topology/edge_reconciler.go
+++ b/internal/topology/edge_reconciler.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 )
 
 // EdgeReconcilerName is the engine identifier.
@@ -34,7 +34,7 @@ func neighborKinds() []string { return []string{"lldp", "cdp", "fdp"} }
 type edgeStore interface {
 	NodeIDForTarget(ctx context.Context, clientID, targetID string) (string, error)
 	NodeIDForSysName(ctx context.Context, clientID, sysName string) (string, error)
-	UpsertLink(ctx context.Context, link *database.TopologyLink) error
+	UpsertLink(ctx context.Context, link *Link) error
 }
 
 // EdgeReconciler turns lldp/cdp/fdp observations into
@@ -213,7 +213,7 @@ func (r *EdgeReconciler) reconcileKind(
 	kind string,
 	since time.Time,
 ) (int, time.Time, error) {
-	observations, err := r.obs.List(ctx, database.ListOptions{
+	observations, err := r.obs.List(ctx, observation.ListOptions{
 		Kind:  kind,
 		Since: since,
 		Limit: defaultBatchLimit,
@@ -230,7 +230,7 @@ func (r *EdgeReconciler) reconcileKind(
 		}
 		sourceNodeID, lookupErr := r.store.NodeIDForTarget(ctx, obs.ClientID, obs.TargetID)
 		if lookupErr != nil {
-			if errors.Is(lookupErr, database.ErrTopologyNodeNotFound) {
+			if errors.Is(lookupErr, ErrTopologyNodeNotFound) {
 				continue
 			}
 			r.logger.WarnContext(ctx, "edge: source node lookup failed",
@@ -255,7 +255,7 @@ type neighborRecord struct {
 // that landed.
 func (r *EdgeReconciler) applyObservation(
 	ctx context.Context,
-	obs *database.SNMPObservation,
+	obs *observation.SNMPObservation,
 	kind string,
 	sourceNodeID string,
 ) int {
@@ -282,7 +282,7 @@ func (r *EdgeReconciler) applyObservation(
 			"source_target": obs.TargetID,
 			"remote_name":   n.remoteName,
 		})
-		link := &database.TopologyLink{
+		link := &Link{
 			ID:              linkID,
 			SourceNodeID:    sourceNodeID,
 			TargetNodeID:    remoteNodeID,

--- a/internal/topology/edge_reconciler_test.go
+++ b/internal/topology/edge_reconciler_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 	"github.com/MustardSeedNetworks/seed/internal/topology"
 )
 
@@ -21,7 +21,7 @@ type fakeEdgeStore struct {
 	// sys_name -> node_id for remote-neighbor resolution.
 	sysNameMap map[string]string
 
-	links     []*database.TopologyLink
+	links     []*topology.Link
 	upsertErr error
 }
 
@@ -37,7 +37,7 @@ func (f *fakeEdgeStore) NodeIDForTarget(_ context.Context, clientID, targetID st
 	defer f.mu.Unlock()
 	id, ok := f.targetMap[clientID+"|"+targetID]
 	if !ok {
-		return "", database.ErrTopologyNodeNotFound
+		return "", topology.ErrTopologyNodeNotFound
 	}
 	return id, nil
 }
@@ -47,12 +47,12 @@ func (f *fakeEdgeStore) NodeIDForSysName(_ context.Context, _, sysName string) (
 	defer f.mu.Unlock()
 	id, ok := f.sysNameMap[sysName]
 	if !ok {
-		return "", database.ErrTopologyNodeNotFound
+		return "", topology.ErrTopologyNodeNotFound
 	}
 	return id, nil
 }
 
-func (f *fakeEdgeStore) UpsertLink(_ context.Context, link *database.TopologyLink) error {
+func (f *fakeEdgeStore) UpsertLink(_ context.Context, link *topology.Link) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.upsertErr != nil {
@@ -67,17 +67,17 @@ func (f *fakeEdgeStore) UpsertLink(_ context.Context, link *database.TopologyLin
 // client_id matters for identity merging.
 const edgeTestClient = "c"
 
-func lldpObs(target string, observed time.Time, neighbors []map[string]any) *database.SNMPObservation {
+func lldpObs(target string, observed time.Time, neighbors []map[string]any) *observation.SNMPObservation {
 	b, _ := json.Marshal(map[string]any{"Neighbors": neighbors})
-	return &database.SNMPObservation{
+	return &observation.SNMPObservation{
 		ClientID: edgeTestClient, TargetID: target, Kind: "lldp",
 		ObservedAt: observed, PayloadJSON: string(b),
 	}
 }
 
-func cdpObs(target, kind string, observed time.Time, neighbors []map[string]any) *database.SNMPObservation {
+func cdpObs(target, kind string, observed time.Time, neighbors []map[string]any) *observation.SNMPObservation {
 	b, _ := json.Marshal(map[string]any{"Neighbors": neighbors})
-	return &database.SNMPObservation{
+	return &observation.SNMPObservation{
 		ClientID: edgeTestClient, TargetID: target, Kind: kind,
 		ObservedAt: observed, PayloadJSON: string(b),
 	}
@@ -109,7 +109,7 @@ func TestEdgeReconcileOnce_LLDPEmitsOneLinkPerNeighbor(t *testing.T) {
 	store.targetMap["c|t-source"] = "node-A"
 	store.sysNameMap["core-sw"] = "node-B"
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		lldpObs("t-source", at(), []map[string]any{
 			{"LocalPortNum": 24, "PortID": "Gi0/24", "SysName": "core-sw"},
 		}),
@@ -141,7 +141,7 @@ func TestEdgeReconcileOnce_OrphanNeighborSkipped(t *testing.T) {
 	store.targetMap["c|t-source"] = "node-A"
 	// sysNameMap deliberately empty — remote unknown.
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		lldpObs("t-source", at(), []map[string]any{
 			{"LocalPortNum": 1, "SysName": "unknown-edge"},
 		}),
@@ -172,7 +172,7 @@ func TestEdgeReconcileOnce_SameLinkFromBothSidesMergesToOneRow(t *testing.T) {
 	// upserts must hit the same ID — but interfaces differ between
 	// the two views, so the resulting row will reflect whichever
 	// arrived last (deterministic given high-water ordering).
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		lldpObs("t-A", at(), []map[string]any{
 			{"LocalPortNum": 24, "PortID": "Gi0/12", "SysName": "sw-B"},
 		}),
@@ -206,7 +206,7 @@ func TestEdgeReconcileOnce_CDPAlsoCreatesLinks(t *testing.T) {
 	store.targetMap["c|t-A"] = "node-A"
 	store.sysNameMap["fqdn-core-sw"] = "node-B"
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		cdpObs("t-A", "cdp", at(), []map[string]any{
 			{"LocalIfIndex": 5, "DeviceID": "fqdn-core-sw", "DevicePort": "Gi1/0/24"},
 		}),
@@ -231,7 +231,7 @@ func TestEdgeReconcileOnce_FDPRoutedThroughCDPPayloadShape(t *testing.T) {
 	store.targetMap["c|t-A"] = "node-A"
 	store.sysNameMap["foundry-edge"] = "node-B"
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		cdpObs("t-A", "fdp", at(), []map[string]any{
 			{"LocalIfIndex": 1, "DeviceID": "foundry-edge", "DevicePort": "ether-1"},
 		}),
@@ -251,7 +251,7 @@ func TestEdgeReconcileOnce_SourceNotKnownSkips(t *testing.T) {
 	t.Parallel()
 	store := newFakeEdgeStore()
 	// targetMap empty -> source unknown.
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		lldpObs("t-A", at(), []map[string]any{
 			{"LocalPortNum": 1, "SysName": "core"},
 		}),
@@ -275,7 +275,7 @@ func TestEdgeReconcileOnce_ListErrorOnOneKindContinuesOthers(t *testing.T) {
 	// fakeObservations.List ignores kind filter — so a list error
 	// kills all kinds at once. Use a per-kind capable fake.
 	pc := &perKindObservations{
-		byKind: map[string][]*database.SNMPObservation{
+		byKind: map[string][]*observation.SNMPObservation{
 			"lldp": {lldpObs("t-A", at(), []map[string]any{
 				{"LocalPortNum": 1, "SysName": "core"},
 			})},
@@ -300,11 +300,14 @@ func TestEdgeReconcileOnce_ListErrorOnOneKindContinuesOthers(t *testing.T) {
 // test the per-kind error-isolation behavior.
 type perKindObservations struct {
 	mu        sync.Mutex
-	byKind    map[string][]*database.SNMPObservation
+	byKind    map[string][]*observation.SNMPObservation
 	errByKind map[string]error
 }
 
-func (p *perKindObservations) List(_ context.Context, opts database.ListOptions) ([]*database.SNMPObservation, error) {
+func (p *perKindObservations) List(
+	_ context.Context,
+	opts observation.ListOptions,
+) ([]*observation.SNMPObservation, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if err, ok := p.errByKind[opts.Kind]; ok {
@@ -321,7 +324,7 @@ func TestEdgeReconcileOnce_MaxObservedAtAcrossKinds(t *testing.T) {
 
 	older := at().Add(-time.Hour)
 	newer := at()
-	pc := &perKindObservations{byKind: map[string][]*database.SNMPObservation{
+	pc := &perKindObservations{byKind: map[string][]*observation.SNMPObservation{
 		"lldp": {lldpObs("t-A", older, []map[string]any{{"LocalPortNum": 1, "SysName": "b"}})},
 		"cdp":  {cdpObs("t-A", "cdp", newer, []map[string]any{{"LocalIfIndex": 1, "DeviceID": "b"}})},
 	}}

--- a/internal/topology/iftable_reconciler.go
+++ b/internal/topology/iftable_reconciler.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 )
 
 // IfTableReconcilerName is the engine identifier.
@@ -26,7 +26,7 @@ const ifTableHighWaterKey = "topology.iftable.high_water"
 // one row per interface.
 type nodeIfaceUpserter interface {
 	NodeIDForTarget(ctx context.Context, clientID, targetID string) (string, error)
-	UpsertInterface(ctx context.Context, iface *database.TopologyInterface) error
+	UpsertInterface(ctx context.Context, iface *Interface) error
 }
 
 // IfTableReconciler turns if_table observations into
@@ -169,7 +169,7 @@ func (r *IfTableReconciler) reconcileOnceInner(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)
 	}
-	observations, err := r.obs.List(ctx, database.ListOptions{
+	observations, err := r.obs.List(ctx, observation.ListOptions{
 		Kind:  "if_table",
 		Since: since,
 		Limit: defaultBatchLimit,
@@ -189,7 +189,7 @@ func (r *IfTableReconciler) reconcileOnceInner(ctx context.Context) error {
 		}
 		nodeID, lookupErr := r.store.NodeIDForTarget(ctx, obs.ClientID, obs.TargetID)
 		if lookupErr != nil {
-			if errors.Is(lookupErr, database.ErrTopologyNodeNotFound) {
+			if errors.Is(lookupErr, ErrTopologyNodeNotFound) {
 				r.logger.DebugContext(ctx, "iftable: target has no node mapping yet, skipping",
 					"target_id", obs.TargetID)
 				continue
@@ -234,7 +234,7 @@ type ifRow struct {
 // per interface. Returns the count of upserts that succeeded.
 func (r *IfTableReconciler) applyObservation(
 	ctx context.Context,
-	obs *database.SNMPObservation,
+	obs *observation.SNMPObservation,
 	nodeID string,
 ) int {
 	var p ifTablePayload
@@ -248,7 +248,7 @@ func (r *IfTableReconciler) applyObservation(
 		if row.IfIndex == 0 {
 			continue
 		}
-		iface := &database.TopologyInterface{
+		iface := &Interface{
 			NodeID:        nodeID,
 			IfIndex:       row.IfIndex,
 			IfName:        row.IfName,

--- a/internal/topology/iftable_reconciler_test.go
+++ b/internal/topology/iftable_reconciler_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 	"github.com/MustardSeedNetworks/seed/internal/topology"
 )
 
@@ -16,7 +16,7 @@ type fakeIfStore struct {
 	mu        sync.Mutex
 	nodeFor   map[string]string // (client|target) -> nodeID
 	lookupErr error
-	upserts   []*database.TopologyInterface
+	upserts   []*topology.Interface
 	upsertErr error
 }
 
@@ -32,12 +32,12 @@ func (f *fakeIfStore) NodeIDForTarget(_ context.Context, clientID, targetID stri
 	}
 	id, ok := f.nodeFor[clientID+"|"+targetID]
 	if !ok {
-		return "", database.ErrTopologyNodeNotFound
+		return "", topology.ErrTopologyNodeNotFound
 	}
 	return id, nil
 }
 
-func (f *fakeIfStore) UpsertInterface(_ context.Context, iface *database.TopologyInterface) error {
+func (f *fakeIfStore) UpsertInterface(_ context.Context, iface *topology.Interface) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.upsertErr != nil {
@@ -52,8 +52,8 @@ func ifPayload(rows ...map[string]any) string {
 	return string(b)
 }
 
-func ifObs(client, target string, observed time.Time, rows ...map[string]any) *database.SNMPObservation {
-	return &database.SNMPObservation{
+func ifObs(client, target string, observed time.Time, rows ...map[string]any) *observation.SNMPObservation {
+	return &observation.SNMPObservation{
 		ClientID:    client,
 		TargetID:    target,
 		Kind:        "if_table",
@@ -87,7 +87,7 @@ func TestIfTableReconcileOnce_UpsertsOneRowPerInterface(t *testing.T) {
 	store := newFakeIfStore()
 	store.nodeFor["client-a|t-1"] = "node-abc"
 
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		ifObs("client-a", "t-1", at(),
 			map[string]any{
 				"IfIndex": 1, "IfName": "Gi0/0", "IfAdmin": 1, "IfOper": 1, "SpeedBps": 1000000000,
@@ -118,7 +118,7 @@ func TestIfTableReconcileOnce_UpsertsOneRowPerInterface(t *testing.T) {
 func TestIfTableReconcileOnce_SkipsObservationsWithoutNodeMapping(t *testing.T) {
 	t.Parallel()
 	store := newFakeIfStore() // empty mapping
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		ifObs("c", "t-orphan", at(),
 			map[string]any{"IfIndex": 1, "IfName": "eth0"},
 		),
@@ -150,7 +150,7 @@ func TestIfTableReconcileOnce_PersistsMaxObservedAt(t *testing.T) {
 
 	old := at().Add(-time.Hour)
 	newer := at()
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		ifObs("c", "t-1", newer, map[string]any{"IfIndex": 1, "IfName": "e0"}),
 		ifObs("c", "t-2", old, map[string]any{"IfIndex": 1, "IfName": "e0"}),
 	}}
@@ -175,7 +175,7 @@ func TestIfTableReconcileOnce_MalformedPayloadSkipsObservation(t *testing.T) {
 	t.Parallel()
 	store := newFakeIfStore()
 	store.nodeFor["c|t-1"] = "node-1"
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		{
 			ClientID: "c", TargetID: "t-1", Kind: "if_table",
 			ObservedAt: at(), PayloadJSON: "{not valid json",
@@ -197,7 +197,7 @@ func TestIfTableReconcileOnce_ZeroIfIndexSkipped(t *testing.T) {
 	t.Parallel()
 	store := newFakeIfStore()
 	store.nodeFor["c|t-1"] = "node-1"
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		ifObs("c", "t-1", at(),
 			map[string]any{"IfIndex": 0, "IfName": "invalid"},
 			map[string]any{"IfIndex": 1, "IfName": "ok"},
@@ -217,7 +217,7 @@ func TestIfTableReconcileOnce_LookupErrorContinuesBatch(t *testing.T) {
 	t.Parallel()
 	store := newFakeIfStore()
 	store.lookupErr = errors.New("db down")
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		ifObs("c", "t-1", at(), map[string]any{"IfIndex": 1, "IfName": "e0"}),
 	}}
 	r, _ := topology.NewIfTableReconciler(topology.IfTableConfig{

--- a/internal/topology/read.go
+++ b/internal/topology/read.go
@@ -8,8 +8,6 @@ package topology
 import (
 	"context"
 	"errors"
-
-	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
 // ErrNodeNotFound is returned by Node when no node matches the id.
@@ -22,18 +20,18 @@ var ErrUnavailable = errors.New("topology: store unavailable")
 // Reader is the read surface the topology queries need. It mirrors the topology
 // repository's read methods; the adapter satisfies it over database.TopologyRepository.
 type Reader interface {
-	List(ctx context.Context, opts database.TopologyListOptions) ([]*database.TopologyNode, error)
-	ListInterfaces(ctx context.Context, nodeID string) ([]*database.TopologyInterface, error)
-	ListLinks(ctx context.Context, nodeID string) ([]*database.TopologyLink, error)
-	ListARPBindings(ctx context.Context, opts database.TopologyARPListOptions) ([]*database.TopologyARPBinding, error)
+	List(ctx context.Context, opts ListOptions) ([]*Node, error)
+	ListInterfaces(ctx context.Context, nodeID string) ([]*Interface, error)
+	ListLinks(ctx context.Context, nodeID string) ([]*Link, error)
+	ListARPBindings(ctx context.Context, opts ARPListOptions) ([]*ARPBinding, error)
 }
 
 // NodeDetail is the single-node read model: the node plus its interfaces and
 // incident links.
 type NodeDetail struct {
-	Node       *database.TopologyNode
-	Interfaces []*database.TopologyInterface
-	Links      []*database.TopologyLink
+	Node       *Node
+	Interfaces []*Interface
+	Links      []*Link
 }
 
 // Queries is the topology read use-case.
@@ -49,7 +47,7 @@ func NewQueries(reader Reader, maxLimit int) *Queries {
 }
 
 // Nodes lists topology nodes matching opts.
-func (q *Queries) Nodes(ctx context.Context, opts database.TopologyListOptions) ([]*database.TopologyNode, error) {
+func (q *Queries) Nodes(ctx context.Context, opts ListOptions) ([]*Node, error) {
 	return q.reader.List(ctx, opts)
 }
 
@@ -58,11 +56,11 @@ func (q *Queries) Nodes(ctx context.Context, opts database.TopologyListOptions) 
 // yields an empty list rather than failing the whole detail view (the prior
 // handler behavior).
 func (q *Queries) Node(ctx context.Context, id string) (NodeDetail, error) {
-	nodes, err := q.reader.List(ctx, database.TopologyListOptions{Limit: q.maxLimit})
+	nodes, err := q.reader.List(ctx, ListOptions{Limit: q.maxLimit})
 	if err != nil {
 		return NodeDetail{}, err
 	}
-	var node *database.TopologyNode
+	var node *Node
 	for _, n := range nodes {
 		if n.ID == id {
 			node = n
@@ -78,14 +76,14 @@ func (q *Queries) Node(ctx context.Context, id string) (NodeDetail, error) {
 }
 
 // Links returns the links incident to nodeID.
-func (q *Queries) Links(ctx context.Context, nodeID string) ([]*database.TopologyLink, error) {
+func (q *Queries) Links(ctx context.Context, nodeID string) ([]*Link, error) {
 	return q.reader.ListLinks(ctx, nodeID)
 }
 
 // ARP returns the ARP bindings matching opts.
 func (q *Queries) ARP(
 	ctx context.Context,
-	opts database.TopologyARPListOptions,
-) ([]*database.TopologyARPBinding, error) {
+	opts ARPListOptions,
+) ([]*ARPBinding, error) {
 	return q.reader.ListARPBindings(ctx, opts)
 }

--- a/internal/topology/read_test.go
+++ b/internal/topology/read_test.go
@@ -5,41 +5,40 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/topology"
 )
 
 type fakeReader struct {
-	nodes      []*database.TopologyNode
-	interfaces []*database.TopologyInterface
-	links      []*database.TopologyLink
+	nodes      []*topology.Node
+	interfaces []*topology.Interface
+	links      []*topology.Link
 	listErr    error
 }
 
-func (f fakeReader) List(context.Context, database.TopologyListOptions) ([]*database.TopologyNode, error) {
+func (f fakeReader) List(context.Context, topology.ListOptions) ([]*topology.Node, error) {
 	return f.nodes, f.listErr
 }
 
-func (f fakeReader) ListInterfaces(context.Context, string) ([]*database.TopologyInterface, error) {
+func (f fakeReader) ListInterfaces(context.Context, string) ([]*topology.Interface, error) {
 	return f.interfaces, nil
 }
 
-func (f fakeReader) ListLinks(context.Context, string) ([]*database.TopologyLink, error) {
+func (f fakeReader) ListLinks(context.Context, string) ([]*topology.Link, error) {
 	return f.links, nil
 }
 
 func (f fakeReader) ListARPBindings(
 	context.Context,
-	database.TopologyARPListOptions,
-) ([]*database.TopologyARPBinding, error) {
+	topology.ARPListOptions,
+) ([]*topology.ARPBinding, error) {
 	return nil, nil
 }
 
 func TestNodeReturnsDetailForMatch(t *testing.T) {
 	r := fakeReader{
-		nodes:      []*database.TopologyNode{{ID: "a"}, {ID: "b"}},
-		interfaces: []*database.TopologyInterface{{IfName: "eth0"}},
-		links:      []*database.TopologyLink{{LinkType: "lldp"}},
+		nodes:      []*topology.Node{{ID: "a"}, {ID: "b"}},
+		interfaces: []*topology.Interface{{IfName: "eth0"}},
+		links:      []*topology.Link{{LinkType: "lldp"}},
 	}
 	q := topology.NewQueries(r, 1000)
 
@@ -56,7 +55,7 @@ func TestNodeReturnsDetailForMatch(t *testing.T) {
 }
 
 func TestNodeUnknownReturnsNotFound(t *testing.T) {
-	q := topology.NewQueries(fakeReader{nodes: []*database.TopologyNode{{ID: "a"}}}, 1000)
+	q := topology.NewQueries(fakeReader{nodes: []*topology.Node{{ID: "a"}}}, 1000)
 	if _, err := q.Node(context.Background(), "missing"); !errors.Is(err, topology.ErrNodeNotFound) {
 		t.Errorf("want ErrNodeNotFound, got %v", err)
 	}

--- a/internal/topology/sysinfo_reconciler.go
+++ b/internal/topology/sysinfo_reconciler.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 )
 
 // SysInfoReconcilerName is the engine identifier.
@@ -51,7 +51,7 @@ const (
 // observationsReader is the narrowed surface the reconciler needs
 // from the SNMP observations repo. Tests inject a fake.
 type observationsReader interface {
-	List(ctx context.Context, opts database.ListOptions) ([]*database.SNMPObservation, error)
+	List(ctx context.Context, opts observation.ListOptions) ([]*observation.SNMPObservation, error)
 }
 
 // nodeUpserter is the narrowed surface for topology_nodes writes.
@@ -60,7 +60,7 @@ type observationsReader interface {
 // can resolve their observations to the right node without re-
 // decoding sysinfo on every pass.
 type nodeUpserter interface {
-	Upsert(ctx context.Context, node *database.TopologyNode) (*database.TopologyNode, error)
+	Upsert(ctx context.Context, node *Node) (*Node, error)
 	UpsertTargetNode(
 		ctx context.Context,
 		clientID, targetID, nodeID string,
@@ -215,7 +215,7 @@ func (r *SysInfoReconciler) reconcileOnceInner(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)
 	}
-	observations, err := r.obs.List(ctx, database.ListOptions{
+	observations, err := r.obs.List(ctx, observation.ListOptions{
 		Kind:  "sys_info",
 		Since: since,
 		Limit: defaultBatchLimit,
@@ -285,11 +285,11 @@ type sysInfoPayload struct {
 	SysContact  string `json:"SysContact"`
 }
 
-// buildNode decodes the observation payload into a TopologyNode
+// buildNode decodes the observation payload into a Node
 // ready for upsert.
 func (r *SysInfoReconciler) buildNode(
-	obs *database.SNMPObservation,
-) (*database.TopologyNode, error) {
+	obs *observation.SNMPObservation,
+) (*Node, error) {
 	var p sysInfoPayload
 	if err := json.Unmarshal([]byte(obs.PayloadJSON), &p); err != nil {
 		return nil, fmt.Errorf("unmarshal sysinfo payload: %w", err)
@@ -313,7 +313,7 @@ func (r *SysInfoReconciler) buildNode(
 		"sys_contact":  p.SysContact,
 	})
 
-	node := &database.TopologyNode{
+	node := &Node{
 		ID:           "node-" + hash[:16],
 		ClientID:     obs.ClientID,
 		IdentityHash: hash,

--- a/internal/topology/sysinfo_reconciler_test.go
+++ b/internal/topology/sysinfo_reconciler_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 	"github.com/MustardSeedNetworks/seed/internal/topology"
 )
 
@@ -18,14 +18,14 @@ func at() time.Time              { return time.Date(2026, 5, 31, 12, 0, 0, 0, ti
 
 type fakeObservations struct {
 	mu      sync.Mutex
-	rows    []*database.SNMPObservation
+	rows    []*observation.SNMPObservation
 	listErr error
 }
 
 func (f *fakeObservations) List(
 	_ context.Context,
-	opts database.ListOptions,
-) ([]*database.SNMPObservation, error) {
+	opts observation.ListOptions,
+) ([]*observation.SNMPObservation, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.listErr != nil {
@@ -33,7 +33,7 @@ func (f *fakeObservations) List(
 	}
 	// Honor the kind filter so reconcilers that fan out across
 	// multiple kinds (lldp/cdp/fdp) don't see each other's rows.
-	out := make([]*database.SNMPObservation, 0, len(f.rows))
+	out := make([]*observation.SNMPObservation, 0, len(f.rows))
 	for _, row := range f.rows {
 		if opts.Kind != "" && row.Kind != opts.Kind {
 			continue
@@ -45,7 +45,7 @@ func (f *fakeObservations) List(
 
 type fakeNodes struct {
 	mu        sync.Mutex
-	upserts   []*database.TopologyNode
+	upserts   []*topology.Node
 	mappings  []targetNodeMapping
 	upsertErr error
 }
@@ -57,8 +57,8 @@ type targetNodeMapping struct {
 
 func (f *fakeNodes) Upsert(
 	_ context.Context,
-	node *database.TopologyNode,
-) (*database.TopologyNode, error) {
+	node *topology.Node,
+) (*topology.Node, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.upsertErr != nil {
@@ -121,8 +121,8 @@ func payload(client, target, sysName, sysObjectID string) string {
 func obs(
 	client, target, sysName, sysObjectID string,
 	observed time.Time,
-) *database.SNMPObservation {
-	return &database.SNMPObservation{
+) *observation.SNMPObservation {
+	return &observation.SNMPObservation{
 		ClientID:    client,
 		TargetID:    target,
 		Kind:        "sys_info",
@@ -176,7 +176,7 @@ func TestNew_EngineName(t *testing.T) {
 
 func TestReconcileOnce_UpsertsOneNodePerObservation(t *testing.T) {
 	t.Parallel()
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		obs("client-a", "t-1", "router-1", "1.3.6.1.4.1.9.1.123", at()),
 		obs("client-a", "t-2", "router-2", "1.3.6.1.4.1.9.1.456", at()),
 	}}
@@ -204,7 +204,7 @@ func TestReconcileOnce_PersistsHighWaterMark(t *testing.T) {
 	t.Parallel()
 	old := at().Add(-1 * time.Hour)
 	newer := at()
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		obs("c", "t-1", "h-1", "1.3.6.1.4.1.9.1.1", newer),
 		obs("c", "t-2", "h-2", "1.3.6.1.4.1.9.1.2", old),
 	}}
@@ -230,7 +230,7 @@ func TestReconcileOnce_IdentityHashMergesObservationsFromSameDevice(t *testing.T
 	t.Parallel()
 	// Same client + sysName + sysObjectID across two observations
 	// at different times -> same identity_hash -> same node.
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		obs("c", "t-1", "router-1", "1.3.6.1.4.1.9.1.1", at().Add(-1*time.Minute)),
 		obs("c", "t-1", "router-1", "1.3.6.1.4.1.9.1.1", at()),
 	}}
@@ -252,7 +252,7 @@ func TestReconcileOnce_IdentityHashMergesObservationsFromSameDevice(t *testing.T
 
 func TestReconcileOnce_DifferentClientsGetDifferentNodes(t *testing.T) {
 	t.Parallel()
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		obs("client-a", "t-1", "router-1", "1.3.6.1.4.1.9.1.1", at()),
 		obs("client-b", "t-1", "router-1", "1.3.6.1.4.1.9.1.1", at()),
 	}}
@@ -303,7 +303,7 @@ func TestReconcileOnce_ListErrorPropagates(t *testing.T) {
 
 func TestReconcileOnce_UpsertFailureContinuesBatch(t *testing.T) {
 	t.Parallel()
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		obs("c", "t-1", "h-1", "1.3.6.1.4.1.9.1.1", at()),
 		obs("c", "t-2", "h-2", "1.3.6.1.4.1.9.1.2", at()),
 	}}
@@ -329,7 +329,7 @@ func TestReconcileOnce_UpsertFailureContinuesBatch(t *testing.T) {
 func TestReconcileOnce_SkipsObservationWithoutIdentity(t *testing.T) {
 	t.Parallel()
 	// Empty SysName + SysObjectID — buildNode rejects this.
-	o := &fakeObservations{rows: []*database.SNMPObservation{
+	o := &fakeObservations{rows: []*observation.SNMPObservation{
 		obs("c", "t-1", "", "", at()),
 	}}
 	n := &fakeNodes{}

--- a/internal/topology/types.go
+++ b/internal/topology/types.go
@@ -1,0 +1,101 @@
+package topology
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrTopologyNodeNotFound is returned when a node lookup misses.
+var ErrTopologyNodeNotFound = errors.New("topology node not found")
+
+// Node is one row of topology_nodes. The fat-Node carries
+// every observation source's contribution: identity from sys_info,
+// per-interface state from if_table (folded into MetadataJSON),
+// addresses from arp, neighbors from lldp/cdp/fdp. Reconcilers in
+// internal/topology own writes; alert rules + the operator UI own
+// reads.
+type Node struct {
+	ID           string
+	ClientID     string
+	IdentityHash string
+	DisplayName  string
+	DeviceType   string
+	ChassisID    string
+	SysName      string
+	PrimaryMAC   string
+	PrimaryIP    string
+	FirstSeen    time.Time
+	LastSeen     time.Time
+	ExpiresAt    time.Time
+	MetadataJSON string
+}
+
+// ListOptions narrows a topology_nodes query.
+type ListOptions struct {
+	ClientID   string
+	DeviceType string
+	SeenSince  time.Time
+	Limit      int
+}
+
+// ARPBinding mirrors one row of topology_arp_bindings.
+// Reconciled from arp observations; the row's MAC is the join key
+// used to backfill node.primary_ip when a binding matches a known
+// node's chassis/primary MAC.
+type ARPBinding struct {
+	ID           int64
+	ClientID     string
+	SourceNodeID string
+	IfIndex      uint32
+	IPAddress    string
+	MACAddress   string
+	MediaType    int
+	LastSeen     time.Time
+}
+
+// ARPListOptions filters the ListARPBindings query.
+// Empty fields mean "no filter".
+type ARPListOptions struct {
+	ClientID     string
+	SourceNodeID string
+	Since        time.Time
+	Limit        int
+}
+
+// Link mirrors one row of topology_links. Edges are
+// identity-merged the same way nodes are — the link ID is derived
+// from (source_node, source_interface, target_node, target_interface)
+// so re-observations of the same physical cable upsert rather than
+// duplicate.
+type Link struct {
+	ID              string
+	SourceNodeID    string
+	TargetNodeID    string
+	SourceInterface string
+	TargetInterface string
+	LinkType        string // "lldp", "cdp", "fdp"
+	Status          string // "up", "down", "unknown"
+	SpeedMbps       uint32
+	UtilizationPct  float64
+	FirstSeen       time.Time
+	LastSeen        time.Time
+	EvidenceJSON    string
+}
+
+// Interface mirrors one row of topology_interfaces.
+// Reconciled from if_table observations; columns shaped so alert
+// rules can index admin/oper status and speed without parsing JSON.
+type Interface struct {
+	ID            int64
+	NodeID        string
+	IfIndex       uint32
+	IfName        string
+	IfDescr       string
+	IfAlias       string
+	IfType        uint32
+	IfAdminStatus int
+	IfOperStatus  int
+	IfPhysAddr    string
+	SpeedBps      uint64
+	LastSeen      time.Time
+}


### PR DESCRIPTION
## What

WS-B (Architecture Completion Plan), first of the heavy four. `internal/topology` imported `internal/database` for its own row types — a repository-port-discipline bypass. This relocates the types into the domain that owns them and points the dependency **inward**.

## Change (strategy B: relocate row types into the owning domain package)

- **Topology row types** (`Node`, `Link`, `Interface`, `ARPBinding`, list options, `ErrTopologyNodeNotFound`) → `internal/topology/types.go`. Dropped the stuttering `Topology*` prefix (`topology.Node`, not `topology.TopologyNode`) per ADR-0010 / revive.
- **`SNMPObservation` + its `ListOptions`** → new dependency-light leaf package `internal/polling/observation`. It's shared: the topology reconcilers and the alerts observation pipeline consume it, the SNMP sink produces it — a leaf type package keeps all three off `internal/database` without pulling the SNMP poller's deps.
- **`TopologyRepository` / `SNMPObservationsRepository`** stay in `internal/database` and now **import the domain packages**, mapping SQL rows → domain types. `internal/database` depends on the domain (inward); `internal/topology` no longer imports `internal/database` at all.
- A topology→database import is now a hard **compile-time import cycle**; the new `topology-no-persistence` depguard rule is the documented belt-and-suspenders (consistent with `reporting-*`).
- **Pre-v1 no-compat:** removed the deprecated `database.*` type aliases that were staged as a migration shim — every consumer (`internal/api`, `internal/app`, SNMP sink, alerts pipeline) uses the relocated types directly.

## Evidence
- `go build ./...` clean
- `go test -race` green: topology, polling/**, alerts/**, app, plus targeted database + api topology/SNMP suites
- `golangci-lint run` on touched packages → 0 issues (stutter resolved; golines/gofumpt clean). depguard GREEN; topology→database is a compile-time cycle.
- `scripts/check-filename-policy.sh` + `scripts/check-output-escaping.sh` pass · gofmt clean · gitleaks clean
- Confirmed: `internal/topology` production code has **zero** `internal/database` imports.

Note: branched before #1672 (probe WS-B1) merged — will rebase the `.golangci.yml` rule region on top of it.

Next in WS-B: polling (`PollingTarget`), alerts/pipeline (`Alert*`, `ListenerEvent`), identity (auth-coordinate).