### PR TITLE
refactor(health): make health surface persistence-free (WS-B)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -362,6 +362,21 @@ linters:
           deny:
             - pkg: github.com/MustardSeedNetworks/seed/internal/database
               desc: "timeseries is persistence-free — the RollupSource port lives in internal/timeseries/retention; the MetricsRollupSource/ProbeRollupSource SQL adapters (internal/database) implement it; wire them in internal/app/api"
+        # WS-B repository-port discipline: the health surface owns its config
+        # endpoint mapping (internal/health/probemap) and settings use-case
+        # (internal/health/settings) in domain terms — it maps config endpoints to
+        # the probe.Probe domain type, never the database row. The probes table is
+        # reached only through the probe repository, wired in internal/app
+        # (healthProbeStore / dbProbeToModel / modelToDBProbe). So internal/health
+        # never imports internal/database. Production-only (tests are mini
+        # composition roots).
+        "health-no-persistence":
+          files:
+            - "**/internal/health/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "health is persistence-free — probemap maps to the probe.Probe domain type; the probe repository (internal/database) is wired in internal/app (healthProbeStore); never import internal/database from internal/health"
         # Phase 6 capture port: libpcap (via gopacket/pcap) carries the CGO
         # taint that re-links libpcap into every dependent test binary. It is
         # confined to the single adapter package internal/capture/pcap; every

--- a/internal/api/handlers_health_checks_settings_internal_test.go
+++ b/internal/api/handlers_health_checks_settings_internal_test.go
@@ -22,6 +22,7 @@ func wireHealthSettings(s *Server) {
 	s.healthSettings = app.NewHealthSettings(
 		s.healthProbeRepo, s.rescheduleProbeEngine,
 		s.config, s.configPath, s.dnsTester, s.speedtestTester,
+		s.healthSettingsRepo,
 	)
 }
 

--- a/internal/api/handlers_settings.go
+++ b/internal/api/handlers_settings.go
@@ -97,6 +97,7 @@ func (s *Server) updateSettings(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("ETag", s.settingsManagement.ETag())
 	sendJSONResponse(w, logger, http.StatusOK, map[string]string{"status": "updated"})
 }
+
 func (s *Server) handleLinkSettings(w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(r.Context())
 	switch r.Method {

--- a/internal/api/healthcheckrun.go
+++ b/internal/api/healthcheckrun.go
@@ -17,12 +17,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"slices"
 	"sync"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
-	"github.com/MustardSeedNetworks/seed/internal/database"
-	"github.com/MustardSeedNetworks/seed/internal/health/probemap"
 	"github.com/MustardSeedNetworks/seed/internal/i18n"
 	"github.com/MustardSeedNetworks/seed/internal/logging"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
@@ -238,7 +235,7 @@ type ModbusTestResult struct {
 
 // runProbeResult pairs a dispatched probe with its Result for mapping.
 type runProbeResult struct {
-	probe  *database.Probe
+	probe  probe.Probe
 	result probe.Result
 }
 
@@ -282,38 +279,22 @@ func (s *Server) handleHealthChecks(w http.ResponseWriter, r *http.Request) {
 // healthCheckProbes lists the operator's configured probes of the health-check
 // kinds (ping/tcp/udp/http/rtsp/dicom + the eight verticals), in a stable
 // display order.
-func (s *Server) healthCheckProbes(ctx context.Context) ([]*database.Probe, error) {
-	all, err := s.db().Probes().ListProbes(ctx, database.DefaultClientID, "")
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*database.Probe, 0, len(all))
-	for _, p := range all {
-		if isHealthCheckKind(p.Kind) {
-			out = append(out, p)
-		}
-	}
-	return out, nil
-}
-
-// isHealthCheckKind reports whether kind is one of the fourteen kinds the
-// health-check surface owns.
-func isHealthCheckKind(kind string) bool {
-	return slices.Contains(probemap.Kinds(), kind)
+func (s *Server) healthCheckProbes(ctx context.Context) ([]probe.Probe, error) {
+	return s.healthSettings.HealthCheckProbes(ctx)
 }
 
 // dispatchProbes runs each probe via Engine.RunNow with bounded concurrency
 // and returns the (probe, result) pairs in the input order. A probe whose
 // dispatch errors (e.g. storage hiccup) still yields its error as a failed
 // Result so the card shows it rather than silently dropping the row.
-func (s *Server) dispatchProbes(ctx context.Context, probes []*database.Probe) []runProbeResult {
+func (s *Server) dispatchProbes(ctx context.Context, probes []probe.Probe) []runProbeResult {
 	out := make([]runProbeResult, len(probes))
 	sem := make(chan struct{}, maxConcurrentRunProbes)
 	var wg sync.WaitGroup
 	for i, p := range probes {
 		wg.Add(1)
 		sem <- struct{}{}
-		go func(idx int, pr *database.Probe) {
+		go func(idx int, pr probe.Probe) {
 			defer wg.Done()
 			defer func() { <-sem }()
 			res, err := s.probeEngine.RunNow(ctx, pr.ID)
@@ -329,7 +310,7 @@ func (s *Server) dispatchProbes(ctx context.Context, probes []*database.Probe) [
 
 // mapRunResult dispatches a single (probe, result) into the right slot of the
 // response by kind. The per-kind mappers live in healthcheckrunmappers.go.
-func mapRunResult(resp *HealthCheckRunResponse, p *database.Probe, r probe.Result, th *config.CustomThresholds) {
+func mapRunResult(resp *HealthCheckRunResponse, p probe.Probe, r probe.Result, th *config.CustomThresholds) {
 	switch p.Kind {
 	case probe.KindPing:
 		resp.PingResults = append(resp.PingResults, mapPingResult(p, r))
@@ -402,13 +383,13 @@ func (resp *HealthCheckRunResponse) industrial() *IndustrialResults {
 // mapPingResult maps a ping probe Result. Ping reports reachability + dial
 // latency; extended loss/jitter stats are not produced by the scheduled
 // probe (ADR-0027 P3a non-port), so those fields stay zero/absent.
-func mapPingResult(p *database.Probe, r probe.Result) TestResult {
+func mapPingResult(p probe.Probe, r probe.Result) TestResult {
 	return baseTestResult(p, r)
 }
 
 // mapPortResult maps a tcp/udp probe Result, deriving testStatus from the
 // connect-latency threshold for that kind.
-func mapPortResult(p *database.Probe, r probe.Result, th config.Threshold) TestResult {
+func mapPortResult(p probe.Probe, r probe.Result, th config.Threshold) TestResult {
 	out := baseTestResult(p, r)
 	if r.Success {
 		out.TestStatus = getTestStatus(r.LatencyMs, th.Warning.Milliseconds(), th.Critical.Milliseconds())
@@ -418,7 +399,7 @@ func mapPortResult(p *database.Probe, r probe.Result, th config.Threshold) TestR
 
 // mapHTTPResult maps an http/https probe Result: status code, per-phase
 // timing breakdown + derived statuses, and (for https) the cert summary.
-func mapHTTPResult(p *database.Probe, r probe.Result, th *config.CustomThresholds) TestResult {
+func mapHTTPResult(p probe.Probe, r probe.Result, th *config.CustomThresholds) TestResult {
 	out := baseTestResult(p, r)
 	var meta checkers.HTTPRunMetadata
 	if len(r.Metadata) > 0 {
@@ -485,7 +466,7 @@ func certStatusFromDays(days int, th config.CertExpiryThreshold) string {
 
 // baseTestResult fills the fields common to every kind: the display name,
 // success, latency, and error.
-func baseTestResult(p *database.Probe, r probe.Result) TestResult {
+func baseTestResult(p probe.Probe, r probe.Result) TestResult {
 	out := TestResult{
 		Name:    p.DisplayName,
 		Success: r.Success,

--- a/internal/api/healthcheckrun_internal_test.go
+++ b/internal/api/healthcheckrun_internal_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
 )
 
@@ -28,7 +27,7 @@ func lenientThresholds() config.CustomThresholds {
 // success testStatus when every phase is within bounds.
 func TestMapHTTPResult_TimingsAndCert(t *testing.T) {
 	th := lenientThresholds()
-	p := &database.Probe{Kind: probe.KindHTTPS, DisplayName: "api", Target: "https://api.example"}
+	p := probe.Probe{Kind: probe.KindHTTPS, DisplayName: "api", Target: "https://api.example"}
 	meta, _ := json.Marshal(map[string]any{
 		"status_code": 200,
 		"timings_ms":  map[string]float64{"dns": 1, "tcp": 2, "tls": 3, "ttfb": 10},
@@ -58,7 +57,7 @@ func TestMapHTTPResult_TimingsAndCert(t *testing.T) {
 // downgrades both certStatus and the overall testStatus to warning.
 func TestMapHTTPResult_CertNearExpiryWarns(t *testing.T) {
 	th := lenientThresholds()
-	p := &database.Probe{Kind: probe.KindHTTPS, DisplayName: "api", Target: "https://api.example"}
+	p := probe.Probe{Kind: probe.KindHTTPS, DisplayName: "api", Target: "https://api.example"}
 	meta, _ := json.Marshal(map[string]any{
 		"status_code": 200,
 		"timings_ms":  map[string]float64{"ttfb": 5},
@@ -76,7 +75,7 @@ func TestMapHTTPResult_CertNearExpiryWarns(t *testing.T) {
 // from the connect-latency threshold.
 func TestMapPortResult_DerivesStatusFromThreshold(t *testing.T) {
 	th := config.Threshold{Warning: 10 * time.Millisecond, Critical: 50 * time.Millisecond}
-	p := &database.Probe{Kind: probe.KindTCP, DisplayName: "db", Target: "db:5432"}
+	p := probe.Probe{Kind: probe.KindTCP, DisplayName: "db", Target: "db:5432"}
 
 	warn := mapPortResult(p, probe.Result{Success: true, LatencyMs: 20}, th)
 	require.Equal(t, statusWarning, warn.TestStatus)
@@ -94,14 +93,17 @@ func TestMapRunResult_GroupsByFamily(t *testing.T) {
 
 	hl7Params, _ := json.Marshal(config.HL7Endpoint{Host: "hl7.example", Port: 2575})
 	hl7Meta, _ := json.Marshal(map[string]any{"ack_code": "AA"})
-	mapRunResult(&resp, &database.Probe{Kind: probe.KindHL7, DisplayName: "lab", ParamsJSON: string(hl7Params)},
+	mapRunResult(&resp,
+		probe.Probe{Kind: probe.KindHL7, DisplayName: "lab", Params: json.RawMessage(hl7Params)},
 		probe.Result{Kind: probe.KindHL7, Success: true, LatencyMs: 8, Metadata: hl7Meta}, &th)
 
 	sqlParams, _ := json.Marshal(config.SQLEndpoint{Driver: "postgres", Host: "db", Port: 5432})
-	mapRunResult(&resp, &database.Probe{Kind: probe.KindSQL, DisplayName: "pg", ParamsJSON: string(sqlParams)},
+	mapRunResult(&resp,
+		probe.Probe{Kind: probe.KindSQL, DisplayName: "pg", Params: json.RawMessage(sqlParams)},
 		probe.Result{Kind: probe.KindSQL, Success: true, LatencyMs: 4}, &th)
 
-	mapRunResult(&resp, &database.Probe{Kind: probe.KindPing, DisplayName: "gw", Target: "1.1.1.1"},
+	mapRunResult(&resp,
+		probe.Probe{Kind: probe.KindPing, DisplayName: "gw", Target: "1.1.1.1"},
 		probe.Result{Kind: probe.KindPing, Success: true, LatencyMs: 2}, &th)
 
 	require.Len(t, resp.PingResults, 1)

--- a/internal/api/healthcheckrunmappers.go
+++ b/internal/api/healthcheckrunmappers.go
@@ -2,26 +2,25 @@ package api
 
 // healthcheckrunmappers.go contains the per-kind result mappers for the
 // health-check /run endpoint (ADR-0027 P3). Each mapper converts a
-// (database.Probe, probe.Result) pair into the wire DTO the HealthCheckCard
+// (probe.Probe, probe.Result) pair into the wire DTO the HealthCheckCard
 // renders. Static fields (host, port, driver, …) come from the probe's
-// ParamsJSON; dynamic fields (server version, ack code, …) come from
+// Params; dynamic fields (server version, ack code, …) come from
 // probe.Result.Metadata.
 
 import (
 	"encoding/json"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
 	"github.com/MustardSeedNetworks/seed/internal/probe/checkers"
 )
 
 // mapSQLResult maps a KindSQL probe result. Driver/host/port come from
-// ParamsJSON; server_version comes from Result.Metadata.
-func mapSQLResult(p *database.Probe, r probe.Result) SQLTestResult {
+// Params; server_version comes from Result.Metadata.
+func mapSQLResult(p probe.Probe, r probe.Result) SQLTestResult {
 	var ep config.SQLEndpoint
-	if p.ParamsJSON != "" {
-		_ = json.Unmarshal([]byte(p.ParamsJSON), &ep)
+	if len(p.Params) > 0 {
+		_ = json.Unmarshal(p.Params, &ep)
 	}
 	var md checkers.SQLRunMetadata
 	if len(r.Metadata) > 0 {
@@ -41,11 +40,11 @@ func mapSQLResult(p *database.Probe, r probe.Result) SQLTestResult {
 }
 
 // mapFileShareResult maps a KindFileShare probe result. Protocol/host/share
-// come from ParamsJSON; speed fields have no metadata source and stay zero.
-func mapFileShareResult(p *database.Probe, r probe.Result) FileShareTestResult {
+// come from Params; speed fields have no metadata source and stay zero.
+func mapFileShareResult(p probe.Probe, r probe.Result) FileShareTestResult {
 	var ep config.FileShareEndpoint
-	if p.ParamsJSON != "" {
-		_ = json.Unmarshal([]byte(p.ParamsJSON), &ep)
+	if len(p.Params) > 0 {
+		_ = json.Unmarshal(p.Params, &ep)
 	}
 	return FileShareTestResult{
 		Name:          p.DisplayName,
@@ -59,11 +58,11 @@ func mapFileShareResult(p *database.Probe, r probe.Result) FileShareTestResult {
 }
 
 // mapLDAPResult maps a KindLDAP probe result. UseTLS/host/port come from
-// ParamsJSON; ServerInfo has no reliable metadata source and stays empty.
-func mapLDAPResult(p *database.Probe, r probe.Result) LDAPTestResult {
+// Params; ServerInfo has no reliable metadata source and stays empty.
+func mapLDAPResult(p probe.Probe, r probe.Result) LDAPTestResult {
 	var ep config.LDAPEndpoint
-	if p.ParamsJSON != "" {
-		_ = json.Unmarshal([]byte(p.ParamsJSON), &ep)
+	if len(p.Params) > 0 {
+		_ = json.Unmarshal(p.Params, &ep)
 	}
 	return LDAPTestResult{
 		Name:          p.DisplayName,
@@ -77,12 +76,12 @@ func mapLDAPResult(p *database.Probe, r probe.Result) LDAPTestResult {
 	}
 }
 
-// mapRTSPResult maps a KindRTSP probe result. URL comes from ParamsJSON;
+// mapRTSPResult maps a KindRTSP probe result. URL comes from Params;
 // codec and resolution have no metadata source and stay empty.
-func mapRTSPResult(p *database.Probe, r probe.Result) RTSPTestResult {
+func mapRTSPResult(p probe.Probe, r probe.Result) RTSPTestResult {
 	var ep config.RTSPEndpoint
-	if p.ParamsJSON != "" {
-		_ = json.Unmarshal([]byte(p.ParamsJSON), &ep)
+	if len(p.Params) > 0 {
+		_ = json.Unmarshal(p.Params, &ep)
 	}
 	return RTSPTestResult{
 		Name:          p.DisplayName,
@@ -94,12 +93,12 @@ func mapRTSPResult(p *database.Probe, r probe.Result) RTSPTestResult {
 }
 
 // mapDICOMResult maps a KindDICOM probe result. Host/port come from
-// ParamsJSON; AETitle is the CalledAE static field. Dynamic fields
+// Params; AETitle is the CalledAE static field. Dynamic fields
 // (ServerAETitle, EchoTimeMs) have no metadata source and stay zero/empty.
-func mapDICOMResult(p *database.Probe, r probe.Result) DICOMTestResult {
+func mapDICOMResult(p probe.Probe, r probe.Result) DICOMTestResult {
 	var ep config.DICOMEndpoint
-	if p.ParamsJSON != "" {
-		_ = json.Unmarshal([]byte(p.ParamsJSON), &ep)
+	if len(p.Params) > 0 {
+		_ = json.Unmarshal(p.Params, &ep)
 	}
 	return DICOMTestResult{
 		Name:        p.DisplayName,
@@ -112,13 +111,13 @@ func mapDICOMResult(p *database.Probe, r probe.Result) DICOMTestResult {
 	}
 }
 
-// mapHL7Result maps a KindHL7 probe result. Host/port come from ParamsJSON;
+// mapHL7Result maps a KindHL7 probe result. Host/port come from Params;
 // ack_code comes from Result.Metadata. ServerVersion has no source and stays
 // empty.
-func mapHL7Result(p *database.Probe, r probe.Result) HL7TestResult {
+func mapHL7Result(p probe.Probe, r probe.Result) HL7TestResult {
 	var ep config.HL7Endpoint
-	if p.ParamsJSON != "" {
-		_ = json.Unmarshal([]byte(p.ParamsJSON), &ep)
+	if len(p.Params) > 0 {
+		_ = json.Unmarshal(p.Params, &ep)
 	}
 	var md checkers.HL7RunMetadata
 	if len(r.Metadata) > 0 {
@@ -135,12 +134,12 @@ func mapHL7Result(p *database.Probe, r probe.Result) HL7TestResult {
 	}
 }
 
-// mapFHIRResult maps a KindFHIR probe result. BaseURL comes from ParamsJSON;
+// mapFHIRResult maps a KindFHIR probe result. BaseURL comes from Params;
 // fhir_version/server_name/resource_count come from Result.Metadata.
-func mapFHIRResult(p *database.Probe, r probe.Result) FHIRTestResult {
+func mapFHIRResult(p probe.Probe, r probe.Result) FHIRTestResult {
 	var ep config.FHIREndpoint
-	if p.ParamsJSON != "" {
-		_ = json.Unmarshal([]byte(p.ParamsJSON), &ep)
+	if len(p.Params) > 0 {
+		_ = json.Unmarshal(p.Params, &ep)
 	}
 	var md checkers.FHIRRunMetadata
 	if len(r.Metadata) > 0 {
@@ -158,12 +157,12 @@ func mapFHIRResult(p *database.Probe, r probe.Result) FHIRTestResult {
 	}
 }
 
-// mapLTIResult maps a KindLTI probe result. LaunchURL comes from ParamsJSON;
+// mapLTIResult maps a KindLTI probe result. LaunchURL comes from Params;
 // lti_version comes from Result.Metadata.
-func mapLTIResult(p *database.Probe, r probe.Result) LTITestResult {
+func mapLTIResult(p probe.Probe, r probe.Result) LTITestResult {
 	var ep config.LTIEndpoint
-	if p.ParamsJSON != "" {
-		_ = json.Unmarshal([]byte(p.ParamsJSON), &ep)
+	if len(p.Params) > 0 {
+		_ = json.Unmarshal(p.Params, &ep)
 	}
 	var md checkers.LTIRunMetadata
 	if len(r.Metadata) > 0 {
@@ -180,12 +179,12 @@ func mapLTIResult(p *database.Probe, r probe.Result) LTITestResult {
 }
 
 // mapOPCUAResult maps a KindOPCUA probe result. EndpointURL comes from
-// ParamsJSON; security_mode comes from Result.Metadata. ProductName and
+// Params; security_mode comes from Result.Metadata. ProductName and
 // ServerState have no metadata source and stay empty.
-func mapOPCUAResult(p *database.Probe, r probe.Result) OPCUATestResult {
+func mapOPCUAResult(p probe.Probe, r probe.Result) OPCUATestResult {
 	var ep config.OPCUAEndpoint
-	if p.ParamsJSON != "" {
-		_ = json.Unmarshal([]byte(p.ParamsJSON), &ep)
+	if len(p.Params) > 0 {
+		_ = json.Unmarshal(p.Params, &ep)
 	}
 	var md checkers.OPCUARunMetadata
 	if len(r.Metadata) > 0 {
@@ -202,11 +201,11 @@ func mapOPCUAResult(p *database.Probe, r probe.Result) OPCUATestResult {
 }
 
 // mapModbusResult maps a KindMODBUS probe result. Host/port/unitId come from
-// ParamsJSON; register_value comes from Result.Metadata.
-func mapModbusResult(p *database.Probe, r probe.Result) ModbusTestResult {
+// Params; register_value comes from Result.Metadata.
+func mapModbusResult(p probe.Probe, r probe.Result) ModbusTestResult {
 	var ep config.ModbusEndpoint
-	if p.ParamsJSON != "" {
-		_ = json.Unmarshal([]byte(p.ParamsJSON), &ep)
+	if len(p.Params) > 0 {
+		_ = json.Unmarshal(p.Params, &ep)
 	}
 	var md checkers.ModbusRunMetadata
 	if len(r.Metadata) > 0 {

--- a/internal/api/healthcheckseed.go
+++ b/internal/api/healthcheckseed.go
@@ -1,75 +1,19 @@
 package api
 
 // healthcheckseed.go restores the pre-ADR-0027 out-of-box behavior: a fresh
-// install ships with the factory health-check targets visible. Since P2 the
-// probes table is the store of record (see healthcheckmapping.go), and the
-// only writer is the settings-PUT path — so nothing populated it on first
-// run and the health-check card came up empty. This seeds the factory
-// defaults once, gated by a persistent marker so an operator who later
+// install ships with the factory health-check targets visible. The probes table
+// is the store of record (ADR-0027 P2); seeding is owned by the health-checks
+// settings use-case, gated by a persistent marker so an operator who later
 // deletes every probe stays empty across restarts.
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
-	"github.com/MustardSeedNetworks/seed/internal/database"
-	"github.com/MustardSeedNetworks/seed/internal/health/probemap"
 )
 
-// settingKeyHealthChecksSeeded marks that the factory health-check probes
-// have been seeded. Its presence — not the probe count — is the gate, so
-// deleting every health-check probe does not trigger a re-seed.
-const settingKeyHealthChecksSeeded = "health_checks.seeded"
-
-// seedDefaultHealthCheckProbes seeds the factory health-check targets into
-// the probes table on a genuine first run. It is a no-op once the seed
-// marker is set, and it never overwrites an install that already holds
-// health-check probes (the upgrade path, where the marker predates this
-// code). The factory set comes from config.DefaultConfig().HealthChecks and
-// is mapped through the same ProbesFromConfig used by the
-// settings-PUT save, so the two paths can never diverge.
-func (s *Server) seedDefaultHealthCheckProbes(ctx context.Context, db *database.DB) error {
-	settings := db.Settings()
-
-	marker, err := settings.GetValue(ctx, settingKeyHealthChecksSeeded)
-	if err != nil {
-		return fmt.Errorf("read health-check seed marker: %w", err)
-	}
-	if marker != "" {
-		return nil // already seeded — honor an operator's later delete-all.
-	}
-
-	// Upgrade guard: an install that already configured health-check probes
-	// (saved before this seeding existed, so no marker) must keep its set.
-	// Mark it seeded and leave the probes untouched.
-	existing, err := probemap.CountProbes(ctx, db.Probes())
-	if err != nil {
-		return fmt.Errorf("count existing health-check probes: %w", err)
-	}
-	if existing > 0 {
-		return s.markHealthChecksSeeded(ctx, settings)
-	}
-
-	hc := config.DefaultConfig().HealthChecks
-	probes, err := probemap.ProbesFromConfig(&hc)
-	if err != nil {
-		return fmt.Errorf("build default health-check probes: %w", err)
-	}
-	if err = db.Probes().ReplaceProbesByKinds(
-		ctx, database.DefaultClientID, probemap.Kinds(), probes,
-	); err != nil {
-		return fmt.Errorf("seed default health-check probes: %w", err)
-	}
-	return s.markHealthChecksSeeded(ctx, settings)
-}
-
-// markHealthChecksSeeded records the seed marker with a UTC timestamp value.
-// The value is informational; only its presence gates re-seeding.
-func (s *Server) markHealthChecksSeeded(ctx context.Context, settings *database.SettingsRepository) error {
-	if err := settings.Set(ctx, settingKeyHealthChecksSeeded, time.Now().UTC().Format(time.RFC3339)); err != nil {
-		return fmt.Errorf("set health-check seed marker: %w", err)
-	}
-	return nil
+// seedDefaultHealthCheckProbes seeds the factory health-check targets on a
+// genuine first run via the health-settings use-case. No-op once seeded.
+func (s *Server) seedDefaultHealthCheckProbes(ctx context.Context) error {
+	return s.healthSettings.SeedDefaults(ctx, config.DefaultConfig().HealthChecks)
 }

--- a/internal/api/healthcheckseed_internal_test.go
+++ b/internal/api/healthcheckseed_internal_test.go
@@ -25,7 +25,7 @@ func TestSeedDefaultHealthCheckProbes_FreshInstall(t *testing.T) {
 	wireHealthSettings(s)
 	ctx := context.Background()
 
-	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx))
 
 	// The factory ping targets are now persisted as probe rows.
 	pings, err := db.Probes().ListProbes(ctx, database.DefaultClientID, probe.KindPing)
@@ -51,14 +51,15 @@ func TestSeedDefaultHealthCheckProbes_FreshInstall(t *testing.T) {
 func TestSeedDefaultHealthCheckProbes_Idempotent(t *testing.T) {
 	db := newTestDB(t)
 	s := &Server{config: &config.Config{}, dbConn: db}
+	wireHealthSettings(s)
 	ctx := context.Background()
 
-	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx))
 	first, err := db.Probes().CountProbes(ctx, database.DefaultClientID, probe.KindPing)
 	require.NoError(t, err)
 	require.Equal(t, 2, first, "factory set has two ping targets")
 
-	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx))
 	second, err := db.Probes().CountProbes(ctx, database.DefaultClientID, probe.KindPing)
 	require.NoError(t, err)
 	require.Equal(t, first, second, "second seed must not duplicate the factory set")
@@ -71,9 +72,10 @@ func TestSeedDefaultHealthCheckProbes_Idempotent(t *testing.T) {
 func TestSeedDefaultHealthCheckProbes_NoReseedAfterDeleteAll(t *testing.T) {
 	db := newTestDB(t)
 	s := &Server{config: &config.Config{}, dbConn: db}
+	wireHealthSettings(s)
 	ctx := context.Background()
 
-	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx))
 
 	// Operator clears the whole health-check set (settings save with no targets).
 	require.NoError(t, db.Probes().ReplaceProbesByKinds(
@@ -81,7 +83,7 @@ func TestSeedDefaultHealthCheckProbes_NoReseedAfterDeleteAll(t *testing.T) {
 	))
 
 	// A subsequent boot must NOT re-seed.
-	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx))
 	count, err := db.Probes().CountProbes(ctx, database.DefaultClientID, probe.KindPing)
 	require.NoError(t, err)
 	require.Equal(t, 0, count, "deleting all probes must not trigger a re-seed")
@@ -94,6 +96,7 @@ func TestSeedDefaultHealthCheckProbes_NoReseedAfterDeleteAll(t *testing.T) {
 func TestSeedDefaultHealthCheckProbes_PreservesExistingProbes(t *testing.T) {
 	db := newTestDB(t)
 	s := &Server{config: &config.Config{}, dbConn: db}
+	wireHealthSettings(s)
 	ctx := context.Background()
 
 	// Pre-existing operator-configured set, no seed marker, written straight to
@@ -104,11 +107,22 @@ func TestSeedDefaultHealthCheckProbes_PreservesExistingProbes(t *testing.T) {
 	hc := requestEndpointTargets(&custom)
 	customProbes, err := probemap.ProbesFromConfig(&hc)
 	require.NoError(t, err)
+	rows := make([]*database.Probe, 0, len(customProbes))
+	for _, p := range customProbes {
+		rows = append(rows, &database.Probe{
+			Kind:            p.Kind,
+			DisplayName:     p.DisplayName,
+			Target:          p.Target,
+			ParamsJSON:      string(p.Params),
+			Enabled:         p.Enabled,
+			IntervalSeconds: p.IntervalSeconds,
+		})
+	}
 	require.NoError(t, db.Probes().ReplaceProbesByKinds(
-		ctx, database.DefaultClientID, probemap.Kinds(), customProbes,
+		ctx, database.DefaultClientID, probemap.Kinds(), rows,
 	))
 
-	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx, db))
+	require.NoError(t, s.seedDefaultHealthCheckProbes(ctx))
 
 	pings, err := db.Probes().ListProbes(ctx, database.DefaultClientID, probe.KindPing)
 	require.NoError(t, err)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -384,6 +384,19 @@ func NewServer(
 	// Wire the ADR-0020 use-cases now the discovery components exist.
 	s.initUseCases()
 
+	// Seed the factory health-check targets on first run (ADR-0027 follow-up).
+	// Runs after initUseCases (so s.healthSettings is wired — the seed goes
+	// through the use-case) and before initProbeEngine (so the engine loads the
+	// seeded probes on start). The probes table is the store of record since P2;
+	// without this a fresh install comes up with an empty health-check card.
+	// Gated by a persistent marker, so a later delete-all is not re-seeded.
+	// Non-fatal: a failure degrades to the empty card rather than aborting startup.
+	if db != nil {
+		if err := s.seedDefaultHealthCheckProbes(context.Background()); err != nil {
+			logging.GetLogger().Error("Failed to seed default health-check probes", "error", err)
+		}
+	}
+
 	// Wire the settings-persistence use-case (ADR-0020). The composition root
 	// builds the adapters; api passes its lazy db accessor + live config.
 	s.settingsStore = app.NewSettings(s.db, s.config)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -987,6 +987,7 @@ func (s *Server) initHealthUseCases() {
 	s.healthSettings = app.NewHealthSettings(
 		s.healthProbeRepo, s.rescheduleProbeEngine,
 		s.config, s.configPath, s.dnsTester, s.speedtestTester,
+		s.healthSettingsRepo,
 	)
 }
 
@@ -997,6 +998,15 @@ func (s *Server) healthProbeRepo() *database.ProbeRepository {
 		return nil
 	}
 	return s.dbConn.Probes()
+}
+
+// healthSettingsRepo is the settings-KV accessor the health seed-marker reads and
+// writes through; nil when no DB is wired (the test harness).
+func (s *Server) healthSettingsRepo() *database.SettingsRepository {
+	if s.dbConn == nil {
+		return nil
+	}
+	return s.dbConn.Settings()
 }
 
 // rescheduleProbeEngine reschedules the running probe engine after a settings

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -116,7 +116,7 @@ func (s *Server) initDatabaseServices(cfg *config.Config, db *database.DB) {
 	// install comes up with an empty health-check card. Gated by a persistent
 	// marker, so a later delete-all is not re-seeded. Non-fatal: a failure
 	// degrades to the empty card rather than aborting startup.
-	if err := s.seedDefaultHealthCheckProbes(context.Background(), db); err != nil {
+	if err := s.seedDefaultHealthCheckProbes(context.Background()); err != nil {
 		logging.GetLogger().Error("Failed to seed default health-check probes", "error", err)
 	}
 

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -111,15 +111,6 @@ func (s *Server) initDatabaseServices(cfg *config.Config, db *database.DB) {
 		}
 	}
 
-	// Seed the factory health-check targets on first run (ADR-0027 follow-up).
-	// The probes table is the store of record since P2; without this a fresh
-	// install comes up with an empty health-check card. Gated by a persistent
-	// marker, so a later delete-all is not re-seeded. Non-fatal: a failure
-	// degrades to the empty card rather than aborting startup.
-	if err := s.seedDefaultHealthCheckProbes(context.Background()); err != nil {
-		logging.GetLogger().Error("Failed to seed default health-check probes", "error", err)
-	}
-
 	// Initialize MIB database for SNMP OID resolution
 	s.initMibDatabase(db)
 

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -162,6 +162,7 @@ func NewTestServerWithConfig(cfg *config.Config) *Server {
 	s.healthSettings = app.NewHealthSettings(
 		s.healthProbeRepo, s.rescheduleProbeEngine,
 		s.config, s.configPath, s.dnsTester, s.speedtestTester,
+		s.healthSettingsRepo,
 	)
 	s.profiles = app.NewProfiles(s.db, s.config, s.configPath)
 	s.networkIP = app.NewNetworkIP(s.netManager, s.config, s.configPath)

--- a/internal/app/healthsettings.go
+++ b/internal/app/healthsettings.go
@@ -10,6 +10,9 @@ package app
 
 import (
 	"context"
+	"fmt"
+	"slices"
+	"time"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/database"
@@ -17,6 +20,7 @@ import (
 	"github.com/MustardSeedNetworks/seed/internal/diagnostics/speedtest"
 	"github.com/MustardSeedNetworks/seed/internal/health/probemap"
 	healthsettings "github.com/MustardSeedNetworks/seed/internal/health/settings"
+	"github.com/MustardSeedNetworks/seed/internal/probe"
 )
 
 // NewHealthSettings builds the health-checks settings use-case over the probes
@@ -30,11 +34,13 @@ func NewHealthSettings(
 	path string,
 	dnsTester func() *dns.Tester,
 	speedTester func() *speedtest.Tester,
+	settings func() *database.SettingsRepository,
 ) *healthsettings.Service {
 	return healthsettings.NewService(
 		healthProbeStore{probes: probes, reschedule: reschedule},
 		healthConfigStore{cfg: cfg, path: path},
 		healthAppliers{dnsTester: dnsTester, speedTester: speedTester},
+		healthSeedMarker{settings: settings},
 	)
 }
 
@@ -46,16 +52,54 @@ type healthProbeStore struct {
 }
 
 func (a healthProbeStore) Endpoints(ctx context.Context) (config.HealthChecksConfig, error) {
-	return probemap.LoadEndpoints(ctx, a.probes())
+	probes, err := a.list(ctx)
+	if err != nil {
+		return config.HealthChecksConfig{}, err
+	}
+	return probemap.EndpointsFromProbes(probes)
+}
+
+// list loads the health-check probes and translates rows to domain probes.
+func (a healthProbeStore) list(ctx context.Context) ([]probe.Probe, error) {
+	rows, err := a.probes().ListProbes(ctx, database.DefaultClientID, "")
+	if err != nil {
+		return nil, err
+	}
+	kinds := probemap.Kinds()
+	out := make([]probe.Probe, 0, len(rows))
+	for _, p := range rows {
+		if slices.Contains(kinds, p.Kind) {
+			out = append(out, dbProbeToModel(p))
+		}
+	}
+	return out, nil
+}
+
+func (a healthProbeStore) List(ctx context.Context) ([]probe.Probe, error) { return a.list(ctx) }
+
+func (a healthProbeStore) Count(ctx context.Context) (int, error) {
+	total := 0
+	for _, kind := range probemap.Kinds() {
+		n, err := a.probes().CountProbes(ctx, database.DefaultClientID, kind)
+		if err != nil {
+			return 0, fmt.Errorf("count %s probes: %w", kind, err)
+		}
+		total += n
+	}
+	return total, nil
 }
 
 func (a healthProbeStore) SaveEndpoints(ctx context.Context, hc config.HealthChecksConfig) error {
-	probes, err := probemap.ProbesFromConfig(&hc)
+	domain, err := probemap.ProbesFromConfig(&hc)
 	if err != nil {
 		return err
 	}
+	rows := make([]*database.Probe, 0, len(domain))
+	for _, p := range domain {
+		rows = append(rows, modelToDBProbe(p))
+	}
 	if err = a.probes().ReplaceProbesByKinds(
-		ctx, database.DefaultClientID, probemap.Kinds(), probes,
+		ctx, database.DefaultClientID, probemap.Kinds(), rows,
 	); err != nil {
 		return err
 	}
@@ -117,4 +161,28 @@ func (a healthAppliers) ApplySpeedtestServer(id string) {
 	if t := a.speedTester(); t != nil {
 		t.SetServerID(id)
 	}
+}
+
+// settingKeyHealthChecksSeeded marks that the factory health-check probes have
+// been seeded. Its presence (not the probe count) is the gate.
+const settingKeyHealthChecksSeeded = "health_checks.seeded"
+
+// healthSeedMarker implements healthsettings.SeedMarker over the settings KV.
+type healthSeedMarker struct {
+	settings func() *database.SettingsRepository
+}
+
+func (m healthSeedMarker) Seeded(ctx context.Context) (bool, error) {
+	v, err := m.settings().GetValue(ctx, settingKeyHealthChecksSeeded)
+	if err != nil {
+		return false, fmt.Errorf("read health-check seed marker: %w", err)
+	}
+	return v != "", nil
+}
+
+func (m healthSeedMarker) MarkSeeded(ctx context.Context) error {
+	if err := m.settings().Set(ctx, settingKeyHealthChecksSeeded, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("set health-check seed marker: %w", err)
+	}
+	return nil
 }

--- a/internal/app/probe.go
+++ b/internal/app/probe.go
@@ -68,6 +68,27 @@ func (s *ProbeStorage) RecordResult(ctx context.Context, r probe.Result) error {
 	})
 }
 
+// modelToDBProbe converts the probe package's domain Probe into the database
+// row representation. The inverse of dbProbeToModel: the [json.RawMessage] columns
+// become TEXT. ID/ClientID/timestamps pass through (empty on the save path, where
+// the repository fills them).
+func modelToDBProbe(p probe.Probe) *database.Probe {
+	return &database.Probe{
+		ID:              p.ID,
+		ClientID:        p.ClientID,
+		Kind:            p.Kind,
+		DisplayName:     p.DisplayName,
+		Target:          p.Target,
+		ParamsJSON:      string(p.Params),
+		IntervalSeconds: p.IntervalSeconds,
+		Enabled:         p.Enabled,
+		WarningJSON:     string(p.Warning),
+		CriticalJSON:    string(p.Critical),
+		CreatedAt:       p.CreatedAt,
+		UpdatedAt:       p.UpdatedAt,
+	}
+}
+
 // dbProbeToModel converts the database row representation into the probe
 // package's Probe type. The JSON columns are passed through as
 // [json.RawMessage]; consumers decode them per-Kind.

--- a/internal/health/probemap/probemap.go
+++ b/internal/health/probemap/probemap.go
@@ -14,12 +14,10 @@ package probemap
 // JSON key namespaces are kept aligned so one params blob serves both.
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
 )
 
@@ -40,117 +38,101 @@ func Kinds() []string {
 	}
 }
 
-// CountProbes returns the total number of probes across the
-// health-check kinds for the default client. Used by the first-run seed to
-// detect an install that already holds a configured set (the upgrade path)
-// so the factory defaults never overwrite it.
-func CountProbes(ctx context.Context, repo *database.ProbeRepository) (int, error) {
-	total := 0
-	for _, kind := range Kinds() {
-		n, err := repo.CountProbes(ctx, database.DefaultClientID, kind)
-		if err != nil {
-			return 0, fmt.Errorf("count %s probes: %w", kind, err)
-		}
-		total += n
-	}
-	return total, nil
-}
-
-// endpointToProbe builds a probe row from an endpoint: the endpoint is
-// marshaled wholesale into params_json (Name/Target/Enabled are also
-// authoritative columns, so the duplicate keys in params are harmless
+// endpointToProbe builds a probe.Probe from an endpoint: the endpoint is
+// marshaled wholesale into Params (Name/Target/Enabled are also
+// authoritative fields, so the duplicate keys in params are harmless
 // and the columns win on read). ID and ClientID are left empty for
-// CreateProbe to fill (uuid + default client).
-func endpointToProbe(kind, name, target string, enabled bool, endpoint any) (*database.Probe, error) {
+// the repository to fill (uuid + default client).
+func endpointToProbe(kind, name, target string, enabled bool, endpoint any) (probe.Probe, error) {
 	pj, err := json.Marshal(endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("marshal %s endpoint params: %w", kind, err)
+		return probe.Probe{}, fmt.Errorf("marshal %s endpoint params: %w", kind, err)
 	}
-	return &database.Probe{
+	return probe.Probe{
 		Kind:            kind,
 		DisplayName:     name,
 		Target:          target,
-		ParamsJSON:      string(pj),
+		Params:          json.RawMessage(pj),
 		IntervalSeconds: defaultHealthCheckIntervalSeconds,
 		Enabled:         enabled,
 	}, nil
 }
 
-// endpointFromProbe unmarshals a probe's params_json into the endpoint
+// endpointFromProbe unmarshals a probe's Params into the endpoint
 // type T. The caller overwrites the identity fields (Name/Target/Enabled)
 // from the authoritative columns afterwards.
-func endpointFromProbe[T any](p *database.Probe) (T, error) {
+func endpointFromProbe[T any](p probe.Probe) (T, error) {
 	var e T
-	if p.ParamsJSON == "" {
+	if len(p.Params) == 0 {
 		return e, nil
 	}
-	if err := json.Unmarshal([]byte(p.ParamsJSON), &e); err != nil {
+	if err := json.Unmarshal(p.Params, &e); err != nil {
 		return e, fmt.Errorf("unmarshal %s probe params: %w", p.Kind, err)
 	}
 	return e, nil
 }
 
-// --- per-kind forward mappings (config endpoint -> probe row) ---
+// --- per-kind forward mappings (config endpoint -> probe.Probe) ---
 
-func pingTargetToProbe(e config.PingTarget) (*database.Probe, error) {
+func pingTargetToProbe(e config.PingTarget) (probe.Probe, error) {
 	return endpointToProbe(probe.KindPing, e.Name, e.Host, e.Enabled, e)
 }
 
-func tcpPortToProbe(e config.TCPPortTest) (*database.Probe, error) {
+func tcpPortToProbe(e config.TCPPortTest) (probe.Probe, error) {
 	return endpointToProbe(probe.KindTCP, e.Name, e.Host, e.Enabled, e)
 }
 
-func udpPortToProbe(e config.UDPPortTest) (*database.Probe, error) {
+func udpPortToProbe(e config.UDPPortTest) (probe.Probe, error) {
 	return endpointToProbe(probe.KindUDP, e.Name, e.Host, e.Enabled, e)
 }
 
-func httpEndpointToProbe(e config.HTTPEndpoint) (*database.Probe, error) {
+func httpEndpointToProbe(e config.HTTPEndpoint) (probe.Probe, error) {
 	return endpointToProbe(probe.KindHTTP, e.Name, e.URL, e.Enabled, e)
 }
 
-func rtspEndpointToProbe(e config.RTSPEndpoint) (*database.Probe, error) {
+func rtspEndpointToProbe(e config.RTSPEndpoint) (probe.Probe, error) {
 	return endpointToProbe(probe.KindRTSP, e.Name, e.URL, e.Enabled, e)
 }
 
-func dicomEndpointToProbe(e config.DICOMEndpoint) (*database.Probe, error) {
+func dicomEndpointToProbe(e config.DICOMEndpoint) (probe.Probe, error) {
 	return endpointToProbe(probe.KindDICOM, e.Name, e.Host, e.Enabled, e)
 }
 
-func hl7EndpointToProbe(e config.HL7Endpoint) (*database.Probe, error) {
+func hl7EndpointToProbe(e config.HL7Endpoint) (probe.Probe, error) {
 	return endpointToProbe(probe.KindHL7, e.Name, e.Host, e.Enabled, e)
 }
 
-func fhirEndpointToProbe(e config.FHIREndpoint) (*database.Probe, error) {
+func fhirEndpointToProbe(e config.FHIREndpoint) (probe.Probe, error) {
 	return endpointToProbe(probe.KindFHIR, e.Name, e.BaseURL, e.Enabled, e)
 }
 
-func sqlEndpointToProbe(e config.SQLEndpoint) (*database.Probe, error) {
+func sqlEndpointToProbe(e config.SQLEndpoint) (probe.Probe, error) {
 	return endpointToProbe(probe.KindSQL, e.Name, e.Host, e.Enabled, e)
 }
 
-func fileShareEndpointToProbe(e config.FileShareEndpoint) (*database.Probe, error) {
+func fileShareEndpointToProbe(e config.FileShareEndpoint) (probe.Probe, error) {
 	return endpointToProbe(probe.KindFileShare, e.Name, e.Host, e.Enabled, e)
 }
 
-func ldapEndpointToProbe(e config.LDAPEndpoint) (*database.Probe, error) {
+func ldapEndpointToProbe(e config.LDAPEndpoint) (probe.Probe, error) {
 	return endpointToProbe(probe.KindLDAP, e.Name, e.Host, e.Enabled, e)
 }
 
-func ltiEndpointToProbe(e config.LTIEndpoint) (*database.Probe, error) {
+func ltiEndpointToProbe(e config.LTIEndpoint) (probe.Probe, error) {
 	return endpointToProbe(probe.KindLTI, e.Name, e.LaunchURL, e.Enabled, e)
 }
 
-func opcuaEndpointToProbe(e config.OPCUAEndpoint) (*database.Probe, error) {
+func opcuaEndpointToProbe(e config.OPCUAEndpoint) (probe.Probe, error) {
 	return endpointToProbe(probe.KindOPCUA, e.Name, e.EndpointURL, e.Enabled, e)
 }
 
-func modbusEndpointToProbe(e config.ModbusEndpoint) (*database.Probe, error) {
+func modbusEndpointToProbe(e config.ModbusEndpoint) (probe.Probe, error) {
 	return endpointToProbe(probe.KindMODBUS, e.Name, e.Host, e.Enabled, e)
 }
 
-// --- per-kind reverse mappings (probe row -> config endpoint) ---
+// --- per-kind reverse mappings (probe.Probe -> config endpoint) ---
 
-func probeToPingTarget(p *database.Probe) (config.PingTarget, error) {
+func probeToPingTarget(p probe.Probe) (config.PingTarget, error) {
 	e, err := endpointFromProbe[config.PingTarget](p)
 	if err != nil {
 		return e, err
@@ -159,7 +141,7 @@ func probeToPingTarget(p *database.Probe) (config.PingTarget, error) {
 	return e, nil
 }
 
-func probeToTCPPort(p *database.Probe) (config.TCPPortTest, error) {
+func probeToTCPPort(p probe.Probe) (config.TCPPortTest, error) {
 	e, err := endpointFromProbe[config.TCPPortTest](p)
 	if err != nil {
 		return e, err
@@ -168,7 +150,7 @@ func probeToTCPPort(p *database.Probe) (config.TCPPortTest, error) {
 	return e, nil
 }
 
-func probeToUDPPort(p *database.Probe) (config.UDPPortTest, error) {
+func probeToUDPPort(p probe.Probe) (config.UDPPortTest, error) {
 	e, err := endpointFromProbe[config.UDPPortTest](p)
 	if err != nil {
 		return e, err
@@ -177,7 +159,7 @@ func probeToUDPPort(p *database.Probe) (config.UDPPortTest, error) {
 	return e, nil
 }
 
-func probeToHTTPEndpoint(p *database.Probe) (config.HTTPEndpoint, error) {
+func probeToHTTPEndpoint(p probe.Probe) (config.HTTPEndpoint, error) {
 	e, err := endpointFromProbe[config.HTTPEndpoint](p)
 	if err != nil {
 		return e, err
@@ -186,7 +168,7 @@ func probeToHTTPEndpoint(p *database.Probe) (config.HTTPEndpoint, error) {
 	return e, nil
 }
 
-func probeToRTSPEndpoint(p *database.Probe) (config.RTSPEndpoint, error) {
+func probeToRTSPEndpoint(p probe.Probe) (config.RTSPEndpoint, error) {
 	e, err := endpointFromProbe[config.RTSPEndpoint](p)
 	if err != nil {
 		return e, err
@@ -195,7 +177,7 @@ func probeToRTSPEndpoint(p *database.Probe) (config.RTSPEndpoint, error) {
 	return e, nil
 }
 
-func probeToDICOMEndpoint(p *database.Probe) (config.DICOMEndpoint, error) {
+func probeToDICOMEndpoint(p probe.Probe) (config.DICOMEndpoint, error) {
 	e, err := endpointFromProbe[config.DICOMEndpoint](p)
 	if err != nil {
 		return e, err
@@ -204,7 +186,7 @@ func probeToDICOMEndpoint(p *database.Probe) (config.DICOMEndpoint, error) {
 	return e, nil
 }
 
-func probeToHL7Endpoint(p *database.Probe) (config.HL7Endpoint, error) {
+func probeToHL7Endpoint(p probe.Probe) (config.HL7Endpoint, error) {
 	e, err := endpointFromProbe[config.HL7Endpoint](p)
 	if err != nil {
 		return e, err
@@ -213,7 +195,7 @@ func probeToHL7Endpoint(p *database.Probe) (config.HL7Endpoint, error) {
 	return e, nil
 }
 
-func probeToFHIREndpoint(p *database.Probe) (config.FHIREndpoint, error) {
+func probeToFHIREndpoint(p probe.Probe) (config.FHIREndpoint, error) {
 	e, err := endpointFromProbe[config.FHIREndpoint](p)
 	if err != nil {
 		return e, err
@@ -222,7 +204,7 @@ func probeToFHIREndpoint(p *database.Probe) (config.FHIREndpoint, error) {
 	return e, nil
 }
 
-func probeToSQLEndpoint(p *database.Probe) (config.SQLEndpoint, error) {
+func probeToSQLEndpoint(p probe.Probe) (config.SQLEndpoint, error) {
 	e, err := endpointFromProbe[config.SQLEndpoint](p)
 	if err != nil {
 		return e, err
@@ -231,7 +213,7 @@ func probeToSQLEndpoint(p *database.Probe) (config.SQLEndpoint, error) {
 	return e, nil
 }
 
-func probeToFileShareEndpoint(p *database.Probe) (config.FileShareEndpoint, error) {
+func probeToFileShareEndpoint(p probe.Probe) (config.FileShareEndpoint, error) {
 	e, err := endpointFromProbe[config.FileShareEndpoint](p)
 	if err != nil {
 		return e, err
@@ -240,7 +222,7 @@ func probeToFileShareEndpoint(p *database.Probe) (config.FileShareEndpoint, erro
 	return e, nil
 }
 
-func probeToLDAPEndpoint(p *database.Probe) (config.LDAPEndpoint, error) {
+func probeToLDAPEndpoint(p probe.Probe) (config.LDAPEndpoint, error) {
 	e, err := endpointFromProbe[config.LDAPEndpoint](p)
 	if err != nil {
 		return e, err
@@ -249,7 +231,7 @@ func probeToLDAPEndpoint(p *database.Probe) (config.LDAPEndpoint, error) {
 	return e, nil
 }
 
-func probeToLTIEndpoint(p *database.Probe) (config.LTIEndpoint, error) {
+func probeToLTIEndpoint(p probe.Probe) (config.LTIEndpoint, error) {
 	e, err := endpointFromProbe[config.LTIEndpoint](p)
 	if err != nil {
 		return e, err
@@ -258,7 +240,7 @@ func probeToLTIEndpoint(p *database.Probe) (config.LTIEndpoint, error) {
 	return e, nil
 }
 
-func probeToOPCUAEndpoint(p *database.Probe) (config.OPCUAEndpoint, error) {
+func probeToOPCUAEndpoint(p probe.Probe) (config.OPCUAEndpoint, error) {
 	e, err := endpointFromProbe[config.OPCUAEndpoint](p)
 	if err != nil {
 		return e, err
@@ -267,7 +249,7 @@ func probeToOPCUAEndpoint(p *database.Probe) (config.OPCUAEndpoint, error) {
 	return e, nil
 }
 
-func probeToModbusEndpoint(p *database.Probe) (config.ModbusEndpoint, error) {
+func probeToModbusEndpoint(p probe.Probe) (config.ModbusEndpoint, error) {
 	e, err := endpointFromProbe[config.ModbusEndpoint](p)
 	if err != nil {
 		return e, err
@@ -276,31 +258,24 @@ func probeToModbusEndpoint(p *database.Probe) (config.ModbusEndpoint, error) {
 	return e, nil
 }
 
-// LoadEndpoints reads the health-check probe definitions from
-// the probes table and assembles them into the endpoint lists of a
-// HealthChecksConfig. Only the endpoint lists are populated; the
-// performance/discovery toggles live in the config file and are not
-// sourced here. A malformed params row is skipped with the error
-// returned so the caller can log it without dropping the whole set.
-func LoadEndpoints(ctx context.Context, repo *database.ProbeRepository) (config.HealthChecksConfig, error) {
+// EndpointsFromProbes assembles the health-check endpoint lists of a
+// HealthChecksConfig from probe definitions. Probes of non-health-check kinds
+// are ignored. A malformed params row aborts with the error.
+func EndpointsFromProbes(probes []probe.Probe) (config.HealthChecksConfig, error) {
 	var hc config.HealthChecksConfig
-	probes, err := repo.ListProbes(ctx, database.DefaultClientID, "")
-	if err != nil {
-		return hc, fmt.Errorf("list health-check probes: %w", err)
-	}
 	for _, p := range probes {
-		if err = appendProbeToConfig(&hc, p); err != nil {
+		if err := appendProbeToConfig(&hc, p); err != nil {
 			return hc, err
 		}
 	}
 	return hc, nil
 }
 
-// appendProbeToConfig maps one probe row onto its endpoint list in hc.
+// appendProbeToConfig maps one probe.Probe onto its endpoint list in hc.
 // Probes of non-health-check kinds are ignored.
 //
 //nolint:gocognit,cyclop,funlen // A flat dispatch over the fourteen probe kinds; one case each.
-func appendProbeToConfig(hc *config.HealthChecksConfig, p *database.Probe) error {
+func appendProbeToConfig(hc *config.HealthChecksConfig, p probe.Probe) error {
 	switch p.Kind {
 	case probe.KindPing:
 		e, err := probeToPingTarget(p)
@@ -391,13 +366,13 @@ func appendProbeToConfig(hc *config.HealthChecksConfig, p *database.Probe) error
 }
 
 // ProbesFromConfig flattens the endpoint lists of a
-// HealthChecksConfig into the probe rows to persist. Order follows
+// HealthChecksConfig into the probe.Probe slice to persist. Order follows
 // Kinds; a marshal failure aborts the whole set.
 //
 //nolint:gocognit,cyclop // A flat fan over the fourteen endpoint lists; one block each.
-func ProbesFromConfig(hc *config.HealthChecksConfig) ([]*database.Probe, error) {
-	var out []*database.Probe
-	add := func(p *database.Probe, err error) error {
+func ProbesFromConfig(hc *config.HealthChecksConfig) ([]probe.Probe, error) {
+	var out []probe.Probe
+	add := func(p probe.Probe, err error) error {
 		if err != nil {
 			return err
 		}

--- a/internal/health/probemap/probemap_internal_test.go
+++ b/internal/health/probemap/probemap_internal_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
-	"github.com/MustardSeedNetworks/seed/internal/database"
 	"github.com/MustardSeedNetworks/seed/internal/probe"
 )
 
@@ -34,8 +33,8 @@ func TestHL7EndpointRoundTrip(t *testing.T) {
 			p.Enabled,
 		)
 	}
-	if !strings.Contains(p.ParamsJSON, `"sending_facility":"MAIN"`) {
-		t.Errorf("params_json should carry checker-aligned key sending_facility; got %s", p.ParamsJSON)
+	if !strings.Contains(string(p.Params), `"sending_facility":"MAIN"`) {
+		t.Errorf("Params should carry checker-aligned key sending_facility; got %s", string(p.Params))
 	}
 	out, err := probeToHL7Endpoint(p)
 	if err != nil {
@@ -48,7 +47,7 @@ func TestHL7EndpointRoundTrip(t *testing.T) {
 
 // TestFHIREndpointPreservesSettingsOnlyFields verifies that fields the
 // checker never reads (ClientSecret, TokenURL) still round-trip, since
-// params_json stores the whole endpoint.
+// Params stores the whole endpoint.
 func TestFHIREndpointPreservesSettingsOnlyFields(t *testing.T) {
 	t.Parallel()
 	in := config.FHIREndpoint{
@@ -117,7 +116,7 @@ func TestNonHealthCheckKindIgnored(t *testing.T) {
 	t.Parallel()
 	var hc config.HealthChecksConfig
 	params, _ := json.Marshal(map[string]any{"x": 1})
-	dnsProbe := &database.Probe{Kind: "dns", Target: "8.8.8.8", ParamsJSON: string(params)}
+	dnsProbe := probe.Probe{Kind: "dns", Target: "8.8.8.8", Params: json.RawMessage(params)}
 	if err := appendProbeToConfig(&hc, dnsProbe); err != nil {
 		t.Fatalf("appendProbeToConfig: %v", err)
 	}

--- a/internal/health/settings/settings.go
+++ b/internal/health/settings/settings.go
@@ -11,6 +11,7 @@ import (
 	"context"
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
+	"github.com/MustardSeedNetworks/seed/internal/probe"
 )
 
 // ProbeStore is the endpoint-target store of record (the probes table). Endpoints
@@ -19,6 +20,12 @@ import (
 type ProbeStore interface {
 	Endpoints(ctx context.Context) (config.HealthChecksConfig, error)
 	SaveEndpoints(ctx context.Context, hc config.HealthChecksConfig) error
+	// Count returns how many health-check probes are configured (across the
+	// fourteen kinds). Used by the first-run seed's upgrade guard.
+	Count(ctx context.Context) (int, error)
+	// List returns the configured health-check probes in display order. Used by
+	// the on-demand /run path.
+	List(ctx context.Context) ([]probe.Probe, error)
 }
 
 // ConfigStore reads/persists the config-file-backed toggles. Read runs fn under
@@ -35,16 +42,25 @@ type Appliers interface {
 	ApplySpeedtestServer(id string)
 }
 
+// SeedMarker gates the one-time first-run seeding. Seeded reports whether the
+// factory set has been seeded; MarkSeeded records it. Its presence — not the
+// probe count — is the gate, so an operator's later delete-all stays empty.
+type SeedMarker interface {
+	Seeded(ctx context.Context) (bool, error)
+	MarkSeeded(ctx context.Context) error
+}
+
 // Service is the health-checks settings application service.
 type Service struct {
 	probes   ProbeStore
 	cfg      ConfigStore
 	appliers Appliers
+	marker   SeedMarker
 }
 
 // NewService builds the service over its ports.
-func NewService(probes ProbeStore, cfg ConfigStore, appliers Appliers) *Service {
-	return &Service{probes: probes, cfg: cfg, appliers: appliers}
+func NewService(probes ProbeStore, cfg ConfigStore, appliers Appliers, marker SeedMarker) *Service {
+	return &Service{probes: probes, cfg: cfg, appliers: appliers, marker: marker}
 }
 
 // Settings is the read/write model: the endpoint targets plus the
@@ -114,4 +130,35 @@ func (s *Service) Update(ctx context.Context, in Settings) error {
 	s.appliers.ApplyDNS(in.DNSHostname, in.DNSServers)
 	s.appliers.ApplySpeedtestServer(in.SpeedtestServerID)
 	return nil
+}
+
+// HealthCheckProbes returns the operator's configured health-check probes for
+// the on-demand run path.
+func (s *Service) HealthCheckProbes(ctx context.Context) ([]probe.Probe, error) {
+	return s.probes.List(ctx)
+}
+
+// SeedDefaults seeds the factory health-check targets on a genuine first run.
+// No-op once the marker is set (honoring a later delete-all). An install that
+// already holds health-check probes (upgrade path, no marker) is marked seeded
+// without overwriting its set.
+func (s *Service) SeedDefaults(ctx context.Context, defaults config.HealthChecksConfig) error {
+	seeded, err := s.marker.Seeded(ctx)
+	if err != nil {
+		return err
+	}
+	if seeded {
+		return nil
+	}
+	n, err := s.probes.Count(ctx)
+	if err != nil {
+		return err
+	}
+	if n > 0 {
+		return s.marker.MarkSeeded(ctx)
+	}
+	if saveErr := s.probes.SaveEndpoints(ctx, defaults); saveErr != nil {
+		return saveErr
+	}
+	return s.marker.MarkSeeded(ctx)
 }

--- a/internal/health/settings/settings_test.go
+++ b/internal/health/settings/settings_test.go
@@ -7,13 +7,17 @@ import (
 
 	"github.com/MustardSeedNetworks/seed/internal/config"
 	"github.com/MustardSeedNetworks/seed/internal/health/settings"
+	"github.com/MustardSeedNetworks/seed/internal/probe"
 )
 
 type fakeProbeStore struct {
 	endpoints config.HealthChecksConfig
 	saved     *config.HealthChecksConfig
+	probes    []probe.Probe
+	count     int
 	loadErr   error
 	saveErr   error
+	countErr  error
 }
 
 func (f *fakeProbeStore) Endpoints(context.Context) (config.HealthChecksConfig, error) {
@@ -26,6 +30,14 @@ func (f *fakeProbeStore) SaveEndpoints(_ context.Context, hc config.HealthChecks
 	}
 	f.saved = &hc
 	return nil
+}
+
+func (f *fakeProbeStore) Count(context.Context) (int, error) {
+	return f.count, f.countErr
+}
+
+func (f *fakeProbeStore) List(context.Context) ([]probe.Probe, error) {
+	return f.probes, f.loadErr
 }
 
 type fakeConfigStore struct{ cfg *config.Config }
@@ -45,6 +57,20 @@ func (f *fakeAppliers) ApplyDNS(hostname string, servers []config.DNSServer) {
 }
 func (f *fakeAppliers) ApplySpeedtestServer(id string) { f.speedID = id }
 
+type fakeSeedMarker struct {
+	seeded  bool
+	markErr error
+}
+
+func (f *fakeSeedMarker) Seeded(context.Context) (bool, error) { return f.seeded, nil }
+func (f *fakeSeedMarker) MarkSeeded(context.Context) error {
+	if f.markErr != nil {
+		return f.markErr
+	}
+	f.seeded = true
+	return nil
+}
+
 func TestGetComposesProbesAndConfig(t *testing.T) {
 	probes := &fakeProbeStore{endpoints: config.HealthChecksConfig{
 		PingTargets: []config.PingTarget{{Name: "g", Host: "8.8.8.8", Enabled: true}},
@@ -53,7 +79,7 @@ func TestGetComposesProbesAndConfig(t *testing.T) {
 	cfg.DNS.TestHostname = "example.com"
 	cfg.HealthChecks.RunSpeedtest = true
 	cfg.Speedtest.ServerID = "42"
-	svc := settings.NewService(probes, &fakeConfigStore{cfg: cfg}, &fakeAppliers{})
+	svc := settings.NewService(probes, &fakeConfigStore{cfg: cfg}, &fakeAppliers{}, &fakeSeedMarker{})
 
 	got, err := svc.Get(context.Background())
 	if err != nil {
@@ -70,7 +96,7 @@ func TestGetComposesProbesAndConfig(t *testing.T) {
 func TestGetSurfacesProbeError(t *testing.T) {
 	wantErr := errors.New("db down")
 	svc := settings.NewService(
-		&fakeProbeStore{loadErr: wantErr}, &fakeConfigStore{cfg: &config.Config{}}, &fakeAppliers{})
+		&fakeProbeStore{loadErr: wantErr}, &fakeConfigStore{cfg: &config.Config{}}, &fakeAppliers{}, &fakeSeedMarker{})
 	if _, err := svc.Get(context.Background()); !errors.Is(err, wantErr) {
 		t.Errorf("probe load error not surfaced: %v", err)
 	}
@@ -80,7 +106,7 @@ func TestUpdatePersistsProbesConfigAndSyncsTesters(t *testing.T) {
 	probes := &fakeProbeStore{}
 	cfg := &config.Config{}
 	appliers := &fakeAppliers{}
-	svc := settings.NewService(probes, &fakeConfigStore{cfg: cfg}, appliers)
+	svc := settings.NewService(probes, &fakeConfigStore{cfg: cfg}, appliers, &fakeSeedMarker{})
 
 	in := settings.Settings{
 		Endpoints:         config.HealthChecksConfig{PingTargets: []config.PingTarget{{Host: "1.1.1.1"}}},
@@ -109,12 +135,65 @@ func TestUpdateSkipsConfigOnProbeFailure(t *testing.T) {
 	probes := &fakeProbeStore{saveErr: errors.New("probe write failed")}
 	cfg := &config.Config{}
 	appliers := &fakeAppliers{}
-	svc := settings.NewService(probes, &fakeConfigStore{cfg: cfg}, appliers)
+	svc := settings.NewService(probes, &fakeConfigStore{cfg: cfg}, appliers, &fakeSeedMarker{})
 
 	if err := svc.Update(context.Background(), settings.Settings{DNSHostname: "x"}); err == nil {
 		t.Fatal("Update should return the probe save error")
 	}
 	if cfg.DNS.TestHostname != "" || appliers.dnsHostname != "" {
 		t.Error("config/testers must not be touched when probe save fails")
+	}
+}
+
+// TestSeedDefaults_FreshInstall verifies that on a genuine first run the
+// factory defaults are saved and the marker is set.
+func TestSeedDefaults_FreshInstall(t *testing.T) {
+	probes := &fakeProbeStore{count: 0}
+	marker := &fakeSeedMarker{}
+	svc := settings.NewService(probes, &fakeConfigStore{cfg: &config.Config{}}, &fakeAppliers{}, marker)
+
+	defaults := config.HealthChecksConfig{
+		PingTargets: []config.PingTarget{{Name: "gw", Host: "8.8.8.8", Enabled: true}},
+	}
+	if err := svc.SeedDefaults(context.Background(), defaults); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+	if probes.saved == nil {
+		t.Error("defaults must be saved to the probe store on first run")
+	}
+	if !marker.seeded {
+		t.Error("marker must be set after seeding")
+	}
+}
+
+// TestSeedDefaults_Idempotent verifies the marker short-circuits a second seed.
+func TestSeedDefaults_Idempotent(t *testing.T) {
+	probes := &fakeProbeStore{count: 0}
+	marker := &fakeSeedMarker{seeded: true}
+	svc := settings.NewService(probes, &fakeConfigStore{cfg: &config.Config{}}, &fakeAppliers{}, marker)
+
+	if err := svc.SeedDefaults(context.Background(), config.HealthChecksConfig{}); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+	if probes.saved != nil {
+		t.Error("already-seeded install must not overwrite probes")
+	}
+}
+
+// TestSeedDefaults_UpgradeGuard verifies that an install with existing probes
+// but no marker is marked seeded without overwriting the operator's set.
+func TestSeedDefaults_UpgradeGuard(t *testing.T) {
+	probes := &fakeProbeStore{count: 3}
+	marker := &fakeSeedMarker{}
+	svc := settings.NewService(probes, &fakeConfigStore{cfg: &config.Config{}}, &fakeAppliers{}, marker)
+
+	if err := svc.SeedDefaults(context.Background(), config.HealthChecksConfig{}); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+	if probes.saved != nil {
+		t.Error("upgrade path must not overwrite existing probes")
+	}
+	if !marker.seeded {
+		t.Error("marker must be set on the upgrade path")
 	}
 }


### PR DESCRIPTION
## What / Why

WS-B repository-port discipline: `internal/health` (probemap + settings) was importing `internal/database` directly, violating the hexagonal architecture boundary. This PR enforces the rule that the health surface operates in domain terms (`probe.Probe`) and never touches the database row type.

## Changes

- **`internal/health/probemap`**: removed `internal/database` import. All 14 forward/reverse mappers now take/return `probe.Probe` (value). New `EndpointsFromProbes([]probe.Probe)` replaces `LoadEndpoints(ctx, repo)`. `CountProbes` moved to the app adapter. `ProbesFromConfig` returns `[]probe.Probe`.
- **`internal/health/settings`**: `ProbeStore` interface extended with `Count`/`List`; new `SeedMarker` port added; `Service` gains `HealthCheckProbes()` + `SeedDefaults()` methods; `NewService` takes 4th `SeedMarker` arg.
- **`internal/app/probe.go`**: add `modelToDBProbe()` (inverse of existing `dbProbeToModel`).
- **`internal/app/healthsettings.go`**: `NewHealthSettings` takes new `settings func() *database.SettingsRepository` arg; `healthProbeStore` gains `list`/`List`/`Count` helpers; `SaveEndpoints` translates through `modelToDBProbe`; new `healthSeedMarker` adapter implements `SeedMarker` over the settings KV.
- **`internal/api/healthcheckseed.go`**: slimmed to a one-liner delegating to `healthSettings.SeedDefaults`; all direct DB/probemap/time usage removed.
- **`internal/api/healthcheckrun.go`**: `runProbeResult.probe` retyped to `probe.Probe` (value); `healthCheckProbes()` is a one-liner through the use-case; `isHealthCheckKind` deleted; `database`/`probemap`/`slices` imports removed.
- **`internal/api/healthcheckrunmappers.go`**: 10 vertical mappers retyped from `*database.Probe` → `probe.Probe`; `ParamsJSON` string check → `len(p.Params)` + `json.Unmarshal(p.Params, ...)`; `internal/database` import removed.
- **`.golangci.yml`**: new `health-no-persistence` depguard rule (RED-proven before fix, now GREEN).
- All callsites updated: `server.go`, `testing.go`, `wireHealthSettings`, seed/run/mapper tests.

## Gate results

**RED-proof (depguard before fix):**
```
internal/health/probemap/probemap.go:22:2: import 'github.com/MustardSeedNetworks/seed/internal/database' is not allowed from list 'health-no-persistence' (depguard)
1 issues: * depguard: 1
```

**Build:** `go build ./...` — clean (linker `-lpcap` warnings only, pre-existing)

**Tests:**
```
ok  github.com/MustardSeedNetworks/seed/internal/health/probemap   1.087s
ok  github.com/MustardSeedNetworks/seed/internal/health/settings   1.314s
ok  github.com/MustardSeedNetworks/seed/internal/app               1.457s
ok  github.com/MustardSeedNetworks/seed/internal/api               1.418s  (run: HealthCheck|Health|Probe|Seed — 17 PASS)
```

**Lint:** `golangci-lint run ./internal/health/... ./internal/app/... ./internal/api/...` — **0 issues**

**depguard GREEN:** `golangci-lint run --enable-only depguard ./internal/health/...` — 0 issues

**Scripts:** `check-filename-policy.sh` ✓ · `check-output-escaping.sh` ✓ · `gofmt -l` (all touched files) empty

## Behavior

Pure refactor — wire contract unchanged. `/telemetry/probes/run` output, first-run seed behavior, and health-checks settings GET/PUT are byte-for-byte identical.