### PR TITLE
feat(ui): per-item module accent colour in the sidebar (M1 follow-up)

### DIFF
--- a/ui/src/navGroups.ts
+++ b/ui/src/navGroups.ts
@@ -42,20 +42,26 @@ export const navGroups: SidebarNavGroup[] = [
   {
     label: 'Live Telemetry',
     items: [
-      { path: '/link', label: 'Link', icon: Network },
-      { path: '/network', label: 'Network', icon: Server },
-      { path: '/performance', label: 'Performance', icon: Activity },
+      { path: '/link', label: 'Link', icon: Network, accent: 'text-module-telemetry' },
+      { path: '/network', label: 'Network', icon: Server, accent: 'text-module-telemetry' },
+      {
+        path: '/performance',
+        label: 'Performance',
+        icon: Activity,
+        accent: 'text-module-telemetry',
+      },
     ],
   },
   {
     label: 'Diagnostics',
     items: [
-      { path: '/path', label: 'Path Analysis', icon: Route },
-      { path: '/wifi', label: 'Wi-Fi', icon: Wifi },
-      { path: '/security', label: 'Security', icon: Shield },
+      { path: '/path', label: 'Path Analysis', icon: Route, accent: 'text-module-path' },
+      { path: '/wifi', label: 'Wi-Fi', icon: Wifi, accent: 'text-module-wifi' },
+      { path: '/security', label: 'Security', icon: Shield, accent: 'text-module-security' },
     ],
   },
   {
+    // NMS pages have no botanical module; they keep the neutral colouring.
     label: 'Monitoring',
     items: [
       { path: '/topology', label: 'Topology', icon: Share2 },
@@ -66,8 +72,8 @@ export const navGroups: SidebarNavGroup[] = [
   {
     label: 'Reporting',
     items: [
-      { path: '/reports', label: 'Reports', icon: BarChart3 },
-      { path: '/logs', label: 'Logs', icon: ScrollText },
+      { path: '/reports', label: 'Reports', icon: BarChart3, accent: 'text-module-reporting' },
+      { path: '/logs', label: 'Logs', icon: ScrollText, accent: 'text-module-reporting' },
     ],
   },
 ];

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -34,6 +34,14 @@ export interface SidebarNavItem {
   label: string;
   icon: LucideIcon;
   badge?: string;
+  /**
+   * Optional module accent — a semantic text-colour utility (e.g.
+   * `text-module-wifi`). Carries the per-module brand identity that the
+   * function-first nav (M1) moved off the group headers. Items with no module
+   * (e.g. NMS) omit it and fall back to the neutral/brand colouring. Optional
+   * so the sibling repos' navGroups stay valid until they adopt it.
+   */
+  accent?: string;
 }
 
 export interface SidebarNavGroup {
@@ -86,8 +94,18 @@ const NavItemButton: FC<NavItemButtonProps> = ({ item, active, collapsed, onNavi
     title={collapsed ? item.label : undefined}
   >
     {createElement(item.icon, {
+      // Module accent (M1 follow-up): the icon carries the per-module brand
+      // colour the function-first nav moved off the group headers — dimmed at
+      // rest, full-strength when active. Items without a module accent keep the
+      // neutral→brand colouring.
       className: `${iconSizes.lg} flex-shrink-0 ${
-        active ? 'text-brand-accent' : 'text-text-muted group-hover:text-text-secondary'
+        item.accent
+          ? active
+            ? item.accent
+            : `${item.accent} opacity-60 group-hover:opacity-100`
+          : active
+            ? 'text-brand-accent'
+            : 'text-text-muted group-hover:text-text-secondary'
       }`,
     })}
     {!collapsed ? (


### PR DESCRIPTION
**Stacked on #1681** (function-first nav). Merge #1681 first.

The M1 nav redesign moved the botanical metaphor off the sidebar group headers. This wires the per-module brand identity back in as the **accent colour** on each nav item's icon — the deliberate fast-follow noted in #1681.

## What
- Adds an optional `accent` field to the shared `SidebarNavItem` type (a semantic `text-module-*` utility).
- `NavItemButton` renders it: module colour dimmed (`opacity-60`) at rest, full-strength when active. Items without an accent keep the neutral→brand colouring.
- Assigns accents in `navGroups`: Live Telemetry → `module-telemetry` (cyan), Path → `module-path` (amber), Wi-Fi → `module-wifi` (green), Security → `module-security` (orange), Reports/Logs → `module-reporting` (gold). **Monitoring/NMS has no botanical module → stays neutral.**

`accent` is optional so stem/niac `navGroups` remain valid until they adopt it (shared Sidebar shape).

## Verification
- tsc `--noEmit` clean; Biome clean.
- Token gate green (`text-module-*` are semantic tokens, already used across pages).
- navGroups↔route parity test green.
- `npm run build` compiles the `text-module-*` utilities (Tailwind v4 `@theme`).
- Full E2E in CI.