### PR TITLE
ci(lint): make golangci-lint full-tree, clearing the backlog (WS-Z Z1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,11 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.12.1
-          args: --timeout=5m --new-from-rev=HEAD~1
+          version: v2.12.2
+          # WS-Z Z1: lint the FULL tree, not just the PR diff. The prior
+          # --new-from-rev=HEAD~1 was a blind gate that let whole-tree backlog
+          # accumulate unseen; the backlog is now zero, so the gate goes full.
+          args: --timeout=10m
 
       - name: Run go vet
         run: go vet ./...

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -297,28 +297,8 @@ func NewServer(
 		engines:       engine.NewRegistry(nil),
 	}
 
-	// Initialize auth services
-	s.authMgr = auth.NewManager(
-		cfg.Auth.JWTSecret,
-		cfg.Auth.SessionTimeout,
-		cfg.Auth.DefaultUsername,
-		cfg.Auth.DefaultPasswordHash,
-	)
-	s.csrf = auth.NewCSRFManager()
-	s.setupToken = NewSetupTokenManager()
-	s.recovery = auth.NewRecoveryTokenManager(paths.Resolve(paths.ModeAuto).DataDir)
-	s.proxies = trustedProxies
-
-	// Wave 3 (#85): initialise the WebAuthn manager. The relying-party
-	// ID and origins are derived from the server config; failures here
-	// are non-fatal because the rest of the auth surface still works
-	// without passkeys.
-	if wan, wanErr := auth.NewWebAuthnManager(webAuthnConfigFromServer(cfg)); wanErr != nil {
-		logging.GetLogger().Warn("WebAuthn manager init failed; passkeys disabled",
-			"error", wanErr)
-	} else {
-		s.webAuthn = wan
-	}
+	// Initialize auth services (manager, CSRF, setup/recovery tokens, WebAuthn).
+	s.initAuthServices(cfg, trustedProxies)
 
 	// Initialize rate limiters
 	s.loginLimiter = NewRateLimiter(DefaultRateLimitConfig())
@@ -426,6 +406,34 @@ func NewServer(
 	s.setupRoutes()
 
 	return s
+}
+
+// initAuthServices wires the authentication surface: the JWT/session manager,
+// the per-session CSRF manager, the first-run setup-token and recovery-token
+// managers, the trusted-proxy set, and (best-effort) the WebAuthn/passkey
+// manager. Split out of NewServer to keep the composition root under the funlen
+// limit; failures wiring WebAuthn are non-fatal (passkeys disabled, rest works).
+func (s *Server) initAuthServices(cfg *config.Config, trustedProxies *TrustedProxies) {
+	s.authMgr = auth.NewManager(
+		cfg.Auth.JWTSecret,
+		cfg.Auth.SessionTimeout,
+		cfg.Auth.DefaultUsername,
+		cfg.Auth.DefaultPasswordHash,
+	)
+	s.csrf = auth.NewCSRFManager()
+	s.setupToken = NewSetupTokenManager()
+	s.recovery = auth.NewRecoveryTokenManager(paths.Resolve(paths.ModeAuto).DataDir)
+	s.proxies = trustedProxies
+
+	// Wave 3 (#85): initialise the WebAuthn manager. The relying-party ID and
+	// origins are derived from the server config; failures here are non-fatal
+	// because the rest of the auth surface still works without passkeys.
+	if wan, wanErr := auth.NewWebAuthnManager(webAuthnConfigFromServer(cfg)); wanErr != nil {
+		logging.GetLogger().Warn("WebAuthn manager init failed; passkeys disabled",
+			"error", wanErr)
+	} else {
+		s.webAuthn = wan
+	}
 }
 
 // initCaptureServices constructs the services that perform live packet capture

--- a/internal/app/profiles.go
+++ b/internal/app/profiles.go
@@ -175,5 +175,6 @@ func (a profilesLiveConfig) Apply(ctx context.Context, profileJSON string) error
 // resolved through db on each call so the api test harness's later-set DB is
 // honored; the use-case reports Available()==false when no DB is wired.
 func NewProfiles(db func() *database.DB, cfg *config.Config, path string) *catalog.Service {
-	return catalog.NewService(profilesStore{db: db}, profilesLiveConfig{cfg: cfg, path: path})
+	store := profilesStore{db: db}
+	return catalog.NewService(store, store, profilesLiveConfig{cfg: cfg, path: path})
 }

--- a/internal/probe/anomaly/producer_internal_test.go
+++ b/internal/probe/anomaly/producer_internal_test.go
@@ -54,7 +54,8 @@ func coordFor(t *testing.T, store anomaly.Store) *anomaly.Coordinator {
 	return anomaly.NewCoordinator(anomaly.NewEngine(cat), store)
 }
 
-func latencyEvent(probeID string) probe.ResultEvent {
+func latencyEvent() probe.ResultEvent {
+	const probeID = "p1"
 	return probe.ResultEvent{
 		Result: probe.Result{ProbeID: probeID, Kind: "http"},
 		Breaches: []probe.Breach{
@@ -86,7 +87,7 @@ func TestObserveCleanResultResolvesImmediately(t *testing.T) {
 	}
 	ctx := context.Background()
 	t0 := time.Unix(3000, 0).UTC()
-	p.observe(ctx, latencyEvent("p1"), t0) // active anomaly
+	p.observe(ctx, latencyEvent(), t0) // active anomaly
 
 	// A clean run resolves it immediately — no flushAndPrune / silence wait.
 	p.observe(ctx, cleanEvent("p1"), t0.Add(time.Minute))
@@ -135,7 +136,7 @@ func TestObservePersistsThroughCoordinator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	p.observe(context.Background(), latencyEvent("p1"), time.Unix(1000, 0).UTC())
+	p.observe(context.Background(), latencyEvent(), time.Unix(1000, 0).UTC())
 
 	upserts, rows, _ := fs.snapshot()
 	if upserts != 1 || len(rows) != 1 {
@@ -173,7 +174,7 @@ func TestFlushAndPruneResolvesAfterSilence(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	t0 := time.Unix(2000, 0).UTC()
-	p.observe(context.Background(), latencyEvent("p1"), t0)
+	p.observe(context.Background(), latencyEvent(), t0)
 
 	// Within the window: not yet resolved.
 	p.flushAndPrune(context.Background(), t0.Add(5*time.Minute))
@@ -210,7 +211,7 @@ func TestStartStopIsIdempotentAndDrains(t *testing.T) {
 		t.Fatalf("second Start: %v", err)
 	}
 
-	events <- latencyEvent("p1")
+	events <- latencyEvent()
 	// Wait for the consume goroutine to persist it.
 	deadline := time.Now().Add(2 * time.Second)
 	for {

--- a/internal/profiles/catalog/catalog.go
+++ b/internal/profiles/catalog/catalog.go
@@ -112,6 +112,12 @@ type Store interface {
 	Update(ctx context.Context, p Profile, ifMatch string) error
 	Delete(ctx context.Context, id string) error
 	Count(ctx context.Context) (int, error)
+}
+
+// ActiveStore is the persistence surface for the "currently active profile"
+// pointer, split from Store (ADR-0016 consumer port) so neither interface
+// exceeds the cohesion budget. The same adapter satisfies both.
+type ActiveStore interface {
 	ActiveID(ctx context.Context) (string, error)
 	SetActiveID(ctx context.Context, id string) error
 }
@@ -127,14 +133,16 @@ type LiveConfig interface {
 
 // Service is the profiles use-case.
 type Service struct {
-	store Store
-	live  LiveConfig
+	store  Store
+	active ActiveStore
+	live   LiveConfig
 }
 
-// NewService builds the use-case over its Store port and an optional LiveConfig
-// applier (nil = activation does not touch the running config).
-func NewService(store Store, live LiveConfig) *Service {
-	return &Service{store: store, live: live}
+// NewService builds the use-case over its Store + ActiveStore ports and an
+// optional LiveConfig applier (nil = activation does not touch the running
+// config). In production a single adapter satisfies both store and active.
+func NewService(store Store, active ActiveStore, live LiveConfig) *Service {
+	return &Service{store: store, active: active, live: live}
 }
 
 // Available reports whether the profiles subsystem can serve requests.
@@ -215,7 +223,7 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 		return ErrDeleteDefault
 	}
 	// A failed active-id read must not block deletion (best-effort, as before).
-	if activeID, activeErr := s.store.ActiveID(ctx); activeErr == nil && activeID == id {
+	if activeID, activeErr := s.active.ActiveID(ctx); activeErr == nil && activeID == id {
 		return ErrDeleteActive
 	}
 	return s.store.Delete(ctx, id)
@@ -224,7 +232,7 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 // ActiveProfile resolves the active profile, falling back to the default and
 // self-healing a stale active-id pointer, mirroring the pre-strangle handler.
 func (s *Service) ActiveProfile(ctx context.Context) (Profile, error) {
-	activeID, err := s.store.ActiveID(ctx)
+	activeID, err := s.active.ActiveID(ctx)
 	if err != nil {
 		return Profile{}, ErrActiveLookup
 	}
@@ -250,7 +258,7 @@ func (s *Service) ActiveProfile(ctx context.Context) (Profile, error) {
 		if defErr != nil {
 			return Profile{}, ErrActiveNotFound
 		}
-		_ = s.store.SetActiveID(ctx, def.ID)
+		_ = s.active.SetActiveID(ctx, def.ID)
 		return def, nil
 	}
 	return p, nil
@@ -266,7 +274,7 @@ func (s *Service) SetActiveProfile(ctx context.Context, id string) (Profile, err
 	if err != nil {
 		return Profile{}, err
 	}
-	if setErr := s.store.SetActiveID(ctx, id); setErr != nil {
+	if setErr := s.active.SetActiveID(ctx, id); setErr != nil {
 		return Profile{}, setErr
 	}
 

--- a/internal/profiles/catalog/catalog_test.go
+++ b/internal/profiles/catalog/catalog_test.go
@@ -94,8 +94,15 @@ func (f *fakeStore) SetActiveID(_ context.Context, id string) error {
 
 func ctx() context.Context { return context.Background() }
 
+// newSvc builds the use-case with the fake satisfying both the Store and
+// ActiveStore ports (as the production adapter does), so active-profile state
+// is shared across the two ports.
+func newSvc(store *fakeStore, live catalog.LiveConfig) *catalog.Service {
+	return catalog.NewService(store, store, live)
+}
+
 func TestCreateValidatesNameAndStores(t *testing.T) {
-	svc := catalog.NewService(newFakeStore(), nil)
+	svc := newSvc(newFakeStore(), nil)
 
 	if _, err := svc.Create(ctx(), catalog.NewProfile{Name: ""}); !errors.Is(err, catalog.ErrNameRequired) {
 		t.Fatalf("empty name should be ErrNameRequired, got %v", err)
@@ -120,7 +127,7 @@ func TestCreateValidatesNameAndStores(t *testing.T) {
 func TestUpdatePartialSemantics(t *testing.T) {
 	store := newFakeStore()
 	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "orig", Description: "d", ConfigJSON: "{}"}
-	svc := catalog.NewService(store, nil)
+	svc := newSvc(store, nil)
 
 	// Empty name keeps existing; nil config keeps existing; description always applied.
 	got, err := svc.Update(ctx(), "p1", catalog.ProfileUpdate{Name: "", Description: "new", ConfigJSON: nil}, "")
@@ -149,7 +156,7 @@ func TestUpdateIfMatch(t *testing.T) {
 	store := newFakeStore()
 	// fakeStore.UpdateIfMatch treats ConfigJSON as the version token.
 	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "n", ConfigJSON: "v1"}
-	svc := catalog.NewService(store, nil)
+	svc := newSvc(store, nil)
 
 	// Matching ETag writes through.
 	upd := `v2`
@@ -179,7 +186,7 @@ func TestDeleteGuards(t *testing.T) {
 	store.byID["act"] = catalog.Profile{ID: "act", Name: "active"}
 	store.byID["ok"] = catalog.Profile{ID: "ok", Name: "ok"}
 	store.activeID = "act"
-	svc := catalog.NewService(store, nil)
+	svc := newSvc(store, nil)
 
 	if err := svc.Delete(ctx(), "def"); !errors.Is(err, catalog.ErrDeleteDefault) {
 		t.Fatalf("deleting default should be ErrDeleteDefault, got %v", err)
@@ -200,7 +207,7 @@ func TestActiveProfileResolution(t *testing.T) {
 		store := newFakeStore()
 		store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one"}
 		store.activeID = "p1"
-		got, err := catalog.NewService(store, nil).ActiveProfile(ctx())
+		got, err := newSvc(store, nil).ActiveProfile(ctx())
 		if err != nil || got.ID != "p1" {
 			t.Fatalf("want p1, got %+v err=%v", got, err)
 		}
@@ -209,14 +216,14 @@ func TestActiveProfileResolution(t *testing.T) {
 	t.Run("falls back to default when unset", func(t *testing.T) {
 		store := newFakeStore()
 		store.byID["d"] = catalog.Profile{ID: "d", Name: "def", IsDefault: true}
-		got, err := catalog.NewService(store, nil).ActiveProfile(ctx())
+		got, err := newSvc(store, nil).ActiveProfile(ctx())
 		if err != nil || got.ID != "d" {
 			t.Fatalf("want default d, got %+v err=%v", got, err)
 		}
 	})
 
 	t.Run("no active and no default", func(t *testing.T) {
-		_, err := catalog.NewService(newFakeStore(), nil).ActiveProfile(ctx())
+		_, err := newSvc(newFakeStore(), nil).ActiveProfile(ctx())
 		if !errors.Is(err, catalog.ErrNoActiveOrDefault) {
 			t.Fatalf("want ErrNoActiveOrDefault, got %v", err)
 		}
@@ -226,7 +233,7 @@ func TestActiveProfileResolution(t *testing.T) {
 		store := newFakeStore()
 		store.byID["d"] = catalog.Profile{ID: "d", Name: "def", IsDefault: true}
 		store.activeID = "ghost" // points at a deleted profile
-		got, err := catalog.NewService(store, nil).ActiveProfile(ctx())
+		got, err := newSvc(store, nil).ActiveProfile(ctx())
 		if err != nil || got.ID != "d" {
 			t.Fatalf("want self-heal to d, got %+v err=%v", got, err)
 		}
@@ -239,7 +246,7 @@ func TestActiveProfileResolution(t *testing.T) {
 func TestSetActiveProfile(t *testing.T) {
 	store := newFakeStore()
 	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one"}
-	svc := catalog.NewService(store, nil)
+	svc := newSvc(store, nil)
 
 	if _, err := svc.SetActiveProfile(ctx(), ""); !errors.Is(err, catalog.ErrIDRequired) {
 		t.Fatalf("empty id should be ErrIDRequired, got %v", err)
@@ -268,7 +275,7 @@ func TestSetActiveProfileAppliesConfig(t *testing.T) {
 	store := newFakeStore()
 	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one", ConfigJSON: `{"k":1}`}
 	live := &fakeLive{}
-	svc := catalog.NewService(store, live)
+	svc := newSvc(store, live)
 
 	if _, err := svc.SetActiveProfile(ctx(), "p1"); err != nil {
 		t.Fatalf("set active: %v", err)
@@ -281,7 +288,7 @@ func TestSetActiveProfileAppliesConfig(t *testing.T) {
 func TestSetActiveProfileSurfacesApplyError(t *testing.T) {
 	store := newFakeStore()
 	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one", ConfigJSON: `{"k":1}`}
-	svc := catalog.NewService(store, &fakeLive{err: catalog.ErrConfigApply})
+	svc := newSvc(store, &fakeLive{err: catalog.ErrConfigApply})
 
 	_, err := svc.SetActiveProfile(ctx(), "p1")
 	if !errors.Is(err, catalog.ErrConfigApply) {
@@ -297,7 +304,7 @@ func TestSetActiveProfileSkipsApplyWhenConfigEmpty(t *testing.T) {
 	store := newFakeStore()
 	store.byID["p1"] = catalog.Profile{ID: "p1", Name: "one"} // no ConfigJSON
 	live := &fakeLive{err: errors.New("should not be called")}
-	svc := catalog.NewService(store, live)
+	svc := newSvc(store, live)
 
 	if _, err := svc.SetActiveProfile(ctx(), "p1"); err != nil {
 		t.Fatalf("set active with empty config should not invoke apply: %v", err)
@@ -311,7 +318,7 @@ func TestDuplicateRetriesOnNameCollision(t *testing.T) {
 	store := newFakeStore()
 	store.byID["src"] = catalog.Profile{ID: "src", Name: "src", ConfigJSON: `{"k":1}`}
 	store.byID["copy"] = catalog.Profile{ID: "copy", Name: "src (Copy)"} // forces first-attempt collision
-	svc := catalog.NewService(store, nil)
+	svc := newSvc(store, nil)
 
 	dup, err := svc.Duplicate(ctx(), "src", "")
 	if err != nil {
@@ -328,7 +335,7 @@ func TestDuplicateRetriesOnNameCollision(t *testing.T) {
 func TestImportCreateUpdateSkip(t *testing.T) {
 	store := newFakeStore()
 	store.byID["e"] = catalog.Profile{ID: "e", Name: "exists", ConfigJSON: "{}"}
-	svc := catalog.NewService(store, nil)
+	svc := newSvc(store, nil)
 
 	res := svc.Import(ctx(), []catalog.ImportItem{
 		{Name: "fresh", ConfigJSON: `{"a":1}`},


### PR DESCRIPTION
## Summary

WS-Z Z1 (gate keystone — full-tree golangci). The CI golangci gate ran with
`--new-from-rev=HEAD~1`, linting only each PR's diff — a **blind gate** that let
whole-tree violations accumulate unseen. This flips it to lint the full tree
(drops `--new-from-rev`) and bumps the pinned version `v2.12.1 → v2.12.2` to
match the mandated toolchain (CLAUDE.md).

The pre-existing full-tree backlog was exactly **3 issues**, all fixed here so
the gate goes green — no production behavior change:

- **`internal/profiles/catalog`** (`interfacebloat`): the consumer-defined
  `Store` port had 11 methods. Split into `Store` (9 CRUD methods) + a new
  `ActiveStore` (`ActiveID`/`SetActiveID`); `Service` now holds both ports and
  the single production adapter (`profilesStore`) satisfies each. CQS-style
  segregation — the active-profile pointer is a distinct persistence concern.
- **`internal/api/server`** (`funlen`): `NewServer` was 51 statements (limit
  50). Extracted the auth-services wiring into `initAuthServices`, following the
  package's existing `init*` composition-helper pattern.
- **`internal/probe/anomaly`** (`unparam`): dropped the always-`"p1"` parameter
  from the `latencyEvent` test helper.

## Linked Issue

Related to #187

## Type of Change

- [x] CI / release / packaging
- [x] Chore / refactor (small backlog fixes to enable the gate)

## Risk

- [x] Low

## Testing Evidence

```text
golangci-lint run ./... (v2.12.2, full tree):  0 issues
gofmt -l (touched .go):                        clean
go vet (api, catalog, app, probe/anomaly):     OK
go test catalog / probe-anomaly / app:         ok
go build ./internal/api/:                       OK
```

The heavier `internal/api` `-race` suite is left to CI.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (auth wiring relocated verbatim into a helper; no behavior change)
- [x] Dependencies are pinned and justified if changed. (golangci-lint pin bumped to the mandated v2.12.2)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (CI-only + internal refactor)