### PR TITLE
docs(ws-b): close B3 — identity is the documented ADR-0024 exception

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -377,6 +377,20 @@ linters:
           deny:
             - pkg: github.com/MustardSeedNetworks/seed/internal/database
               desc: "health is persistence-free — probemap maps to the probe.Probe domain type; the probe repository (internal/database) is wired in internal/app (healthProbeStore); never import internal/database from internal/health"
+        # WS-B repository-port discipline — identity is the ONE intentional
+        # exception, so it has NO no-persistence deny rule (this comment is the
+        # record). ADR-0024 (Accepted 2026-06-10) decomposed identity into
+        # users/oauth/tokens use-cases over consumer-defined repository ports, but
+        # deliberately kept those ports typed on the existing database rows —
+        # *database.User / database.APITokenRecord / database.SSOUserInput plus the
+        # ErrUser*/ErrLastAdmin sentinels — because "thin CRUD stays thin: inventing
+        # a DTO here is churn without a security or clarity gain" on the most
+        # security-sensitive store in the codebase (the users / api_tokens tables the
+        # whole authz model rests on). So internal/identity/{users,oauth,tokens}
+        # import internal/database BY DESIGN. The repository-port win (no raw store
+        # handle in handler bodies) already landed in #1624; relocating the row types
+        # would reverse a reasoned ADR for no gain. See ADR-0024 §Decision/§Consequences
+        # and the Architecture Completion Plan WS-B (B3).
         # Phase 6 capture port: libpcap (via gopacket/pcap) carries the CGO
         # taint that re-links libpcap into every dependent test binary. It is
         # confined to the single adapter package internal/capture/pcap; every

--- a/docs/architecture/ARCHITECTURE_COMPLETION_PLAN.md
+++ b/docs/architecture/ARCHITECTURE_COMPLETION_PLAN.md
@@ -98,6 +98,21 @@ The 7 bypass packages define consumer-side repo ports + receive concretes from
   B6 `polling/snmp` · B7 `alerts/pipeline`.
 - Each PR adds a **depguard rule** (RED-proven) banning `internal/database` in that
   package, so it can't regress.
+- **Status (2026-06-14): B1–B2 + B4–B7 DONE** (probe #1672, topology #1673,
+  listener/sink + alerts #1676, polling #1675, retention #1677, health #1678 — each
+  with its RED-proven `*-no-persistence` depguard rule).
+- **B3 `identity` — CLOSED as a documented exception, NOT a relocation.** It is the
+  one intentional exception to this workstream. ADR-0024 (Accepted 2026-06-10)
+  deliberately kept the identity repository ports typed on the existing
+  `*database.User` / `database.APITokenRecord` / `database.SSOUserInput` rows
+  (plus the `ErrUser*`/`ErrLastAdmin` sentinels): "thin CRUD stays thin — inventing
+  a DTO here is churn without a security or clarity gain" on the codebase's most
+  security-sensitive store. The repository-port win (no raw store handle in handler
+  bodies) already landed in #1624; relocating the row types would reverse a reasoned
+  ADR for no gain. So `internal/identity` keeps its `internal/database` import by
+  design and gets **no** `identity-no-persistence` deny rule — the exception is
+  recorded as a comment in `.golangci.yml` and in ADR-0024 §Consequences. This makes
+  WS-B complete: every domain package has a purity rule **or** a documented exception.
 
 ### WS-C — Domain purity (net/http) + depguard coverage
 - C1 Move `iperf/installer.go` net/http into an adapter (composition root or `internal/app`).

--- a/docs/architecture/decisions/0024-identity-use-cases-and-repository-ports.md
+++ b/docs/architecture/decisions/0024-identity-use-cases-and-repository-ports.md
@@ -115,6 +115,18 @@ prefix (`handlers_users.go` → `users.go`, `handlers_oauth.go` → `oauth.go`,
   OAuth package is thin by design (one method) — accepted as honest capability
   segregation, not over-packaging, because it backs an independent route tree with
   upsert-by-external-id semantics distinct from CRUD.
+- **Relationship to WS-B (repository-port discipline, 2026-06-12).** WS-B relocates
+  each domain package's row types into the package so it stops importing
+  `internal/database`. **This ADR takes precedence for identity:** the ports here
+  intentionally return `*database.User` / `database.APITokenRecord` /
+  `database.SSOUserInput` (and pass the `ErrUser*`/`ErrLastAdmin` sentinels through),
+  so `internal/identity/{users,oauth,tokens}` keep their `internal/database` import
+  **by design** — the "thin CRUD stays thin" decision above stands. Identity is
+  therefore the **one documented exception** to WS-B: it gets no
+  `identity-no-persistence` depguard rule (the exemption is recorded as a comment in
+  `.golangci.yml`, next to the other WS-B rules). Should a future change give the
+  user/token store domain-meaningful behavior beyond thin CRUD, revisit this — the
+  exception is scoped to the current thin-CRUD shape, not a permanent carve-out.
 
 ## Implementation phasing
 


### PR DESCRIPTION
## What

Closes **WS-B/B3** by documenting `internal/identity` as the *one intentional exception* to repository-port discipline — not a relocation.

## Why

WS-B/B3 (relocate `User`/`APITokenRecord`/`SSOUserInput`/`Role*`/`Err*` into `internal/identity`) directly conflicts with **ADR-0024 (Accepted 2026-06-10)**, which deliberately kept the identity repository ports typed on the existing `*database.User` etc.: *"thin CRUD stays thin — inventing a DTO here is churn without a security or clarity gain"* on the codebase's most security-sensitive store (the `users`/`api_tokens` tables the whole authz model rests on). The repository-port win (no raw store handle in handler bodies) already landed in #1624. Reversing a reasoned ADR for no gain isn't warranted; owner decision was to honor ADR-0024.

## Changes (docs + config comment only — no code)

- `.golangci.yml` — comment recording identity's intentional exemption (it gets **no** `identity-no-persistence` deny rule).
- `docs/architecture/ARCHITECTURE_COMPLETION_PLAN.md` — WS-B status: B1–B2/B4–B7 done; **B3 closed as documented exception**. WS-B complete: every domain pkg has a purity rule **or** a documented exception.
- ADR-0024 §Consequences — WS-B reconciliation bullet (this ADR takes precedence for identity; exception scoped to the current thin-CRUD shape).

## Gates

`golangci-lint` config parses; `./internal/identity/...` = 0 issues.