### PR TITLE
refactor(ci): add domain-purity depguard rules for six capability packages (WS-C4)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -427,6 +427,109 @@ linters:
               desc: "inward-only — a discovery stage (internal/discovery/fingerprint) imports the kernel, never the reverse; the Engine holds the PortScannerPort and the composition root injects the scanner"
             - pkg: github.com/MustardSeedNetworks/seed/internal/discovery/enumerate
               desc: "inward-only — a discovery stage (internal/discovery/enumerate) imports the kernel, never the reverse; the Engine holds the BluetoothCollectorPort and the composition root injects the collector"
+        # WS-C4 domain-purity coverage: the capability packages below are pure
+        # domain — they hold business logic and consumer-side ports, never
+        # transport (net/http) nor persistence (database/sql or our internal/database
+        # wrapper). The WS-A handler strangle and WS-B repository-port discipline
+        # already removed every such reach; these rules lock that in so it cannot
+        # regress. Each capability gets the same two-rule shape used by reporting
+        # and the WS-B packages above: a transport+raw-SQL ban across all files,
+        # and a production-only internal/database ban (tests stay exempt as mini
+        # composition roots, matching the rest of this file). All six are
+        # currently green on every file, production and test.
+        "wifi-domain-purity":
+          files:
+            - "**/internal/wifi/**"
+          deny:
+            - pkg: net/http
+              desc: "wifi is transport-free — capture/decode goes through the capture port; expose a port and implement it in an adapter"
+            - pkg: database/sql
+              desc: "wifi is persistence-free — define a Repo port and implement it in an adapter wired at the composition root"
+        "wifi-no-persistence":
+          files:
+            - "**/internal/wifi/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "wifi is persistence-free — define a Repo port in internal/wifi and map rows to its domain types in internal/database; wire it in internal/app"
+        "security-domain-purity":
+          files:
+            - "**/internal/security/**"
+          deny:
+            - pkg: net/http
+              desc: "security is transport-free — define a port and implement it in an adapter"
+            - pkg: database/sql
+              desc: "security is persistence-free — define a Repo port and implement it in an adapter wired at the composition root"
+        "security-no-persistence":
+          files:
+            - "**/internal/security/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "security is persistence-free — define a Repo port in internal/security and map rows to its domain types in internal/database; wire it in internal/app"
+        "network-domain-purity":
+          files:
+            - "**/internal/network/**"
+          deny:
+            - pkg: net/http
+              desc: "network is transport-free — define a port and implement it in an adapter"
+            - pkg: database/sql
+              desc: "network is persistence-free — define a Repo port and implement it in an adapter wired at the composition root"
+        "network-no-persistence":
+          files:
+            - "**/internal/network/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "network is persistence-free — define a Repo port in internal/network and map rows to its domain types in internal/database; wire it in internal/app"
+        "settings-domain-purity":
+          files:
+            - "**/internal/settings/**"
+          deny:
+            - pkg: net/http
+              desc: "settings is transport-free — define a port and implement it in an adapter"
+            - pkg: database/sql
+              desc: "settings is persistence-free — define a Repo port and implement it in an adapter wired at the composition root"
+        "settings-no-persistence":
+          files:
+            - "**/internal/settings/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "settings is persistence-free — define a Repo port in internal/settings and map rows to its domain types in internal/database; wire it in internal/app"
+        "profiles-domain-purity":
+          files:
+            - "**/internal/profiles/**"
+          deny:
+            - pkg: net/http
+              desc: "profiles is transport-free — define a port and implement it in an adapter"
+            - pkg: database/sql
+              desc: "profiles is persistence-free — define a Repo port and implement it in an adapter wired at the composition root"
+        "profiles-no-persistence":
+          files:
+            - "**/internal/profiles/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "profiles is persistence-free — define a Repo port in internal/profiles and map rows to its domain types in internal/database; wire it in internal/app"
+        # anomaly already declares its persistence needs as a port (ADR-0021/0029,
+        # implemented by internal/database); these rules document and enforce that
+        # the anomaly domain itself stays transport- and persistence-free.
+        "anomaly-domain-purity":
+          files:
+            - "**/internal/anomaly/**"
+          deny:
+            - pkg: net/http
+              desc: "anomaly is transport-free — define a port and implement it in an adapter"
+            - pkg: database/sql
+              desc: "anomaly is persistence-free — it declares its persistence port (ADR-0021/0029); implement it in internal/database"
+        "anomaly-no-persistence":
+          files:
+            - "**/internal/anomaly/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/seed/internal/database
+              desc: "anomaly is persistence-free — its persistence port (ADR-0021/0029) is implemented by internal/database and wired at the composition root; never import internal/database from internal/anomaly"
 
     embeddedstructfieldcheck:
       # Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.


### PR DESCRIPTION
## Summary

Locks in the WS-A handler strangle and WS-B repository-port discipline so the
pure capability packages cannot regress into transport or persistence reaches.

`wifi`, `security`, `network`, `settings`, `profiles` and `anomaly` are all
currently free of `net/http`, `database/sql` and `internal/database` in both
production and test files, but had **no depguard rule** guarding that. Each now
gets the same two-rule shape already used by `reporting` and the WS-B packages:

- `<pkg>-domain-purity` — deny `net/http` + `database/sql` across all files
- `<pkg>-no-persistence` — deny `internal/database` in production files only
  (tests stay exempt as mini composition roots, matching the rest of the file)

Config-only change (`.golangci.yml`, +103 lines). No code moves. Advances the
Architecture Completion Plan **WS-C4** (domain-purity depguard coverage) and is a
precondition for the **WS-Z Z3** regression gate (every domain package has a
purity rule or a documented exception).

## Linked Issue

Related to #187

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [x] Chore / refactor / dependency update
- [ ] Documentation
- [x] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

Config-only change; verified the config parses, the rules are live (RED-proven),
and the six target trees stay green.

```text
$ golangci-lint config verify
(no output — valid)

# RED-proof: inject net/http + internal/database into a wifi production file
$ golangci-lint run --enable-only depguard ./internal/wifi/...
internal/wifi/scanner_darwin.go:6:2: import 'net/http' is not allowed from list 'wifi-domain-purity' (depguard)
internal/wifi/scanner_darwin.go:7:2: import 'github.com/.../internal/database' is not allowed from list 'wifi-no-persistence' (depguard)
2 issues
# (reverted)

# GREEN on current tree across all six capability packages
$ golangci-lint run --enable-only depguard ./internal/wifi/... ./internal/security/... \
    ./internal/network/... ./internal/settings/... ./internal/profiles/... ./internal/anomaly/...
0 issues.

$ go build ./...
(ok)
```

Full `golangci-lint run` on the six trees is clean apart from one pre-existing,
unrelated `interfacebloat` finding in `profiles/catalog/catalog.go` (untouched by
this diff; full-tree backlog tracked for WS-Z).

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (n/a — config-only)
- [x] Dependencies are pinned and justified if changed. (n/a — no dep change)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (rule rationale documented inline in `.golangci.yml`)