### PR TITLE
chore(release): expose release train metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "26.2.0"
+          node-version: "26.3.0"
           cache: npm
           cache-dependency-path: ui/package-lock.json
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 # REQUIREMENTS
 # ------------
 #   - Go 1.25.5+ (with CGO for libpcap)
-#   - Node.js 26.2.0+ and npm
+#   - Node.js 26.3.0 and npm 11.17.0
 #   - libpcap-dev (Linux) or libpcap (macOS via Homebrew)
 #
 # =============================================================================

--- a/internal/api/testdata/golden/authchain/version.txt
+++ b/internal/api/testdata/golden/authchain/version.txt
@@ -9,6 +9,7 @@ body:
 {
   "buildTime": "\u003cvolatile\u003e",
   "commit": "\u003cvolatile\u003e",
+  "releaseTrain": "unknown",
   "tlsFingerprint": "",
   "uiBuildHash": "\u003cvolatile\u003e",
   "version": "\u003cvolatile\u003e"

--- a/internal/api/testdata/golden/version.txt
+++ b/internal/api/testdata/golden/version.txt
@@ -3,6 +3,7 @@ body:
 {
   "buildTime": "\u003cvolatile\u003e",
   "commit": "\u003cvolatile\u003e",
+  "releaseTrain": "unknown",
   "tlsFingerprint": "",
   "uiBuildHash": "\u003cvolatile\u003e",
   "version": "\u003cvolatile\u003e"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,6 +5,7 @@ package version
 
 import (
 	"runtime/debug"
+	"strings"
 )
 
 // These variables are set via ldflags at build time.
@@ -117,6 +118,11 @@ func GetBuildTime() string {
 	return buildTime
 }
 
+// GetReleaseTrain returns the calendar release train in YYYY.MM format.
+func GetReleaseTrain() string {
+	return releaseTrainFromBuildTime(GetBuildTime())
+}
+
 // GetUIBuildHash returns the md5 hash of the embedded UI assets.
 // Returns unknownValue when not injected via -ldflags at build time.
 func GetUIBuildHash() string {
@@ -126,13 +132,21 @@ func GetUIBuildHash() string {
 	return UIBuildHash
 }
 
+func releaseTrainFromBuildTime(buildTime string) string {
+	if len(buildTime) < len("2006-01") || buildTime == unknownValue {
+		return unknownValue
+	}
+	return strings.ReplaceAll(buildTime[:len("2006-01")], "-", ".")
+}
+
 // Info returns all version information.
 func Info() map[string]string {
 	ver, commit, buildTime := getVersionInfo()
 	return map[string]string{
-		"version":     ver,
-		"commit":      commit,
-		"buildTime":   buildTime,
-		"uiBuildHash": GetUIBuildHash(),
+		"version":      ver,
+		"commit":       commit,
+		"buildTime":    buildTime,
+		"releaseTrain": releaseTrainFromBuildTime(buildTime),
+		"uiBuildHash":  GetUIBuildHash(),
 	}
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -13,7 +13,7 @@ func TestInfo(t *testing.T) {
 	}{
 		{
 			name:     "returns all version fields",
-			wantKeys: []string{"version", "commit", "buildTime", "uiBuildHash"},
+			wantKeys: []string{"version", "commit", "buildTime", "releaseTrain", "uiBuildHash"},
 		},
 	}
 
@@ -92,6 +92,11 @@ func TestGetterFunctions(t *testing.T) {
 		{
 			name:     "GetBuildTime returns value",
 			getter:   version.GetBuildTime,
+			notEmpty: true,
+		},
+		{
+			name:     "GetReleaseTrain returns value",
+			getter:   version.GetReleaseTrain,
 			notEmpty: true,
 		},
 		{


### PR DESCRIPTION
## Summary

Adds `releaseTrain` to Seed runtime version metadata, derived automatically from `buildTime` as `YYYY.MM`, and updates the golden `/__version` responses. Also brings the release workflow Node pin and Makefile requirement note to Node `26.3.0` / npm `11.17.0`.

## Linked Issue

Fixes #1692

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [x] Chore / refactor / dependency update
- [ ] Documentation
- [x] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
/opt/homebrew/bin/go test ./internal/version
ok  github.com/MustardSeedNetworks/seed/internal/version  0.870s

/opt/homebrew/bin/go test ./internal/api ./internal/version
ok  github.com/MustardSeedNetworks/seed/internal/api      48.545s
ok  github.com/MustardSeedNetworks/seed/internal/version  (cached)

/opt/homebrew/bin/go test ./...
ok  github.com/MustardSeedNetworks/seed/...  (full suite passed; linker emitted existing duplicate -lpcap warnings)

git diff --check
<no output>
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.
