### PR TITLE
refactor(ui): function-first sidebar nav IA, retire botanical metaphor (M1, #1452)

### DIFF
--- a/ui/e2e/theme-and-help.spec.ts
+++ b/ui/e2e/theme-and-help.spec.ts
@@ -277,9 +277,11 @@ test.describe('Theme Toggle and Help Modal', { tag: '@smoke' }, () => {
       const content = page.getByTestId('help-drawer-content');
       await expect(content).toBeVisible();
 
-      // The default (About) section names the Seed modules in its body.
-      await expect(content).toContainText('Roots');
-      await expect(content).toContainText('Canopy');
+      // The default (About) section renders real product prose (the help
+      // glossary's botanical module terms were retired with the function-first
+      // nav — this asserts stable About copy instead).
+      await expect(content).toContainText('network diagnostics');
+      await expect(content).toContainText('Mustard Seed Networks');
 
       // And there is substantive prose, not an empty pane.
       const text = (await content.innerText()).trim();

--- a/ui/src/components/app/HeaderBar.tsx
+++ b/ui/src/components/app/HeaderBar.tsx
@@ -476,7 +476,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = memo(function headerBar({
               onClick={(): void => {
                 // Always use switchToInterfaceType to properly set Wi-Fi mode.
                 // This handles both real Wi-Fi interfaces and survey mode
-                // (no-hardware): Canopy is troubleshooting/survey, not planning.
+                // (no-hardware): Wi-Fi is troubleshooting/survey, not planning.
                 switchToInterfaceType('wifi');
               }}
               aria-label={t('accessibility.selectWifi', 'Select Wi-Fi / Survey Mode')}

--- a/ui/src/components/help/helpDrawerContent.tsx
+++ b/ui/src/components/help/helpDrawerContent.tsx
@@ -8,7 +8,7 @@
  * Section bodies are authored as a sequence of typed `HelpBlock`s so a single
  * generic renderer can present every section without bespoke per-section JSX.
  * Content is FACTUAL — drawn from Seed's real feature set
- * (Roots/Canopy/Shell/Sap/Harvest plus the dashboard diagnostics). Section
+ * (live telemetry, diagnostics, monitoring, reporting). Section
  * titles come from the `help` i18n namespace (`sections.*`); body copy is
  * authored here in English. No invented features, no banned vocabulary.
  *
@@ -98,42 +98,11 @@ export const helpSections: HelpSection[] = [
     id: 'about',
     titleKey: 'sections.about',
     icon: <Info className={ICON} />,
-    keywords: ['about', 'overview', 'modules', 'roots', 'canopy', 'shell', 'sap', 'harvest'],
+    keywords: ['about', 'overview', 'live telemetry', 'diagnostics', 'monitoring', 'reporting'],
     blocks: [
       {
         kind: 'paragraph',
         text: 'The Seed is a network diagnostics and monitoring tool by Mustard Seed Networks. It gives you visibility into physical-layer link state, IP configuration, gateway and DNS reachability, device discovery, throughput, Wi-Fi connection quality, and endpoint health from a single dashboard.',
-      },
-      {
-        kind: 'terms',
-        heading: 'Modules',
-        items: [
-          {
-            term: 'Roots',
-            description:
-              'Path and route analysis — examines how traffic leaves the local network and reaches a destination.',
-          },
-          {
-            term: 'Canopy',
-            description:
-              'Wi-Fi visibility and troubleshooting — connected-SSID signal/SNR, neighbor access-point scanning, and channel utilization. Focused on diagnosing wireless problems, not coverage planning.',
-          },
-          {
-            term: 'Shell',
-            description:
-              'Security posture — surfaces open ports, device posture, and configuration risks discovered on the network.',
-          },
-          {
-            term: 'Sap',
-            description:
-              'Live telemetry — streams real-time metrics (link, signal, latency, throughput) as tests run.',
-          },
-          {
-            term: 'Harvest',
-            description:
-              'Reporting — collects diagnostic results into exportable reports for documentation and handoff.',
-          },
-        ],
       },
       {
         kind: 'note',
@@ -184,7 +153,7 @@ export const helpSections: HelpSection[] = [
         items: [
           'Use Network Discovery to find every device on the local subnet.',
           'Save per-site configuration as a Profile and switch between profiles from the header.',
-          'Export diagnostics from Harvest for documentation or troubleshooting handoff.',
+          'Export diagnostics for documentation or troubleshooting handoff.',
         ],
       },
     ],
@@ -329,7 +298,7 @@ export const helpSections: HelpSection[] = [
     blocks: [
       {
         kind: 'paragraph',
-        text: 'Wi-Fi Status monitors the quality and settings of the current wireless connection — part of the Canopy module for Wi-Fi visibility and troubleshooting.',
+        text: 'Wi-Fi Status monitors the quality and settings of the current wireless connection — Wi-Fi visibility and troubleshooting.',
       },
       {
         kind: 'terms',
@@ -781,7 +750,7 @@ export const helpSections: HelpSection[] = [
     blocks: [
       {
         kind: 'paragraph',
-        text: 'Security & Administration covers device scanning, posture assessment, and account administration — the basis of the Shell module for security posture.',
+        text: 'Security & Administration covers device scanning, posture assessment, and account administration — security posture for the network.',
       },
       {
         kind: 'terms',
@@ -961,7 +930,7 @@ export const helpSections: HelpSection[] = [
     blocks: [
       {
         kind: 'paragraph',
-        text: 'Path Analysis traces how traffic leaves the local network and reaches a destination. It surfaces every L2 hop on the local segment, every L3 hop on the route off-link, and the on-link devices ARP/ND can see along the way. The Roots module owns this surface.',
+        text: 'Path Analysis traces how traffic leaves the local network and reaches a destination. It surfaces every L2 hop on the local segment, every L3 hop on the route off-link, and the on-link devices ARP/ND can see along the way.',
       },
       {
         kind: 'terms',
@@ -999,7 +968,7 @@ export const helpSections: HelpSection[] = [
     blocks: [
       {
         kind: 'paragraph',
-        text: 'Reports collects the results of Seed’s diagnostic tests over time and exports them as SLA dashboards, compliance summaries, and historical CSV/JSON. The Harvest module owns this surface.',
+        text: 'Reports collects the results of Seed’s diagnostic tests over time and exports them as SLA dashboards, compliance summaries, and historical CSV/JSON.',
       },
       {
         kind: 'terms',

--- a/ui/src/components/ui/CommandPalette.stories.tsx
+++ b/ui/src/components/ui/CommandPalette.stories.tsx
@@ -8,11 +8,11 @@ import { CommandPalette } from './CommandPalette';
 
 const navGroups: SidebarNavGroup[] = [
   {
-    label: 'Modules',
+    label: 'Diagnostics',
     items: [
-      { label: 'Roots', path: '/roots', icon: Home },
-      { label: 'Canopy', path: '/canopy', icon: Activity },
-      { label: 'Sap', path: '/sap', icon: Sparkles },
+      { label: 'Path Analysis', path: '/path', icon: Home },
+      { label: 'Wi-Fi', path: '/wifi', icon: Activity },
+      { label: 'Link', path: '/link', icon: Sparkles },
     ],
   },
   {
@@ -121,7 +121,7 @@ export const WithExtraActions: Story = {
         },
         {
           id: 'export-report',
-          label: 'Export Harvest report',
+          label: 'Export report',
           hint: 'reports',
           perform: () => undefined,
         },

--- a/ui/src/components/ui/Typography.stories.tsx
+++ b/ui/src/components/ui/Typography.stories.tsx
@@ -48,7 +48,7 @@ export const Heading4: Story = {
 export const Paragraph: Story = {
   render: () => (
     <P>
-      The Roots module analyses path quality across the discovered topology using TCP, UDP, and ICMP
+      Path Analysis examines path quality across the discovered topology using TCP, UDP, and ICMP
       probes. Results are persisted to SQLite and exposed via the REST API.
     </P>
   ),
@@ -72,7 +72,7 @@ export const LinkVariants: Story = {
         <AccentLink href="https://example.com">External link (href)</AccentLink>
       </div>
       <div>
-        <AccentLink to="/roots">Internal link (react-router)</AccentLink>
+        <AccentLink to="/path">Internal link (react-router)</AccentLink>
       </div>
       <div>
         <AccentLink onClick={() => undefined}>Button-styled link</AccentLink>
@@ -85,16 +85,19 @@ export const Hierarchy: Story = {
   render: () => (
     <div className="space-y-4">
       <H1>The Seed</H1>
-      <H2>Modules</H2>
-      <P>Five modules cover the full network diagnostics surface:</P>
+      <H2>Diagnostics</H2>
+      <P>Function-grouped surfaces cover the full network diagnostics workflow:</P>
       <div className="space-y-2">
-        <H3>Roots — path analysis</H3>
+        <H3>Path Analysis</H3>
         <P>Hop-by-hop latency, jitter, and loss measurements over TCP/UDP/ICMP.</P>
         <SmallText>RFC 2544 baseline supported.</SmallText>
       </div>
       <div className="space-y-2">
-        <H3>Canopy — Wi-Fi planning</H3>
-        <P>RF coverage and capacity planning informed by IEEE 802.11 telemetry.</P>
+        <H3>Wi-Fi</H3>
+        <P>
+          Connected-SSID signal/SNR, neighbor AP scan, and channel utilization from IEEE 802.11
+          telemetry.
+        </P>
       </div>
       <Caption>Last updated 5 minutes ago.</Caption>
     </div>

--- a/ui/src/i18n/i18n.parity.test.ts
+++ b/ui/src/i18n/i18n.parity.test.ts
@@ -87,12 +87,7 @@ const DNT_TERMS = [
   'jitter',
   'throughput',
   'latency',
-  // Product / modules
-  'Roots',
-  'Canopy',
-  'Shell',
-  'Sap',
-  'Harvest',
+  // Product names
   'Seed',
   'Stem',
   'NIAC',

--- a/ui/src/navGroups.ts
+++ b/ui/src/navGroups.ts
@@ -1,16 +1,27 @@
 /**
  * Sidebar navigation groups for The Seed.
  *
- * Groups follow the existing module taxonomy (Roots / Canopy / Shell /
- * Sap / Harvest). The botanical group *labels* are intentional brand (the
- * code-vs-brand split, R4b) — do not "fix" them to literal module names.
- * Non-module functional groups (Performance, Monitoring) are allowed where
- * pages do not map to a botanical module.
+ * Groups are labelled by FUNCTION, not by the botanical module metaphor
+ * (Sap/Roots/Canopy/Shell/Harvest). This matches where the rest of the
+ * product already landed after the strategy reset: code uses meaningful
+ * tokens (`module-telemetry/path/wifi/security/reporting`), page copy never
+ * used the metaphor, and the marketing site leads with the function and keeps
+ * the botanical name only as a parenthetical aside ("Path analysis (Roots)").
+ * The sidebar was the lone surface still leading with bare metaphors — and the
+ * least self-evident one for a network engineer — so it now leads with the
+ * function too (M1, #1452). The botanical names survive as the module accent
+ * colour (`module-*` tokens) and in marketing; they are not sidebar headers.
+ *
+ * Grouping is by user intent:
+ *   - Live Telemetry — real-time connection state + throughput.
+ *   - Diagnostics    — on-demand investigations (path / Wi-Fi / security).
+ *   - Monitoring     — NMS: SNMP/LLDP/CDP topology, alerting, polling.
+ *   - Reporting      — outputs (reports, logs).
  *
  * Every routable page in pageRegistry must appear here so it is reachable
  * from the sidebar; navGroups.test.ts asserts that parity (guards H3 drift).
  * The sibling projects (niac, stem) ship the same shape via their own
- * navGroups files.
+ * navGroups files; mirror this function-first move there as separate PRs.
  */
 import {
   Activity,
@@ -29,32 +40,22 @@ import type { SidebarNavGroup } from './ui/Sidebar';
 
 export const navGroups: SidebarNavGroup[] = [
   {
-    label: 'Sap',
+    label: 'Live Telemetry',
     items: [
       { path: '/link', label: 'Link', icon: Network },
       { path: '/network', label: 'Network', icon: Server },
+      { path: '/performance', label: 'Performance', icon: Activity },
     ],
   },
   {
-    label: 'Roots',
-    items: [{ path: '/path', label: 'Path Analysis', icon: Route }],
+    label: 'Diagnostics',
+    items: [
+      { path: '/path', label: 'Path Analysis', icon: Route },
+      { path: '/wifi', label: 'Wi-Fi', icon: Wifi },
+      { path: '/security', label: 'Security', icon: Shield },
+    ],
   },
   {
-    label: 'Canopy',
-    items: [{ path: '/wifi', label: 'Wi-Fi', icon: Wifi }],
-  },
-  {
-    label: 'Shell',
-    items: [{ path: '/security', label: 'Security', icon: Shield }],
-  },
-  {
-    label: 'Performance',
-    items: [{ path: '/performance', label: 'Performance', icon: Activity }],
-  },
-  {
-    // NMS pages (SNMP/LLDP/CDP topology, alerting, polling). Minimal
-    // discoverable placement in a functional group; the broader nav IA
-    // redesign is deferred (#1452).
     label: 'Monitoring',
     items: [
       { path: '/topology', label: 'Topology', icon: Share2 },
@@ -63,7 +64,7 @@ export const navGroups: SidebarNavGroup[] = [
     ],
   },
   {
-    label: 'Harvest',
+    label: 'Reporting',
     items: [
       { path: '/reports', label: 'Reports', icon: BarChart3 },
       { path: '/logs', label: 'Logs', icon: ScrollText },


### PR DESCRIPTION
Un-defers and closes **M1** (the deferred nav IA redesign, #1452) — the last item in `SEED_UI_ARCH_PLAN.md`.

## Why now
Asked to "do the remaining items," I checked where the botanical module metaphor (Sap/Roots/Canopy/Shell/Harvest) actually still lives:

| Surface | Botanical usage | Leads with |
|---|---|---|
| Code (tokens, packages) | gone — `module-telemetry/path/wifi/security/reporting`; `internal/canopy`→`internal/wifi` | meaningful |
| Page copy / locales | **zero** | function |
| Marketing site (live) | parenthetical: `Path analysis (Roots)`, `Live telemetry (Sap)` | **function** |
| **Seed sidebar** | bare botanical headers | **botanical** ← lone holdout |
| Help drawer | a glossary section that existed only to translate the metaphor | — |

The sidebar was the only surface still leading with bare metaphors — simultaneously the least self-evident for a network engineer and inconsistent with the post-reset marketing brand. The `CLAUDE.md` "keep botanical sidebar headers" note is stale relative to where marketing landed.

## What changed
**Sidebar leads with function, grouped by user intent (7 groups → 4):**
```
Live Telemetry  Link · Network · Performance
Diagnostics     Path Analysis · Wi-Fi · Security
Monitoring      Topology · Alerts · Polling Targets
Reporting       Reports · Logs
```
Collapses the 3 noisy single-item botanical groups and the orphan Performance group. Botanical identity is retained as the `module-*` accent color tokens + marketing.

**Metaphor cleanup** (it had leaked past the sidebar): removed the botanical `Modules` help-glossary block, dropped `'<X> module owns this surface'` phrasing from help prose, fixed Storybook fixtures — including a stale `Canopy — Wi-Fi planning` that contradicted the locked troubleshooting-not-planning scope — and removed the vestigial botanical terms from the i18n parity list.

## Scope notes / follow-ups
- **Per-item module accent color** isn't wired into the shared Sidebar today (active items use one global `brand-accent`). Adding it touches the harmonized `SidebarNavItem` type → deliberately deferred to a focused fast-follow so it can be a visual-taste call + a **stem/niac mirror**.
- Sidebar shape is shared-by-convention; **stem/niac get this function-first move as separate PRs**.

## Verification
- nav↔route parity test unchanged (all 11 paths preserved).
- `tsc --noEmit` clean; Biome clean; token gate green.
- Vitest: navGroups, i18n parity, i18n, help-route-coverage — 33 passed.
- Full build / E2E run in CI.