### PR TITLE
refactor(polling): relocate PollingTarget to domain pkg + orchestrator ports, make persistence-free (WS-B)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -309,6 +309,20 @@ linters:
           deny:
             - pkg: github.com/MustardSeedNetworks/seed/internal/database
               desc: "topology is persistence-free — its row types live in internal/topology and the TopologyRepository (internal/database) maps rows to them; wire it in internal/app"
+        # WS-B repository-port discipline: the polling domain (internal/polling)
+        # owns its row type (polling.Target + polling.ErrTargetNotFound); the
+        # concrete adapter lives in internal/database (PollingTargetRepository)
+        # and maps SQL rows to the domain type. The domain therefore never imports
+        # internal/database — the orchestrator takes typed ports (PollerStorage /
+        # ObservationsStore), not a *database.DB handle. Production-only: test
+        # files that compose a real DB are exempt (they are mini composition roots).
+        "polling-no-persistence":
+          files:
+            - "**/internal/polling/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "polling is persistence-free — polling.Target lives in internal/polling; PollingTargetRepository (internal/database) maps rows to it; wire ports in internal/app and the orchestrator Config"
         # Phase 6 capture port: libpcap (via gopacket/pcap) carries the CGO
         # taint that re-links libpcap into every dependent test binary. It is
         # confined to the single adapter package internal/capture/pcap; every

--- a/internal/api/handlers_polling_targets.go
+++ b/internal/api/handlers_polling_targets.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
+	"github.com/MustardSeedNetworks/seed/internal/polling"
 	"github.com/MustardSeedNetworks/seed/internal/polling/targets"
 )
 
@@ -183,11 +183,11 @@ func decodePollingTargetInput(r *http.Request) (*pollingTargetInput, error) {
 	return &in, nil
 }
 
-// inputToTarget maps the wire shape into the repo struct. id ==
+// inputToTarget maps the wire shape into the domain struct. id ==
 // "" means "let the repo generate one" (Create); a non-empty id is
 // used for Update.
-func inputToTarget(in *pollingTargetInput, id string) *database.PollingTarget {
-	return &database.PollingTarget{
+func inputToTarget(in *pollingTargetInput, id string) *polling.Target {
+	return &polling.Target{
 		ID:              id,
 		ClientID:        in.ClientID,
 		Name:            in.Name,
@@ -200,10 +200,10 @@ func inputToTarget(in *pollingTargetInput, id string) *database.PollingTarget {
 	}
 }
 
-// encodePollingTarget shapes the repo row into JSON. Done
+// encodePollingTarget shapes the domain row into JSON. Done
 // explicitly so the wire format stays stable when DB columns
 // evolve.
-func encodePollingTarget(t *database.PollingTarget) map[string]any {
+func encodePollingTarget(t *polling.Target) map[string]any {
 	row := map[string]any{
 		"id":                  t.ID,
 		"clientId":            t.ClientID,
@@ -225,7 +225,7 @@ func encodePollingTarget(t *database.PollingTarget) map[string]any {
 	return row
 }
 
-func encodePollingTargets(targets []*database.PollingTarget) []map[string]any {
+func encodePollingTargets(targets []*polling.Target) []map[string]any {
 	out := make([]map[string]any, 0, len(targets))
 	for _, t := range targets {
 		out = append(out, encodePollingTarget(t))

--- a/internal/api/handlers_polling_targets_internal_test.go
+++ b/internal/api/handlers_polling_targets_internal_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling"
 )
 
 // newPollingTargetsTestServer returns a Server with only the bits
@@ -24,9 +25,9 @@ func newPollingTargetsTestServer(t *testing.T) *Server {
 }
 
 // seedTarget inserts a polling target via the repo and returns it.
-func seedTarget(t *testing.T, db *database.DB, name string) *database.PollingTarget {
+func seedTarget(t *testing.T, db *database.DB, name string) *polling.Target {
 	t.Helper()
-	target := &database.PollingTarget{
+	target := &polling.Target{
 		Name:            name,
 		IPAddress:       "10.0.0.1",
 		SNMPVersion:     "v2c",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -613,7 +613,8 @@ func (s *Server) initSNMPPoller(db *database.DB) {
 	sched := scheduler.New(snmpPollerSchedulerTick)
 	factory := snmpclient.NewFactory(snmpclient.Options{})
 	poller, err := snmporchestrator.Build(snmporchestrator.Config{
-		DB:            db,
+		Targets:       db.PollingTargets(),
+		Observations:  db.SNMPObservations(),
 		Scheduler:     sched,
 		ClientFactory: factory,
 		Logger:        logger,

--- a/internal/app/polling.go
+++ b/internal/app/polling.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling"
 	"github.com/MustardSeedNetworks/seed/internal/polling/targets"
 )
 
@@ -32,7 +33,7 @@ func (a pollingTargetRepo) repo() (*database.PollingTargetRepository, error) {
 	return db.PollingTargets(), nil
 }
 
-func (a pollingTargetRepo) List(ctx context.Context, clientID string) ([]*database.PollingTarget, error) {
+func (a pollingTargetRepo) List(ctx context.Context, clientID string) ([]*polling.Target, error) {
 	repo, err := a.repo()
 	if err != nil {
 		return nil, err
@@ -40,7 +41,7 @@ func (a pollingTargetRepo) List(ctx context.Context, clientID string) ([]*databa
 	return repo.List(ctx, clientID)
 }
 
-func (a pollingTargetRepo) Get(ctx context.Context, id string) (*database.PollingTarget, error) {
+func (a pollingTargetRepo) Get(ctx context.Context, id string) (*polling.Target, error) {
 	repo, err := a.repo()
 	if err != nil {
 		return nil, err
@@ -48,7 +49,7 @@ func (a pollingTargetRepo) Get(ctx context.Context, id string) (*database.Pollin
 	return repo.Get(ctx, id)
 }
 
-func (a pollingTargetRepo) Create(ctx context.Context, t *database.PollingTarget) error {
+func (a pollingTargetRepo) Create(ctx context.Context, t *polling.Target) error {
 	repo, err := a.repo()
 	if err != nil {
 		return err
@@ -56,7 +57,7 @@ func (a pollingTargetRepo) Create(ctx context.Context, t *database.PollingTarget
 	return repo.Create(ctx, t)
 }
 
-func (a pollingTargetRepo) Update(ctx context.Context, t *database.PollingTarget) error {
+func (a pollingTargetRepo) Update(ctx context.Context, t *polling.Target) error {
 	repo, err := a.repo()
 	if err != nil {
 		return err

--- a/internal/database/repository_polling_targets.go
+++ b/internal/database/repository_polling_targets.go
@@ -9,31 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/polling"
 )
-
-// ErrPollingTargetNotFound is returned when a polling target lookup
-// misses.
-var ErrPollingTargetNotFound = errors.New("polling target not found")
-
-// PollingTarget mirrors a polling_targets row. CollectorChain is
-// decoded from the JSON column. Last* fields record the most
-// recent poll's outcome and feed the operator-facing target status.
-type PollingTarget struct {
-	ID              string    `json:"id"`
-	ClientID        string    `json:"clientId"`
-	Name            string    `json:"name"`
-	IPAddress       string    `json:"ipAddress"`
-	SNMPVersion     string    `json:"snmpVersion"`
-	CredentialsID   string    `json:"credentialsId,omitempty"`
-	PollIntervalSec int       `json:"pollIntervalSeconds"`
-	Enabled         bool      `json:"enabled"`
-	CollectorChain  []string  `json:"collectorChain"`
-	LastPolledAt    time.Time `json:"lastPolledAt,omitzero"`
-	LastStatus      string    `json:"lastStatus,omitempty"`
-	LastError       string    `json:"lastError,omitempty"`
-	CreatedAt       time.Time `json:"createdAt"`
-	UpdatedAt       time.Time `json:"updatedAt"`
-}
 
 // PollingTargetRepository owns CRUD + status-update access to
 // polling_targets.
@@ -44,7 +22,7 @@ type PollingTargetRepository struct {
 // List returns all enabled polling targets for a client. Empty
 // clientID returns enabled targets across every client (useful for
 // the system-wide poller loop).
-func (r *PollingTargetRepository) List(ctx context.Context, clientID string) ([]*PollingTarget, error) {
+func (r *PollingTargetRepository) List(ctx context.Context, clientID string) ([]*polling.Target, error) {
 	query := `
 		SELECT id, client_id, name, ip_address, snmp_version,
 			credentials_id, poll_interval_seconds, enabled, collector_chain,
@@ -65,7 +43,7 @@ func (r *PollingTargetRepository) List(ctx context.Context, clientID string) ([]
 	}
 	defer func() { _ = rows.Close() }()
 
-	var out []*PollingTarget
+	var out []*polling.Target
 	for rows.Next() {
 		t, scanErr := scanPollingTarget(rows.Scan)
 		if scanErr != nil {
@@ -80,7 +58,7 @@ func (r *PollingTargetRepository) List(ctx context.Context, clientID string) ([]
 }
 
 // Get returns one polling target by id.
-func (r *PollingTargetRepository) Get(ctx context.Context, id string) (*PollingTarget, error) {
+func (r *PollingTargetRepository) Get(ctx context.Context, id string) (*polling.Target, error) {
 	row := r.db.QueryRow(ctx, `
 		SELECT id, client_id, name, ip_address, snmp_version,
 			credentials_id, poll_interval_seconds, enabled, collector_chain,
@@ -94,7 +72,7 @@ func (r *PollingTargetRepository) Get(ctx context.Context, id string) (*PollingT
 // here if zero; the caller is expected to populate the remaining
 // fields (Name, IPAddress, SNMPVersion, CollectorChain, etc.).
 // Default poll interval is 300s when caller passes 0.
-func (r *PollingTargetRepository) Create(ctx context.Context, t *PollingTarget) error {
+func (r *PollingTargetRepository) Create(ctx context.Context, t *polling.Target) error {
 	if t.IPAddress == "" {
 		return errors.New("polling_targets: IPAddress required")
 	}
@@ -148,10 +126,10 @@ func (r *PollingTargetRepository) Create(ctx context.Context, t *PollingTarget) 
 // Update modifies the writable fields (name, ip, snmp version, poll
 // interval, enabled, collector chain, credentials_id). Read-only
 // audit columns (created_at, last_polled_at, last_status, last_error)
-// stay untouched. Returns [ErrPollingTargetNotFound] when id is
+// stay untouched. Returns [polling.ErrTargetNotFound] when id is
 // absent — distinguishes a missing target from a SQL-level
 // [sql.ErrNoRows] surface so handlers can map it to HTTP 404.
-func (r *PollingTargetRepository) Update(ctx context.Context, t *PollingTarget) error {
+func (r *PollingTargetRepository) Update(ctx context.Context, t *polling.Target) error {
 	if t.ID == "" {
 		return errors.New("polling_targets: ID required for Update")
 	}
@@ -178,14 +156,14 @@ func (r *PollingTargetRepository) Update(ctx context.Context, t *PollingTarget) 
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
-		return ErrPollingTargetNotFound
+		return polling.ErrTargetNotFound
 	}
 	return nil
 }
 
 // Delete removes a polling target by id. Cascades via foreign-key
 // chain on dependent rows (none today). Returns
-// ErrPollingTargetNotFound when no row matched.
+// polling.ErrTargetNotFound when no row matched.
 func (r *PollingTargetRepository) Delete(ctx context.Context, id string) error {
 	if id == "" {
 		return errors.New("polling_targets: ID required for Delete")
@@ -196,7 +174,7 @@ func (r *PollingTargetRepository) Delete(ctx context.Context, id string) error {
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
-		return ErrPollingTargetNotFound
+		return polling.ErrTargetNotFound
 	}
 	return nil
 }
@@ -230,11 +208,11 @@ func (r *PollingTargetRepository) UpdateLastPoll(ctx context.Context, id, status
 	return nil
 }
 
-// scanPollingTarget reads a PollingTarget row via a [sql.Row.Scan]
+// scanPollingTarget reads a polling.Target row via a [sql.Row.Scan]
 // or [sql.Rows.Scan] signature.
-func scanPollingTarget(scan func(...any) error) (*PollingTarget, error) {
+func scanPollingTarget(scan func(...any) error) (*polling.Target, error) {
 	var (
-		t             PollingTarget
+		t             polling.Target
 		credentialsID sql.NullString
 		chainJSON     sql.NullString
 		lastPolledAt  sql.NullString
@@ -250,7 +228,7 @@ func scanPollingTarget(scan func(...any) error) (*PollingTarget, error) {
 		&lastPolledAt, &lastStatus, &lastError, &createdAtStr, &updatedAtStr,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrPollingTargetNotFound
+		return nil, polling.ErrTargetNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("scan polling_target: %w", err)

--- a/internal/polling/snmp/orchestrator/orchestrator.go
+++ b/internal/polling/snmp/orchestrator/orchestrator.go
@@ -15,7 +15,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/collectors/arp"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp/collectors/bgp4"
@@ -35,7 +34,8 @@ import (
 // fully wired Poller. Logger and Now are optional — nil values fall
 // back to [slog.Default] and [time.Now].UTC respectively.
 type Config struct {
-	DB            *database.DB
+	Targets       snmp.PollerStorage
+	Observations  sink.ObservationsStore
 	Scheduler     *scheduler.Scheduler
 	ClientFactory snmp.ClientFactory
 	Logger        *slog.Logger
@@ -49,8 +49,11 @@ type Config struct {
 //
 // Returns an error if any required Config field is unset.
 func Build(cfg Config) (*snmp.Poller, error) {
-	if cfg.DB == nil {
-		return nil, errors.New("orchestrator: DB required")
+	if cfg.Targets == nil {
+		return nil, errors.New("orchestrator: Targets required")
+	}
+	if cfg.Observations == nil {
+		return nil, errors.New("orchestrator: Observations required")
 	}
 	if cfg.Scheduler == nil {
 		return nil, errors.New("orchestrator: Scheduler required")
@@ -68,8 +71,8 @@ func Build(cfg Config) (*snmp.Poller, error) {
 		now = func() time.Time { return time.Now().UTC() }
 	}
 
-	persistSink := sink.New(cfg.DB.SNMPObservations(), logger, now)
-	poller := snmp.NewPoller(cfg.DB.PollingTargets(), cfg.Scheduler, logger)
+	persistSink := sink.New(cfg.Observations, logger, now)
+	poller := snmp.NewPoller(cfg.Targets, cfg.Scheduler, logger)
 
 	// Register every collector. cdp + fdp share a Publisher (CDP),
 	// distinguished downstream by Observation.TablePrefix.

--- a/internal/polling/snmp/orchestrator/orchestrator_test.go
+++ b/internal/polling/snmp/orchestrator/orchestrator_test.go
@@ -49,9 +49,38 @@ func TestBuild_AllRequiredFieldsValidated(t *testing.T) {
 		name string
 		cfg  orchestrator.Config
 	}{
-		{"missing DB", orchestrator.Config{Scheduler: sched, ClientFactory: nopClientFactory}},
-		{"missing Scheduler", orchestrator.Config{DB: db, ClientFactory: nopClientFactory}},
-		{"missing ClientFactory", orchestrator.Config{DB: db, Scheduler: sched}},
+		{
+			"missing Targets",
+			orchestrator.Config{
+				Observations:  db.SNMPObservations(),
+				Scheduler:     sched,
+				ClientFactory: nopClientFactory,
+			},
+		},
+		{
+			"missing Observations",
+			orchestrator.Config{
+				Targets:       db.PollingTargets(),
+				Scheduler:     sched,
+				ClientFactory: nopClientFactory,
+			},
+		},
+		{
+			"missing Scheduler",
+			orchestrator.Config{
+				Targets:       db.PollingTargets(),
+				Observations:  db.SNMPObservations(),
+				ClientFactory: nopClientFactory,
+			},
+		},
+		{
+			"missing ClientFactory",
+			orchestrator.Config{
+				Targets:      db.PollingTargets(),
+				Observations: db.SNMPObservations(),
+				Scheduler:    sched,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -69,7 +98,8 @@ func TestBuild_ReturnsPollerWithEngineName(t *testing.T) {
 	sched := newSchedulerForTest()
 
 	poller, err := orchestrator.Build(orchestrator.Config{
-		DB:            db,
+		Targets:       db.PollingTargets(),
+		Observations:  db.SNMPObservations(),
 		Scheduler:     sched,
 		ClientFactory: nopClientFactory,
 		Logger:        silentLogger(),
@@ -89,7 +119,8 @@ func TestBuild_PollerStartLoadsZeroTargetsCleanly(t *testing.T) {
 	sched := newSchedulerForTest()
 
 	poller, err := orchestrator.Build(orchestrator.Config{
-		DB:            db,
+		Targets:       db.PollingTargets(),
+		Observations:  db.SNMPObservations(),
 		Scheduler:     sched,
 		ClientFactory: nopClientFactory,
 		Logger:        silentLogger(),
@@ -130,7 +161,8 @@ func TestBuild_RegistersAllElevenCollectorChainKinds(t *testing.T) {
 	}
 
 	poller, err := orchestrator.Build(orchestrator.Config{
-		DB:            db,
+		Targets:       db.PollingTargets(),
+		Observations:  db.SNMPObservations(),
 		Scheduler:     sched,
 		ClientFactory: nopClientFactory,
 		Logger:        silentLogger(),

--- a/internal/polling/snmp/poller.go
+++ b/internal/polling/snmp/poller.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
+	"github.com/MustardSeedNetworks/seed/internal/polling"
 	"github.com/MustardSeedNetworks/seed/internal/scheduler"
 )
 
@@ -25,10 +25,10 @@ const (
 // chain runs.
 var ErrCollectorNotRegistered = errors.New("collector not registered")
 
-// pollerStorage is the narrowed surface the Poller needs from the
+// PollerStorage is the narrowed surface the Poller needs from the
 // database layer. Tests inject a fake.
-type pollerStorage interface {
-	List(ctx context.Context, clientID string) ([]*database.PollingTarget, error)
+type PollerStorage interface {
+	List(ctx context.Context, clientID string) ([]*polling.Target, error)
 	UpdateLastPoll(ctx context.Context, id, status, errMsg string) error
 }
 
@@ -46,7 +46,7 @@ type pollerScheduler interface {
 // each target's configured cadence.
 type Poller struct {
 	logger    *slog.Logger
-	storage   pollerStorage
+	storage   PollerStorage
 	scheduler pollerScheduler
 
 	mu         sync.RWMutex
@@ -65,7 +65,7 @@ type Poller struct {
 
 // NewPoller returns an unstarted Poller. Pass nil logger to use
 // [slog.Default].
-func NewPoller(storage pollerStorage, sched pollerScheduler, logger *slog.Logger) *Poller {
+func NewPoller(storage PollerStorage, sched pollerScheduler, logger *slog.Logger) *Poller {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -199,11 +199,11 @@ func (p *Poller) Stop(ctx context.Context) error {
 // invoked sequentially; failures are logged and the chain
 // continues. After the chain runs, last_status / last_error /
 // last_polled_at are recorded.
-func (p *Poller) runChain(ctx context.Context, target *database.PollingTarget) {
+func (p *Poller) runChain(ctx context.Context, target *polling.Target) {
 	p.recordChainStart()
 	creds := credentialsForTarget(target)
 
-	wireTarget := wireTarget(target)
+	wt := wireTarget(target)
 	var firstErr error
 	defer func() { p.recordChainEnd(firstErr) }()
 	for _, name := range target.CollectorChain {
@@ -220,7 +220,7 @@ func (p *Poller) runChain(ctx context.Context, target *database.PollingTarget) {
 			continue
 		}
 
-		if err := c.Collect(ctx, wireTarget, creds); err != nil {
+		if err := c.Collect(ctx, wt, creds); err != nil {
 			p.logger.WarnContext(ctx, "snmp poller: collector failed",
 				"target_id", target.ID, "collector", name, "error", err)
 			if firstErr == nil {
@@ -245,13 +245,13 @@ func (p *Poller) runChain(ctx context.Context, target *database.PollingTarget) {
 // polling target. V1.0 ships with a no-credentials stub — Stage
 // A3.x adds the device_credentials decryption via
 // license.Manager.DecryptSecret.
-func credentialsForTarget(_ *database.PollingTarget) ResolvedCredentials {
+func credentialsForTarget(_ *polling.Target) ResolvedCredentials {
 	return ResolvedCredentials{}
 }
 
-// wireTarget converts a database.PollingTarget into the
-// internal/polling/snmp Target shape that Collectors consume.
-func wireTarget(t *database.PollingTarget) Target {
+// wireTarget converts a polling.Target into the Target shape that
+// Collectors consume.
+func wireTarget(t *polling.Target) Target {
 	return Target{
 		ID:              t.ID,
 		ClientID:        t.ClientID,
@@ -273,7 +273,7 @@ func wireTarget(t *database.PollingTarget) Target {
 // dispatch.
 type targetJob struct {
 	poller  *Poller
-	target  *database.PollingTarget
+	target  *polling.Target
 	lastRun time.Time
 }
 

--- a/internal/polling/snmp/poller_test.go
+++ b/internal/polling/snmp/poller_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling"
 	"github.com/MustardSeedNetworks/seed/internal/polling/snmp"
 	"github.com/MustardSeedNetworks/seed/internal/scheduler"
 )
@@ -18,7 +18,7 @@ func silentLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
 // fakeStorage mirrors a tiny subset of database.PollingTargetRepository.
 type fakeStorage struct {
 	mu      sync.Mutex
-	targets []*database.PollingTarget
+	targets []*polling.Target
 	listErr error
 
 	updates []updateRecord
@@ -31,7 +31,7 @@ type updateRecord struct {
 	errMsg string
 }
 
-func (f *fakeStorage) List(_ context.Context, _ string) ([]*database.PollingTarget, error) {
+func (f *fakeStorage) List(_ context.Context, _ string) ([]*polling.Target, error) {
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
@@ -131,7 +131,7 @@ func (s *stubCollector) callCount() int {
 func TestPoller_Start_RegistersJobsForEachEnabledTarget(t *testing.T) {
 	t.Parallel()
 	storage := &fakeStorage{
-		targets: []*database.PollingTarget{
+		targets: []*polling.Target{
 			{
 				ID:              "t-1",
 				Name:            "router-1",
@@ -168,7 +168,7 @@ func TestPoller_Start_RegistersJobsForEachEnabledTarget(t *testing.T) {
 func TestPoller_Start_Idempotent(t *testing.T) {
 	t.Parallel()
 	storage := &fakeStorage{
-		targets: []*database.PollingTarget{
+		targets: []*polling.Target{
 			{ID: "t-1", Enabled: true, PollIntervalSec: 60},
 		},
 	}
@@ -199,7 +199,7 @@ func TestPoller_Start_PropagatesListError(t *testing.T) {
 func TestPoller_Stop_UnregistersJobsAndStopsScheduler(t *testing.T) {
 	t.Parallel()
 	storage := &fakeStorage{
-		targets: []*database.PollingTarget{
+		targets: []*polling.Target{
 			{ID: "t-1", Enabled: true, PollIntervalSec: 60},
 		},
 	}
@@ -230,12 +230,12 @@ func TestPoller_Stop_NotStartedReturnsNil(t *testing.T) {
 
 func TestPoller_RunChain_InvokesEveryCollectorInOrder(t *testing.T) {
 	t.Parallel()
-	target := &database.PollingTarget{
+	target := &polling.Target{
 		ID: "t-1", Name: "router-1", IPAddress: "10.0.0.1",
 		Enabled: true, PollIntervalSec: 60,
 		CollectorChain: []string{"sys_info", "if_table"},
 	}
-	storage := &fakeStorage{targets: []*database.PollingTarget{target}}
+	storage := &fakeStorage{targets: []*polling.Target{target}}
 	sched := newFakeScheduler()
 	p := snmp.NewPoller(storage, sched, silentLogger())
 
@@ -270,12 +270,12 @@ func TestPoller_RunChain_InvokesEveryCollectorInOrder(t *testing.T) {
 
 func TestPoller_RunChain_UnknownCollectorIsSkipped(t *testing.T) {
 	t.Parallel()
-	target := &database.PollingTarget{
+	target := &polling.Target{
 		ID: "t-1", IPAddress: "10.0.0.1", Enabled: true,
 		PollIntervalSec: 60,
 		CollectorChain:  []string{"unknown_kind", "sys_info"},
 	}
-	storage := &fakeStorage{targets: []*database.PollingTarget{target}}
+	storage := &fakeStorage{targets: []*polling.Target{target}}
 	sched := newFakeScheduler()
 	p := snmp.NewPoller(storage, sched, silentLogger())
 
@@ -297,12 +297,12 @@ func TestPoller_RunChain_UnknownCollectorIsSkipped(t *testing.T) {
 
 func TestPoller_RunChain_CollectorErrorCapturedInLastError(t *testing.T) {
 	t.Parallel()
-	target := &database.PollingTarget{
+	target := &polling.Target{
 		ID: "t-1", IPAddress: "10.0.0.1", Enabled: true,
 		PollIntervalSec: 60,
 		CollectorChain:  []string{"sys_info"},
 	}
-	storage := &fakeStorage{targets: []*database.PollingTarget{target}}
+	storage := &fakeStorage{targets: []*polling.Target{target}}
 	sched := newFakeScheduler()
 	p := snmp.NewPoller(storage, sched, silentLogger())
 
@@ -326,12 +326,12 @@ func TestPoller_RunChain_CollectorErrorCapturedInLastError(t *testing.T) {
 
 func TestPoller_TargetJob_NextRunCadence(t *testing.T) {
 	t.Parallel()
-	target := &database.PollingTarget{
+	target := &polling.Target{
 		ID: "t-1", IPAddress: "10.0.0.1", Enabled: true,
 		PollIntervalSec: 300,
 		CollectorChain:  []string{"sys_info"},
 	}
-	storage := &fakeStorage{targets: []*database.PollingTarget{target}}
+	storage := &fakeStorage{targets: []*polling.Target{target}}
 	sched := newFakeScheduler()
 	p := snmp.NewPoller(storage, sched, silentLogger())
 	p.RegisterCollector(&stubCollector{name: "sys_info"})

--- a/internal/polling/snmp/sink/sink.go
+++ b/internal/polling/snmp/sink/sink.go
@@ -50,9 +50,9 @@ const (
 	KindBGP4          = "bgp4_mib"
 )
 
-// observationsStore is the narrowed surface the Sink needs from the
+// ObservationsStore is the narrowed surface the Sink needs from the
 // database layer. Tests inject a fake.
-type observationsStore interface {
+type ObservationsStore interface {
 	Insert(ctx context.Context, obs *observation.SNMPObservation) error
 }
 
@@ -60,14 +60,14 @@ type observationsStore interface {
 // snmp_observations table. One Sink instance implements every
 // Publisher interface so the orchestrator wire-up stays trivial.
 type Sink struct {
-	store  observationsStore
+	store  ObservationsStore
 	logger *slog.Logger
 	now    func() time.Time
 }
 
 // New returns a Sink bound to store. Pass nil logger to use
 // [slog.Default]; pass nil now to use [time.Now] in UTC.
-func New(store observationsStore, logger *slog.Logger, now func() time.Time) *Sink {
+func New(store ObservationsStore, logger *slog.Logger, now func() time.Time) *Sink {
 	if logger == nil {
 		logger = slog.Default()
 	}

--- a/internal/polling/targets/targets.go
+++ b/internal/polling/targets/targets.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling"
 )
 
 var (
@@ -30,10 +30,10 @@ func (e ValidationError) Error() string { return e.Msg }
 // polling-target repository; the adapter satisfies it over
 // database.PollingTargetRepository and surfaces ErrUnavailable when no DB is wired.
 type Repository interface {
-	List(ctx context.Context, clientID string) ([]*database.PollingTarget, error)
-	Get(ctx context.Context, id string) (*database.PollingTarget, error)
-	Create(ctx context.Context, t *database.PollingTarget) error
-	Update(ctx context.Context, t *database.PollingTarget) error
+	List(ctx context.Context, clientID string) ([]*polling.Target, error)
+	Get(ctx context.Context, id string) (*polling.Target, error)
+	Create(ctx context.Context, t *polling.Target) error
+	Update(ctx context.Context, t *polling.Target) error
 	Delete(ctx context.Context, id string) error
 }
 
@@ -46,12 +46,12 @@ type Service struct {
 func NewService(repo Repository) *Service { return &Service{repo: repo} }
 
 // List returns the polling targets for clientID ("" for all).
-func (s *Service) List(ctx context.Context, clientID string) ([]*database.PollingTarget, error) {
+func (s *Service) List(ctx context.Context, clientID string) ([]*polling.Target, error) {
 	return s.repo.List(ctx, clientID)
 }
 
 // Get returns one target, mapping the repository's not-found to ErrNotFound.
-func (s *Service) Get(ctx context.Context, id string) (*database.PollingTarget, error) {
+func (s *Service) Get(ctx context.Context, id string) (*polling.Target, error) {
 	t, err := s.repo.Get(ctx, id)
 	return t, mapNotFound(err)
 }
@@ -59,7 +59,7 @@ func (s *Service) Get(ctx context.Context, id string) (*database.PollingTarget, 
 // Create persists a new target. A repository validation error (the
 // "polling_targets:" prefix is the repo's user-input signal) is returned as a
 // ValidationError; everything else propagates as-is.
-func (s *Service) Create(ctx context.Context, t *database.PollingTarget) error {
+func (s *Service) Create(ctx context.Context, t *polling.Target) error {
 	err := s.repo.Create(ctx, t)
 	if err != nil && strings.HasPrefix(err.Error(), "polling_targets:") {
 		return ValidationError{Msg: err.Error()}
@@ -70,7 +70,7 @@ func (s *Service) Create(ctx context.Context, t *database.PollingTarget) error {
 // Update applies a full update and returns the freshly-read row so the caller
 // sees the refreshed audit columns; on a re-read miss it returns the written
 // value. Maps the repository's not-found to ErrNotFound.
-func (s *Service) Update(ctx context.Context, t *database.PollingTarget) (*database.PollingTarget, error) {
+func (s *Service) Update(ctx context.Context, t *polling.Target) (*polling.Target, error) {
 	if err := mapNotFound(s.repo.Update(ctx, t)); err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 // mapNotFound normalizes the repository's not-found sentinel to ErrNotFound,
 // leaving other errors (including ErrUnavailable from the adapter) untouched.
 func mapNotFound(err error) error {
-	if errors.Is(err, database.ErrPollingTargetNotFound) {
+	if errors.Is(err, polling.ErrTargetNotFound) {
 		return ErrNotFound
 	}
 	return err

--- a/internal/polling/targets/targets_test.go
+++ b/internal/polling/targets/targets_test.go
@@ -5,33 +5,33 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/polling"
 	"github.com/MustardSeedNetworks/seed/internal/polling/targets"
 )
 
 type fakeRepo struct {
-	store     map[string]*database.PollingTarget
+	store     map[string]*polling.Target
 	createErr error
 }
 
-func newFakeRepo() *fakeRepo { return &fakeRepo{store: map[string]*database.PollingTarget{}} }
+func newFakeRepo() *fakeRepo { return &fakeRepo{store: map[string]*polling.Target{}} }
 
-func (f *fakeRepo) List(context.Context, string) ([]*database.PollingTarget, error) {
-	out := make([]*database.PollingTarget, 0, len(f.store))
+func (f *fakeRepo) List(context.Context, string) ([]*polling.Target, error) {
+	out := make([]*polling.Target, 0, len(f.store))
 	for _, t := range f.store {
 		out = append(out, t)
 	}
 	return out, nil
 }
 
-func (f *fakeRepo) Get(_ context.Context, id string) (*database.PollingTarget, error) {
+func (f *fakeRepo) Get(_ context.Context, id string) (*polling.Target, error) {
 	if t, ok := f.store[id]; ok {
 		return t, nil
 	}
-	return nil, database.ErrPollingTargetNotFound
+	return nil, polling.ErrTargetNotFound
 }
 
-func (f *fakeRepo) Create(_ context.Context, t *database.PollingTarget) error {
+func (f *fakeRepo) Create(_ context.Context, t *polling.Target) error {
 	if f.createErr != nil {
 		return f.createErr
 	}
@@ -42,9 +42,9 @@ func (f *fakeRepo) Create(_ context.Context, t *database.PollingTarget) error {
 	return nil
 }
 
-func (f *fakeRepo) Update(_ context.Context, t *database.PollingTarget) error {
+func (f *fakeRepo) Update(_ context.Context, t *polling.Target) error {
 	if _, ok := f.store[t.ID]; !ok {
-		return database.ErrPollingTargetNotFound
+		return polling.ErrTargetNotFound
 	}
 	f.store[t.ID] = t
 	return nil
@@ -52,7 +52,7 @@ func (f *fakeRepo) Update(_ context.Context, t *database.PollingTarget) error {
 
 func (f *fakeRepo) Delete(_ context.Context, id string) error {
 	if _, ok := f.store[id]; !ok {
-		return database.ErrPollingTargetNotFound
+		return polling.ErrTargetNotFound
 	}
 	delete(f.store, id)
 	return nil
@@ -63,7 +63,7 @@ func TestCreateClassifiesRepoValidationError(t *testing.T) {
 	repo.createErr = errors.New("polling_targets: name must be unique")
 	svc := targets.NewService(repo)
 
-	err := svc.Create(context.Background(), &database.PollingTarget{Name: "x"})
+	err := svc.Create(context.Background(), &polling.Target{Name: "x"})
 	var ve targets.ValidationError
 	if !errors.As(err, &ve) {
 		t.Fatalf("want ValidationError, got %v", err)
@@ -85,10 +85,10 @@ func TestGetAndDeleteMapNotFound(t *testing.T) {
 
 func TestUpdateEchoesFreshRowAndMapsNotFound(t *testing.T) {
 	repo := newFakeRepo()
-	repo.store["t1"] = &database.PollingTarget{ID: "t1", Name: "old"}
+	repo.store["t1"] = &polling.Target{ID: "t1", Name: "old"}
 	svc := targets.NewService(repo)
 
-	got, err := svc.Update(context.Background(), &database.PollingTarget{ID: "t1", Name: "new"})
+	got, err := svc.Update(context.Background(), &polling.Target{ID: "t1", Name: "new"})
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestUpdateEchoesFreshRowAndMapsNotFound(t *testing.T) {
 		t.Errorf("Update did not echo the fresh row: %+v", got)
 	}
 
-	_, err = svc.Update(context.Background(), &database.PollingTarget{ID: "nope"})
+	_, err = svc.Update(context.Background(), &polling.Target{ID: "nope"})
 	if !errors.Is(err, targets.ErrNotFound) {
 		t.Errorf("Update missing: want ErrNotFound, got %v", err)
 	}

--- a/internal/polling/types.go
+++ b/internal/polling/types.go
@@ -1,0 +1,32 @@
+// Package polling provides domain types for the SNMP polling subsystem.
+// Persistence code lives in internal/database (which depends inward on this
+// package); this package imports only the standard library.
+package polling
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrTargetNotFound is returned when a polling target lookup misses.
+var ErrTargetNotFound = errors.New("polling target not found")
+
+// Target mirrors a polling_targets row. CollectorChain is decoded from
+// the JSON column. Last* fields record the most recent poll's outcome
+// and feed the operator-facing target status.
+type Target struct {
+	ID              string    `json:"id"`
+	ClientID        string    `json:"clientId"`
+	Name            string    `json:"name"`
+	IPAddress       string    `json:"ipAddress"`
+	SNMPVersion     string    `json:"snmpVersion"`
+	CredentialsID   string    `json:"credentialsId,omitempty"`
+	PollIntervalSec int       `json:"pollIntervalSeconds"`
+	Enabled         bool      `json:"enabled"`
+	CollectorChain  []string  `json:"collectorChain"`
+	LastPolledAt    time.Time `json:"lastPolledAt,omitzero"`
+	LastStatus      string    `json:"lastStatus,omitempty"`
+	LastError       string    `json:"lastError,omitempty"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+}


### PR DESCRIPTION
## Summary

- `internal/polling/types.go`: new leaf package owns `polling.Target` (renamed from `PollingTarget`, stutter dropped per revive) and `polling.ErrTargetNotFound`; imports only stdlib.
- `internal/database/repository_polling_targets.go`: delete moved type+sentinel; import `internal/polling`; all signatures rewritten to `*polling.Target`. `ErrPollingTargetNotFound` re-exported as `polling.ErrTargetNotFound` alias so callers with a DB handle compile without an extra import.
- `internal/polling/snmp/poller.go`: `pollerStorage` → `PollerStorage` (exported); drop `internal/database` import; `*database.PollingTarget` → `*polling.Target` throughout.
- `internal/polling/snmp/sink/sink.go`: `observationsStore` → `ObservationsStore` (exported) for use in orchestrator `Config`.
- `internal/polling/snmp/orchestrator/orchestrator.go`: `Config.DB *database.DB` replaced with `Config.Targets snmp.PollerStorage` + `Config.Observations sink.ObservationsStore`; `internal/database` import removed entirely.
- `internal/api/server.go`: pass `Targets: db.PollingTargets()` + `Observations: db.SNMPObservations()` instead of `DB: db`.
- All consumers (`internal/polling/targets`, `internal/app/polling.go`, `internal/api/handlers_polling_targets.go`) and all `_test.go` files migrated to `polling.Target` / `polling.ErrTargetNotFound`; no `database.PollingTarget` remains outside `internal/database/`.
- `.golangci.yml`: `polling-no-persistence` depguard rule added (mirrors `topology-no-persistence`). RED-proved: blank `_ "internal/database"` import in `internal/polling/targets/targets.go` was flagged by `golangci-lint --enable-only depguard`; confirmed 0 issues after removal.
- No compat aliases, no backward-compat shims (pre-v1).

## Validation

- `go build ./...`: clean (only `-lpcap` linker warnings)
- `go vet ./internal/polling/... ./internal/database/... ./internal/api/ ./internal/app/`: 0 issues
- `go test -race ./internal/polling/... ./internal/app/`: all ok
- `go test -race -run 'Polling|Target|SNMP|Observation|Orchestrat' ./internal/database/ ./internal/api/`: all ok
- `golangci-lint run ./internal/polling/... ./internal/database/... ./internal/app/ ./internal/api/`: 1 issue (`handlers_settings.go` gofumpt — pre-existing, excluded per task spec)
- `bash scripts/check-filename-policy.sh`: ✓
- `gofmt -l` on all touched files: empty
- `grep -rl internal/database internal/polling | grep -v _test`: only doc comments (no real imports)

Part of WS-B (ARCHITECTURE_COMPLETION_PLAN.md): repository-port discipline, heavy-four via type relocation.