### PR TITLE
refactor(alerts): relocate Alert/Rule/ListenerEvent rows to domain pkgs, make persistence-free (WS-B)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -323,6 +323,31 @@ linters:
           deny:
             - pkg: github.com/MustardSeedNetworks/seed/internal/database
               desc: "polling is persistence-free — polling.Target lives in internal/polling; PollingTargetRepository (internal/database) maps rows to it; wire ports in internal/app and the orchestrator Config"
+        # WS-B repository-port discipline: the alert domain (internal/alerts) owns
+        # its row types (alerts.Alert / alerts.Rule / alerts.ListOptions + the
+        # Severity/Type consts + alerts.ErrRuleNotFound); the Alert/AlertRules
+        # repositories in internal/database import internal/alerts and map SQL rows
+        # to them. The alert pipeline/inbox/rules subpackages therefore never import
+        # internal/database. Production-only (tests are mini composition roots).
+        "alerts-no-persistence":
+          files:
+            - "**/internal/alerts/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "alerts is persistence-free — its row types live in internal/alerts; the Alert/AlertRules repositories (internal/database) map rows to them; wire it in internal/app"
+        # WS-B repository-port discipline: the listener domain owns both the live
+        # Event and the persisted listener.EventRecord (+ EventListOptions); the
+        # ListenerEventsRepository in internal/database maps SQL rows to EventRecord.
+        # The sink and listeners build domain values and persist through a port, so
+        # internal/listener never imports internal/database. Production-only.
+        "listener-no-persistence":
+          files:
+            - "**/internal/listener/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "listener is persistence-free — listener.EventRecord lives in internal/listener; the ListenerEventsRepository (internal/database) maps rows to it; wire it in internal/app"
         # Phase 6 capture port: libpcap (via gopacket/pcap) carries the CGO
         # taint that re-links libpcap into every dependent test binary. It is
         # confined to the single adapter package internal/capture/pcap; every

--- a/internal/alerts/inbox/inbox.go
+++ b/internal/alerts/inbox/inbox.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
 )
 
 // ErrUnavailable is returned when the store is not wired (handler → 503).
@@ -18,7 +18,7 @@ var ErrUnavailable = errors.New("inbox: store unavailable")
 // Repository is the alert-store surface the use-case needs: list the alerts the
 // pipelines have written, and mark one acknowledged or resolved.
 type Repository interface {
-	List(ctx context.Context, opts database.AlertListOptions) ([]*database.Alert, error)
+	List(ctx context.Context, opts alerts.ListOptions) ([]*alerts.Alert, error)
 	Acknowledge(ctx context.Context, id int64, username string) error
 	Resolve(ctx context.Context, id int64) error
 }
@@ -32,7 +32,7 @@ type Service struct {
 func NewService(repo Repository) *Service { return &Service{repo: repo} }
 
 // List returns the alerts matching opts.
-func (s *Service) List(ctx context.Context, opts database.AlertListOptions) ([]*database.Alert, error) {
+func (s *Service) List(ctx context.Context, opts alerts.ListOptions) ([]*alerts.Alert, error) {
 	return s.repo.List(ctx, opts)
 }
 

--- a/internal/alerts/inbox/inbox_test.go
+++ b/internal/alerts/inbox/inbox_test.go
@@ -5,21 +5,21 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/alerts/inbox"
-	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
 type fakeRepo struct {
-	listOpts  database.AlertListOptions
+	listOpts  alerts.ListOptions
 	ackID     int64
 	ackUser   string
 	resolveID int64
 	err       error
 }
 
-func (f *fakeRepo) List(_ context.Context, opts database.AlertListOptions) ([]*database.Alert, error) {
+func (f *fakeRepo) List(_ context.Context, opts alerts.ListOptions) ([]*alerts.Alert, error) {
 	f.listOpts = opts
-	return []*database.Alert{{ID: 1}}, f.err
+	return []*alerts.Alert{{ID: 1}}, f.err
 }
 
 func (f *fakeRepo) Acknowledge(_ context.Context, id int64, user string) error {
@@ -37,7 +37,7 @@ func TestServiceDelegates(t *testing.T) {
 	svc := inbox.NewService(repo)
 	ctx := context.Background()
 
-	alerts, err := svc.List(ctx, database.AlertListOptions{Severity: "warning"})
+	alerts, err := svc.List(ctx, alerts.ListOptions{Severity: "warning"})
 	if err != nil || len(alerts) != 1 || repo.listOpts.Severity != "warning" {
 		t.Errorf("List did not delegate: alerts=%v err=%v opts=%+v", alerts, err, repo.listOpts)
 	}
@@ -52,7 +52,7 @@ func TestServiceDelegates(t *testing.T) {
 func TestServicePropagatesRepoError(t *testing.T) {
 	wantErr := errors.New("boom")
 	svc := inbox.NewService(&fakeRepo{err: wantErr})
-	if _, err := svc.List(context.Background(), database.AlertListOptions{}); !errors.Is(err, wantErr) {
+	if _, err := svc.List(context.Background(), alerts.ListOptions{}); !errors.Is(err, wantErr) {
 		t.Errorf("repo error not propagated: %v", err)
 	}
 }

--- a/internal/alerts/pipeline/listener_pipeline.go
+++ b/internal/alerts/pipeline/listener_pipeline.go
@@ -25,8 +25,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
+	"github.com/MustardSeedNetworks/seed/internal/listener"
 )
 
 // ListenerPipelineName is the engine identifier.
@@ -48,12 +49,12 @@ const (
 // listenerReader is the narrowed surface the listener pipeline
 // needs from the listener_events repo. Tests inject a fake.
 type listenerReader interface {
-	List(ctx context.Context, opts database.ListenerEventListOptions) ([]*database.ListenerEvent, error)
+	List(ctx context.Context, opts listener.EventListOptions) ([]*listener.EventRecord, error)
 }
 
 // alertWriter is the narrowed surface for writing alerts.
 type alertWriter interface {
-	Create(ctx context.Context, alert *database.Alert) error
+	Create(ctx context.Context, alert *alerts.Alert) error
 }
 
 // settingsKV is the high-water-mark store. Same shape as
@@ -74,11 +75,11 @@ type Rule struct {
 	ID string
 
 	// Match returns true when this rule applies to evt.
-	Match func(evt *database.ListenerEvent) bool
+	Match func(evt *listener.EventRecord) bool
 
 	// Build returns the alert to write. The returned Source is used
 	// in the suppression fingerprint alongside the rule ID.
-	Build func(evt *database.ListenerEvent) *database.Alert
+	Build func(evt *listener.EventRecord) *alerts.Alert
 
 	// Threshold is how many matching events must accrue inside
 	// Window before this rule fires. Threshold=1 / Window=0 is the
@@ -421,7 +422,7 @@ func (p *ListenerPipeline) scanOnceInner(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("load high-water: %w", err)
 	}
-	events, err := p.events.List(ctx, database.ListenerEventListOptions{
+	events, err := p.events.List(ctx, listener.EventListOptions{
 		Since: since,
 		Limit: defaultBatch,
 	})
@@ -454,7 +455,7 @@ func (p *ListenerPipeline) scanOnceInner(ctx context.Context) error {
 
 // evaluate applies every rule to evt and writes any alerts that
 // match + pass suppression. Returns the count of alerts emitted.
-func (p *ListenerPipeline) evaluate(ctx context.Context, evt *database.ListenerEvent) int {
+func (p *ListenerPipeline) evaluate(ctx context.Context, evt *listener.EventRecord) int {
 	now := p.now()
 	count := 0
 	rules := p.snapshotRules()
@@ -557,12 +558,12 @@ func ruleSyslogSevereLogged() Rule {
 	}
 	return Rule{
 		ID: "syslog.severe",
-		Match: func(evt *database.ListenerEvent) bool {
+		Match: func(evt *listener.EventRecord) bool {
 			return evt.Kind == "syslog-udp" && severeSeverities[evt.Severity]
 		},
-		Build: func(evt *database.ListenerEvent) *database.Alert {
-			return &database.Alert{
-				Type:     database.AlertTypeSystem,
+		Build: func(evt *listener.EventRecord) *alerts.Alert {
+			return &alerts.Alert{
+				Type:     alerts.TypeSystem,
 				Severity: mapSyslogSeverity(evt.Severity),
 				Title:    fmt.Sprintf("Syslog %s from %s", evt.Severity, evt.SourceAddr),
 				Message:  summarize(evt.PayloadJSON, "message"),
@@ -576,16 +577,16 @@ func ruleSyslogSevereLogged() Rule {
 func ruleTrapLinkDown() Rule {
 	return Rule{
 		ID: "trap.linkdown",
-		Match: func(evt *database.ListenerEvent) bool {
+		Match: func(evt *listener.EventRecord) bool {
 			if evt.Kind != "snmp-trap-v2c" {
 				return false
 			}
 			return strings.Contains(evt.PayloadJSON, `"1.3.6.1.6.3.1.1.5.3"`)
 		},
-		Build: func(evt *database.ListenerEvent) *database.Alert {
-			return &database.Alert{
-				Type:     database.AlertTypeConnectivity,
-				Severity: database.AlertSeverityWarning,
+		Build: func(evt *listener.EventRecord) *alerts.Alert {
+			return &alerts.Alert{
+				Type:     alerts.TypeConnectivity,
+				Severity: alerts.SeverityWarning,
 				Title:    "Link down trap from " + evt.SourceAddr,
 				Message:  "SNMP linkDown trap received",
 				Source:   evt.SourceAddr,
@@ -598,16 +599,16 @@ func ruleTrapLinkDown() Rule {
 func ruleTrapAuthFailure() Rule {
 	return Rule{
 		ID: "trap.authfail",
-		Match: func(evt *database.ListenerEvent) bool {
+		Match: func(evt *listener.EventRecord) bool {
 			if evt.Kind != "snmp-trap-v2c" {
 				return false
 			}
 			return strings.Contains(evt.PayloadJSON, `"1.3.6.1.6.3.1.1.5.5"`)
 		},
-		Build: func(evt *database.ListenerEvent) *database.Alert {
-			return &database.Alert{
-				Type:     database.AlertTypeSecurity,
-				Severity: database.AlertSeverityError,
+		Build: func(evt *listener.EventRecord) *alerts.Alert {
+			return &alerts.Alert{
+				Type:     alerts.TypeSecurity,
+				Severity: alerts.SeverityError,
 				Title:    "SNMP authentication failure from " + evt.SourceAddr,
 				Message:  "Repeated authentication failures may indicate a credential probe",
 				Source:   evt.SourceAddr,
@@ -622,13 +623,13 @@ func ruleTrapAuthFailure() Rule {
 func mapSyslogSeverity(s string) string {
 	switch s {
 	case "emergency", "alert", "critical":
-		return database.AlertSeverityCritical
+		return alerts.SeverityCritical
 	case "error":
-		return database.AlertSeverityError
+		return alerts.SeverityError
 	case "warning":
-		return database.AlertSeverityWarning
+		return alerts.SeverityWarning
 	default:
-		return database.AlertSeverityInfo
+		return alerts.SeverityInfo
 	}
 }
 

--- a/internal/alerts/pipeline/listener_pipeline_test.go
+++ b/internal/alerts/pipeline/listener_pipeline_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
+	alertmodel "github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/listener"
 )
 
 func silentLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
@@ -18,28 +19,28 @@ func at() time.Time              { return time.Date(2026, 5, 31, 12, 0, 0, 0, ti
 
 type fakeEvents struct {
 	mu      sync.Mutex
-	rows    []*database.ListenerEvent
+	rows    []*listener.EventRecord
 	listErr error
 }
 
-func (f *fakeEvents) List(_ context.Context, _ database.ListenerEventListOptions) ([]*database.ListenerEvent, error) {
+func (f *fakeEvents) List(_ context.Context, _ listener.EventListOptions) ([]*listener.EventRecord, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	out := make([]*database.ListenerEvent, len(f.rows))
+	out := make([]*listener.EventRecord, len(f.rows))
 	copy(out, f.rows)
 	return out, nil
 }
 
 type fakeAlerts struct {
 	mu        sync.Mutex
-	created   []*database.Alert
+	created   []*alertmodel.Alert
 	createErr error
 }
 
-func (f *fakeAlerts) Create(_ context.Context, alert *database.Alert) error {
+func (f *fakeAlerts) Create(_ context.Context, alert *alertmodel.Alert) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.createErr != nil {
@@ -75,13 +76,13 @@ func (f *fakeSettings) Set(_ context.Context, key, value string) error {
 	return nil
 }
 
-func syslogEvent(severity, source string, observed time.Time, message string) *database.ListenerEvent {
+func syslogEvent(severity, source string, observed time.Time, message string) *listener.EventRecord {
 	payload, _ := json.Marshal(map[string]string{
 		"facility":     "3",
 		"severityName": severity,
 		"message":      message,
 	})
-	return &database.ListenerEvent{
+	return &listener.EventRecord{
 		Kind:        "syslog-udp",
 		ClientID:    "default",
 		SourceAddr:  source,
@@ -91,12 +92,12 @@ func syslogEvent(severity, source string, observed time.Time, message string) *d
 	}
 }
 
-func trapEvent(trapOID, source string, observed time.Time) *database.ListenerEvent {
+func trapEvent(trapOID, source string, observed time.Time) *listener.EventRecord {
 	payload, _ := json.Marshal(map[string]string{
 		"version": "v2c",
 		"trapOid": trapOID,
 	})
-	return &database.ListenerEvent{
+	return &listener.EventRecord{
 		Kind:        "snmp-trap-v2c",
 		ClientID:    "default",
 		SourceAddr:  source,
@@ -127,7 +128,7 @@ func TestNewListenerPipeline_RejectsMissingDeps(t *testing.T) {
 
 func TestScanOnce_SyslogSevereErrorEmitsAlert(t *testing.T) {
 	t.Parallel()
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		syslogEvent("error", "10.0.0.1:514", at(), "SSH login failed for user admin"),
 	}}
 	alerts := &fakeAlerts{}
@@ -141,14 +142,14 @@ func TestScanOnce_SyslogSevereErrorEmitsAlert(t *testing.T) {
 	if len(alerts.created) != 1 {
 		t.Fatalf("alerts = %d, want 1", len(alerts.created))
 	}
-	if alerts.created[0].Severity != database.AlertSeverityError {
+	if alerts.created[0].Severity != alertmodel.SeverityError {
 		t.Errorf("severity = %q, want error", alerts.created[0].Severity)
 	}
 }
 
 func TestScanOnce_SyslogInfoDoesNotAlert(t *testing.T) {
 	t.Parallel()
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		syslogEvent("informational", "10.0.0.1:514", at(), "nightly cron run"),
 	}}
 	alerts := &fakeAlerts{}
@@ -164,7 +165,7 @@ func TestScanOnce_SyslogInfoDoesNotAlert(t *testing.T) {
 
 func TestScanOnce_TrapLinkDownEmitsConnectivityAlert(t *testing.T) {
 	t.Parallel()
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		trapEvent("1.3.6.1.6.3.1.1.5.3", "10.0.0.5:0", at()),
 	}}
 	alerts := &fakeAlerts{}
@@ -177,14 +178,14 @@ func TestScanOnce_TrapLinkDownEmitsConnectivityAlert(t *testing.T) {
 		t.Fatalf("alerts = %d, want 1", len(alerts.created))
 	}
 	a := alerts.created[0]
-	if a.Type != database.AlertTypeConnectivity || a.Severity != database.AlertSeverityWarning {
+	if a.Type != alertmodel.TypeConnectivity || a.Severity != alertmodel.SeverityWarning {
 		t.Errorf("type/severity = %q/%q", a.Type, a.Severity)
 	}
 }
 
 func TestScanOnce_TrapAuthFailureEmitsSecurityAlert(t *testing.T) {
 	t.Parallel()
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		trapEvent("1.3.6.1.6.3.1.1.5.5", "10.0.0.5:0", at()),
 	}}
 	alerts := &fakeAlerts{}
@@ -197,7 +198,7 @@ func TestScanOnce_TrapAuthFailureEmitsSecurityAlert(t *testing.T) {
 		t.Fatalf("alerts = %d, want 1", len(alerts.created))
 	}
 	a := alerts.created[0]
-	if a.Type != database.AlertTypeSecurity || a.Severity != database.AlertSeverityError {
+	if a.Type != alertmodel.TypeSecurity || a.Severity != alertmodel.SeverityError {
 		t.Errorf("type/severity = %q/%q", a.Type, a.Severity)
 	}
 }
@@ -205,7 +206,7 @@ func TestScanOnce_TrapAuthFailureEmitsSecurityAlert(t *testing.T) {
 func TestScanOnce_SuppressionBlocksRepeats(t *testing.T) {
 	t.Parallel()
 	// Two identical linkDown traps in the same scan -> one alert.
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		trapEvent("1.3.6.1.6.3.1.1.5.3", "10.0.0.5:0", at()),
 		trapEvent("1.3.6.1.6.3.1.1.5.3", "10.0.0.5:0", at().Add(time.Second)),
 	}}
@@ -222,7 +223,7 @@ func TestScanOnce_SuppressionBlocksRepeats(t *testing.T) {
 
 func TestScanOnce_DifferentSourcesNotSuppressed(t *testing.T) {
 	t.Parallel()
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		trapEvent("1.3.6.1.6.3.1.1.5.3", "10.0.0.5:0", at()),
 		trapEvent("1.3.6.1.6.3.1.1.5.3", "10.0.0.6:0", at()),
 	}}
@@ -241,7 +242,7 @@ func TestScanOnce_PersistsHighWater(t *testing.T) {
 	t.Parallel()
 	older := at().Add(-time.Hour)
 	newer := at()
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		syslogEvent("error", "10.0.0.1:514", older, "old"),
 		syslogEvent("error", "10.0.0.2:514", newer, "new"),
 	}}
@@ -278,7 +279,7 @@ func TestScanOnce_ListErrorPropagates(t *testing.T) {
 
 func TestScanOnce_CreateErrorContinuesBatch(t *testing.T) {
 	t.Parallel()
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		syslogEvent("error", "10.0.0.1:514", at(), "boom"),
 	}}
 	alerts := &fakeAlerts{createErr: errors.New("constraint")}
@@ -297,17 +298,17 @@ func TestScanOnce_CustomRulesOverrideDefaults(t *testing.T) {
 	custom := []pipeline.Rule{
 		{
 			ID:    "test.everything",
-			Match: func(_ *database.ListenerEvent) bool { return true },
-			Build: func(evt *database.ListenerEvent) *database.Alert {
+			Match: func(_ *listener.EventRecord) bool { return true },
+			Build: func(evt *listener.EventRecord) *alertmodel.Alert {
 				hits++
-				return &database.Alert{
+				return &alertmodel.Alert{
 					Type: "test", Severity: "info",
 					Title: "all", Message: "all", Source: evt.SourceAddr,
 				}
 			},
 		},
 	}
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		// An informational syslog would NOT trip the defaults but
 		// will trip our match-all custom rule.
 		syslogEvent("informational", "10.0.0.1:514", at(), "noise"),

--- a/internal/alerts/pipeline/listener_rules_loader.go
+++ b/internal/alerts/pipeline/listener_rules_loader.go
@@ -30,7 +30,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
+	"github.com/MustardSeedNetworks/seed/internal/listener"
 )
 
 // ListenerEventContext is the data passed to AlertTitle / AlertMessage
@@ -58,7 +59,7 @@ type ListenerEventContext struct {
 // runtime Rule. Disabled rows are dropped. Returns an empty slice
 // when no enabled rows are present so callers can decide to fall
 // back to DefaultListenerRules.
-func CompileRulesFromDB(rows []*database.AlertRule) []Rule {
+func CompileRulesFromDB(rows []*alerts.Rule) []Rule {
 	out := make([]Rule, 0, len(rows))
 	for _, row := range rows {
 		if row == nil || !row.Enabled {
@@ -69,7 +70,7 @@ func CompileRulesFromDB(rows []*database.AlertRule) []Rule {
 	return out
 }
 
-func compileOne(row *database.AlertRule) Rule {
+func compileOne(row *alerts.Rule) Rule {
 	matchKind := row.MatchKind
 	matchSev := row.MatchSeverity
 	matchSubstring := row.MatchPayloadContains
@@ -95,7 +96,7 @@ func compileOne(row *database.AlertRule) Rule {
 		Threshold: threshold,
 		Window:    window,
 		counter:   counter,
-		Match: func(evt *database.ListenerEvent) bool {
+		Match: func(evt *listener.EventRecord) bool {
 			if matchKind != "" && evt.Kind != matchKind {
 				return false
 			}
@@ -107,9 +108,9 @@ func compileOne(row *database.AlertRule) Rule {
 			}
 			return true
 		},
-		Build: func(evt *database.ListenerEvent) *database.Alert {
+		Build: func(evt *listener.EventRecord) *alerts.Alert {
 			ctx := buildEventContext(evt, ruleName)
-			return &database.Alert{
+			return &alerts.Alert{
 				Type:     alertType,
 				Severity: alertSeverity,
 				Title:    titleRenderer(ctx),
@@ -153,7 +154,7 @@ func compileTemplate(s string) templateRenderer {
 // visible struct. Payload JSON is best-effort decoded into a map
 // so templates can reach inside it via .Payload.<field>; a bad
 // payload renders as an empty map.
-func buildEventContext(evt *database.ListenerEvent, ruleName string) ListenerEventContext {
+func buildEventContext(evt *listener.EventRecord, ruleName string) ListenerEventContext {
 	payload := map[string]any{}
 	if evt.PayloadJSON != "" {
 		_ = json.Unmarshal([]byte(evt.PayloadJSON), &payload)
@@ -172,5 +173,5 @@ func buildEventContext(evt *database.ListenerEvent, ruleName string) ListenerEve
 // from the alert_rules repo. Tests inject a fake. Implemented by
 // *database.AlertRulesRepository.
 type alertRulesReader interface {
-	List(ctx context.Context, enabledOnly bool) ([]*database.AlertRule, error)
+	List(ctx context.Context, enabledOnly bool) ([]*alerts.Rule, error)
 }

--- a/internal/alerts/pipeline/listener_rules_loader_test.go
+++ b/internal/alerts/pipeline/listener_rules_loader_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
+	alertmodel "github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/listener"
 )
 
 // fakeAlertRulesReader implements the narrow alertRulesReader contract.
@@ -16,19 +17,19 @@ import (
 // copy so the pipeline can hold its own snapshot.
 type fakeAlertRulesReader struct {
 	mu      sync.Mutex
-	rows    []*database.AlertRule
+	rows    []*alertmodel.Rule
 	listErr error
 	calls   int
 }
 
-func (f *fakeAlertRulesReader) List(_ context.Context, enabledOnly bool) ([]*database.AlertRule, error) {
+func (f *fakeAlertRulesReader) List(_ context.Context, enabledOnly bool) ([]*alertmodel.Rule, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls++
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	out := make([]*database.AlertRule, 0, len(f.rows))
+	out := make([]*alertmodel.Rule, 0, len(f.rows))
 	for _, r := range f.rows {
 		if enabledOnly && !r.Enabled {
 			continue
@@ -38,22 +39,22 @@ func (f *fakeAlertRulesReader) List(_ context.Context, enabledOnly bool) ([]*dat
 	return out, nil
 }
 
-func (f *fakeAlertRulesReader) set(rows []*database.AlertRule) {
+func (f *fakeAlertRulesReader) set(rows []*alertmodel.Rule) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.rows = rows
 }
 
-func dbRule(name, kind, severity, contains string, enabled bool) *database.AlertRule {
-	return &database.AlertRule{
+func dbRule(name, kind, severity, contains string, enabled bool) *alertmodel.Rule {
+	return &alertmodel.Rule{
 		ID:                   int64(len(name)),
 		Name:                 name,
 		Enabled:              enabled,
 		MatchKind:            kind,
 		MatchSeverity:        severity,
 		MatchPayloadContains: contains,
-		AlertType:            database.AlertTypeSystem,
-		AlertSeverity:        database.AlertSeverityError,
+		AlertType:            alertmodel.TypeSystem,
+		AlertSeverity:        alertmodel.SeverityError,
 		AlertTitle:           "Rule " + name + " matched",
 		AlertMessage:         "Triggered by listener event",
 	}
@@ -69,7 +70,7 @@ func TestCompileRulesFromDB_EmptySliceReturnsEmpty(t *testing.T) {
 
 func TestCompileRulesFromDB_DisabledRowsSkipped(t *testing.T) {
 	t.Parallel()
-	rows := []*database.AlertRule{
+	rows := []*alertmodel.Rule{
 		dbRule("active", "syslog-udp", "error", "", true),
 		dbRule("inactive", "syslog-udp", "error", "", false),
 	}
@@ -84,7 +85,7 @@ func TestCompileRulesFromDB_DisabledRowsSkipped(t *testing.T) {
 
 func TestCompileRulesFromDB_MatchKindFilter(t *testing.T) {
 	t.Parallel()
-	rows := []*database.AlertRule{
+	rows := []*alertmodel.Rule{
 		dbRule("syslog-only", "syslog-udp", "", "", true),
 	}
 	rules := pipeline.CompileRulesFromDB(rows)
@@ -93,8 +94,8 @@ func TestCompileRulesFromDB_MatchKindFilter(t *testing.T) {
 	}
 	rule := rules[0]
 
-	syslogEvt := &database.ListenerEvent{Kind: "syslog-udp"}
-	trapEvt := &database.ListenerEvent{Kind: "snmp-trap-v2c"}
+	syslogEvt := &listener.EventRecord{Kind: "syslog-udp"}
+	trapEvt := &listener.EventRecord{Kind: "snmp-trap-v2c"}
 
 	if !rule.Match(syslogEvt) {
 		t.Error("syslog-udp event should match syslog-udp filter")
@@ -106,46 +107,46 @@ func TestCompileRulesFromDB_MatchKindFilter(t *testing.T) {
 
 func TestCompileRulesFromDB_MatchKindEmptyMatchesAll(t *testing.T) {
 	t.Parallel()
-	rows := []*database.AlertRule{
+	rows := []*alertmodel.Rule{
 		dbRule("any-kind", "", "", "", true),
 	}
 	rule := pipeline.CompileRulesFromDB(rows)[0]
-	if !rule.Match(&database.ListenerEvent{Kind: "syslog-udp"}) {
+	if !rule.Match(&listener.EventRecord{Kind: "syslog-udp"}) {
 		t.Error("empty match_kind should match syslog-udp")
 	}
-	if !rule.Match(&database.ListenerEvent{Kind: "snmp-trap-v2c"}) {
+	if !rule.Match(&listener.EventRecord{Kind: "snmp-trap-v2c"}) {
 		t.Error("empty match_kind should match snmp-trap-v2c")
 	}
 }
 
 func TestCompileRulesFromDB_MatchSeverityFilter(t *testing.T) {
 	t.Parallel()
-	rows := []*database.AlertRule{
+	rows := []*alertmodel.Rule{
 		dbRule("error-only", "syslog-udp", "error", "", true),
 	}
 	rule := pipeline.CompileRulesFromDB(rows)[0]
-	if !rule.Match(&database.ListenerEvent{Kind: "syslog-udp", Severity: "error"}) {
+	if !rule.Match(&listener.EventRecord{Kind: "syslog-udp", Severity: "error"}) {
 		t.Error("severity=error should match")
 	}
-	if rule.Match(&database.ListenerEvent{Kind: "syslog-udp", Severity: "informational"}) {
+	if rule.Match(&listener.EventRecord{Kind: "syslog-udp", Severity: "informational"}) {
 		t.Error("severity=informational should NOT match error-only rule")
 	}
 }
 
 func TestCompileRulesFromDB_MatchPayloadContainsSubstring(t *testing.T) {
 	t.Parallel()
-	rows := []*database.AlertRule{
+	rows := []*alertmodel.Rule{
 		dbRule("link-state", "syslog-udp", "", "link state", true),
 	}
 	rule := pipeline.CompileRulesFromDB(rows)[0]
 
 	payload, _ := json.Marshal(map[string]string{"message": "interface eth0 link state changed to down"})
-	matching := &database.ListenerEvent{Kind: "syslog-udp", PayloadJSON: string(payload)}
+	matching := &listener.EventRecord{Kind: "syslog-udp", PayloadJSON: string(payload)}
 	if !rule.Match(matching) {
 		t.Error("substring 'link state' should match")
 	}
 
-	nonMatching := &database.ListenerEvent{Kind: "syslog-udp", PayloadJSON: `{"message":"ssh login from 10.0.0.1"}`}
+	nonMatching := &listener.EventRecord{Kind: "syslog-udp", PayloadJSON: `{"message":"ssh login from 10.0.0.1"}`}
 	if rule.Match(nonMatching) {
 		t.Error("payload without substring should NOT match")
 	}
@@ -153,29 +154,29 @@ func TestCompileRulesFromDB_MatchPayloadContainsSubstring(t *testing.T) {
 
 func TestCompileRulesFromDB_BuildPopulatesAlertFields(t *testing.T) {
 	t.Parallel()
-	rows := []*database.AlertRule{
+	rows := []*alertmodel.Rule{
 		{
 			ID: 42, Name: "interface-down", Enabled: true,
 			MatchKind:     "syslog-udp",
-			AlertType:     database.AlertTypeConnectivity,
-			AlertSeverity: database.AlertSeverityWarning,
+			AlertType:     alertmodel.TypeConnectivity,
+			AlertSeverity: alertmodel.SeverityWarning,
 			AlertTitle:    "Interface down",
 			AlertMessage:  "Saw an interface-down event",
 		},
 	}
 	rule := pipeline.CompileRulesFromDB(rows)[0]
-	alert := rule.Build(&database.ListenerEvent{
+	alert := rule.Build(&listener.EventRecord{
 		Kind: "syslog-udp", SourceAddr: "10.0.0.1:514",
 		PayloadJSON: `{"message":"eth0 down"}`,
 	})
 	if alert == nil {
 		t.Fatal("Build returned nil alert")
 	}
-	if alert.Type != database.AlertTypeConnectivity {
-		t.Errorf("Type = %q, want %q", alert.Type, database.AlertTypeConnectivity)
+	if alert.Type != alertmodel.TypeConnectivity {
+		t.Errorf("Type = %q, want %q", alert.Type, alertmodel.TypeConnectivity)
 	}
-	if alert.Severity != database.AlertSeverityWarning {
-		t.Errorf("Severity = %q, want %q", alert.Severity, database.AlertSeverityWarning)
+	if alert.Severity != alertmodel.SeverityWarning {
+		t.Errorf("Severity = %q, want %q", alert.Severity, alertmodel.SeverityWarning)
 	}
 	if alert.Title != "Interface down" {
 		t.Errorf("Title = %q, want literal 'Interface down'", alert.Title)
@@ -193,9 +194,9 @@ func TestCompileRulesFromDB_BuildPopulatesAlertFields(t *testing.T) {
 
 func TestCompileRulesFromDB_StableFingerprintID(t *testing.T) {
 	t.Parallel()
-	rows := []*database.AlertRule{{
+	rows := []*alertmodel.Rule{{
 		ID: 7, Name: "x", Enabled: true,
-		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityInfo,
+		AlertType: alertmodel.TypeSystem, AlertSeverity: alertmodel.SeverityInfo,
 		AlertTitle: "x",
 	}}
 	rule := pipeline.CompileRulesFromDB(rows)[0]
@@ -208,12 +209,12 @@ func TestCompileRulesFromDB_StableFingerprintID(t *testing.T) {
 
 func TestScanOnce_DBRulesReplaceDefaultsWhenNonEmpty(t *testing.T) {
 	t.Parallel()
-	reader := &fakeAlertRulesReader{rows: []*database.AlertRule{
+	reader := &fakeAlertRulesReader{rows: []*alertmodel.Rule{
 		// One DB rule matching only "informational" syslog — would NEVER
 		// fire under the defaults (defaults only alert on error+ severities).
 		dbRule("info-rule", "syslog-udp", "informational", "", true),
 	}}
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		// An error syslog. Under DEFAULTS this would fire (defaults match error+).
 		// Under DB rules only it should NOT fire (DB rule is informational-only).
 		syslogEvent("error", "10.0.0.1:514", at(), "boom"),
@@ -247,7 +248,7 @@ func TestScanOnce_DBRulesReplaceDefaultsWhenNonEmpty(t *testing.T) {
 func TestScanOnce_FallsBackToDefaultsWhenDBEmpty(t *testing.T) {
 	t.Parallel()
 	reader := &fakeAlertRulesReader{rows: nil}
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		syslogEvent("error", "10.0.0.1:514", at(), "default-must-fire"),
 	}}
 	alerts := &fakeAlerts{}
@@ -270,10 +271,10 @@ func TestScanOnce_FallsBackToDefaultsWhenDBEmpty(t *testing.T) {
 
 func TestScanOnce_FallsBackToDefaultsWhenAllDBRulesDisabled(t *testing.T) {
 	t.Parallel()
-	reader := &fakeAlertRulesReader{rows: []*database.AlertRule{
+	reader := &fakeAlertRulesReader{rows: []*alertmodel.Rule{
 		dbRule("disabled", "syslog-udp", "informational", "", false),
 	}}
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		syslogEvent("error", "10.0.0.1:514", at(), "boom"),
 	}}
 	alerts := &fakeAlerts{}
@@ -291,7 +292,7 @@ func TestScanOnce_FallsBackToDefaultsWhenAllDBRulesDisabled(t *testing.T) {
 func TestScanOnce_ReloadPicksUpNewlyInsertedRule(t *testing.T) {
 	t.Parallel()
 	reader := &fakeAlertRulesReader{rows: nil}
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		syslogEvent("informational", "10.0.0.1:514", at(), "ignore-me-under-defaults"),
 	}}
 	alerts := &fakeAlerts{}
@@ -308,7 +309,7 @@ func TestScanOnce_ReloadPicksUpNewlyInsertedRule(t *testing.T) {
 	}
 
 	// Operator inserts a rule, then triggers reload.
-	reader.set([]*database.AlertRule{dbRule("informational-now-fires", "syslog-udp", "informational", "", true)})
+	reader.set([]*alertmodel.Rule{dbRule("informational-now-fires", "syslog-udp", "informational", "", true)})
 	if reloadErr := p.ReloadRules(context.Background()); reloadErr != nil {
 		t.Fatalf("ReloadRules: %v", reloadErr)
 	}
@@ -316,7 +317,7 @@ func TestScanOnce_ReloadPicksUpNewlyInsertedRule(t *testing.T) {
 	// Reset high-water so the same event is re-considered, then scan again.
 	// In production a new event arrives; here we just bump the fake events
 	// observed-at by 1ns to step the high-water forward.
-	events.rows = []*database.ListenerEvent{
+	events.rows = []*listener.EventRecord{
 		syslogEvent("informational", "10.0.0.2:514", at().Add(time.Second), "fire-now"),
 	}
 	_ = p.ScanOnce(context.Background())
@@ -327,10 +328,10 @@ func TestScanOnce_ReloadPicksUpNewlyInsertedRule(t *testing.T) {
 
 func TestScanOnce_ReloadErrorKeepsPreviousRuleset(t *testing.T) {
 	t.Parallel()
-	reader := &fakeAlertRulesReader{rows: []*database.AlertRule{
+	reader := &fakeAlertRulesReader{rows: []*alertmodel.Rule{
 		dbRule("starter", "syslog-udp", "informational", "", true),
 	}}
-	events := &fakeEvents{rows: []*database.ListenerEvent{
+	events := &fakeEvents{rows: []*listener.EventRecord{
 		syslogEvent("informational", "10.0.0.1:514", at(), "should-fire"),
 	}}
 	alerts := &fakeAlerts{}

--- a/internal/alerts/pipeline/listener_rules_templates_test.go
+++ b/internal/alerts/pipeline/listener_rules_templates_test.go
@@ -5,20 +5,21 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/listener"
 )
 
 func TestCompileRulesFromDB_LiteralTitlePassesThrough(t *testing.T) {
 	t.Parallel()
-	row := &database.AlertRule{
+	row := &alerts.Rule{
 		ID: 1, Enabled: true,
-		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertType: alerts.TypeSystem, AlertSeverity: alerts.SeverityError,
 		AlertTitle:   "Static title with no template syntax",
 		AlertMessage: "Static message",
 	}
-	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
-	alert := rule.Build(&database.ListenerEvent{SourceAddr: "10.0.0.1"})
+	rule := pipeline.CompileRulesFromDB([]*alerts.Rule{row})[0]
+	alert := rule.Build(&listener.EventRecord{SourceAddr: "10.0.0.1"})
 	if alert.Title != "Static title with no template syntax" {
 		t.Errorf("literal title was mutated: %q", alert.Title)
 	}
@@ -26,14 +27,14 @@ func TestCompileRulesFromDB_LiteralTitlePassesThrough(t *testing.T) {
 
 func TestCompileRulesFromDB_TemplateRendersSourceAddr(t *testing.T) {
 	t.Parallel()
-	row := &database.AlertRule{
+	row := &alerts.Rule{
 		ID: 1, Enabled: true,
-		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertType: alerts.TypeSystem, AlertSeverity: alerts.SeverityError,
 		AlertTitle:   "{{.SourceAddr}} reported {{.Severity}}",
 		AlertMessage: "Event arrived from {{.SourceAddr}}",
 	}
-	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
-	alert := rule.Build(&database.ListenerEvent{
+	rule := pipeline.CompileRulesFromDB([]*alerts.Rule{row})[0]
+	alert := rule.Build(&listener.EventRecord{
 		SourceAddr:  "10.0.0.1:514",
 		Severity:    "error",
 		Kind:        "syslog-udp",
@@ -49,14 +50,14 @@ func TestCompileRulesFromDB_TemplateRendersSourceAddr(t *testing.T) {
 
 func TestCompileRulesFromDB_TemplateAccessesPayload(t *testing.T) {
 	t.Parallel()
-	row := &database.AlertRule{
+	row := &alerts.Rule{
 		ID: 1, Enabled: true,
-		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertType: alerts.TypeSystem, AlertSeverity: alerts.SeverityError,
 		AlertTitle: "Saw {{.Payload.message}}",
 	}
-	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
+	rule := pipeline.CompileRulesFromDB([]*alerts.Rule{row})[0]
 	payload, _ := json.Marshal(map[string]any{"message": "interface eth0 down"})
-	alert := rule.Build(&database.ListenerEvent{
+	alert := rule.Build(&listener.EventRecord{
 		SourceAddr:  "10.0.0.1",
 		PayloadJSON: string(payload),
 	})
@@ -68,17 +69,17 @@ func TestCompileRulesFromDB_TemplateAccessesPayload(t *testing.T) {
 func TestCompileRulesFromDB_BrokenTemplateFallsBackToLiteral(t *testing.T) {
 	t.Parallel()
 	// "{{" without close — parse error at compile time.
-	row := &database.AlertRule{
+	row := &alerts.Rule{
 		ID: 1, Enabled: true,
-		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertType: alerts.TypeSystem, AlertSeverity: alerts.SeverityError,
 		AlertTitle: "Unclosed {{ template",
 	}
 	// Should not panic + rule should still load.
-	rules := pipeline.CompileRulesFromDB([]*database.AlertRule{row})
+	rules := pipeline.CompileRulesFromDB([]*alerts.Rule{row})
 	if len(rules) != 1 {
 		t.Fatalf("got %d rules, want 1 (broken template should not drop the rule)", len(rules))
 	}
-	alert := rules[0].Build(&database.ListenerEvent{SourceAddr: "10.0.0.1"})
+	alert := rules[0].Build(&listener.EventRecord{SourceAddr: "10.0.0.1"})
 	if alert.Title != "Unclosed {{ template" {
 		t.Errorf("broken template should fall back to literal, got %q", alert.Title)
 	}
@@ -89,13 +90,13 @@ func TestCompileRulesFromDB_MissingPayloadFieldRendersZero(t *testing.T) {
 	// text/template's default behavior on missing map keys is to
 	// render "<no value>" — confirm we don't crash on it and that
 	// the output is something deterministic.
-	row := &database.AlertRule{
+	row := &alerts.Rule{
 		ID: 1, Enabled: true,
-		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertType: alerts.TypeSystem, AlertSeverity: alerts.SeverityError,
 		AlertTitle: "Saw {{.Payload.nonexistent}}",
 	}
-	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
-	alert := rule.Build(&database.ListenerEvent{
+	rule := pipeline.CompileRulesFromDB([]*alerts.Rule{row})[0]
+	alert := rule.Build(&listener.EventRecord{
 		SourceAddr:  "10.0.0.1",
 		PayloadJSON: `{"message":"hello"}`,
 	})
@@ -109,13 +110,13 @@ func TestCompileRulesFromDB_MissingPayloadFieldRendersZero(t *testing.T) {
 
 func TestCompileRulesFromDB_PayloadDecodeFailureRendersEmptyMap(t *testing.T) {
 	t.Parallel()
-	row := &database.AlertRule{
+	row := &alerts.Rule{
 		ID: 1, Enabled: true,
-		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertType: alerts.TypeSystem, AlertSeverity: alerts.SeverityError,
 		AlertTitle: "Got {{.Kind}}",
 	}
-	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
-	alert := rule.Build(&database.ListenerEvent{
+	rule := pipeline.CompileRulesFromDB([]*alerts.Rule{row})[0]
+	alert := rule.Build(&listener.EventRecord{
 		SourceAddr:  "10.0.0.1",
 		Kind:        "syslog-udp",
 		PayloadJSON: `not valid json`, // garbage
@@ -127,13 +128,13 @@ func TestCompileRulesFromDB_PayloadDecodeFailureRendersEmptyMap(t *testing.T) {
 
 func TestCompileRulesFromDB_TemplateAccessesMatchedRuleName(t *testing.T) {
 	t.Parallel()
-	row := &database.AlertRule{
+	row := &alerts.Rule{
 		ID: 1, Enabled: true, Name: "my-rule",
-		AlertType: database.AlertTypeSystem, AlertSeverity: database.AlertSeverityError,
+		AlertType: alerts.TypeSystem, AlertSeverity: alerts.SeverityError,
 		AlertTitle: "Rule {{.MatchedRuleName}} fired",
 	}
-	rule := pipeline.CompileRulesFromDB([]*database.AlertRule{row})[0]
-	alert := rule.Build(&database.ListenerEvent{SourceAddr: "10.0.0.1"})
+	rule := pipeline.CompileRulesFromDB([]*alerts.Rule{row})[0]
+	alert := rule.Build(&listener.EventRecord{SourceAddr: "10.0.0.1"})
 	if alert.Title != "Rule my-rule fired" {
 		t.Errorf("title = %q, want \"Rule my-rule fired\"", alert.Title)
 	}

--- a/internal/alerts/pipeline/observation_pipeline.go
+++ b/internal/alerts/pipeline/observation_pipeline.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/engine"
 	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 )
@@ -460,9 +460,9 @@ func (p *ObservationPipeline) evaluateIfTable(
 		if prev != ifOperUp || row.IfOper == ifOperUp || row.IfAdmin != ifOperUp {
 			continue
 		}
-		alert := &database.Alert{
-			Type:     database.AlertTypeConnectivity,
-			Severity: database.AlertSeverityWarning,
+		alert := &alerts.Alert{
+			Type:     alerts.TypeConnectivity,
+			Severity: alerts.SeverityWarning,
 			Title:    fmt.Sprintf("Interface %s down on %s", row.IfName, obs.TargetID),
 			Message: fmt.Sprintf("ifOperStatus transitioned from up to %d (ifIndex=%d, admin=up)",
 				row.IfOper, row.IfIndex),
@@ -505,9 +505,9 @@ func (p *ObservationPipeline) evaluateBGP(
 		if prev != bgpStateEstablished || peer.State == bgpStateEstablished {
 			continue
 		}
-		alert := &database.Alert{
-			Type:     database.AlertTypeConnectivity,
-			Severity: database.AlertSeverityError,
+		alert := &alerts.Alert{
+			Type:     alerts.TypeConnectivity,
+			Severity: alerts.SeverityError,
 			Title:    fmt.Sprintf("BGP peer %s left Established on %s", peer.RemoteAddr, obs.TargetID),
 			Message: fmt.Sprintf("Peer state transitioned from 6 (Established) to %d, AS%d",
 				peer.State, peer.RemoteAS),
@@ -557,9 +557,9 @@ func (p *ObservationPipeline) evaluateHostResources(
 		// Upward crossings: prev below threshold and now at-or-above.
 		// Two thresholds means two possible alerts per observation.
 		if prev < storageFullPct && pct >= storageFullPct {
-			alert := &database.Alert{
-				Type:     database.AlertTypeSystem,
-				Severity: database.AlertSeverityCritical,
+			alert := &alerts.Alert{
+				Type:     alerts.TypeSystem,
+				Severity: alerts.SeverityCritical,
 				Title:    fmt.Sprintf("Filesystem %s critical on %s", st.Description, obs.TargetID),
 				Message:  fmt.Sprintf("Usage crossed %.0f%%: %.1f%% of %d bytes", storageFullPct, pct, st.SizeBytes),
 				Source:   obs.TargetID,
@@ -569,9 +569,9 @@ func (p *ObservationPipeline) evaluateHostResources(
 				count++
 			}
 		} else if prev < storageHighPct && pct >= storageHighPct {
-			alert := &database.Alert{
-				Type:     database.AlertTypeSystem,
-				Severity: database.AlertSeverityWarning,
+			alert := &alerts.Alert{
+				Type:     alerts.TypeSystem,
+				Severity: alerts.SeverityWarning,
 				Title:    fmt.Sprintf("Filesystem %s high on %s", st.Description, obs.TargetID),
 				Message:  fmt.Sprintf("Usage crossed %.0f%%: %.1f%% of %d bytes", storageHighPct, pct, st.SizeBytes),
 				Source:   obs.TargetID,
@@ -588,7 +588,7 @@ func (p *ObservationPipeline) evaluateHostResources(
 // fire writes an alert if the (ruleID, entityKey) fingerprint isn't
 // suppressed. Returns true when the alert was actually written.
 func (p *ObservationPipeline) fire(
-	ctx context.Context, ruleID, entityKey string, alert *database.Alert,
+	ctx context.Context, ruleID, entityKey string, alert *alerts.Alert,
 ) bool {
 	now := p.now()
 	fingerprint := fingerprintFor(ruleID, entityKey, alert.Source)

--- a/internal/alerts/pipeline/observation_pipeline_test.go
+++ b/internal/alerts/pipeline/observation_pipeline_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
+	alertmodel "github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/polling/observation"
 )
 
@@ -99,7 +99,7 @@ func TestObservationScanOnce_InterfaceUpToDownEmitsAlert(t *testing.T) {
 		t.Fatalf("alerts = %d, want 1 (only the up->down transition)", len(alerts.created))
 	}
 	a := alerts.created[0]
-	if a.Severity != database.AlertSeverityWarning || a.Type != database.AlertTypeConnectivity {
+	if a.Severity != alertmodel.SeverityWarning || a.Type != alertmodel.TypeConnectivity {
 		t.Errorf("type/severity = %q/%q", a.Type, a.Severity)
 	}
 }
@@ -165,7 +165,7 @@ func TestObservationScanOnce_BGPLeavingEstablishedFires(t *testing.T) {
 	if len(alerts.created) != 1 {
 		t.Fatalf("alerts = %d, want 1", len(alerts.created))
 	}
-	if alerts.created[0].Severity != database.AlertSeverityError {
+	if alerts.created[0].Severity != alertmodel.SeverityError {
 		t.Errorf("BGP flap should be error severity, got %q", alerts.created[0].Severity)
 	}
 }
@@ -207,7 +207,7 @@ func TestObservationScanOnce_StorageCrosses85FiresWarning(t *testing.T) {
 		Logger: silentLogger(), Now: at,
 	})
 	_ = p.ScanOnce(context.Background())
-	if len(alerts.created) != 1 || alerts.created[0].Severity != database.AlertSeverityWarning {
+	if len(alerts.created) != 1 || alerts.created[0].Severity != alertmodel.SeverityWarning {
 		t.Errorf("expected one warning alert, got %+v", alerts.created)
 	}
 }
@@ -228,7 +228,7 @@ func TestObservationScanOnce_StorageCrosses95FiresCritical(t *testing.T) {
 		Logger: silentLogger(), Now: at,
 	})
 	_ = p.ScanOnce(context.Background())
-	if len(alerts.created) != 1 || alerts.created[0].Severity != database.AlertSeverityCritical {
+	if len(alerts.created) != 1 || alerts.created[0].Severity != alertmodel.SeverityCritical {
 		t.Errorf("expected one critical alert, got %+v", alerts.created)
 	}
 }

--- a/internal/alerts/pipeline/window_counter_test.go
+++ b/internal/alerts/pipeline/window_counter_test.go
@@ -10,17 +10,18 @@ import (
 	"testing"
 	"time"
 
+	alertmodel "github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/alerts/pipeline"
-	"github.com/MustardSeedNetworks/seed/internal/database"
+	"github.com/MustardSeedNetworks/seed/internal/listener"
 )
 
-func windowedRule(window time.Duration, threshold int) *database.AlertRule {
-	return &database.AlertRule{
+func windowedRule(window time.Duration, threshold int) *alertmodel.Rule {
+	return &alertmodel.Rule{
 		ID: 1, Name: "win", Enabled: true,
 		MatchKind:      "syslog-udp",
 		MatchSeverity:  "error",
-		AlertType:      database.AlertTypeSystem,
-		AlertSeverity:  database.AlertSeverityError,
+		AlertType:      alertmodel.TypeSystem,
+		AlertSeverity:  alertmodel.SeverityError,
 		AlertTitle:     "Windowed fire",
 		WindowSeconds:  int(window.Seconds()),
 		ThresholdCount: threshold,
@@ -28,15 +29,15 @@ func windowedRule(window time.Duration, threshold int) *database.AlertRule {
 }
 
 func runScanWithEvents(
-	t *testing.T, rule *database.AlertRule, events []*database.ListenerEvent,
-) []*database.Alert {
+	t *testing.T, rule *alertmodel.Rule, events []*listener.EventRecord,
+) []*alertmodel.Alert {
 	t.Helper()
 	// Each event triggers one scan with a fresh fakeEvents slice so
 	// we control timing via the event's ObservedAt + the pipeline's
 	// Now func.
 	fakeEv := &fakeEvents{}
 	alerts := &fakeAlerts{}
-	rules := pipeline.CompileRulesFromDB([]*database.AlertRule{rule})
+	rules := pipeline.CompileRulesFromDB([]*alertmodel.Rule{rule})
 	currentNow := events[0].ObservedAt
 	p, _ := pipeline.NewListenerPipeline(pipeline.ListenerConfig{
 		Events:   fakeEv,
@@ -48,7 +49,7 @@ func runScanWithEvents(
 	})
 	for _, evt := range events {
 		currentNow = evt.ObservedAt
-		fakeEv.rows = []*database.ListenerEvent{evt}
+		fakeEv.rows = []*listener.EventRecord{evt}
 		_ = p.ScanOnce(context.Background())
 	}
 	return alerts.created
@@ -58,7 +59,7 @@ func TestWindowedRule_BelowThresholdDoesNotFire(t *testing.T) {
 	t.Parallel()
 	rule := windowedRule(time.Minute, 3)
 	t0 := at()
-	events := []*database.ListenerEvent{
+	events := []*listener.EventRecord{
 		syslogEvent("error", "10.0.0.1:514", t0, "a"),
 		syslogEvent("error", "10.0.0.1:514", t0.Add(time.Second), "b"),
 	}
@@ -72,7 +73,7 @@ func TestWindowedRule_ThirdHitFires(t *testing.T) {
 	t.Parallel()
 	rule := windowedRule(time.Minute, 3)
 	t0 := at()
-	events := []*database.ListenerEvent{
+	events := []*listener.EventRecord{
 		syslogEvent("error", "10.0.0.1:514", t0, "a"),
 		syslogEvent("error", "10.0.0.1:514", t0.Add(time.Second), "b"),
 		syslogEvent("error", "10.0.0.1:514", t0.Add(2*time.Second), "c"),
@@ -87,7 +88,7 @@ func TestWindowedRule_StaleHitsDoNotAccumulate(t *testing.T) {
 	t.Parallel()
 	rule := windowedRule(time.Minute, 3)
 	t0 := at()
-	events := []*database.ListenerEvent{
+	events := []*listener.EventRecord{
 		syslogEvent("error", "10.0.0.1:514", t0, "a"),
 		syslogEvent("error", "10.0.0.1:514", t0.Add(time.Second), "b"),
 		// Two minutes later — first two are past the window.
@@ -105,7 +106,7 @@ func TestWindowedRule_DifferentEntitiesIndependent(t *testing.T) {
 	// values so unparam doesn't flag it as constant-folded.
 	rule := windowedRule(30*time.Second, 2)
 	t0 := at()
-	events := []*database.ListenerEvent{
+	events := []*listener.EventRecord{
 		syslogEvent("error", "10.0.0.1:514", t0, "a-1"),
 		syslogEvent("error", "10.0.0.2:514", t0.Add(time.Second), "b-1"),
 	}
@@ -118,17 +119,17 @@ func TestWindowedRule_DifferentEntitiesIndependent(t *testing.T) {
 func TestWindowedRule_DefaultPreservesLegacyBehavior(t *testing.T) {
 	t.Parallel()
 	// Window=0, Threshold=1 (defaults): fire on first match.
-	rule := &database.AlertRule{
+	rule := &alertmodel.Rule{
 		ID: 1, Name: "legacy", Enabled: true,
 		MatchKind:     "syslog-udp",
 		MatchSeverity: "error",
-		AlertType:     database.AlertTypeSystem,
-		AlertSeverity: database.AlertSeverityError,
+		AlertType:     alertmodel.TypeSystem,
+		AlertSeverity: alertmodel.SeverityError,
 		AlertTitle:    "Legacy",
 	}
 	t0 := at()
 	got := runScanWithEvents(t, rule,
-		[]*database.ListenerEvent{syslogEvent("error", "10.0.0.1:514", t0, "x")})
+		[]*listener.EventRecord{syslogEvent("error", "10.0.0.1:514", t0, "x")})
 	if len(got) != 1 {
 		t.Errorf("legacy threshold=1 should fire on first match; got %d", len(got))
 	}

--- a/internal/alerts/rules/rules.go
+++ b/internal/alerts/rules/rules.go
@@ -23,7 +23,7 @@ type ValidationError struct{ Msg string }
 func (e *ValidationError) Error() string { return e.Msg }
 
 // Rule is the use-case alert-rule model. The adapter maps it to/from
-// database.AlertRule so the app layer stays free of persistence types.
+// alerts.Rule so the app layer stays free of persistence types.
 type Rule struct {
 	ID                   int64
 	Name                 string

--- a/internal/alerts/types.go
+++ b/internal/alerts/types.go
@@ -1,0 +1,81 @@
+// Package alerts holds the alert domain types — the Alert record, the
+// alerting Rule, and their query options — shared by the alert pipeline,
+// inbox, and rules subpackages. The types live here (not in internal/database)
+// so those subpackages stay persistence-free: the alert/rule repositories in
+// internal/database import this package and map SQL rows to these types, so the
+// dependency points inward (database -> alerts), never the reverse.
+package alerts
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrRuleNotFound is returned when an alert-rule lookup misses.
+var ErrRuleNotFound = errors.New("alert rule not found")
+
+// Alert represents a system alert.
+type Alert struct {
+	ID             int64      `json:"id"`
+	Type           string     `json:"type"`     // e.g., "security", "performance", "connectivity"
+	Severity       string     `json:"severity"` // "info", "warning", "error", "critical"
+	Title          string     `json:"title"`
+	Message        string     `json:"message"`
+	Source         string     `json:"source,omitempty"` // What generated the alert
+	DeviceID       *string    `json:"deviceId,omitempty"`
+	Acknowledged   bool       `json:"acknowledged"`
+	AcknowledgedBy *string    `json:"acknowledgedBy,omitempty"`
+	AcknowledgedAt *time.Time `json:"acknowledgedAt,omitempty"`
+	Resolved       bool       `json:"resolved"`
+	ResolvedAt     *time.Time `json:"resolvedAt,omitempty"`
+	CreatedAt      time.Time  `json:"createdAt"`
+	Metadata       string     `json:"metadata,omitempty"` // JSON string for extra data
+}
+
+// Type constants for common alert types.
+const (
+	TypeSecurity     = "security"
+	TypePerformance  = "performance"
+	TypeConnectivity = "connectivity"
+	TypeSystem       = "system"
+	TypeDiscovery    = "discovery"
+)
+
+// Severity constants.
+const (
+	SeverityInfo     = "info"
+	SeverityWarning  = "warning"
+	SeverityError    = "error"
+	SeverityCritical = "critical"
+)
+
+// Rule is one alerting rule: a match predicate over inbound events plus the
+// alert to raise when it fires.
+type Rule struct {
+	ID                   int64
+	Name                 string
+	Enabled              bool
+	MatchKind            string
+	MatchSeverity        string
+	MatchPayloadContains string
+	AlertType            string
+	AlertSeverity        string
+	AlertTitle           string
+	AlertMessage         string
+	WindowSeconds        int
+	ThresholdCount       int
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+// ListOptions narrows an alert list query — empty values disable that filter.
+type ListOptions struct {
+	Type               string
+	Severity           string
+	DeviceID           string
+	UnacknowledgedOnly bool
+	UnresolvedOnly     bool
+	Since              time.Time
+	Limit              int
+	Offset             int
+}

--- a/internal/api/handlers_alert_rules_internal_test.go
+++ b/internal/api/handlers_alert_rules_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
@@ -22,15 +23,15 @@ func newAlertRulesTestServer(t *testing.T) *Server {
 	return s
 }
 
-func seedAlertRule(t *testing.T, db *database.DB, name string, enabled bool) *database.AlertRule {
+func seedAlertRule(t *testing.T, db *database.DB, name string, enabled bool) *alerts.Rule {
 	t.Helper()
-	rule := &database.AlertRule{
+	rule := &alerts.Rule{
 		Name:          name,
 		Enabled:       enabled,
 		MatchKind:     "syslog-udp",
 		MatchSeverity: "error",
-		AlertType:     database.AlertTypeSystem,
-		AlertSeverity: database.AlertSeverityError,
+		AlertType:     alerts.TypeSystem,
+		AlertSeverity: alerts.SeverityError,
 		AlertTitle:    "Test rule",
 		AlertMessage:  "Triggered by test seed",
 	}

--- a/internal/api/handlers_alerts.go
+++ b/internal/api/handlers_alerts.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/alerts/inbox"
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 )
 
@@ -146,9 +146,9 @@ func (s *Server) usernameFromRequest(r *http.Request) string {
 
 // parseAlertListOptions reads query-string filters. Returns 400-
 // shaped errors via plain text.
-func parseAlertListOptions(r *http.Request) (database.AlertListOptions, error) {
+func parseAlertListOptions(r *http.Request) (alerts.ListOptions, error) {
 	q := r.URL.Query()
-	opts := database.AlertListOptions{
+	opts := alerts.ListOptions{
 		Type:     q.Get("type"),
 		Severity: q.Get("severity"),
 		DeviceID: q.Get("device_id"),
@@ -163,14 +163,14 @@ func parseAlertListOptions(r *http.Request) (database.AlertListOptions, error) {
 	if since := q.Get("since"); since != "" {
 		t, err := time.Parse(time.RFC3339, since)
 		if err != nil {
-			return database.AlertListOptions{}, errors.New("invalid 'since' (expect RFC3339)")
+			return alerts.ListOptions{}, errors.New("invalid 'since' (expect RFC3339)")
 		}
 		opts.Since = t
 	}
 	if limitRaw := q.Get("limit"); limitRaw != "" {
 		n, err := strconv.Atoi(limitRaw)
 		if err != nil || n < 1 {
-			return database.AlertListOptions{}, errors.New("invalid 'limit' (positive integer)")
+			return alerts.ListOptions{}, errors.New("invalid 'limit' (positive integer)")
 		}
 		if n > alertsMaxLimit {
 			n = alertsMaxLimit
@@ -180,7 +180,7 @@ func parseAlertListOptions(r *http.Request) (database.AlertListOptions, error) {
 	if offsetRaw := q.Get("offset"); offsetRaw != "" {
 		n, err := strconv.Atoi(offsetRaw)
 		if err != nil || n < 0 {
-			return database.AlertListOptions{}, errors.New("invalid 'offset' (non-negative integer)")
+			return alerts.ListOptions{}, errors.New("invalid 'offset' (non-negative integer)")
 		}
 		opts.Offset = n
 	}
@@ -190,7 +190,7 @@ func parseAlertListOptions(r *http.Request) (database.AlertListOptions, error) {
 // encodeAlerts shapes the AlertRepository rows into the JSON
 // envelope. Done explicitly so the wire format stays stable when
 // DB columns evolve.
-func encodeAlerts(alerts []*database.Alert) []map[string]any {
+func encodeAlerts(alerts []*alerts.Alert) []map[string]any {
 	out := make([]map[string]any, 0, len(alerts))
 	for _, a := range alerts {
 		row := map[string]any{

--- a/internal/api/handlers_alerts_internal_test.go
+++ b/internal/api/handlers_alerts_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/app"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
@@ -28,8 +29,8 @@ func newAlertsTestServer(t *testing.T) *Server {
 // generated ID.
 func seedAlert(t *testing.T, db *database.DB, severity string) int64 {
 	t.Helper()
-	a := &database.Alert{
-		Type:     database.AlertTypeConnectivity,
+	a := &alerts.Alert{
+		Type:     alerts.TypeConnectivity,
 		Severity: severity,
 		Title:    "test alert",
 		Message:  "for testing",
@@ -43,8 +44,8 @@ func seedAlert(t *testing.T, db *database.DB, severity string) int64 {
 
 func TestHandleAlerts_ReturnsList(t *testing.T) {
 	s := newAlertsTestServer(t)
-	seedAlert(t, s.db(), database.AlertSeverityWarning)
-	seedAlert(t, s.db(), database.AlertSeverityError)
+	seedAlert(t, s.db(), alerts.SeverityWarning)
+	seedAlert(t, s.db(), alerts.SeverityError)
 
 	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alerts", http.NoBody)
 	w := httptest.NewRecorder()
@@ -66,8 +67,8 @@ func TestHandleAlerts_ReturnsList(t *testing.T) {
 
 func TestHandleAlerts_SeverityFilter(t *testing.T) {
 	s := newAlertsTestServer(t)
-	seedAlert(t, s.db(), database.AlertSeverityWarning)
-	seedAlert(t, s.db(), database.AlertSeverityError)
+	seedAlert(t, s.db(), alerts.SeverityWarning)
+	seedAlert(t, s.db(), alerts.SeverityError)
 
 	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alerts?severity=error", http.NoBody)
 	w := httptest.NewRecorder()
@@ -96,7 +97,7 @@ func TestHandleAlerts_InvalidSinceReturns400(t *testing.T) {
 
 func TestHandleAlertAction_Acknowledge(t *testing.T) {
 	s := newAlertsTestServer(t)
-	id := seedAlert(t, s.db(), database.AlertSeverityWarning)
+	id := seedAlert(t, s.db(), alerts.SeverityWarning)
 
 	url := APIVersionPrefix + "/alerts/" + strconv.FormatInt(id, 10) + "/acknowledge"
 	req := httptest.NewRequest(http.MethodPost, url, http.NoBody)
@@ -122,7 +123,7 @@ func TestHandleAlertAction_Acknowledge(t *testing.T) {
 
 func TestHandleAlertAction_Resolve(t *testing.T) {
 	s := newAlertsTestServer(t)
-	id := seedAlert(t, s.db(), database.AlertSeverityWarning)
+	id := seedAlert(t, s.db(), alerts.SeverityWarning)
 
 	url := APIVersionPrefix + "/alerts/" + strconv.FormatInt(id, 10) + "/resolve"
 	req := httptest.NewRequest(http.MethodPost, url, http.NoBody)
@@ -160,7 +161,7 @@ func TestHandleAlertAction_BadPathReturns400(t *testing.T) {
 
 func TestHandleAlertAction_UnknownActionReturns400(t *testing.T) {
 	s := newAlertsTestServer(t)
-	id := seedAlert(t, s.db(), database.AlertSeverityWarning)
+	id := seedAlert(t, s.db(), alerts.SeverityWarning)
 	url := APIVersionPrefix + "/alerts/" + strconv.FormatInt(id, 10) + "/explode"
 	req := httptest.NewRequest(http.MethodPost, url, http.NoBody)
 	w := httptest.NewRecorder()
@@ -173,7 +174,7 @@ func TestHandleAlertAction_UnknownActionReturns400(t *testing.T) {
 func TestHandleAlerts_PaginationLimitClamped(t *testing.T) {
 	s := newAlertsTestServer(t)
 	for range 5 {
-		seedAlert(t, s.db(), database.AlertSeverityInfo)
+		seedAlert(t, s.db(), alerts.SeverityInfo)
 	}
 	req := httptest.NewRequest(http.MethodGet, APIVersionPrefix+"/alerts?limit=2", http.NoBody)
 	w := httptest.NewRecorder()
@@ -201,7 +202,7 @@ func TestUsernameFromRequest_FallsBackToSystem(t *testing.T) {
 // "0001-01-01T00:00:00Z" instead of "".
 func TestSeedAlert_HasNonZeroCreatedAt(t *testing.T) {
 	s := newAlertsTestServer(t)
-	id := seedAlert(t, s.db(), database.AlertSeverityWarning)
+	id := seedAlert(t, s.db(), alerts.SeverityWarning)
 	alert, _ := s.db().Alerts().Get(context.Background(), id)
 	if alert.CreatedAt.IsZero() {
 		t.Error("CreatedAt should be auto-populated by repo")

--- a/internal/app/alerts.go
+++ b/internal/app/alerts.go
@@ -2,7 +2,7 @@ package app
 
 // alerts.go wires the composition root to the alert-rule application (use-case)
 // service (ADR-0020). The adapter implements the narrow rules.Store port over
-// the database AlertRules repository, mapping the database.AlertRule row to the
+// the database AlertRules repository, mapping the alerts.Rule row to the
 // use-case model and the repo's ErrAlertRuleNotFound / "alert_rules:"-prefixed
 // validation errors to the use-case's sentinels.
 
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/alerts/rules"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
@@ -31,7 +32,7 @@ type alertRuleStore struct {
 
 func (a alertRuleStore) Available() bool { return a.db() != nil }
 
-func toAppRule(r *database.AlertRule) rules.Rule {
+func toAppRule(r *alerts.Rule) rules.Rule {
 	return rules.Rule{
 		ID:                   r.ID,
 		Name:                 r.Name,
@@ -50,8 +51,8 @@ func toAppRule(r *database.AlertRule) rules.Rule {
 	}
 }
 
-func toDBRule(r rules.Rule) *database.AlertRule {
-	return &database.AlertRule{
+func toDBRule(r rules.Rule) *alerts.Rule {
+	return &alerts.Rule{
 		ID:                   r.ID,
 		Name:                 r.Name,
 		Enabled:              r.Enabled,
@@ -70,7 +71,7 @@ func toDBRule(r rules.Rule) *database.AlertRule {
 }
 
 func mapAlertRuleErr(err error) error {
-	if errors.Is(err, database.ErrAlertRuleNotFound) {
+	if errors.Is(err, alerts.ErrRuleNotFound) {
 		return rules.ErrNotFound
 	}
 	return err

--- a/internal/app/alerts_inbox.go
+++ b/internal/app/alerts_inbox.go
@@ -8,6 +8,7 @@ package app
 import (
 	"context"
 
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/alerts/inbox"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
@@ -32,8 +33,8 @@ func (a alertInboxRepo) repo() (*database.AlertRepository, error) {
 }
 
 func (a alertInboxRepo) List(
-	ctx context.Context, opts database.AlertListOptions,
-) ([]*database.Alert, error) {
+	ctx context.Context, opts alerts.ListOptions,
+) ([]*alerts.Alert, error) {
 	repo, err := a.repo()
 	if err != nil {
 		return nil, err

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	alertmodel "github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
@@ -815,9 +816,9 @@ func TestAlertRepository(t *testing.T) {
 	repo := db.Alerts()
 
 	// Create
-	alert := &database.Alert{
-		Type:     database.AlertTypeSecurity,
-		Severity: database.AlertSeverityWarning,
+	alert := &alertmodel.Alert{
+		Type:     alertmodel.TypeSecurity,
+		Severity: alertmodel.SeverityWarning,
 		Title:    "Test Alert",
 		Message:  "This is a test alert",
 		Source:   "test",
@@ -843,7 +844,7 @@ func TestAlertRepository(t *testing.T) {
 	}
 
 	// List
-	alerts, err := repo.List(ctx, database.AlertListOptions{})
+	alerts, err := repo.List(ctx, alertmodel.ListOptions{})
 	if err != nil {
 		t.Fatalf("failed to list alerts: %v", err)
 	}
@@ -877,7 +878,7 @@ func TestAlertRepository(t *testing.T) {
 	}
 
 	// Count
-	count, err := repo.Count(ctx, database.AlertListOptions{})
+	count, err := repo.Count(ctx, alertmodel.ListOptions{})
 	if err != nil {
 		t.Fatalf("failed to count: %v", err)
 	}
@@ -1301,7 +1302,7 @@ func TestAlertRepositoryExtended(t *testing.T) {
 	repo := db.Alerts()
 
 	// Create test alerts
-	alerts := []*database.Alert{
+	alerts := []*alertmodel.Alert{
 		{Title: "Alert 1", Severity: "critical", Source: "test"},
 		{Title: "Alert 2", Severity: "warning", Source: "test"},
 		{Title: "Alert 3", Severity: "info", Source: "test"},
@@ -1313,7 +1314,7 @@ func TestAlertRepositoryExtended(t *testing.T) {
 	}
 
 	t.Run("AcknowledgeAll", func(t *testing.T) {
-		count, err := repo.AcknowledgeAll(ctx, database.AlertListOptions{}, "testuser")
+		count, err := repo.AcknowledgeAll(ctx, alertmodel.ListOptions{}, "testuser")
 		require.NoError(t, err)
 		if count != 3 {
 			t.Errorf("expected 3 acknowledged, got %d", count)
@@ -1324,7 +1325,7 @@ func TestAlertRepositoryExtended(t *testing.T) {
 		// Create one more unacknowledged
 		err := repo.Create(
 			ctx,
-			&database.Alert{Title: "New Alert", Severity: "info", Source: "test"},
+			&alertmodel.Alert{Title: "New Alert", Severity: "info", Source: "test"},
 		)
 		require.NoError(t, err)
 
@@ -1698,7 +1699,7 @@ func TestAlertListWithFilters(t *testing.T) {
 	repo := db.Alerts()
 
 	// Create alerts with different severities and sources
-	alerts := []*database.Alert{
+	alerts := []*alertmodel.Alert{
 		{Title: "Critical Alert", Severity: "critical", Source: "system"},
 		{Title: "Warning Alert", Severity: "warning", Source: "network"},
 		{Title: "Info Alert", Severity: "info", Source: "system"},
@@ -1709,7 +1710,7 @@ func TestAlertListWithFilters(t *testing.T) {
 	}
 
 	t.Run("filter by severity", func(t *testing.T) {
-		list, err := repo.List(ctx, database.AlertListOptions{Severity: "critical"})
+		list, err := repo.List(ctx, alertmodel.ListOptions{Severity: "critical"})
 		require.NoError(t, err)
 		if len(list) != 1 {
 			t.Errorf("expected 1 critical alert, got %d", len(list))
@@ -1717,7 +1718,7 @@ func TestAlertListWithFilters(t *testing.T) {
 	})
 
 	t.Run("filter unresolved only", func(t *testing.T) {
-		list, err := repo.List(ctx, database.AlertListOptions{UnresolvedOnly: true})
+		list, err := repo.List(ctx, alertmodel.ListOptions{UnresolvedOnly: true})
 		require.NoError(t, err)
 		if len(list) != 3 {
 			t.Errorf("expected 3 unresolved alerts, got %d", len(list))
@@ -1725,7 +1726,7 @@ func TestAlertListWithFilters(t *testing.T) {
 	})
 
 	t.Run("with pagination", func(t *testing.T) {
-		list, err := repo.List(ctx, database.AlertListOptions{Limit: 1, Offset: 1})
+		list, err := repo.List(ctx, alertmodel.ListOptions{Limit: 1, Offset: 1})
 		require.NoError(t, err)
 		if len(list) != 1 {
 			t.Errorf("expected 1 alert with pagination, got %d", len(list))
@@ -1799,7 +1800,7 @@ func TestAcknowledgeAndResolve(t *testing.T) {
 	repo := db.Alerts()
 
 	// Create an alert
-	alert := &database.Alert{Title: "Test Alert", Severity: "warning", Source: "test"}
+	alert := &alertmodel.Alert{Title: "Test Alert", Severity: "warning", Source: "test"}
 	createErr := repo.Create(ctx, alert)
 	require.NoError(t, createErr)
 

--- a/internal/database/edge_cases_test.go
+++ b/internal/database/edge_cases_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	alertmodel "github.com/MustardSeedNetworks/seed/internal/alerts"
 	"github.com/MustardSeedNetworks/seed/internal/database"
 )
 
@@ -169,9 +170,9 @@ func TestAlertRepositoryFilters(t *testing.T) {
 	require.NoError(t, deviceRepo.Create(ctx, testDevice))
 
 	// Create test alert with device
-	alert := &database.Alert{
-		Type:     database.AlertTypeSecurity,
-		Severity: database.AlertSeverityCritical,
+	alert := &alertmodel.Alert{
+		Type:     alertmodel.TypeSecurity,
+		Severity: alertmodel.SeverityCritical,
 		Title:    "Alert with device",
 		Message:  "Test",
 		Source:   "test",
@@ -180,21 +181,21 @@ func TestAlertRepositoryFilters(t *testing.T) {
 	require.NoError(t, repo.Create(ctx, alert))
 
 	t.Run("List with type filter", func(t *testing.T) {
-		alerts, err := repo.List(ctx, database.AlertListOptions{Type: database.AlertTypeSecurity})
+		alerts, err := repo.List(ctx, alertmodel.ListOptions{Type: alertmodel.TypeSecurity})
 		require.NoError(t, err)
 		for _, a := range alerts {
-			require.Equal(t, database.AlertTypeSecurity, a.Type)
+			require.Equal(t, alertmodel.TypeSecurity, a.Type)
 		}
 	})
 
 	t.Run("List with device ID filter", func(t *testing.T) {
-		alerts, err := repo.List(ctx, database.AlertListOptions{DeviceID: testDevice.ID})
+		alerts, err := repo.List(ctx, alertmodel.ListOptions{DeviceID: testDevice.ID})
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(alerts), 1)
 	})
 
 	t.Run("List with unacknowledged only", func(t *testing.T) {
-		alerts, err := repo.List(ctx, database.AlertListOptions{UnacknowledgedOnly: true})
+		alerts, err := repo.List(ctx, alertmodel.ListOptions{UnacknowledgedOnly: true})
 		require.NoError(t, err)
 		for _, a := range alerts {
 			require.False(t, a.Acknowledged)
@@ -214,9 +215,9 @@ func TestAlertRepositoryEdgeCases(t *testing.T) {
 	require.NoError(t, deviceRepo.Create(ctx, testDevice))
 
 	t.Run("Alert with device ID and metadata", func(t *testing.T) {
-		alert := &database.Alert{
-			Type:     database.AlertTypeSecurity,
-			Severity: database.AlertSeverityCritical,
+		alert := &alertmodel.Alert{
+			Type:     alertmodel.TypeSecurity,
+			Severity: alertmodel.SeverityCritical,
 			Title:    "Alert with device",
 			Message:  "Test message",
 			Source:   "test",
@@ -234,25 +235,25 @@ func TestAlertRepositoryEdgeCases(t *testing.T) {
 
 	t.Run("AcknowledgeAll operations", func(t *testing.T) {
 		// Create unacknowledged alert
-		require.NoError(t, repo.Create(ctx, &database.Alert{
-			Type:     database.AlertTypeSystem,
-			Severity: database.AlertSeverityWarning,
+		require.NoError(t, repo.Create(ctx, &alertmodel.Alert{
+			Type:     alertmodel.TypeSystem,
+			Severity: alertmodel.SeverityWarning,
 			Title:    "Warning alert",
 			Message:  "Test",
 			Source:   "test",
 		}))
 
-		count, err := repo.AcknowledgeAll(ctx, database.AlertListOptions{
-			Severity: database.AlertSeverityWarning,
+		count, err := repo.AcknowledgeAll(ctx, alertmodel.ListOptions{
+			Severity: alertmodel.SeverityWarning,
 		}, "admin")
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, count, int64(1))
 	})
 
 	t.Run("Count with filters", func(t *testing.T) {
-		count, err := repo.Count(ctx, database.AlertListOptions{
-			Type:     database.AlertTypeSecurity,
-			Severity: database.AlertSeverityCritical,
+		count, err := repo.Count(ctx, alertmodel.ListOptions{
+			Type:     alertmodel.TypeSecurity,
+			Severity: alertmodel.SeverityCritical,
 		})
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, count, int64(0))

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -86,41 +86,6 @@ type Device struct {
 	Metadata   string    `json:"metadata,omitempty"` // JSON string for extra data
 }
 
-// Alert represents a system alert.
-type Alert struct {
-	ID             int64      `json:"id"`
-	Type           string     `json:"type"`     // e.g., "security", "performance", "connectivity"
-	Severity       string     `json:"severity"` // "info", "warning", "error", "critical"
-	Title          string     `json:"title"`
-	Message        string     `json:"message"`
-	Source         string     `json:"source,omitempty"` // What generated the alert
-	DeviceID       *string    `json:"deviceId,omitempty"`
-	Acknowledged   bool       `json:"acknowledged"`
-	AcknowledgedBy *string    `json:"acknowledgedBy,omitempty"`
-	AcknowledgedAt *time.Time `json:"acknowledgedAt,omitempty"`
-	Resolved       bool       `json:"resolved"`
-	ResolvedAt     *time.Time `json:"resolvedAt,omitempty"`
-	CreatedAt      time.Time  `json:"createdAt"`
-	Metadata       string     `json:"metadata,omitempty"` // JSON string for extra data
-}
-
-// AlertType constants for common alert types.
-const (
-	AlertTypeSecurity     = "security"
-	AlertTypePerformance  = "performance"
-	AlertTypeConnectivity = "connectivity"
-	AlertTypeSystem       = "system"
-	AlertTypeDiscovery    = "discovery"
-)
-
-// AlertSeverity constants.
-const (
-	AlertSeverityInfo     = "info"
-	AlertSeverityWarning  = "warning"
-	AlertSeverityError    = "error"
-	AlertSeverityCritical = "critical"
-)
-
 // SpeedTestResult represents a speed test result.
 type SpeedTestResult struct {
 	ID             int64     `json:"id"`

--- a/internal/database/repository_alert_rules.go
+++ b/internal/database/repository_alert_rules.go
@@ -6,48 +6,21 @@ import (
 	"errors"
 	"fmt"
 	"time"
-)
 
-// AlertRule is one row of alert_rules. Match fields default to ""
-// which the listener pipeline treats as "any value matches".
-//
-// Time-windowed rules (#1379): WindowSeconds > 0 + ThresholdCount > 1
-// means "fire only after N matching events within W seconds." The
-// default (0/1) preserves the pre-#1379 fire-on-first-match
-// behavior. Validation rejects ThresholdCount > 1 with WindowSeconds
-// = 0 because a threshold without a window has no time bound and
-// would silently never reset.
-type AlertRule struct {
-	ID                   int64
-	Name                 string
-	Enabled              bool
-	MatchKind            string
-	MatchSeverity        string
-	MatchPayloadContains string
-	AlertType            string
-	AlertSeverity        string
-	AlertTitle           string
-	AlertMessage         string
-	WindowSeconds        int
-	ThresholdCount       int
-	CreatedAt            time.Time
-	UpdatedAt            time.Time
-}
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
+)
 
 // AlertRulesRepository owns CRUD over alert_rules.
 type AlertRulesRepository struct {
 	db *DB
 }
 
-// ErrAlertRuleNotFound is returned when a rule lookup misses.
-var ErrAlertRuleNotFound = errors.New("alert rule not found")
-
 // validateRule enforces invariants both Create and Update need.
 // Time-window validation (#1379): threshold > 1 requires a window;
 // negative values are nonsense for either field. ThresholdCount == 0
 // is normalized to 1 in-place so callers (handlers, tests) that
 // don't think about windowing don't need to set the field.
-func validateRule(rule *AlertRule) error {
+func validateRule(rule *alerts.Rule) error {
 	if rule.Name == "" {
 		return errors.New("alert_rules: Name required")
 	}
@@ -73,7 +46,7 @@ func validateRule(rule *AlertRule) error {
 }
 
 // Create inserts a new rule.
-func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) error {
+func (r *AlertRulesRepository) Create(ctx context.Context, rule *alerts.Rule) error {
 	if err := validateRule(rule); err != nil {
 		return err
 	}
@@ -111,7 +84,7 @@ func (r *AlertRulesRepository) Create(ctx context.Context, rule *AlertRule) erro
 }
 
 // Get returns the rule with the given id.
-func (r *AlertRulesRepository) Get(ctx context.Context, id int64) (*AlertRule, error) {
+func (r *AlertRulesRepository) Get(ctx context.Context, id int64) (*alerts.Rule, error) {
 	row := r.db.QueryRow(ctx, `
 		SELECT id, name, enabled, match_kind, match_severity, match_payload_contains,
 		       alert_type, alert_severity, alert_title, alert_message,
@@ -125,7 +98,7 @@ func (r *AlertRulesRepository) Get(ctx context.Context, id int64) (*AlertRule, e
 // List returns every rule ordered by id ascending so the pipeline
 // applies rules in a deterministic order. enabledOnly filters out
 // disabled rows (the pipeline uses true; the operator UI uses false).
-func (r *AlertRulesRepository) List(ctx context.Context, enabledOnly bool) ([]*AlertRule, error) {
+func (r *AlertRulesRepository) List(ctx context.Context, enabledOnly bool) ([]*alerts.Rule, error) {
 	query := `
 		SELECT id, name, enabled, match_kind, match_severity, match_payload_contains,
 		       alert_type, alert_severity, alert_title, alert_message,
@@ -142,8 +115,8 @@ func (r *AlertRulesRepository) List(ctx context.Context, enabledOnly bool) ([]*A
 }
 
 // Update replaces every writable field on the rule. Returns
-// ErrAlertRuleNotFound when id doesn't exist.
-func (r *AlertRulesRepository) Update(ctx context.Context, rule *AlertRule) error {
+// alerts.ErrRuleNotFound when id doesn't exist.
+func (r *AlertRulesRepository) Update(ctx context.Context, rule *alerts.Rule) error {
 	if rule.ID == 0 {
 		return errors.New("alert_rules: ID required for Update")
 	}
@@ -178,7 +151,7 @@ func (r *AlertRulesRepository) Update(ctx context.Context, rule *AlertRule) erro
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
-		return ErrAlertRuleNotFound
+		return alerts.ErrRuleNotFound
 	}
 	return nil
 }
@@ -191,14 +164,14 @@ func (r *AlertRulesRepository) Delete(ctx context.Context, id int64) error {
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
-		return ErrAlertRuleNotFound
+		return alerts.ErrRuleNotFound
 	}
 	return nil
 }
 
-func scanAlertRule(scan func(...any) error) (*AlertRule, error) {
+func scanAlertRule(scan func(...any) error) (*alerts.Rule, error) {
 	var (
-		rule         AlertRule
+		rule         alerts.Rule
 		enabledInt   int
 		matchKind    sql.NullString
 		matchSev     sql.NullString
@@ -215,7 +188,7 @@ func scanAlertRule(scan func(...any) error) (*AlertRule, error) {
 		&createdStr, &updatedStr,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrAlertRuleNotFound
+		return nil, alerts.ErrRuleNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("scan alert_rule: %w", err)

--- a/internal/database/repository_alerts.go
+++ b/internal/database/repository_alerts.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/MustardSeedNetworks/seed/internal/alerts"
 )
 
 // ErrAlertNotFound is returned when an alert is not found.
@@ -17,7 +19,7 @@ type AlertRepository struct {
 }
 
 // Create creates a new alert.
-func (r *AlertRepository) Create(ctx context.Context, alert *Alert) error {
+func (r *AlertRepository) Create(ctx context.Context, alert *alerts.Alert) error {
 	if alert.CreatedAt.IsZero() {
 		alert.CreatedAt = time.Now().UTC()
 	}
@@ -44,7 +46,7 @@ func (r *AlertRepository) Create(ctx context.Context, alert *Alert) error {
 }
 
 // Get retrieves an alert by ID.
-func (r *AlertRepository) Get(ctx context.Context, id int64) (*Alert, error) {
+func (r *AlertRepository) Get(ctx context.Context, id int64) (*alerts.Alert, error) {
 	row := r.db.QueryRow(ctx, `
 		SELECT id, type, severity, title, message, source, device_id, acknowledged,
 		       acknowledged_by, acknowledged_at, resolved, resolved_at, created_at, metadata_json
@@ -57,7 +59,7 @@ func (r *AlertRepository) Get(ctx context.Context, id int64) (*Alert, error) {
 // List retrieves alerts matching the criteria.
 //
 
-func (r *AlertRepository) List(ctx context.Context, opts AlertListOptions) ([]*Alert, error) {
+func (r *AlertRepository) List(ctx context.Context, opts alerts.ListOptions) ([]*alerts.Alert, error) {
 	query := `
 		SELECT id, type, severity, title, message, source, device_id, acknowledged,
 		       acknowledged_by, acknowledged_at, resolved, resolved_at, created_at, metadata_json
@@ -112,28 +114,16 @@ func (r *AlertRepository) List(ctx context.Context, opts AlertListOptions) ([]*A
 	}
 	defer func() { _ = rows.Close() }()
 
-	var alerts []*Alert
+	var out []*alerts.Alert
 	for rows.Next() {
 		a, scanErr := r.scanAlertFromRows(rows)
 		if scanErr != nil {
 			return nil, scanErr
 		}
-		alerts = append(alerts, a)
+		out = append(out, a)
 	}
 
-	return alerts, rows.Err()
-}
-
-// AlertListOptions specifies criteria for listing alerts.
-type AlertListOptions struct {
-	Type               string
-	Severity           string
-	DeviceID           string
-	UnacknowledgedOnly bool
-	UnresolvedOnly     bool
-	Since              time.Time
-	Limit              int
-	Offset             int
+	return out, rows.Err()
 }
 
 // Acknowledge marks an alert as acknowledged.
@@ -165,7 +155,7 @@ func (r *AlertRepository) Acknowledge(ctx context.Context, id int64, by string) 
 
 func (r *AlertRepository) AcknowledgeAll(
 	ctx context.Context,
-	opts AlertListOptions,
+	opts alerts.ListOptions,
 	by string,
 ) (int64, error) {
 	now := time.Now().UTC()
@@ -256,7 +246,7 @@ func (r *AlertRepository) DeleteOlderThan(ctx context.Context, cutoff time.Time)
 // Count returns the number of alerts matching the criteria.
 //
 
-func (r *AlertRepository) Count(ctx context.Context, opts AlertListOptions) (int64, error) {
+func (r *AlertRepository) Count(ctx context.Context, opts alerts.ListOptions) (int64, error) {
 	query := "SELECT COUNT(*) FROM alerts WHERE 1=1"
 	var args []any
 
@@ -288,20 +278,20 @@ func (r *AlertRepository) Count(ctx context.Context, opts AlertListOptions) (int
 
 // GetUnacknowledgedCount returns the number of unacknowledged alerts.
 func (r *AlertRepository) GetUnacknowledgedCount(ctx context.Context) (int64, error) {
-	return r.Count(ctx, AlertListOptions{UnacknowledgedOnly: true})
+	return r.Count(ctx, alerts.ListOptions{UnacknowledgedOnly: true})
 }
 
 // GetCriticalCount returns the number of unresolved critical alerts.
 func (r *AlertRepository) GetCriticalCount(ctx context.Context) (int64, error) {
-	return r.Count(ctx, AlertListOptions{
-		Severity:       AlertSeverityCritical,
+	return r.Count(ctx, alerts.ListOptions{
+		Severity:       alerts.SeverityCritical,
 		UnresolvedOnly: true,
 	})
 }
 
 // scanAlert scans an alert from a row.
-func (r *AlertRepository) scanAlert(row *sql.Row) (*Alert, error) {
-	var a Alert
+func (r *AlertRepository) scanAlert(row *sql.Row) (*alerts.Alert, error) {
+	var a alerts.Alert
 	var createdAt string
 	var acked, resolved int
 	var source, deviceID, ackedBy, ackedAt, resolvedAt, metadata sql.NullString
@@ -344,8 +334,8 @@ func (r *AlertRepository) scanAlert(row *sql.Row) (*Alert, error) {
 }
 
 // scanAlertFromRows scans an alert from rows.
-func (r *AlertRepository) scanAlertFromRows(rows *sql.Rows) (*Alert, error) {
-	var a Alert
+func (r *AlertRepository) scanAlertFromRows(rows *sql.Rows) (*alerts.Alert, error) {
+	var a alerts.Alert
 	var createdAt string
 	var acked, resolved int
 	var source, deviceID, ackedBy, ackedAt, resolvedAt, metadata sql.NullString

--- a/internal/database/repository_listener_events.go
+++ b/internal/database/repository_listener_events.go
@@ -6,21 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"time"
-)
 
-// ListenerEvent is one row of listener_events.
-type ListenerEvent struct {
-	ID          int64
-	ClientID    string
-	Kind        string
-	SourceAddr  string
-	TargetKind  string
-	TargetID    string
-	Severity    string
-	ObservedAt  time.Time
-	PayloadJSON string
-	IngestedAt  time.Time
-}
+	"github.com/MustardSeedNetworks/seed/internal/listener"
+)
 
 // ListenerEventsRepository owns CRUD over listener_events.
 type ListenerEventsRepository struct {
@@ -29,7 +17,7 @@ type ListenerEventsRepository struct {
 
 // Insert records one listener event. ObservedAt and IngestedAt are
 // stamped with the current time if zero.
-func (r *ListenerEventsRepository) Insert(ctx context.Context, evt *ListenerEvent) error {
+func (r *ListenerEventsRepository) Insert(ctx context.Context, evt *listener.EventRecord) error {
 	if evt.Kind == "" {
 		return errors.New("listener_events: Kind required")
 	}
@@ -72,23 +60,12 @@ func (r *ListenerEventsRepository) Insert(ctx context.Context, evt *ListenerEven
 	return nil
 }
 
-// ListenerEventListOptions narrows the query — empty values disable
-// that filter.
-type ListenerEventListOptions struct {
-	ClientID   string
-	Kind       string
-	SourceAddr string
-	Since      time.Time
-	Until      time.Time
-	Limit      int
-}
-
 // List returns events matching opts ordered by ObservedAt desc.
 // Limit defaults to 100; clamped to 1000.
 func (r *ListenerEventsRepository) List(
 	ctx context.Context,
-	opts ListenerEventListOptions,
-) ([]*ListenerEvent, error) {
+	opts listener.EventListOptions,
+) ([]*listener.EventRecord, error) {
 	const defaultLimit, maxLimit = 100, 1000
 
 	query, args := newListQueryBuilder(`
@@ -130,9 +107,9 @@ func (r *ListenerEventsRepository) DeleteOlderThan(
 
 // scanListenerEvent reads a row via either [sql.Row.Scan] or
 // [sql.Rows.Scan] signatures.
-func scanListenerEvent(scan func(...any) error) (*ListenerEvent, error) {
+func scanListenerEvent(scan func(...any) error) (*listener.EventRecord, error) {
 	var (
-		evt           ListenerEvent
+		evt           listener.EventRecord
 		targetKind    sql.NullString
 		targetID      sql.NullString
 		severity      sql.NullString

--- a/internal/listener/events.go
+++ b/internal/listener/events.go
@@ -1,0 +1,33 @@
+package listener
+
+import "time"
+
+// EventRecord is one persisted listener_events row — the durable form of an
+// [Event] after the sink writes it. It carries the storage-assigned ID and
+// ingest timestamp that the in-flight Event does not. The type lives here (not
+// in internal/database) so the sink and the alert pipeline that read/write
+// these rows stay persistence-free: the listener-events repository in
+// internal/database imports this package and maps SQL rows to it.
+type EventRecord struct {
+	ID          int64
+	ClientID    string
+	Kind        string
+	SourceAddr  string
+	TargetKind  string
+	TargetID    string
+	Severity    string
+	ObservedAt  time.Time
+	PayloadJSON string
+	IngestedAt  time.Time
+}
+
+// EventListOptions narrows a listener-events list query — empty values disable
+// that filter.
+type EventListOptions struct {
+	ClientID   string
+	Kind       string
+	SourceAddr string
+	Since      time.Time
+	Until      time.Time
+	Limit      int
+}

--- a/internal/listener/sink/sink.go
+++ b/internal/listener/sink/sink.go
@@ -16,14 +16,13 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/listener"
 )
 
 // eventsStore is the narrowed surface the sink uses. Tests inject a
 // fake.
 type eventsStore interface {
-	Insert(ctx context.Context, evt *database.ListenerEvent) error
+	Insert(ctx context.Context, evt *listener.EventRecord) error
 }
 
 // Sink persists [listener.Event] instances into listener_events.
@@ -63,7 +62,7 @@ func (s *Sink) Publish(ctx context.Context, evt listener.Event) error {
 		return fmt.Errorf("listener sink: invalid JSON payload for %s", evt.Kind)
 	}
 
-	if err := s.store.Insert(ctx, &database.ListenerEvent{
+	if err := s.store.Insert(ctx, &listener.EventRecord{
 		ClientID:    evt.ClientID,
 		Kind:        evt.Kind,
 		SourceAddr:  evt.SourceAddr,

--- a/internal/listener/sink/sink_test.go
+++ b/internal/listener/sink/sink_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/listener"
 	"github.com/MustardSeedNetworks/seed/internal/listener/sink"
 )
@@ -18,11 +17,11 @@ func silentLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
 
 type fakeStore struct {
 	mu   sync.Mutex
-	rows []*database.ListenerEvent
+	rows []*listener.EventRecord
 	err  error
 }
 
-func (f *fakeStore) Insert(_ context.Context, evt *database.ListenerEvent) error {
+func (f *fakeStore) Insert(_ context.Context, evt *listener.EventRecord) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.err != nil {


### PR DESCRIPTION
## What

WS-B (Architecture Completion Plan), **last of the heavy four** — the central junction. `internal/alerts/**` and `internal/listener/sink` imported `internal/database` for their row types. Relocate the types to the domains that own them; the repositories map SQL rows inward.

## Change (strategy B: relocate row types into the owning domain package)

- **→ new `internal/alerts`**: `Alert`, `Rule`(←AlertRule), `ListOptions`(←AlertListOptions), `Severity*`(←AlertSeverity*), `Type*`(←AlertType*), `ErrRuleNotFound`(←ErrAlertRuleNotFound). Stutter prefix dropped per ADR-0010/revive.
- **→ `internal/listener`**: `EventRecord`(←ListenerEvent), `EventListOptions`(←ListenerEventListOptions). Named **EventRecord**, not Event — `internal/listener` already owns the live `Event`; this is the persisted row.
- `Alert`/`AlertRules`/`ListenerEvents` repositories stay in `internal/database` and now import the domain pkgs, mapping rows inward. `internal/alerts` and `internal/listener` no longer import `internal/database` (a back-import is now a compile-time cycle).
- New **`alerts-no-persistence`** + **`listener-no-persistence`** depguard rules (RED-proven). Listener going fully persistence-free folds in the deferred moderate `listener/sink` item — a bonus.
- **Pre-v1 no-compat:** zero `database.*` re-export aliases (verified `grep -rnE '= (alerts|listener)\.' internal/database/*.go` empty). Colliding test files import the domain pkg aliased (`alertmodel`) where a local `alerts` var shadows it.

## Evidence
- `go build ./...` clean
- `go test -race` green: alerts/**, listener/**, app, plus targeted database + api Alert/Listener/Rule suites
- **Full** `golangci-lint run` on all touched packages → 0 issues (only pre-existing `handlers_settings.go:99` gofumpt, not mine)
- depguard GREEN; RED-proven (alerts → rule message; listener → import cycle). filename-policy + gofmt + gitleaks clean
- `internal/alerts` & `internal/listener` production: **zero** `internal/database` imports.

With this, **all four heavy WS-B packages are persistence-free**: probe (#1672), topology (#1673), polling (#1675), alerts+listener (this).